### PR TITLE
all commands: move decision for onyo directory to main.py

### DIFF
--- a/onyo/commands/cat.py
+++ b/onyo/commands/cat.py
@@ -9,15 +9,14 @@ logging.basicConfig()
 logger = logging.getLogger('onyo')
 
 
-def build_cat_cmd(files):
+def build_cat_cmd(files, onyo_root):
     list_of_cat_commands = []
     problem_str = ""
-    onyo_repository_dir = os.environ.get('ONYO_REPOSITORY_DIR')
     for file in files:
-        if os.path.isfile(file):
+        if os.path.isfile(os.path.join(onyo_root, file)):
+            list_of_cat_commands.append("cat \"" + os.path.join(onyo_root, file) + "\"")
+        elif os.path.isfile(file):
             list_of_cat_commands.append("cat \"" + file + "\"")
-        elif not os.path.isfile(file) and onyo_repository_dir is not None:
-            list_of_cat_commands.append("cat \"" + os.path.join(onyo_repository_dir, file) + "\"")
         else:
             problem_str = problem_str + "\n" + file + " does not exist."
     if problem_str != "":
@@ -25,9 +24,9 @@ def build_cat_cmd(files):
     return list_of_cat_commands
 
 
-def cat(args):
+def cat(args, onyo_root):
     # check paths and build commands
-    list_of_cat_commands = build_cat_cmd(args.file)
+    list_of_cat_commands = build_cat_cmd(args.file, onyo_root)
     for command in list_of_cat_commands:
         # run commands
         output = run_cmd(command)

--- a/onyo/commands/edit.py
+++ b/onyo/commands/edit.py
@@ -8,8 +8,6 @@ from git import Repo
 
 from onyo.utils import (
     build_git_add_cmd,
-    get_full_filepath,
-    get_git_root,
     run_cmd,
     edit_file
 )
@@ -18,56 +16,48 @@ logging.basicConfig()
 logger = logging.getLogger('onyo')
 
 
-def build_commit_cmd(files, git_directory):
-    return ["git -C \"" + git_directory + "\" commit -m", "edit files\n" + "\n".join(files)]
+def build_commit_cmd(files, onyo_root):
+    return ["git -C \"" + onyo_root + "\" commit -m", "edit files\n\n" + "\n".join(files)]
 
 
-def prepare_arguments(sources):
+def prepare_arguments(sources, onyo_root):
     problem_str = ""
     list_of_sources = []
     if isinstance(sources, str):
         sources = ["".join(sources)]
-    git_directory = get_git_root(sources[0])
     for source in sources:
-        test_git = get_git_root(source)
-        current_source = get_full_filepath(test_git, source)
-        if git_directory != test_git:
-            problem_str = problem_str + "\n" + current_source + " not in same git as " + sources[0]
+        current_source = source
+        if not os.path.isfile(current_source):
+            current_source = os.path.join(onyo_root, source)
         if not os.path.exists(current_source):
             problem_str = problem_str + "\n" + current_source + " does not exist."
+        # check if file is in git
+        run_output = run_cmd("git -C \"" + onyo_root + "\" ls-tree -r HEAD ")
+        if source not in run_output:
+            problem_str = problem_str + "\n" + current_source + " is not in onyo."
         else:
             list_of_sources.append(current_source)
     if problem_str != "":
-        logger.error(problem_str + "\nNo folders or assets moved.")
+        logger.error(problem_str)
         sys.exit(1)
     return list(dict.fromkeys(list_of_sources))
 
 
-def edit(args):
+def edit(args, onyo_root):
     # check and set paths
-    list_of_sources = prepare_arguments(args.file)
-
+    list_of_sources = prepare_arguments(args.file, onyo_root)
+    # iterate over file list, edit them, add changes
     for source in list_of_sources:
-        git_directory = get_git_root(source)
-        git_filepath = os.path.relpath(source, git_directory)
-
-        # check if file is in git
-        run_output = run_cmd("git -C \"" + git_directory + "\" ls-tree -r HEAD ")
-        if git_filepath not in run_output:
-            logger.error(git_filepath + " is not in onyo.")
-            sys.exit(1)
-
+        git_filepath = os.path.relpath(source, onyo_root)
         # change file
         if not args.non_interactive:
             edit_file(source)
