### PR TITLE
Validation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include onyo/templates/*
+include onyo/validation/*

--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ For examples, see the section "example templates" at the end of the README.
 To keep meta data fields consistent between different assets, rules for fields
 in assets can be defined in `.onyo/validation/validation.yaml` in an onyo
 repository. The validation file will be read from the top down, and the first
-path that fits a file will be used to validate it's contents.
+path in the validation file that fits a asset file will be used to validate
+it's contents.
 
 The structure for rules is:
 ```
@@ -521,15 +522,24 @@ defined before applies to an asset file.
     - Type: float
 ```
 
-When assets directly in `shelf/` have a key `RAM`, it must be integers.
-Additionally, when these assets have a key `Size`, they must also be integers,
-since the second rule `shelf/**` also applies to assets directly in `shelf/`.
+When assets directly in `shelf/` have a key `RAM`, it must be integer. Because
+onyo uses just the first set of rules where the asset matches the path
+defined in validation.yaml, the later rules under `shelf/**` do not apply to
+assets directly in `shelf/`.
+
+When assets are in a subfolder of `shelf/`, the rule for RAM does not apply,
+instead the separate set of rules under `shelf/**` will be used to validate
+these assets.
+
 Asset files in sub-directories of shelf, e.g. `shelf/left/top_row/` have no
 rules regarding the `RAM` key, just the rule for `Size` does apply.
 
-The rule `*/**` enforces for all assets outside of `shelf` that keys for RAM and
-Size must be at least float (e.g. "RAM: 12GB" as string are invalid for all
+The rule `*/**` enforces for all assets outside of `shelf/` that keys for RAM
+and Size must be at least float (e.g. "RAM: 12GB" as string are invalid for all
 assets anywhere in the onyo repository).
+The rules for `*/**` do not apply to assets in `shelf/`, because onyo uses just
+the first set of rules where a path matches, and `shelf/` has a separate set of
+rules already defined above.
 
 **Example 3: Using pointer to define a set of rules for multiple Directories**
 

--- a/onyo/commands/edit.py
+++ b/onyo/commands/edit.py
@@ -11,7 +11,6 @@ from onyo.utils import (
     run_cmd,
     edit_file
 )
-from onyo.commands.fsck import fsck
 
 logging.basicConfig()
 logger = logging.getLogger('onyo')
@@ -45,8 +44,10 @@ def prepare_arguments(sources, onyo_root):
 
 
 def edit(args, onyo_root):
-    # run onyo fsck
-    fsck(args, onyo_root, quiet=True)
+    # do not run onyo fsck! Onyo should allow to correct problems with onyo
+    # edit, and after editing onyo checks the syntax and validates the updated
+    # file anyways, so new problems can't be introduced, but old ones can be
+    # corrected.
     # check and set paths
     list_of_sources = prepare_arguments(args.file, onyo_root)
     # iterate over file list, edit them, add changes

--- a/onyo/commands/fsck.py
+++ b/onyo/commands/fsck.py
@@ -53,45 +53,45 @@ def verify_onyo_working_tree(repo):
     return problem_str
 
 
-def verify_anchors(repo_path):
+def verify_anchors(onyo_root):
     anchor_str = ""
-    for elem in glob.iglob(repo_path + '**/**', recursive=True):
+    for elem in glob.iglob(onyo_root + '**/**', recursive=True):
         if os.path.isdir(elem):
             # the .git does not need a .anchor
             if ".git" in elem:
                 continue
             # the onyo root folder has no .anchor
-            if os.path.samefile(elem, repo_path):
+            if os.path.samefile(elem, onyo_root):
                 continue
-            if run_cmd("git -C " + repo_path + " check-ignore --no-index \"" + elem + "\""):
+            if run_cmd("git -C " + onyo_root + " check-ignore --no-index \"" + elem + "\""):
                 continue
             if not os.path.isfile(os.path.join(elem, ".anchor")):
-                anchor_str = anchor_str + "\n\t" + os.path.relpath(os.path.join(elem, ".anchor"), repo_path)
+                anchor_str = anchor_str + "\n\t" + os.path.relpath(os.path.join(elem, ".anchor"), onyo_root)
     if anchor_str:
         return "\n\n.anchor is missing:" + anchor_str + "\nYou can create them with\ntouch <path/to/.anchor>\nor .gitignore the directories.\n"
     return ""
 
 
-def verify_yaml(repo_path):
+def verify_yaml(onyo_root):
     yaml_str = ""
-    for elem in glob.iglob(repo_path + '**/**', recursive=True):
+    for elem in glob.iglob(onyo_root + '**/**', recursive=True):
         if os.path.isfile(elem):
-            if run_cmd("git -C " + repo_path + " check-ignore --no-index \"" + elem + "\""):
+            if run_cmd("git -C " + onyo_root + " check-ignore --no-index \"" + elem + "\""):
                 continue
             # "assets" saves all names/paths, to later check if they are unique
             with open(elem, "r") as stream:
                 try:
                     yaml.safe_load(stream)
                 except yaml.YAMLError:
-                    yaml_str = yaml_str + "\t" + os.path.relpath(elem, repo_path) + "\n"
+                    yaml_str = yaml_str + "\t" + os.path.relpath(elem, onyo_root) + "\n"
     if yaml_str:
         return "\n\nyaml files with incorrect syntax:\n" + yaml_str + "Please correct the syntax of these files and add the changes to git, or .gitignore them."
     return ""
 
 
-def verify_filenames(repo_path):
+def verify_filenames(onyo_root):
     problem_str = ""
-    assets = get_list_of_assets(repo_path)
+    assets = get_list_of_assets(onyo_root)
     double_elements = []
     for elem in [i[1] for i in assets]:
         elements = [string for string in [i[0] for i in assets] if elem == os.path.basename(string)]
@@ -109,11 +109,11 @@ def verify_filenames(repo_path):
 
 
 # validate the asset contents based on .onyo/validation/
-def validate_assets(repo_path):
+def validate_assets(onyo_root):
     problem_str = ""
-    assets = get_list_of_assets(repo_path)
+    assets = get_list_of_assets(onyo_root)
     for asset_file in assets:
-        problem_str += validate_file(asset_file[0], asset_file[1], repo_path)
+        problem_str += validate_file(asset_file[0], os.path.relpath(asset_file[0], onyo_root), onyo_root)
     if problem_str != "":
         return "\nSome files have invalid contents:\n" + problem_str
     return problem_str
@@ -128,14 +128,14 @@ def read_only_fsck(args, onyo_root, quiet=False):
     # check if is git, and .git and .onyo exist, identify top-level of onyo directory
     [repo, repo_path, info_str] = verify_onyo_existence(onyo_root)
     # check if it is possible to load yaml file for syntax check
-    problem_str = problem_str + verify_yaml(repo_path)
+    problem_str = problem_str + verify_yaml(onyo_root)
     # end block, display problems or state repo is clean.
     if problem_str:
         logger.error(problem_str)
         sys.exit(1)
     else:
         problem_str = "\nOnyo expects a clean onyo working tree before running commands. Please commit or .gitignore all changes and check the syntax of asset files.\n" + problem_str
-        info_str = info_str + "\n" + repo_path + " is clean."
+        info_str = info_str + "\n" + onyo_root + " is clean."
         if not quiet:
             print(info_str)
 

--- a/onyo/commands/fsck.py
+++ b/onyo/commands/fsck.py
@@ -10,7 +10,8 @@ from git import Repo, exc
 
 from onyo.utils import (
     run_cmd,
-    get_list_of_assets
+    get_list_of_assets,
+    validate_file
 )
 
 logging.basicConfig()
@@ -107,6 +108,17 @@ def verify_filenames(repo_path):
         return ""
 
 
+# validate the asset contents based on .onyo/validation/
+def validate_assets(repo_path):
+    problem_str = ""
+    assets = get_list_of_assets(repo_path)
+    for asset_file in assets:
+        problem_str += validate_file(asset_file[0], asset_file[1], repo_path)
+    if problem_str != "":
+        return "\nSome files have invalid contents:\n" + problem_str
+    return problem_str
+
+
 def read_only_fsck(args, onyo_root, quiet=False):
     # set variables
     repo = ""
@@ -144,6 +156,9 @@ def fsck(args, onyo_root, quiet=False):
     problem_str = problem_str + verify_yaml(repo_path)
     # check uniqueness of asset filenames
     problem_str = problem_str + verify_filenames(repo_path)
+    # validate contents of all files with the validation-file
+    problem_str = problem_str + validate_assets(repo_path)
+
     # end block, display problems or state repo is clean.
     if problem_str:
         problem_str = "\nOnyo expects a clean onyo working tree before running commands. Please commit or .gitignore all changes and check the syntax of asset files.\n" + problem_str

--- a/onyo/commands/init.py
+++ b/onyo/commands/init.py
@@ -40,11 +40,11 @@ def build_onyo_init_cmd(directory):
     elif os.path.isdir(os.path.join(directory + "/.onyo")):
         logger.error(directory + " has already an onyo configuration directory.")
         sys.exit(1)
-    return "mkdir \"" + os.path.join(directory + "/.onyo") + "\" \"" + os.path.join(directory + "/.onyo/temp") + "\" \"" + os.path.join(directory, ".onyo/templates/") + "\""
+    return "mkdir \"" + os.path.join(directory + "/.onyo") + "\" \"" + os.path.join(directory + "/.onyo/temp") + "\" \"" + os.path.join(directory, ".onyo/templates/") + "\" \"" + os.path.join(directory, ".onyo/validation/") + "\""
 
 
 def create_file_cmd(directory):
-    return "touch \"" + os.path.join(directory + "/.onyo/.anchor") + "\" \"" + os.path.join(directory + "/.onyo/temp/.anchor") + "\" \"" + os.path.join(directory + "/.onyo/templates/.anchor") + "\""
+    return "touch \"" + os.path.join(directory + "/.onyo/.anchor") + "\" \"" + os.path.join(directory + "/.onyo/temp/.anchor") + "\" \"" + os.path.join(directory + "/.onyo/templates/.anchor") + "\" \"" + os.path.join(directory, ".onyo/validation/.anchor") + "\""
 
 
 def prepare_arguments(directory, onyo_root):
@@ -66,7 +66,7 @@ def init(args, onyo_root):
     git_add_command = build_git_add_cmd(directory, ".onyo/")
     [commit_cmd, commit_msg] = build_commit_cmd(directory)
     template_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../templates/")
-
+    validation_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../validation/")
     # run commands
     if git_init_command is not None:
         run_cmd(git_init_command)
@@ -77,6 +77,7 @@ def init(args, onyo_root):
     os.system("onyo config history.non-interactive \\\"git --no-pager log --follow\\\"")
     os.system("onyo config template.default standard")
     run_cmd("cp -R " + " ".join(glob.glob(os.path.join(template_path, "*"), recursive=True)) + " " + os.path.join(onyo_root, ".onyo/templates/"))
+    run_cmd("cp -R " + " ".join(glob.glob(os.path.join(validation_path, "*"), recursive=True)) + " " + os.path.join(onyo_root, ".onyo/validation/"))
     run_cmd(git_add_command)
     run_cmd(commit_cmd, commit_msg)
     logger.info(commit_msg + ": " + get_git_root(directory))

--- a/onyo/commands/new.py
+++ b/onyo/commands/new.py
@@ -49,7 +49,7 @@ def run_onyo_new(directory, template, non_interactive, onyo_root):
         run_cmd(create_asset_file_cmd(directory, filename))
     # open new file?
     if not non_interactive:
-        edit_file(os.path.join(directory, filename), onyo_root)
+        edit_file(os.path.join(directory, filename), onyo_root, onyo_new=True)
     # add file to git
     git_add_cmd = build_git_add_cmd(directory, filename)
     run_cmd(git_add_cmd)

--- a/onyo/utils.py
+++ b/onyo/utils.py
@@ -6,7 +6,6 @@ import shlex
 import glob
 import yaml
 from ruamel.yaml import YAML
-from fnmatch import fnmatch
 
 from git import Repo, exc
 
@@ -148,7 +147,7 @@ def validate_file(file, original_file, onyo_root):
         if error_str != "":
             return error_str
         # when a rule applies to original_file:
-        if fnmatch(original_file, path_of_rule):
+        if os.path.join(onyo_root, original_file) in glob.glob(os.path.join(onyo_root, path_of_rule), recursive=True):
             for rule in rules_file[path_of_rule]:
                 error_str = error_str + validate_rule_for_file(file, rule, path_of_rule, original_file, onyo_root)
     # give error back for outside handling:

--- a/onyo/utils.py
+++ b/onyo/utils.py
@@ -150,6 +150,7 @@ def validate_file(file, original_file, onyo_root):
         if os.path.join(onyo_root, original_file) in glob.glob(os.path.join(onyo_root, path_of_rule), recursive=True):
             for rule in rules_file[path_of_rule]:
                 error_str = error_str + validate_rule_for_file(file, rule, path_of_rule, original_file, onyo_root)
+            return error_str
     # give error back for outside handling:
     return error_str
 

--- a/onyo/utils.py
+++ b/onyo/utils.py
@@ -6,6 +6,7 @@ import shlex
 import glob
 import yaml
 from ruamel.yaml import YAML
+from fnmatch import fnmatch
 
 from git import Repo, exc
 
@@ -136,22 +137,20 @@ def validate_rule_for_file(file, rule, path_of_rule, original_file, onyo_root):
 
 
 def validate_file(file, original_file, onyo_root):
-    yaml = YAML(typ='safe')
+    ru_yaml = YAML(typ='safe')
     error_str = ""
     with open(os.path.join(onyo_root, ".onyo/validation/validation.yaml"), "r") as stream:
         try:
-            rules_file = yaml.load(stream)
+            rules_file = ru_yaml.load(stream)
         except yaml.YAMLError as e:
             print(e)
     for path_of_rule in rules_file:
-        paths = glob.glob(os.path.join(onyo_root, path_of_rule), recursive=True)
-        for elem in paths:
-            if error_str != "":
-                return error_str
-            # when a rule applies to original_file:
-            if original_file in elem:
-                for rule in rules_file[path_of_rule]:
-                    error_str = error_str + validate_rule_for_file(file, rule, path_of_rule, original_file, onyo_root)
+        if error_str != "":
+            return error_str
+        # when a rule applies to original_file:
+        if fnmatch(original_file, path_of_rule):
+            for rule in rules_file[path_of_rule]:
+                error_str = error_str + validate_rule_for_file(file, rule, path_of_rule, original_file, onyo_root)
     # give error back for outside handling:
     return error_str
 

--- a/onyo/utils.py
+++ b/onyo/utils.py
@@ -190,7 +190,7 @@ def check_float(value):
         return False
 
 
-def edit_file(file, onyo_root):
+def edit_file(file, onyo_root, onyo_new=False):
     if not os.path.isfile(file):
         logger.error(file + " does not exist.")
         sys.exit(1)
@@ -228,8 +228,14 @@ def edit_file(file, onyo_root):
                     if further_editing == 'y':
                         break
                     elif further_editing == 'n':
+                        output_str = "No changes made."
+                        # onyo new should neither create a new file nor a
+                        # temp-file, and have a special info message
+                        if (onyo_new):
+                            run_cmd("rm \"" + file + "\"")
+                            output_str = "No new asset \"" + os.path.relpath(file, onyo_root) + "\" created."
                         run_cmd("rm \"" + temp_file + "\"")
-                        logger.info("No changes made.")
+                        logger.info(output_str)
                         sys.exit(1)
     return
 

--- a/onyo/utils.py
+++ b/onyo/utils.py
@@ -122,15 +122,15 @@ def validate_rule_for_file(file, rule, path_of_rule, original_file, onyo_root):
                 if field1 == "Type":
                     if field2 == "str":
                         if not check_str(asset[value_field]):
-                            current_error = current_error + "\t" + original_file + " (" + path_of_rule + "): values for \"" + value_field + "\" must be str, but is \"" + str(asset[value_field]) + "\"\n"
+                            current_error = current_error + "\t" + os.path.relpath(original_file, onyo_root) + " (" + path_of_rule + "): values for \"" + value_field + "\" must be str, but is \"" + str(asset[value_field]) + "\"\n"
                     elif field2 == "int":
                         if not check_int(asset[value_field]):
-                            current_error = current_error + "\t" + original_file + " (" + path_of_rule + "): values for \"" + value_field + "\" must be int, but is \"" + str(asset[value_field]) + "\"\n"
+                            current_error = current_error + "\t" + os.path.relpath(original_file, onyo_root) + " (" + path_of_rule + "): values for \"" + value_field + "\" must be int, but is \"" + str(asset[value_field]) + "\"\n"
                     elif field2 == "float":
                         if not check_float(asset[value_field]):
-                            current_error = current_error + "\t" + original_file + " (" + path_of_rule + "): values for \"" + value_field + "\" must be float, but is \"" + str(asset[value_field]) + "\"\n"
+                            current_error = current_error + "\t" + os.path.relpath(original_file, onyo_root) + " (" + path_of_rule + "): values for \"" + value_field + "\" must be float, but is \"" + str(asset[value_field]) + "\"\n"
                     else:
-                        current_error = current_error + "\t" + original_file + " (" + path_of_rule + "): Type \"" + field2 + "\" is not known.\n"
+                        current_error = current_error + "\t" + os.path.relpath(original_file, onyo_root) + " (" + path_of_rule + "): Type \"" + field2 + "\" is not known.\n"
 
     # return all errors
     return current_error

--- a/onyo/validation/validation.yaml
+++ b/onyo/validation/validation.yaml
@@ -1,0 +1,11 @@
+"shelf/*":
+- RAM:
+    - Type: int
+- Size:
+    - Type: int
+"*/*":
+- RAM:
+    - Type: int
+- Size:
+    - Type: int
+

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ setup(
     install_requires=[
         'GitPython',
         'pytest',
-        'pyyaml'
+        'pyyaml',
+        'ruamel.yaml'
     ],
     python_requires=">=3.5",
     entry_points={


### PR DESCRIPTION
Hey, I am currently working on the implementation of the validation system.
On the one hand, I am starting with something simple as a proof of concept to make sure everything *can work*, on the other hand I write it so that it can be expanded as much as we want with addtional keys, functionalities etc.

So to give a chance to discuss the validation system how I currently implemented (or still implement) it before creating a PR, I want to show what I have and request comments, in case something is not as discussed earlier.

First, I have a file `.onyo/validation/field_names.rules` (I know the name is bad. I wish no critic about it, but better names are very welcome). I used RAM and Size as 2 different field names, just as examples to work with, but the key names can be choosen freely.

```
"shelf/*":
- RAM:
    - Type: int
