### PR TITLE
edit: retire --non-interactive

### DIFF
--- a/onyo/commands/edit.py
+++ b/onyo/commands/edit.py
@@ -51,8 +51,6 @@ def edit(args, onyo_root):
 
     When multiple asset files are given, Onyo will open them in sequence.
 
-    - ``--non-interactive``: Suppress opening of editor
-
     After editing an ``asset``, ``onyo`` will check the validity of the YAML
     syntax and check if the changed file still follows the rules specified in
     ``.onyo/validation/validation.yaml``, and if problems are found it gives the
@@ -70,8 +68,7 @@ def edit(args, onyo_root):
     for source in list_of_sources:
         git_filepath = os.path.relpath(source, onyo_root)
         # change file
-        if not args.non_interactive:
-            edit_file(source, onyo_root)
+        edit_file(source, onyo_root)
         # check if changes happened and add them
         repo = Repo(onyo_root)
         changed_files = [item.a_path for item in repo.index.diff(None)]

--- a/onyo/utils.py
+++ b/onyo/utils.py
@@ -349,16 +349,9 @@ def parse_args():
         'edit',
         description=textwrap.dedent(commands.edit.__doc__),
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        help='edit an asset'
+        help='open asset with a text editor'
     )
     cmd_edit.set_defaults(run=commands.edit)
-    cmd_edit.add_argument(
-        '-I', '--non-interactive',
-        required=False,
-        default=False,
-        action='store_true',
-        help='do not prompt or open the editor'
-    )
     cmd_edit.add_argument(
         'asset',
         metavar='ASSET',


### PR DESCRIPTION
Unless I am missing something crucial here, `--non-interactive` effectively makes `onyo edit` a no-op.