### PR TITLE
add `onyo shell-completion` command for bash and zsh tab-completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,18 @@ For further help, see "Example Validation".
 
   Files and directories that should not be checked for their validity can be
   added to .gitignore.
+- `onyo shell-completion`:
 
+  Print a shell script for onyo shell completion.
+
+  The output of this command should be "sourced" by bash or zsh to enable shell
+  completion for onyo.
+
+  Example:
+  ```
+  $ source <(onyo shell-completion)
+  $ onyo --<press TAB to display available options>
+  ```
 
 ## Environment Variables
 

--- a/onyo/commands/__init__.py
+++ b/onyo/commands/__init__.py
@@ -10,6 +10,7 @@ from .mv import mv
 from .new import new
 from .rm import rm
 from .set import set
+from .shell_completion import shell_completion
 from .tree import tree
 
 __all__ = [
@@ -25,5 +26,6 @@ __all__ = [
     'new',
     'rm',
     'set',
+    'shell_completion',
     'tree',
 ]

--- a/onyo/commands/__init__.py
+++ b/onyo/commands/__init__.py
@@ -1,18 +1,29 @@
-from .init import init
-from .new import new
-from .mv import mv
-from .edit import edit
-from .tree import tree
-from .history import history
 from .cat import cat
-from .git import git
 from .config import config
-from .mkdir import mkdir
-from .rm import rm
+from .edit import edit
 from .fsck import fsck
+from .git import git
+from .history import history
+from .init import init
+from .mkdir import mkdir
+from .mv import mv
+from .new import new
+from .rm import rm
 from .set import set
+from .tree import tree
 
 __all__ = [
-    'init', 'new', 'mv', 'edit', 'cat', 'tree', 'history', 'git', 'config',
-    'mkdir', 'rm', 'fsck', 'set'
+    'cat',
+    'config',
+    'edit',
+    'fsck',
+    'git',
+    'history',
+    'init',
+    'mkdir',
+    'mv',
+    'new',
+    'rm',
+    'set',
+    'tree',
 ]

--- a/onyo/commands/shell_completion.py
+++ b/onyo/commands/shell_completion.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+import logging
+
+logging.basicConfig()
+logger = logging.getLogger('onyo')
+
+
+def shell_completion(args, onyo_root):
+    """ Print a shell script for onyo shell completion.
+
+    The output of this command should be "sourced" by bash or zsh to enable
+    shell completion for onyo.
+
+    Example:
+
+        $ source <(onyo shell-completion)
+        $ onyo --<PRESS TAB to display available option>
+    """
+
+    content = """\
+#!bash
+#
+# This file is licensed under the ISC license.
+# See the AUTHORS and LICENSE files for more information.
+#
+# bash/zsh completion support for onyo
+#
+# The output of this command is meant to be "sourced" by your shell in order to
+# enable tab-completion for onyo.
+#
+# Instead of just running this command and seeing this output, run
+#
+#    source <(onyo shell-completion)
+#
+
+if [[ -n ${ZSH_VERSION-} ]]; then
+    autoload -U +X bashcompinit && bashcompinit
+fi
+
+__ONYO='onyo'
+
+# print top-level onyo commands
+__onyo_list_commands() {
+    local start='false'
+    # COLUMNS=0 disables argparse's line wrapping
+    COLUMNS=0 $__ONYO -h | \
+    while IFS= read line; do
+        [ "$line" == 'commands:' ] && start='true' && continue
+
+        if [ "$start" == 'true' ]; then
+            [ -z "$line" ] && break
+
+            line=${line#${line%%[!\ ]*}} # trim leading spaces
+            line=${line%% *} # trim everything after the command (help text)
+            printf '%s\n' "$line"
+        fi
+    done
+}
+
+
+# print flags in long form (--) for onyo itself and all subcommands
+__onyo_list_long_flags() {
+    local cmd="$1"
+
+    for i in 'onyo' $(__onyo_list_commands) ; do
+        [ "$cmd" != "$i" ] && continue
+        [ "$cmd" = 'onyo' ] && cmd=''
+
+        local start='false'
+        # COLUMNS=0 disables argparse's line wrapping
+        COLUMNS=0 $__ONYO $cmd -h | \
+        while IFS= read line; do
+            [ "$line" = 'options:' ] && start='true' && continue
+
+            if [ $start == 'true' ]; then
+                [ -z "$line" ] && break
+
+                line=${line#${line%%--*}} # trim anything before '--' (short arg and spaces)
+                line=${line%% *} # trim everything after the argument (help text)
+
+                printf '%s\n' "$line"
+            fi
+        done
+
+        return 0
+    done
+
+    return 1
+}
+
+
+# print flags in short form (-) for onyo itself and all subcommands
+__onyo_list_short_flags() {
+    local cmd="$1"
+
+    for i in 'onyo' $(__onyo_list_commands) ; do
+        [ "$cmd" != "$i" ] && continue
+        [ "$cmd" = 'onyo' ] && cmd=''
+
+        local start='false'
+        # COLUMNS=0 disables argparse's line wrapping
+        COLUMNS=0 $__ONYO $cmd -h | \
+        while IFS= read line; do
+            [ "$line" = 'options:' ] && start='true' && continue
+
+            if [ $start == 'true' ]; then
+                [ -z "$line" ] && break
+
+                line=${line#${line%%[!\ ]*}} # trim leading spaces
+                line=${line%%, *} # trim everything after the short argument (long arg and help text)
+
+                printf '%s\n' "$line"
+            fi
+        done
+
+        return 0
+    done
+
+    return 1
+}
+
+
+__onyo_complete() {
+    COMPREPLY=() # zero out response array
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+    local cmd="${COMP_WORDS[1]}"
+
+    [ "${prev##*/}" = 'onyo' ] && cmd='onyo'
+
+    if [ "${cur:0:2}" = '--' ]; then
+        COMPREPLY=($(compgen -W "$(__onyo_list_long_flags ${cmd})" -- "$cur"))
+        return 0
+    elif [ "${cur:0:1}" = '-' ]; then
+        COMPREPLY=($(compgen -W "$(__onyo_list_short_flags ${cmd})" -- "$cur"))
+        return 0
+    fi
+
+    # only bash >= 4 allows fall-through case statements, and macOS does not
+    # ship a modern bash. Thus the global check for --help here.
+    #
+    # never suggest files or dirs after -h
+    case "$prev" in
+        -h|--help) return 1 ;;
+    esac
+
+    case "$cmd" in
+        # no file or dir completion
+        config|fsck)
+            return 1
+            ;;
+        # TODO: git
+        # suggest dirs only
+        mkdir|tree)
+            # TODO: append / and nospace
+            COMPREPLY=($(compgen -d -o nospace -- "$cur" ))
+            return 0
+            ;;
+        # suggest only one dir
+        init|new)
+            # TODO: limit to one dir
+            COMPREPLY=($(compgen -d -- "$cur" ))
+            return 1
+            ;;
+        # suggest onyo subcommands
+        onyo)
+            COMPREPLY=($(compgen -W "$(__onyo_list_commands)" -- "$cur"))
+            return 0
+            ;;
+        # suggest files and dirs for all subcommands
+        *)
+            COMPREPLY=($(compgen -f -o plusdirs -- "$cur" ))
+            return 0
+            ;;
+    esac
+}
+
+complete -F __onyo_complete onyo
+
+#
+# The output of this command is meant to be "sourced" by your shell in order to
+# enable tab-completion for onyo.
+#
+# Instead of just running this command and seeing this output, run
+#
+#    source <(onyo shell-completion)
+#
+"""
+    print(content)

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -370,6 +370,14 @@ def parse_args():
         help='assets/directories for which to set values'
     )
     #
+    # subcommand shell-completion
+    #
+    cmd_shell_completion = subcommands.add_parser(
+        'shell-completion',
+        help='print a script for shell completion for onyo, suitable for use with "source"'
+    )
+    cmd_shell_completion.set_defaults(run=commands.shell_completion)
+    #
     # subcommand "tree"
     #
     cmd_tree = subcommands.add_parser(


### PR DESCRIPTION
Works towards #28

This adds a tab completion script for bash and zsh that works for 90-95% of situations. It's a bit ugly, and I have talked myself into an alternative approach that will be more maintainable, faster, and better able to handle the corner cases I've discovered.

However, this does work, and may be of value to people who desire this functionality now.

To use, simply:
```
source <(onyo shell-completion)
```