### PR TITLE
RF: onyo invocation; add tests

### DIFF
--- a/docs/source/cmd_cat.rst
+++ b/docs/source/cmd_cat.rst
@@ -3,7 +3,7 @@ onyo cat
 
 .. argparse::
    :module: onyo.main
-   :func: parse_args
+   :func: setup_parser
    :prog: onyo
    :path: cat
 

--- a/docs/source/cmd_config.rst
+++ b/docs/source/cmd_config.rst
@@ -3,7 +3,7 @@ onyo config
 
 .. argparse::
    :module: onyo.main
-   :func: parse_args
+   :func: setup_parser
    :prog: onyo
    :path: config
 

--- a/docs/source/cmd_edit.rst
+++ b/docs/source/cmd_edit.rst
@@ -3,7 +3,7 @@ onyo edit
 
 .. argparse::
    :module: onyo.main
-   :func: parse_args
+   :func: setup_parser
    :prog: onyo
    :path: edit
 

--- a/docs/source/cmd_fsck.rst
+++ b/docs/source/cmd_fsck.rst
@@ -3,7 +3,7 @@ onyo fsck
 
 .. argparse::
    :module: onyo.main
-   :func: parse_args
+   :func: setup_parser
    :prog: onyo
    :path: fsck
 

--- a/docs/source/cmd_history.rst
+++ b/docs/source/cmd_history.rst
@@ -3,7 +3,7 @@ onyo history
 
 .. argparse::
    :module: onyo.main
-   :func: parse_args
+   :func: setup_parser
    :prog: onyo
    :path: history
 

--- a/docs/source/cmd_init.rst
+++ b/docs/source/cmd_init.rst
@@ -3,7 +3,7 @@ onyo init
 
 .. argparse::
    :module: onyo.main
-   :func: parse_args
+   :func: setup_parser
    :prog: onyo
    :path: init
 

--- a/docs/source/cmd_mkdir.rst
+++ b/docs/source/cmd_mkdir.rst
@@ -3,7 +3,7 @@ onyo mkdir
 
 .. argparse::
    :module: onyo.main
-   :func: parse_args
+   :func: setup_parser
    :prog: onyo
    :path: mkdir
 

--- a/docs/source/cmd_mv.rst
+++ b/docs/source/cmd_mv.rst
@@ -3,7 +3,7 @@ onyo mv
 
 .. argparse::
    :module: onyo.main
-   :func: parse_args
+   :func: setup_parser
    :prog: onyo
    :path: mv
 

--- a/docs/source/cmd_new.rst
+++ b/docs/source/cmd_new.rst
@@ -3,7 +3,7 @@ onyo new
 
 .. argparse::
    :module: onyo.main
-   :func: parse_args
+   :func: setup_parser
    :prog: onyo
    :path: new
 

--- a/docs/source/cmd_onyo.rst
+++ b/docs/source/cmd_onyo.rst
@@ -3,6 +3,6 @@ onyo
 
 .. argparse::
    :module: onyo.main
-   :func: parse_args
+   :func: setup_parser
    :prog: onyo
    :nosubcommands:

--- a/docs/source/cmd_rm.rst
+++ b/docs/source/cmd_rm.rst
@@ -3,7 +3,7 @@ onyo rm
 
 .. argparse::
    :module: onyo.main
-   :func: parse_args
+   :func: setup_parser
    :prog: onyo
    :path: rm
 

--- a/docs/source/cmd_set.rst
+++ b/docs/source/cmd_set.rst
@@ -3,7 +3,7 @@ onyo set
 
 .. argparse::
    :module: onyo.main
-   :func: parse_args
+   :func: setup_parser
    :prog: onyo
    :path: set
 

--- a/docs/source/cmd_shell-completion.rst
+++ b/docs/source/cmd_shell-completion.rst
@@ -3,7 +3,7 @@ onyo shell-completion
 
 .. argparse::
    :module: onyo.main
-   :func: parse_args
+   :func: setup_parser
    :prog: onyo
    :path: shell-completion
 

--- a/docs/source/cmd_tree.rst
+++ b/docs/source/cmd_tree.rst
@@ -3,7 +3,7 @@ onyo tree
 
 .. argparse::
    :module: onyo.main
-   :func: parse_args
+   :func: setup_parser
    :prog: onyo
    :path: tree
 

