### PR TITLE
Check files before running command(s), create one commit per command

### DIFF
--- a/onyo/commands/cat.py
+++ b/onyo/commands/cat.py
@@ -9,23 +9,26 @@ logging.basicConfig()
 logger = logging.getLogger('onyo')
 
 
-def build_cat_cmd(file):
-    this_asset = file
+def build_cat_cmd(files):
+    list_of_cat_commands = []
+    problem_str = ""
     onyo_repository_dir = os.environ.get('ONYO_REPOSITORY_DIR')
-    if not os.path.isfile(this_asset) and onyo_repository_dir is not None:
-        this_asset = os.path.join(onyo_repository_dir, this_asset)
-    if not os.path.isfile(this_asset):
-        logger.warning(file + " does not exist.")
-        return None
-    return "cat \"" + this_asset + "\""
+    for file in files:
+        if os.path.isfile(file):
+            list_of_cat_commands.append("cat \"" + file + "\"")
+        elif not os.path.isfile(file) and onyo_repository_dir is not None:
+            list_of_cat_commands.append("cat \"" + os.path.join(onyo_repository_dir, file) + "\"")
+        else:
+            problem_str = problem_str + "\n" + file + " does not exist."
+    if problem_str != "":
+        logger.warning(problem_str)
+    return list_of_cat_commands
 
 
 def cat(args):
-    for file in args.file:
-        # build command
-        cat_command = build_cat_cmd(file)
-
+    # check paths and build commands
+    list_of_cat_commands = build_cat_cmd(args.file)
+    for command in list_of_cat_commands:
         # run commands
-        if cat_command is not None:
-            output = run_cmd(cat_command)
-            print(output.strip())
+        output = run_cmd(command)
+        print(output.strip())

--- a/onyo/commands/mv.py
+++ b/onyo/commands/mv.py
@@ -16,46 +16,59 @@ logger = logging.getLogger('onyo')
 def build_mv_cmd(git_path, source, destination, force, rename):
     if (os.path.basename(destination) != os.path.basename(source) and not
             (rename or os.path.isdir(source))):
-        logger.error(os.path.basename(source) + " -> " +
-                     os.path.basename(destination) + " no renaming allowed.")
-        sys.exit(1)
+        return (os.path.basename(source) + " -> " + os.path.basename(destination) + " no renaming allowed.")
     if os.path.isfile(os.path.join(git_path, destination)):
         if force:
             return "git -C " + git_path + " mv -f \"" + source + "\" \"" + destination + "\""
         else:
-            logger.error(os.path.join(git_path, destination) + " already exists.")
-            sys.exit(1)
+            return (os.path.join(git_path, destination) + " already exists.")
     return "git -C " + git_path + " mv \"" + source + "\" \"" + destination + "\""
 
 
-def build_commit_cmd(source, destination, git_directory):
-    return ["git -C " + git_directory + " commit -m", "\'move \"" + source +
-            "\" to \"" + destination + "\"\'"]
+def build_commit_cmd(list_of_commands, git_directory):
+    return ["git -C " + git_directory + " commit -m", "move assets.\n" + "\n".join(list_of_commands)]
 
 
-def mv(args):
-    for source in args.source:
+def check_sources(sources, destination, force, rename):
+    problem_str = ""
+    list_of_commands = []
+    list_of_destinations = []
+    for source in sources:
         # set all paths
-        git_path = get_git_root(os.path.dirname(args.destination))
+        git_path = get_git_root(os.path.dirname(destination))
         source_filename = os.path.join(os.getcwd(), source)
-        destination_filename = os.path.join(os.getcwd(), args.destination)
+        destination_filename = os.path.join(os.getcwd(), destination)
+        # if source not reached from current directory, try from environmental
         if not os.path.exists(source_filename):
             source_filename = os.path.join(git_path, source)
-            destination_filename = os.path.join(git_path, args.destination)
+            destination_filename = os.path.join(git_path, destination)
         if not os.path.exists(source_filename):
-            logger.error(source + " does not exist.")
-            sys.exit(1)
+            problem_str = problem_str + "\n" + source + " does not exist."
         if os.path.isdir(destination_filename) and not os.path.isdir(source_filename):
             destination_filename = os.path.join(destination_filename, os.path.basename(source_filename))
-
         destination_filename = os.path.relpath(destination_filename, git_path)
         source_filename = os.path.relpath(source_filename, git_path)
         # build commands
-        mv_cmd = build_mv_cmd(git_path, source_filename, destination_filename, args.force, args.rename)
-        [commit_cmd, commit_msg] = build_commit_cmd(source_filename,
-                                                    destination_filename,
-                                                    git_path)
+        current_cmd = build_mv_cmd(git_path, source_filename, destination_filename, force, rename)
+        if destination_filename in list_of_destinations:
+            problem_str = problem_str + "\n" + "Can't move multiple assets to " + destination_filename
+        list_of_destinations.append(destination_filename)
+        if "git -C" in current_cmd:
+            list_of_commands.append(current_cmd)
+        else:
+            problem_str = problem_str + "\n" + current_cmd
+    if problem_str != "":
+        logger.error(problem_str + "\nNo folders or assets moved.")
+        sys.exit(1)
+    return list_of_commands
 
