### PR TITLE
RF: `config`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,6 @@ jobs:
     - name: Test with pytest and collect coverage
       run: |
         export REPO_ROOT=$PWD
-        export COVERAGE_PROCESS_START=${REPO_ROOT}/.coveragerc
         pytest -vv --cov
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ pytest -vv
 
 Generating code coverage reports requires some small gymnastics due to Onyo's tests running in different working directories.
 ```
-REPO_ROOT=$PWD COVERAGE_PROCESS_START=${REPO_ROOT}/.coveragerc pytest -vv --cov
+REPO_ROOT=$PWD pytest -vv --cov
 ```
 
 ### Documentation

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -1,0 +1,40 @@
+Configuration
+=============
+
+Onyo configuration options can be set locally using ``git config`` or tracked in
+the repository using ``onyo config``.
+
+* ``git config`` should be used for preferences of only local relevance, such as
+  ``onyo.core.editor``.
+
+* ``onyo config`` stores values in ``.onyo/config`` which is tracked in the
+  repository. These settings are shared with all consumers of an Onyo
+  repository, making it useful for configuration related to common workflows,
+  such as ``onyo.new.template``.
+
+Within the Onyo code, configuration options are read in the following order of
+precedence:
+
+#. git config (which follows git's own order of precedence: system, global, and
+   repository local configuration files)
+#. onyo config
+
+
+Options
+*******
+
+``onyo.core.editor``
+    The editor to use for commands such as ``edit`` and ``new``. If unset, it
+    will fallback to the environmental variable ``EDITOR`` and lastly ``nano``.
+    (default: unset)
+
+``onyo.history.interactive``
+    The command used to display history when running ``onyo history``. (default:
+    "tig --follow")
+
+``onyo.history.non-interactive``
+    The command used to print history when running ``onyo history`` with
+    ``--non-interactive``.  (default: "git --no-pager log --follow")
+
+``onyo.new.template``
+    The default template to use with ``onyo new``. (default: "standard")

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,6 +15,7 @@ Overview
    :maxdepth: 1
 
    installation
+   configuration
    concepts
    command_line_reference
    examples

--- a/onyo/__init__.py
+++ b/onyo/__init__.py
@@ -3,20 +3,6 @@ from pathlib import Path
 import logging
 from onyo._version import __version__
 
-# Load coverage to enable tracking sub-processes for code coverage.
-#
-# A simple example:
-# COVERAGE_PROCESS_START=.coveragerc pytest --cov -vv .
-#
-# Onyo's tests execute in different working directories, so a more complicated
-# invocation is required. See the README or CI config for the right method.
-#
-# For more information, see
-# https://coverage.readthedocs.io/en/latest/subprocess.html
-if 'COVERAGE_PROCESS_START' in os.environ:
-    import coverage
-    coverage.process_startup()
-
 
 class Configuration:
     def __init__(self):

--- a/onyo/commands/config.py
+++ b/onyo/commands/config.py
@@ -2,46 +2,101 @@
 
 import logging
 import os
-
-from onyo.utils import (
-    run_cmd,
-    get_git_root,
-    build_git_add_cmd
-)
+import subprocess
+import sys
+from git import Repo
 from onyo.commands.fsck import read_only_fsck
 
 logging.basicConfig()
 logger = logging.getLogger('onyo')
 
 
-def build_commit_cmd(command, onyo_root):
-    return ["git -C \"" + onyo_root + "\" commit -m", "update .onyo/config\n\n" + command]
+def sanitize_args(git_config_args):
+    """
+    Check the git config arguments against a list of conflicting options. If
+    conflicts are present, the conflict list will be printed and will exit with
+    error.
 
+    Returns the unmodified  git config args on success.
+    """
+    # git-config supports multiple layers of git configuration. Onyo uses
+    # ``--file`` to write to .onyo/config. Other options are excluded.
+    forbidden_flags = ['--system',
+                       '--global',
+                       '--local',
+                       '--worktree',
+                       '--file',
+                       '--blob',
+                       '--help',
+                       '-h',
+                       ]
 
