### PR TITLE
RF/TST (pathlib, doc-strings, f-strings): `new`; `utils.edit_file()` and `utils.generate_faux_serial()`, `utils.get_list_of_assets()`

### DIFF
--- a/onyo/commands/new.py
+++ b/onyo/commands/new.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 
 import logging
-import os
 import sys
 import uuid
+import shutil
+from git import Repo
+from pathlib import Path
 
 from onyo.utils import (
-    build_git_add_cmd,
-    run_cmd,
     get_config_value,
     get_list_of_assets,
     get_git_root,
@@ -21,44 +21,66 @@ logger = logging.getLogger('onyo')
 reserved_characters = ['_', '.']
 
 
-def build_commit_cmd(file, onyo_root):
-    return ["git -C \"" + onyo_root + "\" commit -m", "new asset.\n\n" + file]
-
-
 def read_new_word(word_description):
+    """
+    Read a new word via user input for the creation of a asset name.
+    Checks for the serial field if it contains reserved characters, and checks
+    for all fields that they are not empty. If a check is not successful, it
+    tries to read the same word again.
+
+    Returns the word on success.
+    """
     # read word for field from keyboard
-    word = str(input(word_description))
+    word = input(word_description)
+
     # if word contains reserved character, inform and read new word
     for char in reserved_characters:
         if word_description != "<serial>*:" and char in word:
-            logger.info(char + " is in list of reserved characters: " + ", ".join(reserved_characters))
+            logger.info(f"'{char}' is in list of reserved characters: {reserved_characters}")
             return read_new_word(word_description)
+
     # if enter pressed without input, read new word
     if len(word) == 0:
         return read_new_word(word_description)
     return word
 
 
-def run_onyo_new(directory, template, non_interactive, onyo_root):
-    # create an asset file, first without content
+def run_onyo_new(directory, template, non_interactive, onyo_root, repo):
+    """
+    Read a new asset name, check it for uniqueness and validity, create the
+    asset (from a template if one was given), edit the new asset (if not
+    suppressed with flag) and stage it with git.
+
+    Returns the newly created asset's filename on success.
+    """
+    # create an asset file
     filename = create_filename(onyo_root, template)
-    if os.path.exists(os.path.join(directory, filename)):
-        logger.error(os.path.join(directory, filename) + " asset already exists.")
+    filename = Path(directory, filename).resolve()
+    template = Path(template).resolve()
+
+    if filename.exists():
+        logger.error(f"{filename}' asset already exists.")
         sys.exit(1)
-    if template:
-        run_cmd("cp \"" + template + "\" \"" + os.path.join(os.path.join(onyo_root, directory), filename) + "\"")
+    if template.is_file():
+        shutil.copyfile(template, filename)
     else:
-        run_cmd(create_asset_file_cmd(directory, filename))
+        filename.touch()
+
     # open new file?
     if not non_interactive:
-        edit_file(os.path.join(directory, filename), onyo_root, onyo_new=True)
+        edit_file(filename, onyo_root, onyo_new=True)
     # add file to git
-    git_add_cmd = build_git_add_cmd(directory, filename)
-    run_cmd(git_add_cmd)
-    return os.path.join(directory, filename)
+    repo.git.add(filename)
+    return filename
 
 
 def create_faux(onyo_root, list_of_assets, faux_length=8):
+    """
+    Create a new faux serial number for the serial field of an asset name.
+    Check for uniqueness of the faux serial in the repository.
+
+    Returns on success a unique faux serial number.
+    """
     faux = "faux" + str(uuid.uuid1())[:faux_length]
     for asset in list_of_assets:
         if faux in asset[1]:
@@ -67,6 +89,12 @@ def create_faux(onyo_root, list_of_assets, faux_length=8):
 
 
 def create_filename(onyo_root, template):
+    """
+    Read fields required for an asset name, check the validity of the fields and
+    uniqueness of the build-together asset name.
+
+    Returns the new asset name on success.
+    """
     words = []
     # build new name, read these words
     for field in ["type", "make", "model", "serial"]:
@@ -75,32 +103,36 @@ def create_filename(onyo_root, template):
             word = create_faux(onyo_root, get_list_of_assets(onyo_root))
         words.append(word)
     filename = words[0] + "_" + words[1] + "_" + words[2] + "." + words[3]
-    # check if the new filename is actually unique in onyo repository
+
+    # check if the new asset name is actually unique in onyo repository
     assets = get_list_of_assets(onyo_root)
     for asset in assets:
         if filename == asset[1]:
-            logger.info(filename + " exists already in " + asset[0] + "\nCreate a new filename:")
+            logger.info(f"{filename} exists already in {asset[0]}\nCreate a new filename:")
             return create_filename(onyo_root, template)
     return filename
 
 
-def create_asset_file_cmd(directory, filename):
-    return "touch \"" + os.path.join(directory, filename) + "\""
+def sanitize_paths(directory, template, onyo_root):
+    """
+    Check and normalize the directory and template for the creation of a new
+    asset.
 
-
-def prepare_arguments(directory, template, onyo_root):
-    directory = os.path.join(onyo_root, directory)
+    Returns the absolute path of the directory and of the template on success.
+    """
+    directory = Path(onyo_root, directory).resolve()
     if not template:
         template = get_config_value('onyo.new.template', onyo_root)
 
-    template = os.path.join(get_git_root(onyo_root), os.path.join(".onyo/templates", template))
+    template = Path(get_git_root(onyo_root), ".onyo/templates", template).resolve()
 
     problem_str = ""
-    if not os.path.isfile(template):
-        problem_str = problem_str + "\nTemplate file " + os.path.join(get_git_root(onyo_root), os.path.join(".onyo/templates", template)) + " does not exist."
-    if not os.path.isdir(directory):
-        problem_str = problem_str + "\n" + directory + " is not a directory."
-    if problem_str != "":
+    if not template.is_file():
+        problem_str += f"\nTemplate file {template} does not exist."
+    if not directory.is_dir():
+        problem_str += f"\n{directory} is not a directory."
+
+    if problem_str:
         logger.error(problem_str)
         sys.exit(1)
     return [directory, template]
@@ -115,15 +147,15 @@ def new(args, onyo_root):
     After the editing is done, the new file will be checked for the validity of
     its YAML syntax and based on the rules in ``.onyo/validation/validation.yaml``.
     """
-
-    # run onyo fsck
+    repo = Repo(onyo_root)
     fsck(args, onyo_root, quiet=True)
-    # set and check paths
-    [directory, template] = prepare_arguments(args.directory, args.template, onyo_root)
+
+    # set and check paths, identify template
+    [directory, template] = sanitize_paths(args.directory, args.template, onyo_root)
+
     # create file for asset, fill in fields
-    created_file = run_onyo_new(directory, template, args.non_interactive, onyo_root)
-    git_filepath = os.path.relpath(created_file, get_git_root(onyo_root))
-    # build commit command
-    [commit_cmd, commit_msg] = build_commit_cmd(git_filepath, onyo_root)
-    # run commands
-    run_cmd(commit_cmd, commit_msg)
+    created_file = run_onyo_new(directory, template, args.non_interactive, onyo_root, repo)
+    git_filepath = created_file.relative_to(get_git_root(onyo_root))
+
+    # commit new asset
+    repo.git.commit(m=f"new asset: {git_filepath}")

--- a/onyo/utils.py
+++ b/onyo/utils.py
@@ -300,14 +300,11 @@ def get_config_value(name, onyo_root):
 
 
 def get_list_of_assets(repo_path):
-    assets = []
-    for elem in glob.iglob(repo_path + '**/**', recursive=True):
-        if os.path.isfile(elem):
-            # when assets are in .gitignore, they should not be listed as such
-            if run_cmd("git -C \"" + repo_path + "\" check-ignore --no-index \"" + elem + "\""):
-                continue
-            assets.append([os.path.relpath(elem, repo_path), os.path.basename(elem)])
-    return assets
+    """
+    Return a list of all assets in an onyo repository.
+    """
+    return [[x[0][0], Path(x[0][0]).name] for x in Repo(repo_path).index.entries.items()
+            if not is_protected_path(x[0][0])]
 
 
 def is_protected_path(path):

--- a/onyo/utils.py
+++ b/onyo/utils.py
@@ -6,6 +6,8 @@ import shlex
 import shutil
 import glob
 import yaml
+import string
+import random
 import argparse
 from pathlib import Path
 from ruamel.yaml import YAML
@@ -72,6 +74,30 @@ def get_editor(onyo_root):
         editor = 'nano'
 
     return editor
+
+
+def generate_faux_serial(onyo_root, faux_length=8):
+    """
+    Generate a unique faux serial number and verify that it does not appear in
+    any other asset file name in any directory of the onyo repository.
+    The requested length of faux serial numbers is limited to the interval
+    between 1 and 37.
+
+    Returns on success a unique faux serial number which does not appear in any
+    other asset file name in any directory of the repository.
+    """
+    # check that the requested faux serial number has a valid length
+    if faux_length < 1 or faux_length > 37:
+        raise ValueError("Length of faux serial numbers must be between 1 and 37")
+
+    # generate a new faux serial number until a unique one (which is in no other
+    # asset name in the repository) is found, then return it.
+    alphanum = string.ascii_letters + string.digits
+    list_of_assets = get_list_of_assets(onyo_root)
+    faux = "faux" + ''.join(random.choices(alphanum, k=faux_length))
+    while True in [faux in asset[1] for asset in list_of_assets]:
+        faux = "faux" + ''.join(random.choices(alphanum, k=faux_length))
+    return faux
 
 
 def validate_rule_for_file(file, rule, path_of_rule, original_file, onyo_root):

--- a/tests/commands/test_new.py
+++ b/tests/commands/test_new.py
@@ -1,0 +1,62 @@
+import subprocess
+import os
+import logging
+from pathlib import Path
+
+logging.basicConfig()
+logger = logging.getLogger('onyo')
+logger.setLevel(logging.INFO)
+
+test_dirs = ['simple',
+             's p a c e s',
+             's p a/c e s',
+             'r/e/c/u/r/s/i/v/e',
+             'relative',
+             'one',
+             'two',
+             'three',
+             'overlap/one',
+             'overlap/two',
+             'overlap/three',
+             'very/very/very/deep'
+             ]
+
+
+def populate_test_repo(path):
+    ret = subprocess.run(['onyo', 'init', path])
+    assert ret.returncode == 0
+
+    # enter repo
+    original_cwd = Path.cwd()
+    os.chdir(path)
+
+    # create dirs
+    ret = subprocess.run(['onyo', 'mkdir'] + test_dirs)
+    assert ret.returncode == 0
+
+    # return to home
+    os.chdir(original_cwd)
+
+
+def test_new_non_interactive():
+    populate_test_repo('./')
+
+    # create new asset for all different folders
+    for i, directory in enumerate(test_dirs):
+        input_str = f'laptop\napple\nmacbookpro\n{i}'
+        file = f'laptop_apple_macbookpro.{i}'
+        ret = subprocess.run(['onyo', 'new', '--non-interactive', directory], input=input_str.encode())
+
+        assert ret.returncode == 0
+        assert Path(directory, file).exists()
+
+
+def test_new_non_interactive_with_faux():
+    # create new asset with faux for all different folders
+    for directory in test_dirs:
+        input_str = 'laptop\napple\nmacbookpro\nfaux'
+        ret = subprocess.run(['onyo', 'new', '--non-interactive', directory], input=input_str.encode())
+
+        # since the faux are by nature changing, it does not check the existence
+        # of the file, just that it exited for all directory names with success
+        assert ret.returncode == 0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import pytest
 
 from onyo import commands  # noqa: F401
 from onyo import utils
@@ -131,6 +132,49 @@ def test_get_editor_precedence():
                          capture_output=True, text=True)
     assert ret.returncode == 0
     assert utils.get_editor(onyo_root) == 'third'
+
+
+def test_generate_faux_serials():
+    """
+    Test the creation of unique serial numbers with the default length through
+    calling the generate_faux_serial() function multiple times and comparing the
+    generated faux serial numbers.
+    """
+    onyo_root = './'
+
+    # technically, creating multiple faux serial numbers without actually
+    # creating assets might lead to duplicates. In practice, this should not
+    # happen if they are sufficiently long and random
+    faux = [utils.generate_faux_serial(onyo_root) for x in range(0, 100)]
+    assert len(faux) == len(set(faux))
+    assert len(faux) > 0
+
+
+def test_length_range_of_generate_faux_serials():
+    """
+    Create many faux serial numbers with different lengths over the range of
+    allowed faux serial number lengths to test that the function returns faux
+    serial numbers, as well as for the values 0 and 38 outside of the interval
+    to verify that the appropriate error gets thrown. Because of the
+    different lengths, they should all be different.
+    """
+    onyo_root = './'
+
+    # test that faux serial numbers must have at least length 1 and the function
+    # raises the correct ValueError:
+    with pytest.raises(ValueError) as ret:
+        utils.generate_faux_serial(onyo_root, faux_length=0)
+    assert ret.type == ValueError
+
+    # test that faux serial numbers can't be requested longer than 37 and the
+    # function raises the correct ValueError:
+    with pytest.raises(ValueError) as ret:
+        utils.generate_faux_serial(onyo_root, faux_length=38)
+    assert ret.type == ValueError
+
+    faux = [utils.generate_faux_serial(onyo_root, x) for x in range(1, 37)]
+    assert len(faux) == len(set(faux))
+    assert len(faux) > 0
 
 
 def test_is_protected_path():


### PR DESCRIPTION
Changes in `onyo new`:
- uses pathlib.Path, shutil, and git.Repo
- updates imports
- adds doc-strings, f-strings and more whitespace
- adds minimal tests for `onyo new`
  - at different folder depths
  - white and without spaces in name
  - with and without faux serial

Changes in `utils`:
- modernize `edit_file()` (pathlib, doc-strings, f-strings)
- refactor `utils.get_list_of_assets()`
- move code `create_faux()` from `new` to `utils` and rename the function to `generate_faux_serial()`
- use `random.choices()` instead of `uuid1()` for the creation of faux serial numbers
- add also pathlib, doc-strings and f-strings
- test `generate_faux_serial()`
  - check for generation of different faux numbers with default length
  - test generation of different faux serial numbers with varying length
  - test for correct error code if faux serial numbers with a length outside of the allowed interval are requested