### PR TITLE
onyo: run commands inside folder e.g. shelf/, fix "spaces in paths" errors

### DIFF
--- a/onyo/commands/config.py
+++ b/onyo/commands/config.py
@@ -5,6 +5,7 @@ import os
 
 from onyo.utils import (
     run_cmd,
+    get_git_root,
     build_git_add_cmd
 )
 from onyo.commands.fsck import read_only_fsck
@@ -31,9 +32,9 @@ def config(args, onyo_root):
     # run onyo fsck
     read_only_fsck(args, onyo_root, quiet=True)
     # build command
-    command = build_command(args.command, onyo_root)
-    git_add_cmd = build_git_add_cmd(onyo_root, ".onyo/config")
-    [commit_cmd, commit_msg] = build_commit_cmd(command, onyo_root)
+    command = build_command(args.command, get_git_root(onyo_root))
+    git_add_cmd = build_git_add_cmd(get_git_root(onyo_root), ".onyo/config")
+    [commit_cmd, commit_msg] = build_commit_cmd(command, get_git_root(onyo_root))
     # run command
     run_cmd(command)
     run_cmd(git_add_cmd)

--- a/onyo/commands/fsck.py
+++ b/onyo/commands/fsck.py
@@ -11,6 +11,7 @@ from git import Repo, exc
 from onyo.utils import (
     run_cmd,
     get_list_of_assets,
+    get_git_root,
     validate_file
 )
 
@@ -63,7 +64,7 @@ def verify_anchors(onyo_root):
             # the onyo root folder has no .anchor
             if os.path.samefile(elem, onyo_root):
                 continue
-            if run_cmd("git -C " + onyo_root + " check-ignore --no-index \"" + elem + "\""):
+            if run_cmd("git -C \"" + onyo_root + "\" check-ignore --no-index \"" + elem + "\""):
                 continue
             if not os.path.isfile(os.path.join(elem, ".anchor")):
                 anchor_str = anchor_str + "\n\t" + os.path.relpath(os.path.join(elem, ".anchor"), onyo_root)
@@ -76,7 +77,7 @@ def verify_yaml(onyo_root):
     yaml_str = ""
     for elem in glob.iglob(onyo_root + '**/**', recursive=True):
         if os.path.isfile(elem):
-            if run_cmd("git -C " + onyo_root + " check-ignore --no-index \"" + elem + "\""):
+            if run_cmd("git -C \"" + onyo_root + "\" check-ignore --no-index \"" + elem + "\""):
                 continue
             # "assets" saves all names/paths, to later check if they are unique
             with open(elem, "r") as stream:
@@ -126,7 +127,7 @@ def read_only_fsck(args, onyo_root, quiet=False):
     problem_str = ""
     info_str = ""
     # check if is git, and .git and .onyo exist, identify top-level of onyo directory
-    [repo, repo_path, info_str] = verify_onyo_existence(onyo_root)
+    [repo, repo_path, info_str] = verify_onyo_existence(get_git_root(onyo_root))
     # check if it is possible to load yaml file for syntax check
     problem_str = problem_str + verify_yaml(onyo_root)
     # end block, display problems or state repo is clean.
@@ -147,7 +148,7 @@ def fsck(args, onyo_root, quiet=False):
     problem_str = ""
     info_str = ""
     # check if is git, and .git and .onyo exist, identify top-level of onyo directory
-    [repo, repo_path, info_str] = verify_onyo_existence(onyo_root)
+    [repo, repo_path, info_str] = verify_onyo_existence(get_git_root(onyo_root))
     # check if git status is clean
     problem_str = problem_str + verify_onyo_working_tree(repo)
     # onyo anchor check for all folders

--- a/onyo/commands/history.py
+++ b/onyo/commands/history.py
@@ -6,7 +6,8 @@ import sys
 import configparser
 
 from onyo.utils import (
-    run_cmd
+    run_cmd,
+    get_git_root
 )
 from onyo.commands.fsck import read_only_fsck
 
@@ -18,7 +19,7 @@ def prepare_arguments(source, onyo_root):
     problem_str = ""
     # find log/history tools:
     config = configparser.ConfigParser()
-    config.read(os.path.join(onyo_root, ".onyo/config"))
+    config.read(os.path.join(get_git_root(onyo_root), ".onyo/config"))
     interactive_tool = ""
     non_interactive_tool = ""
     try:

--- a/onyo/commands/mkdir.py
+++ b/onyo/commands/mkdir.py
@@ -17,7 +17,7 @@ anchor_name = ".anchor"
 
 
 def build_commit_cmd(folders, onyo_root):