-def build_command(key, onyo_root):
-    cmd_str = ""
-    for arg in key:
-        if " " in arg:
-            cmd_str += " \"" + arg + "\""
-        else:
-            cmd_str += " " + arg
-    return " ".join(["git config -f \"" + os.path.join(onyo_root, ".onyo/config") + "\"" + cmd_str])
+    for a in git_config_args:
+        if a in forbidden_flags:
+            logger.error("The following options cannot be used with onyo config:")
+            logger.error('\n'.join(forbidden_flags))
+            logger.error("\nExiting. Nothing was set.")
+            sys.exit(1)
+
+    return git_config_args
 
 
 def config(args, onyo_root):
     """
-    Set a ``variable`` to ``value`` in the ``.onyo/config`` file. This command
-    can for example change the default tool for the interactive mode of ``onyo
-    history`` with ``onyo config history.interactive "git log --follow"``.
-    """
+    Set, query, and unset Onyo repository configuration options. These options
+    are stored in ``.onyo/config`` (which is tracked by git) and are shared with
+    all other consumers of an Onyo repository.
 
-    # run onyo fsck
+    To set configuration options locally (and not commit them to the Onyo
+    repository), use ``git config`` instead.
+
+    ``onyo config`` is a wrapper around ``git config``. All of its options and
+    capabilities are available with the exception of ``--system``, ``--global``,
+    ``--local``, ``--worktree``, and ``--file``. Please see the git-config
+    manpage for more information about usage.
+
+    Onyo configuration options:
+
+    - ``onyo.core.editor``: The editor to use for commands such as ``edit`` and
+      ``new``. If unset, it will fallback to the environmental variable
+      ``EDITOR`` and lastly ``nano``. (default: unset)
+    - ``onyo.history.interactive``: The command used to display history when
+      running ``onyo history``. (default: "tig --follow")
+    - ``onyo.history.non-interactive``: The command used to print history when
+      running ``onyo history`` with ``--non-interactive``.
+      (default: "git --no-pager log --follow")
+    - ``onyo.new.template``: The default template to use with ``onyo new``.
+      (default: "standard")
+
+    Example:
+
+        $ onyo config onyo.core.editor "vim"
+    """
     read_only_fsck(args, onyo_root, quiet=True)
-    # build command
-    command = build_command(args.key, get_git_root(onyo_root))
-    git_add_cmd = build_git_add_cmd(get_git_root(onyo_root), ".onyo/config")
-    [commit_cmd, commit_msg] = build_commit_cmd(command, get_git_root(onyo_root))
-    # run command
-    run_cmd(command)
-    run_cmd(git_add_cmd)
-    run_cmd(commit_cmd, commit_msg)
+
+    git_config_args = sanitize_args(args.git_config_args)
+    repo = Repo(onyo_root)
+    # TODO: because onyo_root is not actually the root of the onyo repo
+    repo_root = repo.git.rev_parse('--show-toplevel')
+
+    # NOTE: streaming stdout and stderr directly to the terminal seems to be
+    # non-trivial with "subprocess". Here we capture them separately. They
+    # won't be interwoven, but will be output to the correct destinations.
+    ret = subprocess.run(["git", 'config', '-f', '.onyo/config'] + git_config_args,
+                         cwd=repo_root, capture_output=True, text=True)
+
+    # print any output gathered
+    if ret.stdout:
+        print(ret.stdout, end='')
+    if ret.stderr:
+        print(ret.stderr, file=sys.stderr, end='')
+
+    # bubble up error retval
+    if ret.returncode != 0:
+        exit(ret.returncode)
+
+    # commit, if there's anything to commit
+    if repo.is_dirty():
+        dot_onyo_config = os.path.join(repo_root, '.onyo/config')
+        repo.git.add(dot_onyo_config)
+        repo.git.commit(m='onyo config: modify shared repository config')

--- a/onyo/commands/edit.py
+++ b/onyo/commands/edit.py
@@ -51,17 +51,16 @@ def edit(args, onyo_root):
 
     When multiple asset files are given, Onyo will open them in sequence.
 
-    After editing an ``asset``, ``onyo`` will check the validity of the YAML
-    syntax and check if the changed file still follows the rules specified in
-    ``.onyo/validation/validation.yaml``, and if problems are found it gives the
-    choice to either correct them or discard the changes to make sure that the
-    repository stays in a valid state.
+    After editing an ``asset``, the contents will be checked for valid YAML and
+    also against any matching rules in ``.onyo/validation/validation.yaml``. If
+    problems are found, the choice will be offered to reopen the editor to fix
+    them, or abort and return to the original state.
     """
