### PR TITLE
bump Python baseline 3.7 -> 3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', 'pypy3.7', 'pypy3.8']
+        python-version: ['3.9', '3.10', 'pypy3.9']
 
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For general feedback, bug reports, and comments, please [open an issue](https://
 
 #### Non-Python Dependencies:
 
-In addition to Python >= 3.7, Onyo depends on a few system utilities.
+In addition to Python >= 3.9, Onyo depends on a few system utilities.
 
 Debian/Ubuntu:
 ```

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -4,7 +4,7 @@ Installation
 Non-Python Dependencies
 ***********************
 
-In addition to Python >= 3.7 and a few Python modules, Onyo depends on a few
+In addition to Python >= 3.9 and a few Python modules, Onyo depends on a few
 system utilities.
 
 **Debian/Ubuntu**:

--- a/onyo/commands/history.py
+++ b/onyo/commands/history.py
@@ -90,10 +90,7 @@ def history(args, onyo_root):
         os.chdir(orig_cwd)
 
     # covert the return status into a return code
-    try:
-        returncode = os.waitstatus_to_exitcode(status)
-    except AttributeError:  # python <3.9
-        returncode = os.WEXITSTATUS(status)
+    returncode = os.waitstatus_to_exitcode(status)
 
     # bubble up error retval
     if returncode != 0:

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     extras_require={
         'tests': ['flake8', 'pytest', 'pytest-cov'],
         'docs': ['sphinx', 'sphinx-argparse', 'sphinx-rtd-theme']},
-    python_requires=">=3.7",
+    python_requires=">=3.9",
     entry_points={
         'console_scripts': [
             'onyo=onyo.main:main'


### PR DESCRIPTION
Debian stable (bullseye), latest macOS (12), and PyPy all support Python 3.9.

Bumping this will help with the soon-to-arrive type hinting efforts (#222) and reduce the number of compute minutes we use on the free-tier for GitHub Actions.