### PR TITLE
shell-completion: refactor

### DIFF
--- a/onyo/commands/shell_completion.py
+++ b/onyo/commands/shell_completion.py
@@ -167,7 +167,7 @@ class Zsh(TabCompletion):
 
     def _zsh_completion(self, cmd_tree):
         """
-        Return a complete script for ZSH tab completion, suitable for use with the
+        Return a script for ZSH tab completion, suitable for use with the
         "source" command.
         """
         # This does not attempt to implement the full spec for _arguments or optspec.
@@ -257,8 +257,8 @@ compdef _onyo onyo
         Build and return a string containing the ZSH completion rule for an
         argument.
 
-        NOTE: Standalone arguments should be one line each. Arguments to a flag
-        (aka option) should be concatenated.
+        NOTE: As per the spec, standalone arguments are one per line, whereas
+        arguments to a flag are concatenated on a single line.
 
         NOTE: Omitted support:
         - :::
@@ -293,8 +293,8 @@ compdef _onyo onyo
 
     def _zsh_build_flag(self, flag, flag_tree):
         """
-        Build and return a string containing the ZSH completion rule for a flag (aka
-        option).
+        Build and return a string containing the ZSH completion rule for a flag
+        and its arguments.
 
         NOTE: Omitted support:
         - Exclusion
@@ -363,7 +363,7 @@ compdef _onyo onyo
     def _zsh_build_subcommands(self, cmd_tree):
         """
         Return a string (for use in a ZSH list) containing subcommands and their
-        help text in the format of
+        help text in the format of:
             'subcommand1:help text'
             'subcommand2:help text'
             '...'

--- a/onyo/commands/shell_completion.py
+++ b/onyo/commands/shell_completion.py
@@ -4,160 +4,160 @@ import argparse
 from onyo.utils import parse_args
 
 
-def build_arg_dict(sp):
-    """
-    Return a dict populated with all the fields for an argument.
-    """
-    arg = {
-        "choices": sp.choices,
-        "help": sp.help,
-        "nargs": get_nargs(sp),
-        "required": get_arg_required(sp),
-        "type": get_type(sp)
-    }
-    return arg
+class Zsh:
+    def __init__(self, parser):
+        self.cmd_tree = self._argparse_to_dict(parser)
 
+    def _argparse_to_dict(self, parser):
+        """Convert an ArgumentParser object to a dict-tree.
+        ArgumentParser was clearly not intended to allow the information registered
+        in it to be queried by anything other than itself. Extracting information is
+        possible, just awkward.
 
-def get_nargs(sp):
-    """Return an nargs string.
-    This returns the nargs string in nargs format. The problem is that argparse
-    often does not require that nargs is set, and assumes a value (1) for the
-    unset field.
+        This function returns a dict-tree, that is intended to be consistent and
+        thus easier to traverse.
 