-
         # check if changes happened and add them
-        repo = Repo(git_directory)
+        repo = Repo(onyo_root)
         changed_files = [item.a_path for item in repo.index.diff(None)]
         if len(changed_files) != 0:
-            git_add_cmd = build_git_add_cmd(git_directory, git_filepath)
+            git_add_cmd = build_git_add_cmd(onyo_root, git_filepath)
             run_cmd(git_add_cmd)
-
     # commit changes
-    [commit_cmd, commit_msg] = build_commit_cmd(changed_files, get_git_root(list_of_sources[0]))
+    [commit_cmd, commit_msg] = build_commit_cmd(changed_files, onyo_root)
     run_cmd(commit_cmd, commit_msg)

--- a/onyo/commands/git.py
+++ b/onyo/commands/git.py
@@ -3,30 +3,30 @@
 import logging
 
 from onyo.utils import (
-    get_git_root,
-    run_cmd,
+    run_cmd
 )
 
 logging.basicConfig()
 logger = logging.getLogger('onyo')
 
 
-def build_command(command, git_directory):
+def build_command(command, onyo_root):
     cmd_str = ""
     for arg in command:
         if " " in arg:
             cmd_str += " \"" + arg + "\""
         else:
             cmd_str += " " + arg
-    return " ".join(["git -C \"" + git_directory + "\" " + cmd_str])
+    return " ".join(["git -C \"" + onyo_root + "\" " + cmd_str])
 
 
-def git(args):
-    # set paths
-    git_directory = get_git_root(args.directory)
+def git(args, onyo_root):
+    # if "onyo git -C <dir>" is called
+    if args.directory is not None:
+        onyo_root = args.directory
 
     # build command
-    command = build_command(args.command, git_directory)
+    command = build_command(args.command, onyo_root)
 
     # run commands
     print(run_cmd(command))

--- a/onyo/commands/init.py
+++ b/onyo/commands/init.py
@@ -48,13 +48,22 @@ def create_file_cmd(directory):
     return "touch \"" + os.path.join(directory + "/.onyo/.anchor") + "\""
 
 
-def init(args):
+def prepare_arguments(directory, onyo_root):
+    if directory is None:
+        directory = onyo_root
+    return directory
+
+
+def init(args, onyo_root):
+    # set and check path
+    directory = prepare_arguments(args.directory, onyo_root)
+
     # build commands
-    git_init_command = build_git_init_cmd(args.directory)
-    onyo_init_command = build_onyo_init_cmd(args.directory)
-    create_file_command = create_file_cmd(args.directory)
-    git_add_command = build_git_add_cmd(args.directory, ".onyo/")
-    [commit_cmd, commit_msg] = build_commit_cmd(args.directory)
+    git_init_command = build_git_init_cmd(directory)
+    onyo_init_command = build_onyo_init_cmd(directory)
+    create_file_command = create_file_cmd(directory)
+    git_add_command = build_git_add_cmd(directory, ".onyo/")
+    [commit_cmd, commit_msg] = build_commit_cmd(directory)
 
     # run commands
     if git_init_command is not None:
@@ -63,4 +72,4 @@ def init(args):
     run_cmd(create_file_command)
     run_cmd(git_add_command)
     run_cmd(commit_cmd, commit_msg)
-    logger.info(commit_msg + ": " + get_git_root(args.directory))
+    logger.info(commit_msg + ": " + get_git_root(directory))

--- a/onyo/commands/mkdir.py
+++ b/onyo/commands/mkdir.py
@@ -6,7 +6,6 @@ import sys
 
 from onyo.utils import (
     build_git_add_cmd,
-    get_git_root,
     run_cmd
 )
 
@@ -16,34 +15,31 @@ logger = logging.getLogger('onyo')
 anchor_name = ".anchor"
 
 
