### PR TITLE
add --version flag

### DIFF
--- a/onyo/__init__.py
+++ b/onyo/__init__.py
@@ -1,6 +1,7 @@
 from os.path import join as opj
 from pathlib import Path
 import logging
+from onyo._version import __version__
 
 
 class Configuration:

--- a/onyo/_version.py
+++ b/onyo/_version.py
@@ -1,0 +1,4 @@
+"""Version information."""
+
+# The following line *must* be the last in the module, exactly as formatted:
+__version__ = "0.0.1"

--- a/onyo/utils.py
+++ b/onyo/utils.py
@@ -10,6 +10,7 @@ from ruamel.yaml import YAML
 from onyo import commands
 from git import Repo, exc
 import textwrap
+from onyo._version import __version__
 
 logging.basicConfig()
 logger = logging.getLogger('onyo')
@@ -296,6 +297,12 @@ def parse_args():
         default=False,
         action='store_true',
         help='enable debug logging'
+    )
+    parser.add_argument(
+        '--version',
+        action='version',
+        version='%(prog)s {version}'.format(version=__version__),
+        help='print the onyo version and exit'
     )
     # subcommands
     subcmds = parser.add_subparsers(

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='onyo',
-    version='0.0.1',
+    version=open("onyo/_version.py").readlines()[-1].split()[-1].strip("\"'"),
     description='Textual inventory system backed by git.',
     author='Tobias Kadelka',
     author_email='t.kadelka@fz-juelich.de',


### PR DESCRIPTION
This PR moves the version number out of `setup.py` and into a location addressable by the rest of Onyo. And then the `--version` flag is added, addressing #137. 