-    See Python's argparse docs for more information:
-    https://docs.python.org/3/library/argparse.html#nargs
-    """
-    if sp.nargs is None:
-        return 1
+        NOTE: This function uses private ArgumentParser variables and functions.
+              They may change without notice.
 
-    return sp.nargs
-
-
-def get_arg_required(sp):
-    """
-    Return whether an argument is required.
-    """
-    # ? means 0 or 1 arguments
-    # * means 0 or more arguments
-    # + means 1 or more arguments
-    # N means N arguments
-    if sp.nargs in ['?', '*']:
-        return False
-    else:
-        return True
-
-
-def get_type(sp):
-    """
-    Return the stringified name of an argument's type.
-    """
-    if sp.type is None:
-        return None
-    else:
-        try:
-            return sp.type.__name__
-        except AttributeError:
-            # an instance of an object
-            return sp.type.__class__.__name__
-
-
-def argparse_to_dict(parser):
-    """Convert an ArgumentParser object to a dict-tree.
-    ArgumentParser was clearly not intended to allow the information registered
-    in it to be queried by anything other than itself. Extracting information is
-    possible, just awkward.
-
-    This function returns a dict-tree, that is intended to be consistent and
-    thus easier to traverse.
-
-    NOTE: This function uses private ArgumentParser variables and functions.
-          They may change without notice.
-
-    Example output:
-    {
-      "flags": {
-        "-I,--igloo": {
-          "help": "not terribly helpful"
-          "required": false,
-        },
-      },
-      "subcmds": {
-        "mv": {
-          "help": "not terribly helpful",
+        Example output:
+        {
           "flags": {
             "-I,--igloo": {
-              "help": "not terribly helpful",
+              "help": "not terribly helpful"
               "required": false,
+            },
+          },
+          "subcmds": {
+            "mv": {
+              "help": "not terribly helpful",
+              "flags": {
+                "-I,--igloo": {
+                  "help": "not terribly helpful",
+                  "required": false,
+                  "args": {
+                    "shape": {
+                      "nargs": *,
+                      "type": 'directory',
+                      "choices": []
+                    }
+                  }
+                },
+                { ...}
+              }
               "args": {
                 "shape": {
-                  "nargs": *,
-                  "type": 'directory',
-                  "choices": []
-                }
-              }
+                  "nargs": 1,
+                  "choices": ['circle', 'square']
             },
-            { ...}
+            {...}
           }
-          "args": {
-            "shape": {
-              "nargs": 1,
-              "choices": ['circle', 'square']
-        },
-        {...}
-      }
-    }
-    """
-    cmd_tree = {
-        'args': {},
-        'flags': {},
-        'subcmds': {}
-    }
+        }
+        """
+        cmd_tree = {
+            'args': {},
+            'flags': {},
+            'subcmds': {}
+        }
 
-    for sp in parser._actions:
-        if isinstance(sp, argparse._SubParsersAction):  # a group of subcommands
-            # _name_parser_map is the only place that the subcommand objects are
-            # available. BUT, it does not contain the help text.
+        for sp in parser._actions:
+            if isinstance(sp, argparse._SubParsersAction):  # a group of subcommands
+                # _name_parser_map is the only place that the subcommand objects are
+                # available. BUT, it does not contain the help text.
 
-            # loop over _name_parser_map to operate on the child flags
-            for subcmd, subcmd_parser in sp._name_parser_map.items():
-                cmd_tree['subcmds'][subcmd] = argparse_to_dict(subcmd_parser)
+                # loop over _name_parser_map to operate on the child flags
+                for subcmd, subcmd_parser in sp._name_parser_map.items():
+                    cmd_tree['subcmds'][subcmd] = self._argparse_to_dict(subcmd_parser)
 
-            # loop over _choices_actions to extract the help text
-            for ca in sp._choices_actions:
-                cmd_tree['subcmds'][ca.metavar]['help'] = ca.help
-        elif sp.option_strings:  # option flag
-            flag_string = ','.join(sp.option_strings)
-            cmd_tree['flags'][flag_string] = {
-                "help": sp.help,
-                "required": sp.required
-            }
+                # loop over _choices_actions to extract the help text
+                for ca in sp._choices_actions:
+                    cmd_tree['subcmds'][ca.metavar]['help'] = ca.help
+            elif sp.option_strings:  # option flag
+                flag_string = ','.join(sp.option_strings)
+                cmd_tree['flags'][flag_string] = {
+                    "help": sp.help,
+                    "required": sp.required
+                }
 
-            # arguments for a flag
-            cmd_tree['flags'][flag_string]['args'] = {}
+                # arguments for a flag
+                cmd_tree['flags'][flag_string]['args'] = {}
 
-            # TODO: handle non-int nargs
-            # TODO: handle >1 nargs
-            if sp.nargs is None or sp.nargs > 0:
-                cmd_tree['flags'][flag_string]['args'][sp.metavar] = build_arg_dict(sp)
-        else:  # argument
-            cmd_tree['args'][sp.metavar] = build_arg_dict(sp)
+                # TODO: handle non-int nargs
+                # TODO: handle >1 nargs
+                if sp.nargs is None or sp.nargs > 0:
+                    cmd_tree['flags'][flag_string]['args'][sp.metavar] = self._build_arg_dict(sp)
+            else:  # argument
+                cmd_tree['args'][sp.metavar] = self._build_arg_dict(sp)
 
-    return cmd_tree
+        return cmd_tree
+
+    def _build_arg_dict(self, sp):
+        """
+        Return a dict populated with all the fields for an argument.
+        """
+        arg = {
+            "choices": sp.choices,
+            "help": sp.help,
+            "nargs": self.get_nargs(sp),
+            "required": self.get_arg_required(sp),
+            "type": self.get_type(sp)
+        }
+        return arg
+
+    def get_nargs(self, sp):
+        """Return an nargs string.
+        This returns the nargs string in nargs format. The problem is that argparse
+        often does not require that nargs is set, and assumes a value (1) for the
+        unset field.
+
+        See Python's argparse docs for more information:
+        https://docs.python.org/3/library/argparse.html#nargs
+        """
+        if sp.nargs is None:
+            return 1
+
+        return sp.nargs
+
+    def get_arg_required(self, sp):
+        """
+        Return whether an argument is required.
+        """
+        # ? means 0 or 1 arguments
+        # * means 0 or more arguments
+        # + means 1 or more arguments
+        # N means N arguments
+        if sp.nargs in ['?', '*']:
+            return False
+        else:
+            return True
+
+    def get_type(self, sp):
+        """
+        Return the stringified name of an argument's type.
+        """
+        if sp.type is None:
+            return None
+        else:
+            try:
+                return sp.type.__name__
+            except AttributeError:
+                # an instance of an object
+                return sp.type.__class__.__name__
 
 
-def zsh_completion(cmd_tree):
-    """
-    Return a complete script for ZSH tab completion, suitable for use with the
-    "source" command.
-    """
-    # This does not attempt to implement the full spec for _arguments or optspec.
-    # It should, however, cover a significant enough portion as to be useful.
+    def zsh_completion(self):
+        """
+        Return a complete script for ZSH tab completion, suitable for use with the
+        "source" command.
+        """
+        # This does not attempt to implement the full spec for _arguments or optspec.
+        # It should, however, cover a significant enough portion as to be useful.
+        cmd_tree = self.cmd_tree
+        toplevel_flags = self._zsh_build_args_and_flags(cmd_tree)
+        subcommands = self._zsh_build_subcommands(cmd_tree)
+        subcommands_case_statement = self._zsh_build_subcommands_case_statement(cmd_tree)
 
-    toplevel_flags = zsh_command_args_and_flags(cmd_tree)
-    subcommands = zsh_subcommands(cmd_tree)
-    subcommands_case_statement = zsh_subcommands_case_statement(cmd_tree)
-
-    content = f"""\
+        content = f"""\
 #compdef onyo
 
 #
@@ -215,170 +215,165 @@ compdef _onyo onyo
 #    source <(onyo shell-completion)
 #
 """
-    return content
+        return content
 
+    def _zsh_build_args_and_flags(self, cmd_tree, padding=0):
+        """
+        Return a string (for use in a ZSH list) containing rules for flags (with
+        their arguments) and standalone arguments.
+        Format information can be found in _zsh_build_arg() and _zsh_build_flag().
+        """
+        output = ''
 
-def zsh_build_arg(arg, arg_tree):
-    """
-    Build and return a string containing the ZSH completion rule for an
-    argument.
+        for flag, flag_tree in cmd_tree['flags'].items():
+            output += (' ' * padding) + self._zsh_build_flag(flag, flag_tree) + '\n'
 
-    NOTE: Standalone arguments should be one line each. Arguments to a flag
-    (aka option) should be concatenated.
+        for arg, arg_tree in cmd_tree['args'].items():
+            output += (' ' * padding) + "'" + self._zsh_build_arg(arg, arg_tree) + "'\n"
 
-    NOTE: Omitted support:
-    - :::
-    """
-    output = ''
-    type_to_action = {
-        'directory': '_path_files -/',
-        'file': '_files',
-        'path': '_files',
-    }
+        return output
 
-    # can an unbound number of arguments can be accepted.
-    if arg_tree['nargs'] in ['*', '+']:  # '*' >= 0 ; '+' >= 1
-        output += '*'
+    def _zsh_build_arg(self, arg, arg_tree):
+        """
+        Build and return a string containing the ZSH completion rule for an
+        argument.
 
-    # required vs optional
-    if arg_tree['required']:
-        output += ':'
-    else:
-        output += '::'
+        NOTE: Standalone arguments should be one line each. Arguments to a flag
+        (aka option) should be concatenated.
 
-    if arg_tree['choices']:  # a list of choices
-        output += "{}:({})".format(arg, ' '.join(arg_tree['choices']))
-    elif arg_tree['type'] in type_to_action:  # known action for this type
-        output += "{}:{}".format(arg, type_to_action[arg_tree['type']])
-    else:  # unknown
-        # A single unquoted space indicates that an argument is required,
-        # but that it is not possible to suggest matches for it.
-        output += "{}:{}".format(arg, ' ')
+        NOTE: Omitted support:
+        - :::
+        """
+        output = ''
+        type_to_action = {
+            'directory': '_path_files -/',
+            'file': '_files',
+            'path': '_files',
+        }
 
-    return output
+        # can an unbound number of arguments can be accepted.
+        if arg_tree['nargs'] in ['*', '+']:  # '*' >= 0 ; '+' >= 1
+            output += '*'
 
-
-def zsh_build_flag(flag, flag_tree):
-    """
-    Build and return a string containing the ZSH completion rule for a flag (aka
-    option).
-
-    NOTE: Omitted support:
-    - Exclusion
-    """
-    output = ''
-    chunks = {
-        "exclude": '',
-        "flag": '',
-        "help": '',
-        "action": ''
-    }
-
-    #
-    # build exclude
-    #
-    # e.g.: '(- : *)'{{-h,--help}}'[display usage information]'
-    # TODO
-
-    #
-    # build flag
-    #
-    if ',' in flag:  # multiple (i.e. short and long form)
-        chunks['flag'] = "{" + flag + "}"
-    else:  # one
-        chunks['flag'] = flag
-
-    #
-    # build help
-    #
-    chunks['help'] = "[" + flag_tree['help'] + "]"
-
-    #
-    # build arg/actions
-    #
-    for arg, arg_tree in flag_tree['args'].items():
-        chunks['action'] += zsh_build_arg(arg, arg_tree)
-
-    # ZSH's _argument optspec format covers:
-    #   - exclusion (pattern which should disallow matching)
-    #   - the flag/arg itself
-    #   - help text
-    #   - arguments to the flag
-    #   - a list of choices (or an action that will return a list) for arg completion
-    # This is in the format:
-    #     '(-e --exclude)--flag[help text]:arg:_files'
-    # However, when there are short and long forms, it is idiomatic to use shell
-    # expansion. Note the location of the single quotes:
-    #     '(-e --exclude)'{-f,--flag}'[help text]:arg:_files
-    # This makes it a bit more awkward to format the output than one would
-    # normally assume.
-    # The format is explained in more detail here:
-    #     https://zsh.sourceforge.io/Doc/Release/Completion-System.html#Completion-Functions
-    if ',' in chunks['flag']:  # multiple flags (i.e. short and long form)
-        if chunks['exclude']:
-            # '(-e --exclude)'{-f,--flag}'[help text]:arg:_files
-            output = "'" + chunks['exclude'] + "'" + chunks['flag'] + "'" + chunks['help'] + chunks['action'] + "'"
+        # required vs optional
+        if arg_tree['required']:
+            output += ':'
         else:
-            # {-f,--flag}'[help text]:arg:_files'
-            output = chunks['flag'] + "'" + chunks['help'] + chunks['action'] + "'"
-    else:  # one flag
-        # '(-e --exclude)--flag[help text]:arg:_files'
-        output = "'" + chunks['exclude'] + chunks['flag'] + chunks['help'] + chunks['action'] + "'"
+            output += '::'
 
-    return output
+        if arg_tree['choices']:  # a list of choices
+            output += "{}:({})".format(arg, ' '.join(arg_tree['choices']))
+        elif arg_tree['type'] in type_to_action:  # known action for this type
+            output += "{}:{}".format(arg, type_to_action[arg_tree['type']])
+        else:  # unknown
+            # A single unquoted space indicates that an argument is required,
+            # but that it is not possible to suggest matches for it.
+            output += "{}:{}".format(arg, ' ')
 
+        return output
 
-def zsh_subcommands(cmd_tree):
-    """
-    Return a string (for use in a ZSH list) containing subcommands and their
-    help text in the format of
-        'subcommand1:help text'
-        'subcommand2:help text'
-        '...'
-    """
-    subcmd_list = ["'{}:{}'".format(subcmd, subcmd_tree['help'])
-                   for subcmd, subcmd_tree in cmd_tree['subcmds'].items()]
+    def _zsh_build_flag(self, flag, flag_tree):
+        """
+        Build and return a string containing the ZSH completion rule for a flag (aka
+        option).
 
-    return "\n".join(subcmd_list)
+        NOTE: Omitted support:
+        - Exclusion
+        """
+        output = ''
+        chunks = {
+            "exclude": '',
+            "flag": '',
+            "help": '',
+            "action": ''
+        }
 
+        #
+        # build exclude
+        #
+        # e.g.: '(- : *)'{{-h,--help}}'[display usage information]'
+        # TODO
 
-def zsh_command_args_and_flags(cmd_tree, padding=0):
-    """
-    Return a string (for use in a ZSH list) containing rules for flags (with
-    their arguments) and standalone arguments.
-    Format information can be found in zsh_build_arg() and zsh_build_flag().
-    """
-    output = ''
+        #
+        # build flag
+        #
+        if ',' in flag:  # multiple (i.e. short and long form)
+            chunks['flag'] = "{" + flag + "}"
+        else:  # one
+            chunks['flag'] = flag
 
-    for flag, flag_tree in cmd_tree['flags'].items():
-        output += (' ' * padding) + zsh_build_flag(flag, flag_tree) + '\n'
+        #
+        # build help
+        #
+        chunks['help'] = "[" + flag_tree['help'] + "]"
 
-    for arg, arg_tree in cmd_tree['args'].items():
-        output += (' ' * padding) + "'" + zsh_build_arg(arg, arg_tree) + "'\n"
+        #
+        # build arg/actions
+        #
+        for arg, arg_tree in flag_tree['args'].items():
+            chunks['action'] += self._zsh_build_arg(arg, arg_tree)
 
-    return output
+        # ZSH's _argument optspec format covers:
+        #   - exclusion (pattern which should disallow matching)
+        #   - the flag/arg itself
+        #   - help text
+        #   - arguments to the flag
+        #   - a list of choices (or an action that will return a list) for arg completion
+        # This is in the format:
+        #     '(-e --exclude)--flag[help text]:arg:_files'
+        # However, when there are short and long forms, it is idiomatic to use shell
+        # expansion. Note the location of the single quotes:
+        #     '(-e --exclude)'{-f,--flag}'[help text]:arg:_files
+        # This makes it a bit more awkward to format the output than one would
+        # normally assume.
+        # The format is explained in more detail here:
+        #     https://zsh.sourceforge.io/Doc/Release/Completion-System.html#Completion-Functions
+        if ',' in chunks['flag']:  # multiple flags (i.e. short and long form)
+            if chunks['exclude']:
+                # '(-e --exclude)'{-f,--flag}'[help text]:arg:_files
+                output = "'" + chunks['exclude'] + "'" + chunks['flag'] + "'" + chunks['help'] + chunks['action'] + "'"
+            else:
+                # {-f,--flag}'[help text]:arg:_files'
+                output = chunks['flag'] + "'" + chunks['help'] + chunks['action'] + "'"
+        else:  # one flag
+            # '(-e --exclude)--flag[help text]:arg:_files'
+            output = "'" + chunks['exclude'] + chunks['flag'] + chunks['help'] + chunks['action'] + "'"
 
+        return output
 
-def zsh_subcommands_case_statement(cmd_tree):
-    """
-    Return a ZSH case statement for subcommands. Within each is defined the
-    flags and args for the appropriate command.
+    def _zsh_build_subcommands(self, cmd_tree):
+        """
+        Return a string (for use in a ZSH list) containing subcommands and their
+        help text in the format of
+            'subcommand1:help text'
+            'subcommand2:help text'
+            '...'
+        """
+        subcmd_list = ["'{}:{}'".format(subcmd, subcmd_tree['help'])
+                       for subcmd, subcmd_tree in cmd_tree['subcmds'].items()]
 
-    This case statement is entered through the use of an action state
-    (i.e. ->string) of an option. Specifically '*::options:->options'
-    """
-    case = ''
+        return "\n".join(subcmd_list)
 
-    for subcmd, subcmd_tree in cmd_tree['subcmds'].items():
-        case += f"{subcmd})\n"
-        case += '    args+=(\n'
+    def _zsh_build_subcommands_case_statement(self, cmd_tree):
+        """
+        Return a ZSH case statement for subcommands. Within each is defined the
+        flags and args for the appropriate command.
 
-        case += zsh_command_args_and_flags(subcmd_tree, padding=8)
+        This case statement is entered through the use of an action state
+        (i.e. ->string) of an option. Specifically '*::options:->options'
+        """
+        case = ''
 
-        case += "    )\n"
-        case += "    ;;\n"
+        for subcmd, subcmd_tree in cmd_tree['subcmds'].items():
+            case += f"{subcmd})\n"
+            case += '    args+=(\n'
 
-    return case
+            case += self._zsh_build_args_and_flags(subcmd_tree, padding=8)
+
+            case += "    )\n"
+            case += "    ;;\n"
+
+        return case
 
 
 def shell_completion(args, onyo_root):
@@ -393,10 +388,10 @@ def shell_completion(args, onyo_root):
         $ onyo --<PRESS TAB to display available options>
     """
     parser = parse_args()
-    cmd_tree = argparse_to_dict(parser)
 
     if args.shell == 'zsh':
-        content = zsh_completion(cmd_tree)
+        tc = Zsh(parser)
+        content = tc.zsh_completion()
     else:
         content = ''
 

--- a/onyo/commands/shell_completion.py
+++ b/onyo/commands/shell_completion.py
@@ -26,18 +26,27 @@ class TabCompletion:
             type_to_action_map = {
                 'directory': '_path_files -/',
                 'file': '_files',
-                'path': '_files'
+                'path': '_files',
+                'template': '_path_files -W $(_template_dir) -g "*(.)"'
             }
+    epilogue : string, optional
+        A string to include at the end of the shell completion script. This is
+        useful when including a custom function to be invoked as an action for a
+        custom type (see type_to_action_map).
+
+        Example:
+            epilogue = '_template_dir() { printf "/a/template/directory" }'
 
     Properties
     ----------
     completion_script
         Returns the completion script.
     """
-    def __init__(self, parser, *, type_to_action_map={}):
+    def __init__(self, parser, *, type_to_action_map={}, epilogue=''):
         self._cmd_tree = self._argparse_to_dict(parser)
         self._type_to_action_map = type_to_action_map
         self._completion_script = None
+        self._epilogue = epilogue
 
     @property
     def completion_script(self):
@@ -238,6 +247,8 @@ _onyo() {{
           _arguments -s -S $args && ret=0
     ;;
   esac
+
+  {self._epilogue}
 
   return ret
 }}

--- a/onyo/commands/shell_completion.py
+++ b/onyo/commands/shell_completion.py
@@ -439,26 +439,29 @@ def shell_completion(args, onyo_root):
 
     if args.shell == 'zsh':
         type_to_action_map = {
-            'directory': '_path_files -/',
-            'file': '_files',
-            'path': '_files',
+            'directory': '_path_files -W $(_onyo_dir) -/',
+            'file': '_files -W $(_onyo_dir)',
+            'path': '_files -W $(_onyo_dir)',
             'template': '_path_files -W $(_template_dir) -g "*(.)"'
         }
         epilogue = """
-        _template_dir() {
+        _onyo_dir() {
           LINE=$BUFFER
-          DIR=$PWD
 
           # -C or --onyopath is used
           [ -z "${LINE%%* -C *}" ] && BACK=${LINE#* -C }
           [ -z "${LINE%%* --onyopath *}" ] && BACK=${LINE#* --onyopath }
           if [ -n "$BACK" ]; then
-              REPO=${BACK%% *}
-              printf "${REPO}/.onyo/templates"
-              return
+            REPO=${BACK%% *}
+            printf "$REPO"
+          else
+            printf "$PWD"
           fi
+        }
 
-          # CWD
+        _template_dir() {
+          DIR=$(_onyo_dir)
+
           while [ "$DIR" != '/' ]; do
             TEMPLATE_DIR="${DIR}/.onyo/templates"
             if [ -d "$TEMPLATE_DIR" ] ; then

--- a/onyo/commands/shell_completion.py
+++ b/onyo/commands/shell_completion.py
@@ -118,11 +118,11 @@ class TabCompletion:
 
                 # loop over _choices_actions to extract the help text
                 for ca in sp._choices_actions:
-                    cmd_tree['subcmds'][ca.metavar]['help'] = ca.help
+                    cmd_tree['subcmds'][ca.metavar]['help'] = ca.help.replace("'", "'\\''")
             elif sp.option_strings:  # option flag
                 flag_string = ','.join(sp.option_strings)
                 cmd_tree['flags'][flag_string] = {
-                    "help": sp.help,
+                    "help": sp.help.replace("'", "'\\''"),
                     "required": sp.required
                 }
 
@@ -144,7 +144,7 @@ class TabCompletion:
         """
         arg = {
             "choices": sp.choices,
-            "help": sp.help,
+            "help": sp.help.replace("'", "'\\''"),
             "nargs": self._get_nargs(sp),
             "required": self._get_arg_required(sp),
             "type": self._get_type(sp)

--- a/onyo/utils.py
+++ b/onyo/utils.py
@@ -280,7 +280,7 @@ def parse_args():
         '--version',
         action='version',
         version='%(prog)s {version}'.format(version=__version__),
-        help='print the onyo version and exit'
+        help="print onyo's version and exit"
     )
     # subcommands
     subcmds = parser.add_subparsers(

--- a/onyo/utils.py
+++ b/onyo/utils.py
@@ -247,6 +247,13 @@ def path(string):
     return string
 
 
+def template(string):
+    """
+    A no-op type-check for ArgParse. Used to hint for shell tab-completion.
+    """
+    return string
+
+
 def parse_args():
     parser = argparse.ArgumentParser(
         description='A text-based inventory system backed by git.',
@@ -472,7 +479,8 @@ def parse_args():
         '-t', '--template',
         metavar='TEMPLATE',
         required=False,
-        default='',
+        default=None,
+        type=template,
         help='the template to seed the new asset'
     )
     cmd_new.add_argument(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,4 +9,7 @@ def clean_sandbox(request):
     previous runs.
     """
     sandbox_dir = 'tests/sandbox/'
-    shutil.rmtree(sandbox_dir)
+    try:
+        shutil.rmtree(sandbox_dir)
+    except FileNotFoundError:
+        pass


### PR DESCRIPTION
Reorganize the code for `shell-completion` for readability and consistency. It also lays down the groundwork to add support for other shells (see #155).