-def build_commit_cmd(folders, git_directory):
-    return ["git -C " + git_directory + " commit -m", "new folder(s)\n\n" + "\n".join(folders)]
+def build_commit_cmd(folders, onyo_root):
+    return ["git -C " + onyo_root + " commit -m", "new folder(s)\n\n" + "\n".join(folders)]
 
 
-def run_mkdir(git_directory, new_directory):
+def run_mkdir(onyo_root, new_directory):
     filename = anchor_name
-    full_directory = os.path.join(git_directory, new_directory)
+    full_directory = os.path.join(onyo_root, new_directory)
     if os.path.isdir(full_directory):
         logger.error(full_directory + " exists already.")
         sys.exit(1)
     # run the actual commands, for creating a folder, anchor it, add it to git
-    current_directory = git_directory
+    current_directory = onyo_root
     for folder in os.path.normpath(new_directory).split(os.path.sep):
         current_directory = os.path.join(current_directory, folder)
         if os.path.isdir(current_directory):
             continue
         run_cmd("mkdir \"" + current_directory + "\"")
         run_cmd("touch \"" + os.path.join(current_directory, filename) + "\"")
-        git_add_cmd = build_git_add_cmd(git_directory, os.path.join(current_directory, filename))
+        git_add_cmd = build_git_add_cmd(onyo_root, os.path.join(current_directory, filename))
         run_cmd(git_add_cmd)
     return full_directory
 
 
-def get_existing_subpath(directory):
-    if os.getenv('ONYO_REPOSITORY_DIR') is not None:
-        existing_path = os.getenv('ONYO_REPOSITORY_DIR')
-    else:
-        existing_path = os.getcwd()
+def get_existing_subpath(directory, onyo_root):
+    existing_path = onyo_root
     missing_path = ""
     for folder in os.path.normpath(directory).split(os.path.sep):
         if os.path.isdir(os.path.join(existing_path, folder)):
@@ -53,11 +49,11 @@ def get_existing_subpath(directory):
     return [existing_path, missing_path]
 
 
-def prepare_arguments(directories):
+def prepare_arguments(directories, onyo_root):
     problem_str = ""
     list_of_folders = []
     for folder in directories:
-        [existing_path, missing_path] = get_existing_subpath(folder)
+        [existing_path, missing_path] = get_existing_subpath(folder, onyo_root)
         if missing_path == "":
             problem_str = problem_str + "\n" + existing_path + " already exists."
         else:
@@ -68,21 +64,13 @@ def prepare_arguments(directories):
     return list(dict.fromkeys(list_of_folders))
 
 
-def mkdir(args):
+def mkdir(args, onyo_root):
     # check and set paths
-    list_of_folders = prepare_arguments(args.directory)
-    git_directory = ""
+    list_of_folders = prepare_arguments(args.directory, onyo_root)
+    # loop over folders and create them with an anchor file
     for folder in list_of_folders:
-        # set paths
-        [existing_path, missing_path] = get_existing_subpath(folder)
-        git_directory = get_git_root(existing_path)
-        new_directory = os.path.join(existing_path, missing_path).replace(git_directory + os.path.sep, "")
-
-        # create anchor file and add it
-        run_mkdir(git_directory, new_directory)
-
+        run_mkdir(onyo_root, folder)
     # build commit command
-    [commit_cmd, commit_msg] = build_commit_cmd(list_of_folders, git_directory)
-
+    [commit_cmd, commit_msg] = build_commit_cmd(list_of_folders, onyo_root)
     # run commands
     run_cmd(commit_cmd, commit_msg)

--- a/onyo/commands/mv.py
+++ b/onyo/commands/mv.py
@@ -5,7 +5,6 @@ import os
 import sys
 
 from onyo.utils import (
-    get_git_root,
     run_cmd
 )
 
@@ -13,43 +12,38 @@ logging.basicConfig()
 logger = logging.getLogger('onyo')
 
 
-def build_mv_cmd(git_path, source, destination, force, rename):
+def build_mv_cmd(onyo_root, source, destination, force, rename):
     if (os.path.basename(destination) != os.path.basename(source) and not
             (rename or os.path.isdir(source))):
         return (os.path.basename(source) + " -> " + os.path.basename(destination) + " Assets can't be renamed without --rename.")