-    return ["git -C " + onyo_root + " commit -m", "new folder(s).\n\n" + "\n".join(folders)]
+    return ["git -C \"" + onyo_root + "\" commit -m", "new folder(s).\n\n" + "\n".join(folders)]
 
 
 def run_mkdir(onyo_root, new_directory):

--- a/onyo/commands/mv.py
+++ b/onyo/commands/mv.py
@@ -21,14 +21,14 @@ def build_mv_cmd(onyo_root, source, destination, force, rename):
         return (os.path.basename(source) + " -> " + os.path.basename(destination) + " Assets can't be renamed without --rename.")
     if os.path.isfile(os.path.join(onyo_root, destination)):
         if force:
-            return "git -C " + onyo_root + " mv -f \"" + source + "\" \"" + destination + "\""
+            return "git -C \"" + onyo_root + "\" mv -f \"" + source + "\" \"" + destination + "\""
         else:
             return (os.path.join(onyo_root, destination) + " already exists.")
-    return "git -C " + onyo_root + " mv \"" + source + "\" \"" + destination + "\""
+    return "git -C \"" + onyo_root + "\" mv \"" + source + "\" \"" + destination + "\""
 
 
 def build_commit_cmd(list_of_commands, onyo_root):
-    return ["git -C " + onyo_root + " commit -m", "move asset(s).\n\n" + "\n".join(list_of_commands)]
+    return ["git -C \"" + onyo_root + "\" commit -m", "move asset(s).\n\n" + "\n".join(list_of_commands)]
 
 
 def prepare_arguments(sources, destination, force, rename, onyo_root):

--- a/onyo/commands/new.py
+++ b/onyo/commands/new.py
@@ -10,6 +10,7 @@ from onyo.utils import (
     build_git_add_cmd,
     run_cmd,
     get_list_of_assets,
+    get_git_root,
     edit_file
 )
 from onyo.commands.fsck import fsck
@@ -21,7 +22,7 @@ reserved_characters = ['_', '.']
 
 
 def build_commit_cmd(file, onyo_root):
-    return ["git -C " + onyo_root + " commit -m", "new asset.\n\n" + file]
+    return ["git -C \"" + onyo_root + "\" commit -m", "new asset.\n\n" + file]
 
 
 def read_new_word(word_description):
@@ -91,16 +92,16 @@ def prepare_arguments(directory, template, onyo_root):
     directory = os.path.join(onyo_root, directory)
     # find the template to use:
     config = configparser.ConfigParser()
-    config.read(os.path.join(onyo_root, ".onyo/config"))
+    config.read(os.path.join(get_git_root(onyo_root), ".onyo/config"))
     if not template:
         try:
             template = config['template']['default']
         except KeyError:
             pass
-    template = os.path.join(onyo_root, os.path.join(".onyo/templates", template))
+    template = os.path.join(get_git_root(onyo_root), os.path.join(".onyo/templates", template))
     problem_str = ""
     if not os.path.isfile(template):
-        problem_str = problem_str + "\nTemplate file " + os.path.join(".onyo/templates", template) + " does not exist."
+        problem_str = problem_str + "\nTemplate file " + os.path.join(get_git_root(onyo_root), os.path.join(".onyo/templates", template)) + " does not exist."
     if not os.path.isdir(directory):
         problem_str = problem_str + "\n" + directory + " is not a directory."
     if problem_str != "":
@@ -116,7 +117,7 @@ def new(args, onyo_root):
     [directory, template] = prepare_arguments(args.directory, args.template, onyo_root)
     # create file for asset, fill in fields
     created_file = run_onyo_new(directory, template, args.non_interactive, onyo_root)
-    git_filepath = os.path.relpath(created_file, onyo_root)
+    git_filepath = os.path.relpath(created_file, get_git_root(onyo_root))
     # build commit command
     [commit_cmd, commit_msg] = build_commit_cmd(git_filepath, onyo_root)
     # run commands

--- a/onyo/commands/rm.py
+++ b/onyo/commands/rm.py
@@ -15,7 +15,7 @@ logger = logging.getLogger('onyo')
 
 
 def build_commit_cmd(sources, onyo_root):
-    return ["git -C " + onyo_root + " commit -m", "deleted asset(s).\n\n" + "\n".join(sources)]
+    return ["git -C \"" + onyo_root + "\" commit -m", "deleted asset(s).\n\n" + "\n".join(sources)]
 
 
 def run_rm(onyo_root, source):

