### PR TITLE
TST: drop dep pytest-shell-utilities

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         'ruamel.yaml'
     ],
     extras_require={
-        'tests': ['pytest', 'pytest-shell-utilities', 'flake8'],
+        'tests': ['pytest', 'flake8'],
         'docs': ['sphinx', 'sphinx-argparse', 'sphinx-rtd-theme']},
     python_requires=">=3.7",
     entry_points={

--- a/tests/test_shell-completion.py
+++ b/tests/test_shell-completion.py
@@ -1,28 +1,31 @@
+import subprocess
+
+
 # command does not explode
-def test_good_returncode(shell):
-    ret = shell.run("onyo", "shell-completion")
+def test_good_returncode():
+    ret = subprocess.run(["onyo", "shell-completion"])
     assert ret.returncode == 0
 
 
 # There should be no "None"s in the output. If so, it is usually due to an unset
 # metavar variable in the argparse arguments.
-def test_no_empty_metavars(shell):
-    ret = shell.run("onyo", "shell-completion")
+def test_no_empty_metavars():
+    ret = subprocess.run(["onyo", "shell-completion"], capture_output=True, text=True)
     assert 'None' not in ret.stdout
 
 
 # A naive test to see if there are "enough" lines. Boilerplate alone was 54
 # lines at the time of this writing and the full script at 168. If there's
 # fewer than 100 lines, then something significant is missing (or has changed).
-def test_script_length(shell):
-    ret = shell.run("onyo", "shell-completion")
+def test_script_length():
+    ret = subprocess.run(["onyo", "shell-completion"], capture_output=True, text=True)
     lines = ret.stdout.count('\n')
     assert lines >= 100
 
 
 # zsh parses the script successfully
-def test_zsh_parseable(shell):
+def test_zsh_parseable():
     # "compinit -C" disables security-related checks. This is necessary for
     # non-interactive environments. See the compinit source for more info.
-    ret = shell.run("zsh", "-c", "autoload -Uz compinit && compinit -C && source <(onyo shell-completion)")
+    ret = subprocess.run(["zsh", "-c", "autoload -Uz compinit && compinit -C && source <(onyo shell-completion)"])
     assert ret.returncode == 0


### PR DESCRIPTION
While testing mkdir, I discovered that it ignores chdirs from fixtures. That was quite annoying to troubleshoot.

Their documentation isn't good, and it's not buying us much. Choosing to keep it simple and use what's in the standard library.