-        # run commands
-        run_cmd(mv_cmd)
-        run_cmd(commit_cmd, commit_msg)
+
+def mv(args):
+    # check and set paths
+    git_path = get_git_root(os.path.dirname(args.destination))
+    list_of_commands = check_sources(args.source, args.destination, args.force, args.rename)
+    # run list of commands, afterwards commit
+    for command in list_of_commands:
+        run_cmd(command)
+    [commit_cmd, commit_msg] = build_commit_cmd(list_of_commands, git_path)
+    run_cmd(commit_cmd, commit_msg)

--- a/onyo/commands/new.py
+++ b/onyo/commands/new.py
@@ -64,13 +64,17 @@ def create_asset_file_cmd(directory, filename):
     return "touch \"" + os.path.join(directory, filename) + "\""
 
 
-def new(args):
-
-    # set paths
-    directory = prepare_directory(args.directory)
+def check_sources(sources):
+    directory = prepare_directory(sources)
     if not os.path.isdir(directory):
         logger.error(directory + " is not a directory.")
         sys.exit(1)
+    return directory
+
+
+def new(args):
+    # set and check paths
+    directory = check_sources(args.directory)
     git_directory = get_git_root(directory)
 
     # create file for asset, fill in fields

--- a/onyo/commands/rm.py
+++ b/onyo/commands/rm.py
@@ -21,9 +21,6 @@ def build_commit_cmd(sources, git_directory):
 
 def run_rm(git_directory, source):
     full_path = os.path.join(git_directory, source)
-    if not os.path.exists(full_path):
-        logger.error(full_path + " does not exist.")
-        sys.exit(1)
     # run the rm commands
     run_cmd("rm -rdf \"" + full_path + "\"")
     # git add
@@ -45,7 +42,7 @@ def check_sources(sources):
     if problem_str != "":
         logger.error(problem_str + "\nNo folders or assets deleted.")
         sys.exit(1)
-    return list_of_sources
+    return list(dict.fromkeys(list_of_sources))
 
 
 def rm(args):
@@ -69,7 +66,11 @@ def rm(args):
     # build commit command and message
     [commit_cmd, commit_msg] = build_commit_cmd(args.source[0], get_git_root(args.source[0]))
 
-    for source in args.source:
+    for source in list_of_sources:
+        # if stopped existing since check_sources(), it was deleted
+        # with the loop before
+        if not os.path.exists(source):
+            continue
         # set paths
         git_directory = get_git_root(source)
         current_source = get_full_filepath(git_directory, source)

--- a/onyo/commands/tree.py
+++ b/onyo/commands/tree.py
@@ -4,7 +4,9 @@ import logging
 import os
 import sys
 
-from onyo.utils import run_cmd
+from onyo.utils import (
+    run_cmd
+)
 
 logging.basicConfig()
 logger = logging.getLogger('onyo')
@@ -17,10 +19,48 @@ def build_tree_cmd(directory):
     return "tree \"" + directory + "\""
 
 
-def tree(args):
-    # build commands
-    tree_command = build_tree_cmd(args.directory)
+def check_sources(sources):
+    problem_str = ""
+    list_of_sources = []
 