--- a/onyo/commands/shell_completion.py
+++ b/onyo/commands/shell_completion.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
-from onyo.utils import parse_args
+from onyo.utils import setup_parser
 
 
 class TabCompletion:
@@ -444,7 +444,7 @@ def shell_completion(args, onyo_root):
         $ source <(onyo shell-completion)
         $ onyo --<PRESS TAB to display available options>
     """
-    parser = parse_args()
+    parser = setup_parser()
 
     if args.shell == 'zsh':
         type_to_action_map = {

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -1,46 +1,67 @@
 #!/usr/bin/env python3
 
-from onyo import commands  # noqa: F401
-from onyo.utils import setup_parser
-
 import logging
 import sys
+
+from onyo import commands  # noqa: F401
+from onyo.utils import setup_parser
 
 logging.basicConfig()
 logger = logging.getLogger('onyo')
 logger.setLevel(logging.INFO)
 
 
+def get_subcmd_index(arglist, start=1):
+    """
+    Get the index of the subcommand from a provided list of arguments (usually sys.argv).
+
+    Returns the index on success, and None in failure.
+    """
+    # TODO: alternatively, this could use TabCompletion._argparse_to_dict()
+    # flags which accept an argument
+    flagplus = ['-C', '--onyopath']
+
+    try:
+        # find the first non-flag argument
+        nonflag = next((a for a in arglist[start:] if a[0] != '-'))
+        index = arglist.index(nonflag, start)
+    except (StopIteration, ValueError):
+        return None
+
+    # check if it's the subcommand, or just an argument to a flag
+    if arglist[index - 1] in flagplus:
+        index = get_subcmd_index(arglist, index + 1)
+
+    return index
+
+
 def main():
-    parser = setup_parser()
-
-    # NOTE: this unfortunately located hack is so "onyo config" args will pass
-    # through uninterpreted. Otherwise, anything starting with - or -- errors as
-    # an unknown option flag.
-    # nargs=argparse.REMAINDER is in theory the correct solution, but is
-    # deprecated as of Python 3.8 (due to being buggy) and did not work for me
-    # in 3.10.
+    # NOTE: this unfortunately-located-hack is to pass uninterpreted args to
+    # "onyo config".
+    # nargs=argparse.REMAINDER is supposed to do this, but did not work for our
+    # needs, and as of Python 3.8 is soft-deprecated (due to being buggy).
     # For more information, see https://docs.python.org/3.10/library/argparse.html#arguments-containing
-    if 'config' in sys.argv:
+    passthrough_subcmds = ['config']
+    subcmd_index = get_subcmd_index(sys.argv)
+    if subcmd_index and sys.argv[subcmd_index] in passthrough_subcmds:
+        # display the subcmd's --help, and don't pass it through
         if not any(x in sys.argv for x in ['-h', '--help']):
-            index = sys.argv.index('config')
-            sys.argv.insert(index + 1, '--')
+            sys.argv.insert(subcmd_index + 1, '--')
 
+    # parse the arguments
+    parser = setup_parser()
     args = parser.parse_args()
 
-    if args.onyopath:
-        onyo_root = args.onyopath
-
-    # TODO: Do onyo fsck here, test if onyo_root exists, .onyo exists, is git repo, other checks
-
+    # debugging
     if args.debug:
         logger.setLevel(logging.DEBUG)
-    if len(sys.argv) > 1 and not args.debug:
-        args.run(args, onyo_root)
-    elif len(sys.argv) > 2:
-        args.run(args, onyo_root)
+
+    # run the subcommand
+    if subcmd_index:
+        args.run(args, args.onyopath)
     else:
         parser.print_help()
+        exit(1)
 
 
 if __name__ == '__main__':

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 from onyo import commands  # noqa: F401
-from onyo.utils import parse_args
+from onyo.utils import setup_parser
 
 import logging
 import sys
@@ -12,7 +12,7 @@ logger.setLevel(logging.INFO)
 
 
 def main():
-    parser = parse_args()
+    parser = setup_parser()
 
     # NOTE: this unfortunately located hack is so "onyo config" args will pass
     # through uninterpreted. Otherwise, anything starting with - or -- errors as

--- a/onyo/utils.py
+++ b/onyo/utils.py
@@ -321,7 +321,7 @@ def template(string):
     return string
 
 
-def parse_args():
+def setup_parser():
     parser = argparse.ArgumentParser(
         description='A text-based inventory system backed by git.',
         formatter_class=SubcommandHelpFormatter

--- a/tests/commands/test_onyo.py
+++ b/tests/commands/test_onyo.py
@@ -1,0 +1,45 @@
+import subprocess
+from itertools import product
+
+
+def test_onyo_init():
+    ret = subprocess.run(["onyo", "init"])
+    assert ret.returncode == 0
+
+
+def test_onyo_debug(helpers):
+    # populate repo, so there's something to be noisy about
+    ret = subprocess.run(['onyo', 'mkdir', 'just-a-dir'])
+    assert ret.returncode == 0
+
+    for i in ['-d', '--debug']:
+        full_cmd = ['onyo', i, 'mkdir', f'flag{i}']
+
+        ret = subprocess.run(full_cmd, capture_output=True, text=True)
+        assert ret.returncode == 0
+        assert 'DEBUG:onyo' in ret.stderr
+
+
+def test_onyo_help(helpers):
+    for i in ['-h', '--help']:
+        full_cmd = ['onyo', i]
+
+        ret = subprocess.run(full_cmd, capture_output=True, text=True)
+        assert ret.returncode == 0
+        assert 'usage: onyo [-h]' in ret.stdout
+        assert not ret.stderr
+
+
+def test_onyo_without_subcommand(helpers):
+    """
+    Test all possible combinations of flags for onyo, without any subcommand.
+    """
+    for i in helpers.powerset(helpers.onyo_flags()):
+        for k in product(*i):
+            args = list(helpers.flatten(k))
+            full_cmd = ['onyo'] + args
+
+            ret = subprocess.run(full_cmd, capture_output=True, text=True)
+            assert ret.returncode == 1
+            assert 'usage: onyo [-h]' in ret.stdout
+            assert not ret.stderr

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 import os
 import shutil
+from collections.abc import Iterable
+from itertools import chain, combinations
 from pathlib import Path
 import pytest
 
@@ -54,6 +56,26 @@ def helpers():
 
 
 class Helpers:
+    @staticmethod
+    def flatten(xs):
+        for x in xs:
+            if isinstance(x, Iterable) and not isinstance(x, (str, bytes)):
+                yield from Helpers.flatten(x)
+            else:
+                yield x
+
+    @staticmethod
+    def onyo_flags():
+        return [['-d', '--debug'],
+                [['-C', '/tmp'], ['--onyopath', '/tmp']],
+                ]
+
+    @staticmethod
+    def powerset(iterable):
+        "powerset([1,2,3]) --> () (1,) (2,) (3,) (1,2) (1,3) (2,3) (1,2,3)"
+        s = list(iterable)
+        return chain.from_iterable(combinations(s, r) for r in range(len(s) + 1))
+
     @staticmethod
     def string_in_file(string, file):
         """

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,27 @@
+from itertools import product
+
+from onyo import main
+
+
+def test_get_subcmd_index_missing(helpers):
+    """
+    Test all possible combinations of flags for onyo, without any subcommand.
+    """
+    for i in helpers.powerset(helpers.onyo_flags()):
+        for k in product(*i):
+            args = list(helpers.flatten(k))
+            full_cmd = ['onyo'] + args
+            idx = main.get_subcmd_index(full_cmd)
+            assert idx is None
+
+
+def test_get_subcmd_index_valid(helpers):
+    """
+    Test all possible combinations of flags for onyo, with a subcommand.
+    """
+    for i in helpers.powerset(helpers.onyo_flags()):
+        for k in product(*i):
+            args = list(helpers.flatten(k))
+            full_cmd = ['onyo'] + args + ['config', '--get', 'onyo.core.editor']
+            idx = main.get_subcmd_index(full_cmd)
+            assert idx is full_cmd.index('config')


### PR DESCRIPTION
This PR refactors main, improves its readability, adds tests and docstrings, and fixes multiple bugs.

The tests focus on behavior when invoking  `onyo` itself and its flags. Helper functions are also added, which should be useful for other tests which could benefit from [powersets](https://en.wikipedia.org/wiki/Power_set).

Bugs fixed:

- insufficient number of args to onyo would still exit 0
- args named 'config' to subcommands would result in subsequent args being ignored
- onyo -d -C /tmp (and similar) would crash with Python trace