--- a/onyo/commands/set.py
+++ b/onyo/commands/set.py
@@ -12,6 +12,7 @@ from git import Repo
 from onyo.utils import (
     run_cmd,
     build_git_add_cmd,
+    get_git_root,
     validate_rule_for_file
 )
 
@@ -20,7 +21,7 @@ logger = logging.getLogger('onyo')
 
 
 def build_commit_cmd(files_to_change, onyo_root):
-    return ["git -C " + onyo_root + " commit -m", "set values.\n\n" +
+    return ["git -C \"" + onyo_root + "\" commit -m", "set values.\n\n" +
             "\n".join(files_to_change)]
 
 
@@ -94,13 +95,13 @@ def diff_changes(file_list, keys, onyo_root):
             # display new value:
             asset_changed = asset_changed + "\n+\t" + key + ": " + str(keys[key])
         if asset_changed:
-            output_str = output_str + "\n" + os.path.relpath(file, onyo_root) + asset_changed
+            output_str = output_str + "\n" + os.path.relpath(file, get_git_root(onyo_root)) + asset_changed
     return output_str
 
 
 def simulate_validation_after_change(file, rules_file, keys, onyo_root):
     problem_str = ""
-    temp_file = os.path.join(onyo_root, os.path.join(".onyo/temp/", os.path.basename(file)))
+    temp_file = os.path.join(get_git_root(onyo_root), os.path.join(".onyo/temp/", os.path.basename(file)))
     run_cmd("cp \"" + file + "\" \"" + temp_file + "\"")
     problem_str = problem_str + set_value(temp_file, temp_file, keys, onyo_root)
     for path_of_rule in rules_file:
@@ -123,7 +124,7 @@ def prepare_arguments(source, keys, quiet, yes, recursive, depth, onyo_root):
     if not depth == -1 and not depth > 0:
         problem_str = problem_str + "\n--depth must be an integer bigger than 0."
     # just open/validate the rules-file once
-    with open(os.path.join(onyo_root, ".onyo/validation/validation.yaml"), "r") as stream:
+    with open(os.path.join(get_git_root(onyo_root), ".onyo/validation/validation.yaml"), "r") as stream:
         try:
             rules_file = ru_yaml.load(stream)
             if not rules_file:

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -388,7 +388,7 @@ def main():
     if args.onyopath:
         onyo_root = args.onyopath
 
-    # TODO: Do onyo fsck here, test if .onyo exists, is git repo, other checks
+    # TODO: Do onyo fsck here, test if onyo_root exists, .onyo exists, is git repo, other checks
 
     if args.debug:
         logger.setLevel(logging.DEBUG)

--- a/onyo/utils.py
+++ b/onyo/utils.py
@@ -124,7 +124,7 @@ def validate_rule_for_file(file, rule, path_of_rule, original_file, onyo_root):
 def validate_file(file, original_file, onyo_root):
     ru_yaml = YAML(typ='safe')
     error_str = ""
-    with open(os.path.join(onyo_root, ".onyo/validation/validation.yaml"), "r") as stream:
+    with open(os.path.join(get_git_root(onyo_root), ".onyo/validation/validation.yaml"), "r") as stream:
         try:
             rules_file = ru_yaml.load(stream)
             if not rules_file:
@@ -183,7 +183,7 @@ def edit_file(file, onyo_root, onyo_new=False):
         logger.error(file + " does not exist.")
         sys.exit(1)
     # create and edit a temporary file, and if that is valid replace original
-    temp_file = os.path.join(onyo_root, os.path.join(".onyo/temp/", os.path.basename(file)))
+    temp_file = os.path.join(get_git_root(onyo_root), os.path.join(".onyo/temp/", os.path.basename(file)))
     if not os.path.isfile(temp_file):
         run_cmd("cp \"" + file + "\" \"" + temp_file + "\"")
     # When temp-file exists, ask if to use it


### PR DESCRIPTION
Most commands should be possible to run from inside a folder like
`shelf/` or `user\ nr\ 2/` and with relative paths.
Because additional functions like validation got added to onyo and
other functions like the environmental variable got removed,
not all possible combinations were possible anymore.

This commit allows for many commands that they can be run from
inside a folder like shelf/ (e.g. when in shelf/ `onyo new .`
creates an asset in the folder shelf/) and run the validation
on it, or calling onyo config from inside a directory, onyo mv
with relative paths, etc.

During the above mentioned changes I also noticed, that sometimes
the internally used commands `git -C <onyo_dir> commit` missed to
have quotes in the newer functions around <onyo_dir>, which could
also lead to errors when inside a directory with spaces, so I fixxed
this, too, and will add additional tests with the comming test-PR
to check all commands more extensively with spaces, too.