### PR TITLE
Add onyo anchor, unanchor

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ converted to a folder, and the license moved into it.
 
   Running `onyo init` on an existing repository is safe. It will not overwrite
   anything; it will exit with an error.
-- `onyo ls subfolder`:
+- `onyo ls directory`:
 
   List names of assets
 
@@ -177,6 +177,12 @@ converted to a folder, and the license moved into it.
   environment variable `EDITOR` (`nano` and then `vi` are used as fallbacks).
 
   TODO: Describe validation
+- `onyo anchor directory`:
+
+  Creates a file  directory/.anchor to track a folder even if it has no assets.
+- `onyo unanchor directory`:
+
+  Removes the directory/.anchor file from a folder.
 - `onyo get [--depth num, -d] [--filter key=value[,key=value]..., -f] [--machine-readable, -m] [--sort-ascending key, -s | --sort-descending key, -S] keyname... [asset | directory]...`:
 
   Print the requested `key`(s) in tabular form for matching assets.

--- a/onyo/commands/__init__.py
+++ b/onyo/commands/__init__.py
@@ -4,7 +4,9 @@ from .mv import mv
 from .edit import edit
 from .tree import tree
 from .cat import cat
+from .anchor import anchor
+from .unanchor import unanchor
 
 __all__ = [
-    'init', 'new', 'mv', 'edit', 'cat', 'tree'
+    'init', 'new', 'mv', 'edit', 'cat', 'tree', 'anchor', 'unanchor'
 ]

--- a/onyo/commands/anchor.py
+++ b/onyo/commands/anchor.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+import logging
+import os
+import sys
+
+from onyo.utils import (
+                        build_git_add_cmd,
+                        get_git_root,
+                        run_cmd,
+                        prepare_directory
+                        )
+
+logging.basicConfig()
+logger = logging.getLogger('onyo')
+
+anchor_name = ".anchor"
+
+def build_commit_cmd(file, git_directory):
+    return ["git -C " + git_directory + " commit -m", "\'anchor: " + file + "\'"]
+
+
+def run_anchor(directory):
+    filename = anchor_name
+    if os.path.exists(os.path.join(directory, filename)):
+        logger.error(os.path.join(directory, filename) + " anchor already exists.")
+        sys.exit(0)
+    run_cmd(create_asset_file_cmd(directory, filename))
+    git_add_cmd = build_git_add_cmd(directory, filename)
+    run_cmd(git_add_cmd)
+    return os.path.join(directory, filename)
+
+
+def create_asset_file_cmd(directory, filename):
+    return "touch " + os.path.join(directory, filename)
+
+
+def anchor(args):
+    # set paths
+    for folder in args.directory:
+        directory = prepare_directory(folder)
+        git_directory = get_git_root(directory)
+
+        # create anchor file and add it
+        created_file = run_anchor(directory)
+        git_filepath = os.path.relpath(created_file, git_directory)
+
+        # build commit command
+        [commit_cmd, commit_msg] = build_commit_cmd(git_filepath, git_directory)
+
+        # run commands
+        run_cmd(commit_cmd, commit_msg)

--- a/onyo/commands/unanchor.py
+++ b/onyo/commands/unanchor.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+import logging
+import os
+import sys
+
+from onyo.utils import (
+                        build_git_add_cmd,
+                        get_git_root,
+                        run_cmd,
+                        prepare_directory
+                        )
+
+logging.basicConfig()
+logger = logging.getLogger('onyo')
+
+anchor_name = ".anchor"
+
+def build_commit_cmd(file, git_directory):
+    return ["git -C " + git_directory + " commit -m", "\'remove anchor: " + file + "\'"]
+
+
+def run_unanchor(directory):
+    filename = anchor_name
+    if not os.path.exists(os.path.join(directory, filename)):
+        logger.error(os.path.join(directory, filename) + " has no anchor.")
+        sys.exit(0)
+    run_cmd("rm -f " + os.path.join(directory, filename))
+    git_add_cmd = build_git_add_cmd(directory, filename)
+    run_cmd(git_add_cmd)
+    return os.path.join(directory, filename)
+
+
+def unanchor(args):
+    # set paths
+    for folder in args.directory:
+        directory = prepare_directory(folder)
+        git_directory = get_git_root(directory)
+
+        # remove anchor file and add it
+        created_file = run_unanchor(directory)
+        git_filepath = os.path.relpath(created_file, git_directory)
+
+        # build commit command
+        [commit_cmd, commit_msg] = build_commit_cmd(git_filepath, git_directory)
+
+        # run commands
+        run_cmd(commit_cmd, commit_msg)

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -120,6 +120,30 @@ def parse_args():
         default=onyo_default_repo,
         help='Directory to show tree'
     )
