### PR TITLE
DOC: strip rst formatting from description text

### DIFF
--- a/onyo/utils.py
+++ b/onyo/utils.py
@@ -698,7 +698,7 @@ class StoreDictKeyPair(argparse.Action):
 # credit: https://stackoverflow.com/a/13429281
 class SubcommandHelpFormatter(argparse.RawDescriptionHelpFormatter):
     def _format_action(self, action):
-        parts = super(argparse.RawDescriptionHelpFormatter, self)._format_action(action)
+        parts = super()._format_action(action)
 
         # strip the first line (metavar) of the subcommands section
         if action.nargs == argparse.PARSER:

--- a/onyo/utils.py
+++ b/onyo/utils.py
@@ -286,7 +286,7 @@ def parse_args():
     cmd_cat = subcmds.add_parser(
         'cat',
         description=textwrap.dedent(commands.cat.__doc__),
-        formatter_class=argparse.RawDescriptionHelpFormatter,
+        formatter_class=SubcommandHelpFormatter,
         help='print the contents of an asset'
     )
     cmd_cat.set_defaults(run=commands.cat)
@@ -303,7 +303,7 @@ def parse_args():
     cmd_config = subcmds.add_parser(
         'config',
         description=textwrap.dedent(commands.config.__doc__),
-        formatter_class=argparse.RawDescriptionHelpFormatter,
+        formatter_class=SubcommandHelpFormatter,
         help='set onyo options in the repository'
     )
     cmd_config.set_defaults(run=commands.config)
@@ -319,7 +319,7 @@ def parse_args():
     cmd_edit = subcmds.add_parser(
         'edit',
         description=textwrap.dedent(commands.edit.__doc__),
-        formatter_class=argparse.RawDescriptionHelpFormatter,
+        formatter_class=SubcommandHelpFormatter,
         help='open asset with a text editor'
     )
     cmd_edit.set_defaults(run=commands.edit)
@@ -336,7 +336,7 @@ def parse_args():
     cmd_fsck = subcmds.add_parser(
         'fsck',
         description=textwrap.dedent(commands.fsck.__doc__),
-        formatter_class=argparse.RawDescriptionHelpFormatter,
+        formatter_class=SubcommandHelpFormatter,
         help='check the onyo repository for sanity, and run YAML and onyo validation on all assets'
     )
     cmd_fsck.set_defaults(run=commands.fsck)
@@ -346,7 +346,7 @@ def parse_args():
     cmd_git = subcmds.add_parser(
         'git',
         description=textwrap.dedent(commands.git.__doc__),
-        formatter_class=argparse.RawDescriptionHelpFormatter,
+        formatter_class=SubcommandHelpFormatter,
         help='run git commands in the onyo repository'
     )
     cmd_git.set_defaults(run=commands.git)
@@ -362,7 +362,7 @@ def parse_args():
     cmd_history = subcmds.add_parser(
         'history',
         description=textwrap.dedent(commands.history.__doc__),
-        formatter_class=argparse.RawDescriptionHelpFormatter,
+        formatter_class=SubcommandHelpFormatter,
         help='show the history of an asset or directory'
     )
     cmd_history.set_defaults(run=commands.history)
@@ -386,7 +386,7 @@ def parse_args():
     cmd_init = subcmds.add_parser(
         'init',
         description=textwrap.dedent(commands.init.__doc__),
-        formatter_class=argparse.RawDescriptionHelpFormatter,
+        formatter_class=SubcommandHelpFormatter,
         help='initialize an onyo repository'
     )
     cmd_init.set_defaults(run=commands.init)
@@ -403,7 +403,7 @@ def parse_args():
     cmd_mkdir = subcmds.add_parser(
         'mkdir',
         description=textwrap.dedent(commands.mkdir.__doc__),
-        formatter_class=argparse.RawDescriptionHelpFormatter,
+        formatter_class=SubcommandHelpFormatter,
         help='create a directory (with git anchor)'
     )
     cmd_mkdir.set_defaults(run=commands.mkdir)
@@ -420,7 +420,7 @@ def parse_args():
     cmd_mv = subcmds.add_parser(
         'mv',
         description=textwrap.dedent(commands.mv.__doc__),
-        formatter_class=argparse.RawDescriptionHelpFormatter,
+        formatter_class=SubcommandHelpFormatter,
         help='move an asset'
     )
     cmd_mv.set_defaults(run=commands.mv)
@@ -457,7 +457,7 @@ def parse_args():
     cmd_new = subcmds.add_parser(
         'new',
         description=textwrap.dedent(commands.new.__doc__),
-        formatter_class=argparse.RawDescriptionHelpFormatter,
+        formatter_class=SubcommandHelpFormatter,
         help='create a new asset'
     )
     cmd_new.set_defaults(run=commands.new)
@@ -487,7 +487,7 @@ def parse_args():
     cmd_rm = subcmds.add_parser(
         'rm',
         description=textwrap.dedent(commands.rm.__doc__),
-        formatter_class=argparse.RawDescriptionHelpFormatter,
+        formatter_class=SubcommandHelpFormatter,
         help='delete asset(s) and directories'
     )
     cmd_rm.set_defaults(run=commands.rm)
@@ -518,7 +518,7 @@ def parse_args():
     cmd_set = subcmds.add_parser(
         'set',
         description=textwrap.dedent(commands.set.__doc__),
-        formatter_class=argparse.RawDescriptionHelpFormatter,
+        formatter_class=SubcommandHelpFormatter,
         help='set values in assets'
     )
     cmd_set.set_defaults(run=commands.set)
@@ -578,7 +578,7 @@ def parse_args():
     cmd_shell_completion = subcmds.add_parser(
         'shell-completion',
         description=textwrap.dedent(commands.shell_completion.__doc__),
-        formatter_class=argparse.RawDescriptionHelpFormatter,
+        formatter_class=SubcommandHelpFormatter,
         help='shell completion for Onyo, suitable for use with "source"'
     )
     cmd_shell_completion.set_defaults(run=commands.shell_completion)
@@ -596,7 +596,7 @@ def parse_args():
     cmd_tree = subcmds.add_parser(
         'tree',
         description=textwrap.dedent(commands.tree.__doc__),
-        formatter_class=argparse.RawDescriptionHelpFormatter,
+        formatter_class=SubcommandHelpFormatter,
         help='print the contents of a directory in a tree-like format'
     )
     cmd_tree.set_defaults(run=commands.tree)
@@ -705,3 +705,18 @@ class SubcommandHelpFormatter(argparse.RawDescriptionHelpFormatter):
             parts = parts.split("\n", 1)[1]
 
         return parts
+
+    def _fill_text(self, text, width, indent):
+        """
+        This is a very, very naive approach to stripping rst syntax from
+        docstrings. Sadly, docutils does not have a plain-text writer. That
+        would be the ideal solution.
+        """
+        text = super()._fill_text(text, width, indent)
+
+        # `` -> `
+        text = text.replace('``', '`')
+        # remove escapes of characters; everything is literal here
+        text = text.replace('\\', '')
+
+        return text


### PR DESCRIPTION
This is a very imperfect solution. But it's the most readily available one, and our needs are not (yet) complicated. I would /love/ for there to be a "plaintext" docutils writer.

Fixes #154