### PR TITLE
set: preserve comments and order when writing

### DIFF
--- a/onyo/commands/set.py
+++ b/onyo/commands/set.py
@@ -26,7 +26,7 @@ def build_commit_cmd(files_to_change, onyo_root):
 
 
 def read_asset(file, onyo_root):
-    yaml = YAML(typ='safe')
+    yaml = YAML(typ='rt')
     asset = {}
     with open(os.path.join(onyo_root, file), "r") as stream:
         try:
@@ -39,6 +39,7 @@ def read_asset(file, onyo_root):
 
 
 def write_asset(data, file, onyo_root):
+    yaml = YAML(typ='rt')
     with open(os.path.join(onyo_root, file), "w") as stream:
         yaml.dump(data, stream)
 

--- a/tests/output_goals/test 1/cat_output.txt
+++ b/tests/output_goals/test 1/cat_output.txt
@@ -1,5 +1,5 @@
-CPU: vier
 RAM: 20
+CPU: vier
 USB: None
 var: str ing
 RAM: 50

--- a/tests/output_goals/test 2/cat_output.txt
+++ b/tests/output_goals/test 2/cat_output.txt
@@ -1,5 +1,5 @@
-CPU: vier
 RAM: 20
+CPU: vier
 USB: None
 var: str ing
 RAM: 50


### PR DESCRIPTION
This puts YAML in "round-trip" mode.

Fix #158