### PR TITLE
DOC: readme fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ To keep meta data fields consistent between different assets, rules for fields
 in assets can be defined in `.onyo/validation/validation.yaml` in an onyo
 repository. The validation file will be read from the top down, and the first
 path in the validation file that fits a asset file will be used to validate
-it's contents.
+its contents.
 
 The structure for rules is:
 ```
@@ -254,7 +254,7 @@ For further help, see "Example Validation".
   the field names defined by the asset name scheme, and after creation opens the
   new `asset` file with the editor.
   After the editing is done, the new file will be checked for the validity of
-  it's YAML syntax and based on the rules in `.onyo/validation/validation.yaml`.
+  its YAML syntax and based on the rules in `.onyo/validation/validation.yaml`.
   - `--template template`: specifies the template copied by the command. If not
     specified, it uses the standard template.
   - `--non-interactive` : Suppress opening of editor after file creation.
@@ -277,11 +277,11 @@ For further help, see "Example Validation".
 - `onyo fsck`:
 
   Runs a comprehensive suite of checks to verify the integrity and validity of
-  an onyo repository and it's contents:
+  an onyo repository and its contents:
   - Checks first if an `onyo repository` is given (a valid git repository, which
     contains an `.onyo` folder), otherwise it errors out and does no further
     checks. If the directory is valid, `onyo fsck` runs these checks for the
-    whole onyo repository and it's contents, and lists all problems encountered:
+    whole onyo repository and its contents, and lists all problems encountered:
     - all asset names are unique
     - all files are valid YAML
     - all files follow the rules specified in `.onyo/validation/validation.yaml`
@@ -421,7 +421,7 @@ instead it has a different set of rules for the keys `Size` and `USB`.
 **Example 2: Directories, Sub-Directories and onyo-wide Rules**
 
 Onyo differentiates between `shelf/*` (to define rules for assets directly under
-`shelf/`) and `shelf/**` (for all assets in shelf and all it's sub-directories).
+`shelf/`) and `shelf/**` (for all assets in shelf and all its sub-directories).
 The user can also use `"**":` at the end of `validation.yaml` to specify a set of
 rules that will be applied to all assets anywhere in onyo, if no other rule
 defined before applies to an asset file.

--- a/README.md
+++ b/README.md
@@ -156,53 +156,15 @@ For further help, see "Example Validation".
 
 ## Commands
 
-- `onyo init [directory]`:
-
-  Initialize an Onyo repository. The directory will be initialized as a git
-  repository (if it is not one already), the .onyo/ directory created
-  (containing default config files, templates, etc), and everything committed.
-
-  The current working directory will be initialized if neither `directory` nor
-  the `onyo -C <dir>` option are specified.
-
-  Running `onyo init` on an existing repository is safe. It will not overwrite
-  anything; it will exit with an error.
-- `onyo tree directory...`:
-
-  List the assets and directories in `directory` using the `tree` program.
-- `onyo mv [--force, -f] [--rename, -r] source... destination`:
-
-  Move `source`(s) to the `destination` directory, or rename `source` directory
-  to `destination`. Onyo will validate the contents of moved assets to make sure
-  that they still follow to specified rules. See "Field Validation".
-
-  - `--force`: Silently overwrite the destination file if it already exists.
-  - `--rename`: Allow a `source` file to be renamed to a different (valid)
-    file name.
-- `onyo mkdir directory...`:
-
-  Create `directory`(s). Intermediate directories will be created as needed
-  (i.e. parent and child directories to be created in one call).
-
-  Onyo creates a `.anchor` file in every folder to track directories with git
-  even when they are empty.
-
-  If the directory already exists, Onyo will throw an error. When multiple
-  directories are passed to Onyo, all will be checked before attempting to
-  create them.
 - `onyo cat asset...`:
 
   Print the contents of `asset`(s) to the terminal without parsing or validating
   the contents.
-- `onyo rm [--quiet, -q] [--yes, -y] asset | directory...`:
+- `onyo config variable value`:
 
-  Delete the `asset`(s) and `directory`(s).
-
-  Onyo will present a complete list of all files and folders to delete, and
-  prompt the user for confirmation.
-
-  - `--quiet`: Silence the output (requires the `--yes` flag)
-  - `--yes`: Respond "yes" to the prompt and run non-interactively
+  Set a `variable` to `value` in the `.onyo/config` file. This command can for
+  example change the default tool for the interactive mode of `onyo history`
+  with `onyo config history.interactive "git log --follow"`.
 - `onyo edit [--non-interactive, -I] asset...`:
 
   Open the `asset` file(s) using the default text editor specified by the
@@ -216,6 +178,87 @@ For further help, see "Example Validation".
   `.onyo/validation/validation.yaml`, and if problems are found it gives the
   choice to either correct them or discard the changes to make sure that the
   repository stays in a valid state.
+- `onyo fsck`:
+
+  Runs a comprehensive suite of checks to verify the integrity and validity of
+  an onyo repository and its contents:
+  - Checks first if an `onyo repository` is given (a valid git repository, which
+    contains an `.onyo` folder), otherwise it errors out and does no further
+    checks. If the directory is valid, `onyo fsck` runs these checks for the
+    whole onyo repository and its contents, and lists all problems encountered:
+    - all asset names are unique
+    - all files are valid YAML
+    - all files follow the rules specified in `.onyo/validation/validation.yaml`
+    - the git working tree is clean (no untracked or changed files)
+    - all directories and sub-directories have a .anchor file
+
+  Files and directories that should not be checked for their validity can be
+  added to .gitignore.
+- `onyo git git-command-args...`:
+
+  Pass `git-command-args` as arguments to `git`, using the Onyo repository as
+  the git repository.
+- `onyo history [--non-interactive, -I] asset | directory`:
+
+  Show the history of a `directory` or `asset` file.
+  By default, to show the history in interactive mode, the command uses
+  `tig --follow asset | directory`, and for the non-interactive mode it calls
+  `git --no-pager log --follow asset | directory`. The default tools can be
+  changed with `onyo config`.
+
+  - `--non-interactive` : Force usage of the non-interactive tool to show the
+  history of a `asset` or `directory`, and do not detect whether the TTY is
+  interactive.
+- `onyo init [directory]`:
+
+  Initialize an Onyo repository. The directory will be initialized as a git
+  repository (if it is not one already), the .onyo/ directory created
+  (containing default config files, templates, etc), and everything committed.
+
+  The current working directory will be initialized if neither `directory` nor
+  the `onyo -C <dir>` option are specified.
+
+  Running `onyo init` on an existing repository is safe. It will not overwrite
+  anything; it will exit with an error.
+- `onyo mkdir directory...`:
+
+  Create `directory`(s). Intermediate directories will be created as needed
+  (i.e. parent and child directories to be created in one call).
+
+  Onyo creates a `.anchor` file in every folder to track directories with git
+  even when they are empty.
+
+  If the directory already exists, Onyo will throw an error. When multiple
+  directories are passed to Onyo, all will be checked before attempting to
+  create them.
+- `onyo mv [--force, -f] [--rename, -r] source... destination`:
+
+  Move `source`(s) to the `destination` directory, or rename `source` directory
+  to `destination`. Onyo will validate the contents of moved assets to make sure
+  that they still follow to specified rules. See "Field Validation".
+
+  - `--force`: Silently overwrite the destination file if it already exists.
+  - `--rename`: Allow a `source` file to be renamed to a different (valid)
+    file name.
+- `onyo new [--template template, -t template] [--non-interactive, -I] directory`:
+
+  Creates a new `asset` in `directory`. The command opens a dialog that asks for
+  the field names defined by the asset name scheme, and after creation opens the
+  new `asset` file with the editor.
+  After the editing is done, the new file will be checked for the validity of
+  its YAML syntax and based on the rules in `.onyo/validation/validation.yaml`.
+  - `--template template`: specifies the template copied by the command. If not
+    specified, it uses the standard template.
+  - `--non-interactive` : Suppress opening of editor after file creation.
+- `onyo rm [--quiet, -q] [--yes, -y] asset | directory...`:
+
+  Delete the `asset`(s) and `directory`(s).
+
+  Onyo will present a complete list of all files and folders to delete, and
+  prompt the user for confirmation.
+
+  - `--quiet`: Silence the output (requires the `--yes` flag)
+  - `--yes`: Respond "yes" to the prompt and run non-interactively
 - `onyo set [--recursive, -R] [--depth num, -d] [--dry-run, -n ] [--quiet, -q] [--yes, -y] key=value[,key=value...] [asset | directory]...`:
 
   Set the `value` of `key` for matching assets. If the key does not exist, it is
@@ -244,52 +287,6 @@ For further help, see "Example Validation".
   Errors reading or parsing files print to STDERR, but do not halt Onyo. Any
   error encountered while writing a file will cause Onyo to error and exit
   immediately.
-- `onyo git git-command-args...`:
-
-  Pass `git-command-args` as arguments to `git`, using the Onyo repository as
-  the git repository.
-- `onyo new [--template template, -t template] [--non-interactive, -I] directory`:
-
-  Creates a new `asset` in `directory`. The command opens a dialog that asks for
-  the field names defined by the asset name scheme, and after creation opens the
-  new `asset` file with the editor.
-  After the editing is done, the new file will be checked for the validity of
-  its YAML syntax and based on the rules in `.onyo/validation/validation.yaml`.
-  - `--template template`: specifies the template copied by the command. If not
-    specified, it uses the standard template.
-  - `--non-interactive` : Suppress opening of editor after file creation.
-- `onyo history [--non-interactive, -I] asset | directory`:
-
-  Show the history of a `directory` or `asset` file.
-  By default, to show the history in interactive mode, the command uses
-  `tig --follow asset | directory`, and for the non-interactive mode it calls
-  `git --no-pager log --follow asset | directory`. The default tools can be
-  changed with `onyo config`.
-
-  - `--non-interactive` : Force usage of the non-interactive tool to show the
-  history of a `asset` or `directory`, and do not detect whether the TTY is
-  interactive.
-- `onyo config variable value`:
-
-  Set a `variable` to `value` in the `.onyo/config` file. This command can for
-  example change the default tool for the interactive mode of `onyo history`
-  with `onyo config history.interactive "git log --follow"`.
-- `onyo fsck`:
-
-  Runs a comprehensive suite of checks to verify the integrity and validity of
-  an onyo repository and its contents:
-  - Checks first if an `onyo repository` is given (a valid git repository, which
-    contains an `.onyo` folder), otherwise it errors out and does no further
-    checks. If the directory is valid, `onyo fsck` runs these checks for the
-    whole onyo repository and its contents, and lists all problems encountered:
-    - all asset names are unique
-    - all files are valid YAML
-    - all files follow the rules specified in `.onyo/validation/validation.yaml`
-    - the git working tree is clean (no untracked or changed files)
-    - all directories and sub-directories have a .anchor file
-
-  Files and directories that should not be checked for their validity can be
-  added to .gitignore.
 - `onyo shell-completion`:
 
   Print a shell script for onyo shell completion.
@@ -302,6 +299,10 @@ For further help, see "Example Validation".
   $ source <(onyo shell-completion)
   $ onyo --<press TAB to display available options>
   ```
+- `onyo tree directory...`:
+
+  List the assets and directories in `directory` using the `tree` program.
+
 
 ## Environment Variables
 


### PR DESCRIPTION
Fix some "it's" -> "its". Also alphabetize the order of onyo commands.