+    # "onyo fsck" is intentionally not run here.
+    # This is so "onyo edit" can be used to fix an existing problem. This has
+    # benefits over just simply using `vim`, etc directly, as "onyo edit" will
+    # validate the contents of the file before saving and committing.
 
-    # do not run onyo fsck! Onyo should allow to correct problems with onyo
-    # edit, and after editing onyo checks the syntax and validates the updated
-    # file anyways, so new problems can't be introduced, but old ones can be
-    # corrected.
     # check and set paths
     list_of_sources = prepare_arguments(args.asset, onyo_root)
     # iterate over file list, edit them, add changes

--- a/onyo/commands/edit.py
+++ b/onyo/commands/edit.py
@@ -45,9 +45,8 @@ def prepare_arguments(sources, onyo_root):
 
 def edit(args, onyo_root):
     """
-    Open the ``asset`` file(s) using the default text editor specified by the
-    environment variable ``EDITOR`` (``nano`` and then ``vi`` are used as
-    fallbacks).
+    Open the ``asset`` file(s) using the editor specified by "onyo.core.editor",
+    the environment variable ``EDITOR``, or ``nano`` (as a final fallback).
 
     When multiple asset files are given, Onyo will open them in sequence.
 

--- a/onyo/commands/history.py
+++ b/onyo/commands/history.py
@@ -23,11 +23,11 @@ def prepare_arguments(path, onyo_root):
     interactive_tool = ""
     non_interactive_tool = ""
     try:
-        interactive_tool = config['history']['interactive']
+        interactive_tool = config['onyo']['history']['interactive']
     except KeyError:
         pass
     try:
-        non_interactive_tool = config['history']['non-interactive']
+        non_interactive_tool = config['onyo']['history']['non-interactive']
     except KeyError:
         pass
     if not interactive_tool:

--- a/onyo/commands/history.py
+++ b/onyo/commands/history.py
@@ -3,11 +3,10 @@
 import logging
 import os
 import sys
-import configparser
 
 from onyo.utils import (
     run_cmd,
-    get_git_root
+    get_config_value
 )
 from onyo.commands.fsck import read_only_fsck
 
@@ -17,19 +16,11 @@ logger = logging.getLogger('onyo')
 
 def prepare_arguments(path, onyo_root):
     problem_str = ""
-    # find log/history tools:
-    config = configparser.ConfigParser()
-    config.read(os.path.join(get_git_root(onyo_root), ".onyo/config"))
-    interactive_tool = ""
-    non_interactive_tool = ""
-    try:
-        interactive_tool = config['onyo']['history']['interactive']
-    except KeyError:
-        pass
-    try:
-        non_interactive_tool = config['onyo']['history']['non-interactive']
-    except KeyError:
-        pass
+
+    # get log/history tools:
+    interactive_tool = get_config_value('onyo.history.interactive', onyo_root)
+    non_interactive_tool = get_config_value('onyo.history.non-interactive', onyo_root)
+
     if not interactive_tool:
         problem_str = problem_str + "\n" + "No interactive logging tool is set. Set with e.g:\n\tonyo config history.interactive \"tig --follow\""
     elif run_cmd("which " + interactive_tool.split()[0].rstrip("\n")) == "":

--- a/onyo/commands/new.py
+++ b/onyo/commands/new.py
@@ -3,12 +3,12 @@
 import logging
 import os
 import sys
-import configparser
 import uuid
 
 from onyo.utils import (
     build_git_add_cmd,
     run_cmd,
+    get_config_value,
     get_list_of_assets,
     get_git_root,
     edit_file
@@ -90,15 +90,11 @@ def create_asset_file_cmd(directory, filename):
 
 def prepare_arguments(directory, template, onyo_root):
     directory = os.path.join(onyo_root, directory)
-    # find the template to use:
-    config = configparser.ConfigParser()
-    config.read(os.path.join(get_git_root(onyo_root), ".onyo/config"))
     if not template:
-        try:
-            template = config['onyo']['new']['template']
-        except KeyError:
-            pass
+        template = get_config_value('onyo.new.template', onyo_root)
+
     template = os.path.join(get_git_root(onyo_root), os.path.join(".onyo/templates", template))
+
     problem_str = ""
     if not os.path.isfile(template):
         problem_str = problem_str + "\nTemplate file " + os.path.join(get_git_root(onyo_root), os.path.join(".onyo/templates", template)) + " does not exist."

--- a/onyo/commands/new.py
+++ b/onyo/commands/new.py
@@ -95,7 +95,7 @@ def prepare_arguments(directory, template, onyo_root):
     config.read(os.path.join(get_git_root(onyo_root), ".onyo/config"))
     if not template:
         try:
-            template = config['template']['default']
+            template = config['onyo']['new']['template']
         except KeyError:
             pass
     template = os.path.join(get_git_root(onyo_root), os.path.join(".onyo/templates", template))

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -13,6 +13,19 @@ logger.setLevel(logging.INFO)
 
 def main():
     parser = parse_args()
+
+    # NOTE: this unfortunately located hack is so "onyo config" args will pass
+    # through uninterpreted. Otherwise, anything starting with - or -- errors as
+    # an unknown option flag.
+    # nargs=argparse.REMAINDER is in theory the correct solution, but is
+    # deprecated as of Python 3.8 (due to being buggy) and did not work for me
+    # in 3.10.
+    # For more information, see https://docs.python.org/3.10/library/argparse.html#arguments-containing
+    if 'config' in sys.argv:
+        if not any(x in sys.argv for x in ['-h', '--help']):
+            index = sys.argv.index('config')
+            sys.argv.insert(index + 1, '--')
+
     args = parser.parse_args()
 
     if args.onyopath:

--- a/onyo/skel/config
+++ b/onyo/skel/config
@@ -1,5 +1,5 @@
-[history]
+[onyo "history"]
 	interactive = tig --follow
 	non-interactive = git --no-pager log --follow
-[template]
-	default = standard
+[onyo "new"]
+	template = standard

--- a/onyo/utils.py
+++ b/onyo/utils.py
@@ -311,14 +311,14 @@ def parse_args():
         'config',
         description=textwrap.dedent(commands.config.__doc__),
         formatter_class=SubcommandHelpFormatter,
-        help='set onyo options in the repository'
+        help='set, query, and unset Onyo repository configuration options'
     )
     cmd_config.set_defaults(run=commands.config)
     cmd_config.add_argument(
-        'key',
-        metavar='KEY',
-        nargs=argparse.REMAINDER,
-        help='configuration key to set in .onyo/config'
+        'git_config_args',
+        metavar='ARGS',
+        nargs='+',
+        help='arguments to set config options in .onyo/config'
     )
     #
     # subcommand "edit"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,3 +13,21 @@ def clean_sandbox(request):
         shutil.rmtree(sandbox_dir)
     except FileNotFoundError:
         pass
+
+
+@pytest.fixture
+def helpers():
+    return Helpers
+
+
+class Helpers:
+    @staticmethod
+    def string_in_file(string, file):
+        """
+        Test whether a string is in a file.
+        """
+        with open(file) as f:
+            if string in f.read():
+                return True
+
+        return False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,17 @@
+import os
 import shutil
 import pytest
+
+
+@pytest.fixture(scope="function", autouse=True)
+def clean_editor(request):
+    """
+    Ensure that $EDITOR is not inherited from the environment or other tests.
+    """
+    try:
+        del os.environ['EDITOR']
+    except KeyError:
+        pass
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,137 @@
+import os
+import subprocess
+from pathlib import Path
+import pytest
+
+
+@pytest.fixture(scope="function", autouse=True)
+def change_test_dir(request, monkeypatch):
+    test_dir = os.path.join(request.fspath.dirname, "sandbox/", "test_config/")
+    Path(test_dir).mkdir(parents=True, exist_ok=True)
+    monkeypatch.chdir(test_dir)
+
+
+def test_onyo_init():
+    ret = subprocess.run(["onyo", "init"])
+    assert ret.returncode == 0
+
+
+def test_config_set(helpers):
+    ret = subprocess.run(["onyo", "config", "onyo.test.set", "set-test"],
+                         capture_output=True, text=True)
+    assert ret.returncode == 0
+    assert not ret.stdout
+    assert not ret.stderr
+    assert helpers.string_in_file('set =', '.onyo/config')
+    assert helpers.string_in_file('= set-test', '.onyo/config')
+
+
+def test_config_get_onyo(helpers):
+    # set
+    ret = subprocess.run(["onyo", "config", "onyo.test.get-onyo", "get-onyo-test"],
+                         capture_output=True, text=True)
+    assert ret.returncode == 0
+    assert helpers.string_in_file('get-onyo =', '.onyo/config')
+    assert helpers.string_in_file('= get-onyo-test', '.onyo/config')
+
+    # get
+    ret = subprocess.run(["onyo", "config", "--get", "onyo.test.get-onyo"],
+                         capture_output=True, text=True)
+    assert ret.returncode == 0
+    assert ret.stdout == 'get-onyo-test\n'
+    assert not ret.stderr
+
+
+# onyo should not alter git config's output (newline, etc)
+def test_config_get_pristine(helpers):
+    ret = subprocess.run(["onyo", "config", "onyo.test.get-pristine", "get-pristine-test"],
+                         capture_output=True, text=True)
+    assert ret.returncode == 0
+    assert helpers.string_in_file('get-pristine =', '.onyo/config')
+    assert helpers.string_in_file('= get-pristine-test', '.onyo/config')
+
+    # git config's output
+    ret = subprocess.run(["git", "config", "-f", ".onyo/config", "onyo.test.get-pristine"],
+                         capture_output=True, text=True)
+    assert ret.returncode == 0
+    assert ret.stdout == 'get-pristine-test\n'
+    git_config_output = ret.stdout
+
+    # onyo config's output
+    ret = subprocess.run(["onyo", "config", "--get", "onyo.test.get-pristine"],
+                         capture_output=True, text=True)
+    assert ret.returncode == 0
+    assert ret.stdout == 'get-pristine-test\n'
+
+    assert ret.stdout == git_config_output
+
+
+def test_config_get_empty(helpers):
+    assert not helpers.string_in_file('onyo.test.not-exist', '.onyo/config')
+
+    ret = subprocess.run(["onyo", "config", "--get", "onyo.test.not-exist"],
+                         capture_output=True, text=True)
+    assert ret.returncode == 1
+    assert not ret.stdout
+    assert not ret.stderr
+
+
+def test_config_unset(helpers):
+    # set
+    ret = subprocess.run(["onyo", "config", "onyo.test.unset", "unset-test"],
+                         capture_output=True, text=True)
+    assert ret.returncode == 0
+    assert helpers.string_in_file('unset =', '.onyo/config')
+    assert helpers.string_in_file('= unset-test', '.onyo/config')
+
+    # unset
+    ret = subprocess.run(["onyo", "config", "--unset", "onyo.test.unset"],
+                         capture_output=True, text=True)
+    assert ret.returncode == 0
+    assert not ret.stdout
+    assert not ret.stderr
+    assert not helpers.string_in_file('unset =', '.onyo/config')
+    assert not helpers.string_in_file('= unset-test', '.onyo/config')
+
+    # get
+    ret = subprocess.run(["onyo", "config", "--get", "onyo.test.unset"],
+                         capture_output=True, text=True)
+    assert ret.returncode == 1
+    assert not ret.stdout
+    assert not ret.stderr
+
+
+def test_config_help():
+    """
+    `onyo config --help` is shown and not `git config --help`.
+    """
+    for flag in ['-h', '--help']:
+        ret = subprocess.run(["onyo", "config", flag],
+                             capture_output=True, text=True)
+        assert ret.returncode == 0
+        assert 'onyo' in ret.stdout
+        assert not ret.stderr
+
+
+def test_config_bubble_retcode(helpers):
+    """
+    Bubble up git-config's retcodes.
+    According to the git config manpage, attempting to unset an option which
+    does not exist exits with "5".
+    """
+    assert not helpers.string_in_file('onyo.test.not-exist', '.onyo/config')
+
+    ret = subprocess.run(["onyo", "config", "--unset", "onyo.test.not-exist"],
+                         capture_output=True, text=True)
+    assert ret.returncode == 5
+
+
+def test_config_bubble_stderr():
+    """
+    Bubble up git-config printing to stderr.
+    """
+    ret = subprocess.run(["onyo", "config", "--invalid-flag-oopsies", "such-an-oops"],
+                         capture_output=True, text=True)
+    assert ret.returncode == 129
+    assert not ret.stdout
+    assert ret.stderr

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -41,3 +41,104 @@ def test_get_config_value_onyo(helpers):
     onyo_root = './'
     value = utils.get_config_value('onyo.test.get-onyo', onyo_root)
     assert value == 'get-onyo-test'
+
+
+def test_get_editor_git():
+    """
+    Get the editor from git settings.
+    """
+    # set the editor
+    ret = subprocess.run(["git", "config", "onyo.core.editor", 'vi'],
+                         capture_output=True, text=True)
+    assert ret.returncode == 0
+
+    onyo_root = './'
+    assert utils.get_editor(onyo_root) == 'vi'
+
+    # cleanup
+    ret = subprocess.run(["git", "config", "--unset", "onyo.core.editor"],
+                         capture_output=True, text=True)
+    assert ret.returncode == 0
+
+
+def test_get_editor_onyo():
+    """
+    Get the editor from onyo settings.
+    """
+    # set the editor
+    ret = subprocess.run(["onyo", "config", "onyo.core.editor", 'vi'],
+                         capture_output=True, text=True)
+    assert ret.returncode == 0
+
+    onyo_root = './'
+    assert utils.get_editor(onyo_root) == 'vi'
+
+    # cleanup
+    ret = subprocess.run(["onyo", "config", "--unset", "onyo.core.editor"],
+                         capture_output=True, text=True)
+    assert ret.returncode == 0
+
+
+def test_get_config_value_envvar(helpers):
+    """
+    Get the editor from $EDITOR.
+    """
+    # verify that onyo.core.editor is not set
+    ret = subprocess.run(["git", "config", "--get", "onyo.core.editor"],
+                         capture_output=True, text=True)
+    assert not ret.stdout
+    ret = subprocess.run(["onyo", "config", "--get", "onyo.core.editor"],
+                         capture_output=True, text=True)
+    assert not ret.stdout
+
+    os.environ['EDITOR'] = 'vi'
+    onyo_root = './'
+    assert utils.get_editor(onyo_root) == 'vi'
+
+
+def test_get_editor_fallback():
+    """
+    When no editor is set, nano should be the fallback.
+    """
+    # verify that onyo.core.editor is not set
+    ret = subprocess.run(["git", "config", "--get", "onyo.core.editor"],
+                         capture_output=True, text=True)
+    assert not ret.stdout
+    ret = subprocess.run(["onyo", "config", "--get", "onyo.core.editor"],
+                         capture_output=True, text=True)
+    assert not ret.stdout
+
+    onyo_root = './'
+    assert utils.get_editor(onyo_root) == 'nano'
+
+
+def test_get_editor_precedence():
+    """
+    The order of precedence should be git > onyo > $EDITOR.
+    """
+    # set for git
+    ret = subprocess.run(["git", "config", "onyo.core.editor", 'first'],
+                         capture_output=True, text=True)
+    assert ret.returncode == 0
+    # set for onyo
+    ret = subprocess.run(["onyo", "config", "onyo.core.editor", 'second'],
+                         capture_output=True, text=True)
+    assert ret.returncode == 0
+    # set $EDITOR
+    os.environ['EDITOR'] = 'third'
+
+    # git should win
+    onyo_root = './'
+    assert utils.get_editor(onyo_root) == 'first'
+
+    # onyo should win
+    ret = subprocess.run(["git", "config", '--unset', "onyo.core.editor"],
+                         capture_output=True, text=True)
+    assert ret.returncode == 0
+    assert utils.get_editor(onyo_root) == 'second'
+
+    # $EDITOR is all that's left
+    ret = subprocess.run(["onyo", "config", '--unset', "onyo.core.editor"],
+                         capture_output=True, text=True)
+    assert ret.returncode == 0
+    assert utils.get_editor(onyo_root) == 'third'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,43 @@
+import os
+import subprocess
+from pathlib import Path
+import pytest
+
+from onyo import commands  # noqa: F401
+from onyo import utils
+
+
+@pytest.fixture(scope="function", autouse=True)
+def change_test_dir(request, monkeypatch):
+    test_dir = os.path.join(request.fspath.dirname, "sandbox/", "test_utils/")
+    Path(test_dir).mkdir(parents=True, exist_ok=True)
+    monkeypatch.chdir(test_dir)
+
+
+def test_onyo_init():
+    ret = subprocess.run(["onyo", "init"])
+    assert ret.returncode == 0
+
+
+def test_get_config_value_git(helpers):
+    ret = subprocess.run(["git", "config", "onyo.test.get-git", "get-git-test"],
+                         capture_output=True, text=True)
+    assert ret.returncode == 0
+    assert helpers.string_in_file('get-git =', '.git/config')
+    assert helpers.string_in_file('= get-git-test', '.git/config')
+
+    onyo_root = './'
+    value = utils.get_config_value('onyo.test.get-git', onyo_root)
+    assert value == 'get-git-test'
+
+
+def test_get_config_value_onyo(helpers):
+    ret = subprocess.run(["onyo", "config", "onyo.test.get-onyo", "get-onyo-test"],
+                         capture_output=True, text=True)
+    assert ret.returncode == 0
+    assert helpers.string_in_file('get-onyo =', '.onyo/config')
+    assert helpers.string_in_file('= get-onyo-test', '.onyo/config')
+
+    onyo_root = './'
+    value = utils.get_config_value('onyo.test.get-onyo', onyo_root)
+    assert value == 'get-onyo-test'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,8 +27,7 @@ def test_get_config_value_git(helpers):
     assert helpers.string_in_file('= get-git-test', '.git/config')
 
     onyo_root = './'
-    value = utils.get_config_value('onyo.test.get-git', onyo_root)
-    assert value == 'get-git-test'
+    assert utils.get_config_value('onyo.test.get-git', onyo_root) == 'get-git-test'
 
 
 def test_get_config_value_onyo(helpers):
@@ -39,8 +38,7 @@ def test_get_config_value_onyo(helpers):
     assert helpers.string_in_file('= get-onyo-test', '.onyo/config')
 
     onyo_root = './'
-    value = utils.get_config_value('onyo.test.get-onyo', onyo_root)
-    assert value == 'get-onyo-test'
+    assert utils.get_config_value('onyo.test.get-onyo', onyo_root) == 'get-onyo-test'
 
 
 def test_get_editor_git():


### PR DESCRIPTION
This PR:

- rewrites `onyo config`, basically turning it into a wrapper for `git config -f .onyo/config`
- adds tests
- adds documentation
- moves all configuration options to an "onyo" namespace, so that they can be set in git without fear of conflict
- the editor spawned by onyo is now configurable via `onyo.core.editor`
- adds a function `get_config_value()` to simplify and improve support in the codebase for using config values