"*/*":
- RAM:
    - Type: int
- Size:
    - Type: int
```

That file defines rules for all assets under "shelf" specifically, and for each location in general with "\*/\*". Currently, one can only specify the type of the variable of a field, and the currently supported options are int, str, float.

Now, I want to follow up with the behaviour of the validation, for different commands to give an idea, how the example above looks in reality.

When using `onyo edit` and giving a field (RAM in this case) a value which violates the rules of validation:
```
❱ onyo edit user/laptop_apple_macbookpro.4 

Onyo Validation failed for:
	user/laptop_apple_macbookpro.4 (*/*): values for "RAM" must be int, but is "12GB"
Continue editing? (y/n)y
```

When using `vim` and messing up an asset manually, and afterwards using `onyo fsck` to verify the state of the repository:
```
❱ onyo fsck
ERROR:onyo:
Onyo expects a clean onyo working tree before running commands. Please commit or .gitignore all changes and check the syntax of asset files.

The Onyo working tree is not clean.
Changes not staged for commit: 
	 user/laptop_apple_macbookpro.4
Please commit all changes or add new files to .gitignore
Some files have invalid contents:
	laptop_apple_macbookpro.4 (*/*): values for "RAM" must be int, but is "12w"
```

While creating a new asset with `onyo new` (similar with the `--template` flag):
```
❱ onyo new shelf/
<type>*:asset
<make>*:asset
<model>*:asset
<serial>*:4

Onyo Validation failed for:
	/Users/tkadelka/new-onyo/second_tests/onyo_tests/test_1/shelf/asset_asset_asset.4 (shelf/*): values for "RAM" must be int, but is "12GB"
Continue editing? (y/n)
```

For this last example, I changed the rules file. Everywhere (including shelf) "RAM" in assets is allowed to be a string. The only exception is, that in the folder "user" RAM keys must be int, not str. This is the result when trying to `onyo mv` a file, which is valid in the folder shelf, but not valid in the folder user:

```
❱ onyo mv shelf/test_asset_file.1234 user
ERROR:onyo:
	user/test_asset_file.1234 (user/*): values for "RAM" must be int, but is "12GB"

No folders or assets moved.
```

In general, I plan to expand parts of the output, to give more precise information. So again, ideas about what information we want always to have in the output are welcome, but I do not need to be told, that it is currently not always optimal, since I am aware of this. :)
I would like to have feedback about the current functionality while updating the output, and writing the readme for the current version.