### PR TITLE
Refactor `mkdir`

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,6 +4,7 @@ import glob
 import logging
 import pytest
 import shlex
+from pathlib import Path
 
 logging.basicConfig()
 logger = logging.getLogger('onyo')
@@ -47,10 +48,8 @@ def check_output_with_file(command, input_str, file, test_dir):
 
 
 class TestClass:
-
-    test_dir = os.path.join(os.getcwd(), "onyo_tests")
-    if not os.path.isdir(test_dir):
-        run_test_cmd("mkdir \"" + test_dir + "\"")
+    test_dir = os.path.join(os.getcwd(), "tests/", "sandbox")
+    Path(test_dir).mkdir(parents=True, exist_ok=True)
 
     # the folder for the wished output lies relative to this script:<
     test_output = os.path.join(os.path.dirname(os.path.realpath(__file__)), "output_goals/")

--- a/tests/test_mkdir.py
+++ b/tests/test_mkdir.py
@@ -1,0 +1,79 @@
+import os
+import subprocess
+from pathlib import Path
+import pytest
+
+
+@pytest.fixture(scope="function", autouse=True)
+def change_test_dir(request, monkeypatch):
+    test_dir = os.path.join(request.fspath.dirname, "sandbox/", "test_mkdir/")
+    Path(test_dir).mkdir(parents=True, exist_ok=True)
+    monkeypatch.chdir(test_dir)
+
+
+def test_onyo_init():
+    ret = subprocess.run(["onyo", "init"])
+    assert ret.returncode == 0
+
+
+def test_simple_dir():
+    ret = subprocess.run(["onyo", "mkdir", "da_dir/"])
+    assert ret.returncode == 0
+    assert os.path.isdir( "da_dir/")  # noqa: E201
+    assert os.path.isfile("da_dir/.anchor")
+
+
+def test_dir_exists():
+    ret = subprocess.run(["onyo", "mkdir", "da_dir/"])
+    assert ret.returncode == 1
+
+
+def test_dir_exists_as_file():
+    ret = subprocess.run(["onyo", "mkdir", "da_dir/.anchor"])
+    assert ret.returncode == 1
+
+
+def test_recursive_dirs():
+    ret = subprocess.run(["onyo", "mkdir", "da_dir/a/b/c/d"])
+    assert ret.returncode == 0
+    assert os.path.isfile("da_dir/a/.anchor")
+    assert os.path.isfile("da_dir/a/b/.anchor")
+    assert os.path.isfile("da_dir/a/b/c/.anchor")
+    assert os.path.isdir( "da_dir/a/b/c/d/")  # noqa: E201
+    assert os.path.isfile("da_dir/a/b/c/d/.anchor")
+
+
+def test_recursive_dir_exists():
+    ret = subprocess.run(["onyo", "mkdir", "da_dir/a/b/c/d"])
+    assert ret.returncode == 1
+
+
+def test_recursive_dir_exists_as_file():
+    ret = subprocess.run(["onyo", "mkdir", "da_dir/a/b/c/d/.anchor"])
+    assert ret.returncode == 1
+
+
+def test_dir_with_spaces():
+    ret = subprocess.run(["onyo", "mkdir", "s p a c e s"])
+    assert ret.returncode == 0
+    assert os.path.isdir( "s p a c e s/")  # noqa: E201
+    assert os.path.isfile("s p a c e s/.anchor")
+    assert not os.path.exists("s")
+
+    ret = subprocess.run(["onyo", "mkdir", "s p a/c e s"])
+    assert ret.returncode == 0
+    assert os.path.isdir( "s p a/")  # noqa: E201
+    assert os.path.isfile("s p a/.anchor")
+    assert os.path.isdir( "s p a/c e s/")  # noqa: E201
+    assert os.path.isfile("s p a/c e s/.anchor")
+    assert not os.path.exists("s")
+    assert not os.path.exists("c")
+    assert not os.path.exists("s p a/c")
+
+
+def test_dir_relative():
+    ret = subprocess.run(["onyo", "mkdir", "da_dir/../relative"])
+    assert ret.returncode == 0
+    assert os.path.isdir( "relative/")  # noqa: E201
+    assert os.path.isfile("relative/.anchor")
+    assert not os.path.exists("da_dir/\.\./relative")


### PR DESCRIPTION
This reduces the number of functions from 5 to 3, adds docstrings, and overall simplifies the logic and var names.

Ideally the dir names would be all relative to the root of the onyo repository. A TODO has been added about this.

It would also be more performant to build a list of anchors and add them all in one call, rather than invoke a new process for each add. But I don't see people adding 10k directories at once, so I figured it best to leave the code simple as it is.