### PR TITLE
main: work always from root of an onyo-repository

### DIFF
--- a/onyo/main.py
+++ b/onyo/main.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 from onyo import commands  # noqa: F401
-from onyo.utils import parse_args
+from onyo.utils import parse_args, get_git_root
 
 import logging
 import sys
@@ -30,6 +30,8 @@ def main():
 
     if args.onyopath:
         onyo_root = args.onyopath
+        if 'init' not in sys.argv:
+            onyo_root = get_git_root(onyo_root)
 
     # TODO: Do onyo fsck here, test if onyo_root exists, .onyo exists, is git repo, other checks
 


### PR DESCRIPTION
fixes #170

There was already a function to get the git-root of a repository, it was just never called in main.py.
This function now gets called for both, with or without -C in the main.py, so all underlying commands (except `onyo init`) get the root of onyo.

The problem with this is, this forces the user to give further path arguments always relative from the onyo root.
e.g. When I am in a folder `shelf/` with a file `asset`, it is not possible to call `onyo mv asset ../user/`, since both paths in the command (and their tab-completion) are given relative from the cwd (and do not exist from the onyo root).

So commands break, when in a sub-directory from the onyo repo and giving paths relative from the sub-directory. It is assumed that all paths given to onyo are always relative from the onyo root. This might be what in #170 was meant with "decrease cognitive load", but I want to mention it explicitely, in case that it was meant to check in all commands separately if the user calls from inside the onyo repository and things might exist relative from the cwd.

Also, I want to mention that in onyos main() we check already for "config" in sys.argv, and this PR checks for "init" in it.
Thereby we do implicitely either make it illigal to use these as directory names, or at least introduce bugs or exeptional behaviour when somebody would call `onyo mkdir config init` and the likes.