### PR TITLE
Edit: do a syntax check after change (with temp file)

### DIFF
--- a/onyo/commands/edit.py
+++ b/onyo/commands/edit.py
@@ -54,7 +54,7 @@ def edit(args, onyo_root):
         git_filepath = os.path.relpath(source, onyo_root)
         # change file
         if not args.non_interactive:
-            edit_file(source)
+            edit_file(source, onyo_root)
         # check if changes happened and add them
         repo = Repo(onyo_root)
         changed_files = [item.a_path for item in repo.index.diff(None)]

--- a/onyo/commands/init.py
+++ b/onyo/commands/init.py
@@ -39,11 +39,11 @@ def build_onyo_init_cmd(directory):
     elif os.path.isdir(os.path.join(directory + "/.onyo")):
         logger.error(directory + " has already an onyo configuration directory.")
         sys.exit(1)
-    return "mkdir \"" + os.path.join(directory + "/.onyo") + "\""
+    return "mkdir \"" + os.path.join(directory + "/.onyo") + "\" \"" + os.path.join(directory + "/.onyo/temp") + "\""
 
 
 def create_file_cmd(directory):
-    return "touch \"" + os.path.join(directory + "/.onyo/.anchor") + "\""
+    return "touch \"" + os.path.join(directory + "/.onyo/.anchor") + "\" \"" + os.path.join(directory + "/.onyo/temp/.anchor") + "\""
 
 
 def prepare_arguments(directory, onyo_root):

--- a/onyo/commands/new.py
+++ b/onyo/commands/new.py
@@ -45,7 +45,7 @@ def run_onyo_new(directory, non_interactive, onyo_root):
         sys.exit(1)
     run_cmd(create_asset_file_cmd(directory, filename))
     if not non_interactive:
-        edit_file(os.path.join(directory, filename))
+        edit_file(os.path.join(directory, filename), onyo_root)
     git_add_cmd = build_git_add_cmd(directory, filename)
     run_cmd(git_add_cmd)
     return os.path.join(directory, filename)


### PR DESCRIPTION
This adds to `onyo edit` a yaml check, so that the command cannot messup a file and automatically saves it (since this would block the next onyo command if it starts with an fsck). This is realized with a temp file, which is created by copying the file which should be edited, then changes that file, and afterwards, if the new file has correct yaml syntax, moves it back to the right location.

`onyo init´ got the addition of creating and anchoring the now needed folder `.onyo/temp/`.

There are multiple other checks and questions, like "exists a temp file for this to beginn with?" and "does the user wants to further edit or discard the syntax breaking changes?".

The files are just under `.onyo/temp/asset`, without further folders. This works because the asset files have to be unique (per fsck) to beginn with, so there can't be 2 temp files with the same name, if not forced by another onyo-external command.

Close #51 