### PR TITLE
tests: runable from other directories/systems; adds github action to run tests automatically

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,18 +6,17 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 5
+      matrix:
+        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10', 'pypy3']
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.5
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
-        python-version: 3.5
-    - name: Add conda to system path
+        python-version: ${{ matrix.python-version }}
+    - name: git config
       run: |
-        # $CONDA is an environment variable pointing to the root of the miniconda directory
-        echo $CONDA/bin >> $GITHUB_PATH
         git config --global user.email "you@example.com"
         git config --global user.name "Your Name"
     - name: Install dependencies
@@ -25,5 +24,4 @@ jobs:
         pip install .
     - name: Test with pytest
       run: |
-        conda install pytest
         pytest tests/default_tests.py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,29 @@
+name: Onyo Tests
+
+on: [push]
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 5
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.5
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.5
+    - name: Add conda to system path
+      run: |
+        # $CONDA is an environment variable pointing to the root of the miniconda directory
+        echo $CONDA/bin >> $GITHUB_PATH
+        git config --global user.email "you@example.com"
+        git config --global user.name "Your Name"
+    - name: Install dependencies
+      run: |
+        pip install .
+    - name: Test with pytest
+      run: |
+        conda install pytest
+        pytest tests/default_tests.py

--- a/onyo/utils.py
+++ b/onyo/utils.py
@@ -45,7 +45,10 @@ def get_git_root(path):
     try:
         git_repo = Repo(path, search_parent_directories=True)
         git_root = git_repo.git.rev_parse("--show-toplevel")
-        return git_root
+        if os.path.isdir(os.path.join(git_root, ".onyo")):
+            return git_root
+        else:
+            raise exc.InvalidGitRepositoryError
     # otherwise checks if given file relative to $ONYO_REPOSITORY_DIR is in a
     # git repository
     except (exc.NoSuchPathError, exc.InvalidGitRepositoryError):

--- a/setup.py
+++ b/setup.py
@@ -11,12 +11,8 @@ setup(
     packages=find_packages(),
     license='ISC',
     install_requires=[
-#        'subprocess',
-#        'logging',
-#        'os',
-#        'sys',
-#       'argparse'
-        'GitPython'
+        'GitPython',
+        'pytest'
     ],
     python_requires=">=3.5",
     entry_points={

--- a/tests/output_goals/test_1/init_test.txt
+++ b/tests/output_goals/test_1/init_test.txt
@@ -1,1 +1,1 @@
-INFO:onyo:'initialize onyo repository': /Users/tkadelka/new-onyo/test_1
+INFO:onyo:'initialize onyo repository': <test_dir>

--- a/tests/output_goals/test_2/init_test.txt
+++ b/tests/output_goals/test_2/init_test.txt
@@ -1,1 +1,1 @@
-INFO:onyo:'initialize onyo repository': /Users/tkadelka/new-onyo/test_2
+INFO:onyo:'initialize onyo repository': <test_dir>

--- a/tests/output_goals/test_3/init_test.txt
+++ b/tests/output_goals/test_3/init_test.txt
@@ -1,1 +1,1 @@
-INFO:onyo:'initialize onyo repository': /Users/tkadelka/new-onyo/test_3
+INFO:onyo:'initialize onyo repository': <test_dir>

--- a/tests/output_goals/test_4/init_test.txt
+++ b/tests/output_goals/test_4/init_test.txt
@@ -1,1 +1,1 @@
-INFO:onyo:'initialize onyo repository': /Users/tkadelka/new-onyo/test_4
+INFO:onyo:'initialize onyo repository': <test_dir>


### PR DESCRIPTION
Instead of using a hardcoded file path, the default_tests.py uses the location relative to itself to find the files to compare the ouput to, and to creates a folder to run all the tests in. Instead of using a set path in the output files, replaces paths in the output with a path for each test, depending on the location the test was run from.

Sets up a github action file to run the tests automatically for each push.