### PR TITLE
DOC: add installation instructions and remove empty introduction page

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,7 +14,7 @@ Overview
 .. toctree::
    :maxdepth: 1
 
-   introduction
+   installation
    concepts
    command_line_reference
    examples

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,0 +1,19 @@
+Installation
+============
+
+With your virtual environment manager of choice, create a virtual environment
+and ensure you have a recent version of Python installed. Then activate the
+environment. E.g. with ``venv``:
+
+.. code::
+
+   python -m venv ~/.venvs/onyo
+   source ~/.venvs/onyo/bin/activate
+
+Clone the repo and install the package.
+
+.. code::
+
+   git clone https://github.com/psyinfra/onyo.git
+   cd onyo
+   pip install -e .

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -1,6 +1,0 @@
-Introduction
-============
-
-.. admonition:: TODO
-
-   Add content


### PR DESCRIPTION
Right now, I don't think we need an introduction page. Instead, I've added a page with installation instructions. Then eventually a quickstart or common work-flows page might make sense to add.

With this change, I think the docs are ready to go live with Read the Docs.