-    if os.path.isfile(os.path.join(git_path, destination)):
+    if os.path.isfile(os.path.join(onyo_root, destination)):
         if force:
-            return "git -C " + git_path + " mv -f \"" + source + "\" \"" + destination + "\""
+            return "git -C " + onyo_root + " mv -f \"" + source + "\" \"" + destination + "\""
         else:
-            return (os.path.join(git_path, destination) + " already exists.")
-    return "git -C " + git_path + " mv \"" + source + "\" \"" + destination + "\""
+            return (os.path.join(onyo_root, destination) + " already exists.")
+    return "git -C " + onyo_root + " mv \"" + source + "\" \"" + destination + "\""
 
 
-def build_commit_cmd(list_of_commands, git_directory):
-    return ["git -C " + git_directory + " commit -m", "move assets.\n" + "\n".join(list_of_commands)]
+def build_commit_cmd(list_of_commands, onyo_root):
+    return ["git -C " + onyo_root + " commit -m", "move assets.\n" + "\n".join(list_of_commands)]
 
 
-def prepare_arguments(sources, destination, force, rename):
+def prepare_arguments(sources, destination, force, rename, onyo_root):
     problem_str = ""
     list_of_commands = []
     list_of_destinations = []
     for source in sources:
         # set all paths
-        git_path = get_git_root(os.path.dirname(destination))
-        source_filename = os.path.join(os.getcwd(), source)
-        destination_filename = os.path.join(os.getcwd(), destination)
-        # if source not reached from current directory, try from environmental
-        if not os.path.exists(source_filename):
-            source_filename = os.path.join(git_path, source)
-            destination_filename = os.path.join(git_path, destination)
+        source_filename = os.path.join(onyo_root, source)
+        destination_filename = os.path.join(onyo_root, destination)
         if not os.path.exists(source_filename):
             problem_str = problem_str + "\n" + source + " does not exist."
         if os.path.isdir(destination_filename) and not os.path.isdir(source_filename):
             destination_filename = os.path.join(destination_filename, os.path.basename(source_filename))
-        destination_filename = os.path.relpath(destination_filename, git_path)
-        source_filename = os.path.relpath(source_filename, git_path)
+        destination_filename = os.path.relpath(destination_filename, onyo_root)
+        source_filename = os.path.relpath(source_filename, onyo_root)
         # build commands
-        current_cmd = build_mv_cmd(git_path, source_filename, destination_filename, force, rename)
+        current_cmd = build_mv_cmd(onyo_root, source_filename, destination_filename, force, rename)
         if destination_filename in list_of_destinations:
             problem_str = problem_str + "\n" + "Can't move multiple assets to " + destination_filename
         list_of_destinations.append(destination_filename)
@@ -63,12 +57,11 @@ def prepare_arguments(sources, destination, force, rename):
     return list_of_commands
 
 
-def mv(args):
+def mv(args, onyo_root):
     # check and set paths
-    git_path = get_git_root(os.path.dirname(args.destination))
-    list_of_commands = prepare_arguments(args.source, args.destination, args.force, args.rename)
+    list_of_commands = prepare_arguments(args.source, args.destination, args.force, args.rename, onyo_root)
     # run list of commands, afterwards commit
     for command in list_of_commands:
         run_cmd(command)
-    [commit_cmd, commit_msg] = build_commit_cmd(list_of_commands, git_path)
+    [commit_cmd, commit_msg] = build_commit_cmd(list_of_commands, onyo_root)
     run_cmd(commit_cmd, commit_msg)

--- a/onyo/commands/new.py
+++ b/onyo/commands/new.py
@@ -6,9 +6,7 @@ import sys
 
 from onyo.utils import (
     build_git_add_cmd,
-    get_git_root,
     run_cmd,
-    prepare_directory,
     edit_file
 )
 
@@ -18,8 +16,8 @@ logger = logging.getLogger('onyo')
 reserved_characters = [".", "_"]
 
 