-    # run commands
-    output = run_cmd(tree_command)
-    print(output)
+    # just a single path?
+    single_source = "".join(sources)
+    if os.path.isdir(single_source):
+        return [single_source]
+    # check if any path for displaying tree exists
+    onyo_default_repo = os.environ.get('ONYO_REPOSITORY_DIR')
+    if len(sources) == 0 and onyo_default_repo is None:
+        logger.error("No sources given and $ONYO_REPOSITORY_DIR not set.")
+        sys.exit(1)
+    elif onyo_default_repo is not None and os.path.isdir(os.path.join(onyo_default_repo, single_source)):
+        return [os.path.join(onyo_default_repo, single_source)]
+
+    # build paths
+    for source in sources:
+        current_source = os.path.join(os.getcwd(), source)
+        # check if path is onyo or not
+        if not os.path.exists(current_source) and onyo_default_repo is not None:
+            current_source = os.path.join(onyo_default_repo, source)
+        # check if path exists
+        if not os.path.exists(current_source):
+            problem_str = problem_str + "\n" + source + " does not exist."
+        elif not os.path.isdir(current_source):
+            problem_str = problem_str + "\n" + source + " is not a directory."
+        else:
+            list_of_sources.append(current_source)
+    if problem_str != "":
+        logger.error(problem_str)
+        sys.exit(1)
+    return list_of_sources
+
+
+def tree(args):
+
+    # check sources
+    list_of_sources = check_sources(args.directory)
+
+    # build and run commands
+    for source in list_of_sources:
+        tree_command = build_tree_cmd(source)
+        output = run_cmd(tree_command)
+        print(output)

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -138,9 +138,8 @@ def parse_args():
     cmd_tree.add_argument(
         'directory',
         metavar='directory',
-        nargs='?',
-        default=onyo_default_repo,
-        help='Directory to show tree'
+        nargs='*',
+        help='Directories to show tree'
     )
     # subcommand "git"
     cmd_git = subcommands.add_parser(

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -115,6 +115,7 @@ def parse_args():
     cmd_edit.add_argument(
         'file',
         metavar='file',
+        nargs='+',
         help='Filename of asset to edit'
     )
     # subcommand cat

--- a/onyo/utils.py
+++ b/onyo/utils.py
@@ -68,10 +68,10 @@ def get_git_root(path):
 
 def get_full_filepath(git_directory, file):
     full_filepath = os.path.join(git_directory, file)
-    if not os.path.isfile(full_filepath):
+    if not os.path.exists(full_filepath):
         full_filepath = os.path.join(git_directory, os.getcwd())
         full_filepath = os.path.join(full_filepath, file)
-    if not os.path.isfile(full_filepath):
+    if not os.path.exists(full_filepath):
         logger.error(file + " not found.")
         sys.exit(1)
     return full_filepath

--- a/tests/default_tests.py
+++ b/tests/default_tests.py
@@ -61,7 +61,7 @@ class TestClass:
         ("onyo mkdir user/", "", test_output, "empty_file.txt"),
         ("onyo mkdir user\ 2/", "", test_output, "empty_file.txt"),
         ("onyo mkdir shelf/", "", test_output, "empty_file.txt"),
-        ("onyo mkdir trash\ bin/", "", test_output, "empty_file.txt"),
+        ("onyo mkdir trash\ bin/ delete_me", "", test_output, "empty_file.txt"),
         ("onyo git status", "", test_output, "git_status_working_tree_clean.txt"),
         ("onyo new --non-interactive shelf", "laptop\napple\nmacbookpro\n1", test_output, "onyo_new_works.txt"),
         ("onyo new --non-interactive shelf", "laptop\napple\nmacbookpro\n2", test_output, "onyo_new_works.txt"),
@@ -81,6 +81,7 @@ class TestClass:
         ("onyo mv shelf/laptop_apple_macbookpro.5 user/", "", test_output, "empty_file.txt"),
         ("onyo mv shelf/laptop_apple_macbookpro.6 user/", "", test_output, "empty_file.txt"),
         ("onyo mv --rename user\ 2 no\ user", "", test_output, "empty_file.txt"),
+        ("onyo rm -q -y delete_me/", "", test_output, "empty_file.txt"),
         ("onyo git status", "", test_output, "git_status_working_tree_clean.txt"),
     ]
 
@@ -146,7 +147,7 @@ class TestClass:
         ("onyo mkdir ./test_4/user/", "", test_output, "empty_file.txt"),
         ("onyo mkdir ./test_4/user\ 2/", "", test_output, "empty_file.txt"),
         ("onyo mkdir ./test_4/shelf", "", test_output, "empty_file.txt"),
-        ("onyo mkdir ./test_4/trash\ bin", "", test_output, "empty_file.txt"),
+        ("onyo mkdir ./test_4/trash\ bin test_4/delete_me/", "", test_output, "empty_file.txt"),
         ("onyo git -C test_4 status", "", test_output, "git_status_working_tree_clean.txt"),
         ("onyo new --non-interactive ./test_4/shelf", "laptop\napple\nmacbookpro\n1", test_output, "onyo_new_works.txt"),
         ("onyo new --non-interactive test_4/shelf", "laptop\napple\nmacbookpro\n2", test_output, "onyo_new_works.txt"),
@@ -167,6 +168,7 @@ class TestClass:
         ("onyo mv test_4/shelf/laptop_apple_macbookpro.5 ./test_4/user/", "", test_output, "empty_file.txt"),
         ("onyo mv test_4/shelf/laptop_apple_macbookpro.6 ./test_4/user/", "", test_output, "empty_file.txt"),
         ("onyo mv --rename ./test_4/user\ 2 ./test_4/no\ user", "", test_output, "empty_file.txt"),
+        ("onyo rm -q -y test_4/delete_me/", "", test_output, "empty_file.txt"),
         ("onyo git -C test_4 status", "", test_output, "git_status_working_tree_clean.txt"),
     ]
 


### PR DESCRIPTION
The commands that can get multiple inputs check all of them now before running any operation, so onyo can inform about problems beforehand, and then after running all operations, onyo creates 1 commit (before, it did one commit per changed/created file/folder).

During this, some commands (like edit) got changed and do now accept multiple inputs. This is part of the PR, so the check_sources() functions do not have to be done first for one source, and then re-written for multiple ones.