+    # subcommand "anchor"
+    cmd_anchor = subcommands.add_parser(
+        'anchor',
+        help='Anchor folder permanently to onyo, even if empty'
+    )
+    cmd_anchor.set_defaults(run=commands.anchor)
+    cmd_anchor.add_argument(
+        'directory',
+        metavar='directory',
+        nargs='+',
+        help='Directory to anchor to onyo'
+    )
+    # subcommand "unanchor"
+    cmd_unanchor = subcommands.add_parser(
+        'unanchor',
+        help='Unanchor folder from onyo'
+    )
+    cmd_unanchor.set_defaults(run=commands.unanchor)
+    cmd_unanchor.add_argument(
+        'directory',
+        metavar='directory',
+        nargs='+',
+        help='Directory to delete anchor from onyo'
+    )
     return parser
 
 

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -80,8 +80,8 @@ def parse_args():
     )
     cmd_new.set_defaults(run=commands.new)
     cmd_new.add_argument(
-        'location',
-        metavar='location',
+        'directory',
+        metavar='directory',
         help='Directory to add the new onyo asset'
     )
     # subcommand "edit"

--- a/onyo/utils.py
+++ b/onyo/utils.py
@@ -74,3 +74,20 @@ def get_full_filepath(git_directory, file):
 
 def build_git_add_cmd(directory, file):
     return "git -C " + directory + " add " + file
+
+
+def prepare_directory(directory):
+    if os.path.isdir(os.path.join(os.getcwd(), directory)):
+        location = os.path.join(os.getcwd(), directory)
+    elif os.environ.get('ONYO_REPOSITORY_DIR') is not None and os.path.isdir(os.path.join(os.environ.get('ONYO_REPOSITORY_DIR'), directory)) and os.path.isdir(os.path.join(get_git_root(directory), directory)):
+        location = os.path.join(get_git_root(directory), directory)
+    elif os.path.isdir(os.path.join(os.getcwd(), os.path.split(directory)[0])) and (os.path.split(directory)[0] != ""):
+        location = os.path.join(os.getcwd(), directory)
+        run_cmd("mkdir " + location)
+    elif os.path.isdir(os.path.join(get_git_root(os.path.split(directory)[0]), os.path.split(directory)[0])):
+        location = os.path.join(get_git_root(os.path.split(directory)[0]), directory)
+        run_cmd("mkdir " + location)
+    else:
+        logger.error(directory + " does not exist.")
+        sys.exit(0)
+    return location

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
 #       'argparse'
         'GitPython'
     ],
-    python_requires=">=3.0",
+    python_requires=">=3.5",
     entry_points={
         'console_scripts': [
             'onyo=onyo.main:main'

--- a/tests/default_tests.py
+++ b/tests/default_tests.py
@@ -53,7 +53,10 @@ class TestClass:
                      ("onyo init", "", test_output + "empty_file.txt"),
                      ("git status", "", test_output + "git_status_working_tree_clean.txt"),
                      ("mkdir user/", "", test_output + "empty_file.txt"),
+                     ("onyo anchor user/", "", test_output + "empty_file.txt"),
                      ("mkdir user2/", "", test_output + "empty_file.txt"),
+                     ("onyo anchor user2", "", test_output + "empty_file.txt"),
+                     ("onyo unanchor user2", "", test_output + "empty_file.txt"),
                      ("git status", "", test_output + "git_status_working_tree_clean.txt"),
                      ("onyo new shelf", "laptop\napple\nmacbookpro\n1", test_output + "onyo_new_works.txt"),
                      ("onyo new shelf", "laptop\napple\nmacbookpro\n2", test_output + "onyo_new_works.txt"),
@@ -123,6 +126,8 @@ class TestClass:
                               ("mkdir ./test_4/user/", "", test_output + "empty_file.txt"),
                               ("mkdir ./test_4/user2/", "", test_output + "empty_file.txt"),
                               ("git status", "", test_output + "git_status_working_tree_clean.txt"),
+                              ("onyo anchor ./test_4/*", "", test_output + "empty_file.txt"),
+                              ("onyo unanchor ./test_4/*", "", test_output + "empty_file.txt"),
                               ("onyo new ./test_4/shelf", "laptop\napple\nmacbookpro\n1", test_output + "onyo_new_works.txt"),
                               ("onyo new test_4/shelf", "laptop\napple\nmacbookpro\n2", test_output + "onyo_new_works.txt"),
                               ("onyo new test_4/shelf", "laptop\napple\nmacbookpro\n3", test_output + "onyo_new_works.txt"),
@@ -147,6 +152,7 @@ class TestClass:
         # Test-specific changes:
         if "*" in command:
             command = command.replace("test_4/user/*", " ".join(glob.glob(os.path.join("test_4/user/*"))))
+            command = command.replace("test_4/*", " ".join(glob.glob(os.path.join("test_4/*"))))
         command = command.replace("git status", "git -C " + current_test_dir + " status")
         check_output_with_file(command, input_str, file)
 


### PR DESCRIPTION
To use the same function in (un)anchor like in `onyo new`, code from new.py got moved to utils.py.
At this point I normalized the variable `location` also to `directory` in `onyo new`.

Implements `anchor` and `unanchor` as subcommands to `onyo`.
Adds anchor/unanchor to the tests.
anchor and unanchor are explained in README.md.

Sets minimum python version to 3.5 in setup.py.