-def build_commit_cmd(file, git_directory):
-    return ["git -C " + git_directory + " commit -m", "\'new \"" + file + "\"\'"]
+def build_commit_cmd(file, onyo_root):
+    return ["git -C " + onyo_root + " commit -m", "\'new \"" + file + "\"\'"]
 
 
 def read_new_word(word_description, char_checks=True):
@@ -64,25 +62,24 @@ def create_asset_file_cmd(directory, filename):
     return "touch \"" + os.path.join(directory, filename) + "\""
 
 
-def prepare_arguments(sources):
-    directory = prepare_directory(sources)
+def prepare_arguments(directory, onyo_root):
+    directory = os.path.join(onyo_root, directory)
     if not os.path.isdir(directory):
         logger.error(directory + " is not a directory.")
         sys.exit(1)
     return directory
 
 
-def new(args):
+def new(args, onyo_root):
     # set and check paths
-    directory = prepare_arguments(args.directory)
-    git_directory = get_git_root(directory)
+    directory = prepare_arguments(args.directory, onyo_root)
 
     # create file for asset, fill in fields
     created_file = run_onyo_new(directory, args.non_interactive)
-    git_filepath = os.path.relpath(created_file, git_directory)
+    git_filepath = os.path.relpath(created_file, onyo_root)
 
     # build commit command
-    [commit_cmd, commit_msg] = build_commit_cmd(git_filepath, git_directory)
+    [commit_cmd, commit_msg] = build_commit_cmd(git_filepath, onyo_root)
 
     # run commands
     run_cmd(commit_cmd, commit_msg)

--- a/onyo/commands/tree.py
+++ b/onyo/commands/tree.py
@@ -19,28 +19,20 @@ def build_tree_cmd(directory):
     return "tree \"" + directory + "\""
 
 
-def prepare_arguments(sources):
+def prepare_arguments(sources, onyo_root):
     problem_str = ""
     list_of_sources = []
-
     # just a single path?
     single_source = "".join(sources)
     if os.path.isdir(single_source):
         return [single_source]
-    # check if any path for displaying tree exists
-    onyo_default_repo = os.environ.get('ONYO_REPOSITORY_DIR')
-    if len(sources) == 0 and onyo_default_repo is None:
-        logger.error("No sources given and $ONYO_REPOSITORY_DIR not set.")
-        sys.exit(1)
-    elif onyo_default_repo is not None and os.path.isdir(os.path.join(onyo_default_repo, single_source)):
-        return [os.path.join(onyo_default_repo, single_source)]
-
+    elif os.path.isdir(os.path.join(onyo_root, single_source)):
+        return [os.path.join(onyo_root, single_source)]
     # build paths
     for source in sources:
-        current_source = os.path.join(os.getcwd(), source)
-        # check if path is onyo or not
-        if not os.path.exists(current_source) and onyo_default_repo is not None:
-            current_source = os.path.join(onyo_default_repo, source)
+        current_source = source
+        if not os.path.exists(current_source):
+            current_source = os.path.join(onyo_root, source)
         # check if path exists
         if not os.path.exists(current_source):
             problem_str = problem_str + "\n" + source + " does not exist."
@@ -54,11 +46,9 @@ def prepare_arguments(sources):
     return list_of_sources
 
 
-def tree(args):
-
+def tree(args, onyo_root):
     # check sources
-    list_of_sources = prepare_arguments(args.directory)
-
+    list_of_sources = prepare_arguments(args.directory, onyo_root)
     # build and run commands
     for source in list_of_sources:
         tree_command = build_tree_cmd(source)

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -25,13 +25,6 @@ def parse_args():
         help='Enable debug logging'
     )
 
-    # if ONYO_REPOSITORY_DIR as environmental variable is set, uses it as
-    # default onyo dir, otherwise it uses the current working directory as
-    # default, but this can always be overwritten by terminal.
-    onyo_default_repo = os.environ.get('ONYO_REPOSITORY_DIR')
-    if onyo_default_repo is None:
-        onyo_default_repo = os.getcwd()
-
     # subcommands
     subcommands = parser.add_subparsers(
         title="onyo commands",
@@ -47,7 +40,6 @@ def parse_args():
         'directory',
         metavar='directory',
         nargs='?',
-        default=onyo_default_repo,
         help='Directory to initialize onyo repository'
     )
     # subcommand "mv"
