### PR TITLE
tests: re-enable pypy3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', 'pypy3.7', 'pypy3.8']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: git config


### PR DESCRIPTION
It was removed in a previous PR (#131), but PyPy3 is compatible with CPython 3.7 and 3.8 (both of which Onyo still supports).

This updates the Python environment used by GitHub Actions, and uses the new pypy<x>.<y> syntax to denote version (the previous generic "pypy3" was compatible with CPython 3.6).