@@ -151,7 +143,6 @@ def parse_args():
     cmd_git.add_argument(
         '-C', '--directory',
         metavar='directory',
-        default=onyo_default_repo,
         help='Command to run in onyo'
     )
     cmd_git.add_argument(
@@ -205,12 +196,21 @@ def main():
     parser = parse_args()
     args = parser.parse_args()
 
+    # if ONYO_REPOSITORY_DIR as environmental variable is set, uses it as
+    # default onyo dir, otherwise it uses the current working directory as
+    # default, but this can always be overwritten by terminal.
+    onyo_root = os.environ.get('ONYO_REPOSITORY_DIR')
+    if onyo_root is None:
+        onyo_root = os.getcwd()
+
+    # TODO: Do onyo fsck here, test if .onyo exists, is git repo, other checks
+
     if args.debug:
         logger.setLevel(logging.DEBUG)
     if len(sys.argv) > 1 and not args.debug:
-        args.run(args)
+        args.run(args, onyo_root)
     elif len(sys.argv) > 2:
-        args.run(args)
+        args.run(args, onyo_root)
     else:
         parser.print_help()
 

--- a/tests/default_tests.py
+++ b/tests/default_tests.py
@@ -140,56 +140,6 @@ class TestClass:
         else:
             check_output_with_file(command, input_str, test_folder + "/test_3/" + file, current_test_dir)
 
-    # run commands from OUTSIDE the current test folder, but with relative paths
-    rel_path_test_commands = [
-        ("onyo init test_4", "", test_output, "init_test.txt"),
-        ("onyo git -C test_4 status", "", test_output, "git_status_working_tree_clean.txt"),
-        ("onyo mkdir ./test_4/user/", "", test_output, "empty_file.txt"),
-        ("onyo mkdir ./test_4/user\ 2/", "", test_output, "empty_file.txt"),
-        ("onyo mkdir ./test_4/shelf", "", test_output, "empty_file.txt"),
-        ("onyo mkdir ./test_4/trash\ bin test_4/delete_me/", "", test_output, "empty_file.txt"),
-        ("onyo git -C test_4 status", "", test_output, "git_status_working_tree_clean.txt"),
-        ("onyo new --non-interactive ./test_4/shelf", "laptop\napple\nmacbookpro\n1", test_output, "onyo_new_works.txt"),
-        ("onyo new --non-interactive test_4/shelf", "laptop\napple\nmacbookpro\n2", test_output, "onyo_new_works.txt"),
-        ("onyo new --non-interactive test_4/shelf", "laptop\napple\nmacbookpro\n3", test_output, "onyo_new_works.txt"),
-        ("onyo new --non-interactive test_4/shelf", "laptop\napple\nmacbookpro\n4", test_output, "onyo_new_works.txt"),
-        ("onyo new --non-interactive test_4/shelf", "laptop\napple\nmacbookpro\n5", test_output, "onyo_new_works.txt"),
-        ("onyo new --non-interactive test_4/shelf", "laptop\napple\nmacbookpro\n6", test_output, "onyo_new_works.txt"),
-        ("onyo new --non-interactive test_4/shelf", "laptop\napple\nmacbookpro\n7", test_output, "onyo_new_works.txt"),
-        ("onyo new --non-interactive test_4/trash\ bin/", "this\ndevice\nis very\ngood", test_output, "onyo_new_works.txt"),
-        ("onyo git -C test_4 status", "", test_output, "git_status_working_tree_clean.txt"),
-        ("onyo rm test_4/shelf/laptop_apple_macbookpro.7", "y", test_output, "delete_device.txt"),
-        ("onyo mv ./test_4/shelf/laptop_apple_macbookpro.1 ./test_4/user/", "", test_output, "empty_file.txt"),
-        ("onyo mv --rename ./test_4/shelf/laptop_apple_macbookpro.2 test_4/user/laptop_apple_macbookpro.4", "", test_output, "empty_file.txt"),
-        ("onyo mv --rename --force ./test_4/shelf/laptop_apple_macbookpro.3 ./test_4/user/laptop_apple_macbookpro.4", "", test_output, "empty_file.txt"),
-        ("onyo mv " + "./test_4/user/*" + " ./test_4/user\ 2/", "", test_output, "empty_file.txt"),
-        ("onyo git -C test_4 status", "", test_output, "git_status_working_tree_clean.txt"),
-        ("onyo mv test_4/shelf/laptop_apple_macbookpro.4 ./test_4/user/", "", test_output, "empty_file.txt"),
-        ("onyo mv test_4/shelf/laptop_apple_macbookpro.5 ./test_4/user/", "", test_output, "empty_file.txt"),
-        ("onyo mv test_4/shelf/laptop_apple_macbookpro.6 ./test_4/user/", "", test_output, "empty_file.txt"),
-        ("onyo mv --rename ./test_4/user\ 2 ./test_4/no\ user", "", test_output, "empty_file.txt"),
-        ("onyo rm -q -y test_4/delete_me/", "", test_output, "empty_file.txt"),
-        ("onyo git -C test_4 status", "", test_output, "git_status_working_tree_clean.txt"),
-    ]
-
-    @pytest.mark.parametrize("command, input_str, test_folder, file", rel_path_test_commands)
-    def test_from_outside_dir_with_relative_path(self, command, input_str, test_folder, file):
-        current_test_dir = os.path.join(self.test_dir, "test_4")
-        os.chdir(self.test_dir)
-        if os.getenv('ONYO_REPOSITORY_DIR') is not None:
-            del os.environ['ONYO_REPOSITORY_DIR']
-        if not os.path.isdir(current_test_dir):
-            run_test_cmd("mkdir " + current_test_dir)
-        # Test-specific changes:
-        if "*" in command:
-            command = command.replace("test_4/user/*", " ".join(glob.glob(os.path.join("test_4/user/*"))))
-            command = command.replace("test_4/*", " ".join(glob.glob(os.path.join("test_4/*"))))
-        # run actual commands
-        if "onyo rm" in command:
-            check_output_with_file(command, input_str, test_folder + "/test_4/" + file, os.path.join(current_test_dir, command.replace("onyo rm test_4/", "")))
-        else:
-            check_output_with_file(command, input_str, test_folder + "/test_4/" + file, current_test_dir)
-
     # tests the complete directory, all test-folders, for there structure
     def test_onyo_tree(self):
         test_tree_output = os.path.join(self.test_output, "test_tree_output.txt")

--- a/tests/output_goals/test_tree_output.txt
+++ b/tests/output_goals/test_tree_output.txt
@@ -21,22 +21,11 @@
 │       ├── laptop_apple_macbookpro.4
 │       ├── laptop_apple_macbookpro.5
 │       └── laptop_apple_macbookpro.6
-├── test_3
-│   ├── no user
-│   │   └── laptop_apple_macbookpro.4
-│   ├── shelf
-│   │   └── laptop_apple_macbookpro.1
-│   ├── trash bin
-│   │   └── this_device_is very.good
-│   └── user
-│       ├── laptop_apple_macbookpro.4
-│       ├── laptop_apple_macbookpro.5
-│       └── laptop_apple_macbookpro.6
-└── test_4
+└── test_3
     ├── no user
-    │   ├── laptop_apple_macbookpro.1
     │   └── laptop_apple_macbookpro.4
     ├── shelf
+    │   └── laptop_apple_macbookpro.1
     ├── trash bin
     │   └── this_device_is very.good
     └── user
@@ -44,4 +33,4 @@
         ├── laptop_apple_macbookpro.5
         └── laptop_apple_macbookpro.6
 
-20 directories, 24 files
+15 directories, 18 files


### PR DESCRIPTION
This PR changes onyo, so that now the onyo directory, in which to run all the commands is decided on the main level of onyo to simplify the code and `onyo fsck` in the future. The possibility to run onyo from outside of the onyo directory with relative paths that lead into the onyo directory is removed, instead the user has either to set the environmental variable or be in the right directory.
This contains also all the implied changes (e.g. variable names, tests).