### PR TITLE
NF/RF: Repo.add(), Repo.commit(), mkdir -> Repo.mkdir()

### DIFF
--- a/onyo/commands/cat.py
+++ b/onyo/commands/cat.py
@@ -2,7 +2,7 @@ import logging
 import sys
 from pathlib import Path
 
-from onyo.lib import Repo, InvalidOnyoRepoError
+from onyo.lib import Repo, OnyoInvalidRepoError
 
 logging.basicConfig()
 log = logging.getLogger('onyo')
@@ -56,7 +56,7 @@ def cat(args, onyo_root):
     try:
         repo = Repo(onyo_root)
         repo.fsck(['asset-yaml'])
-    except InvalidOnyoRepoError:
+    except OnyoInvalidRepoError:
         sys.exit(1)
 
     paths_to_cat = sanitize_paths(args.asset, onyo_root)

--- a/onyo/commands/config.py
+++ b/onyo/commands/config.py
@@ -97,5 +97,5 @@ def config(args, onyo_root):
     # commit, if there's anything to commit
     if repo.files_changed:
         dot_onyo_config = Path(repo.root, '.onyo/config')
-        repo._git(['add', dot_onyo_config])
-        repo._git(['commit', '-m', 'onyo config: modify shared repository config'])
+        repo.add(dot_onyo_config)
+        repo.commit('config: modify repository config')

--- a/onyo/commands/config.py
+++ b/onyo/commands/config.py
@@ -3,7 +3,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from onyo.lib import Repo, InvalidOnyoRepoError
+from onyo.lib import Repo, OnyoInvalidRepoError
 
 logging.basicConfig()
 log = logging.getLogger('onyo')
@@ -73,7 +73,7 @@ def config(args, onyo_root):
     try:
         repo = Repo(onyo_root)
         repo.fsck(['asset-yaml'])
-    except InvalidOnyoRepoError:
+    except OnyoInvalidRepoError:
         sys.exit(1)
 
     git_config_args = sanitize_args(args.git_config_args)

--- a/onyo/commands/edit.py
+++ b/onyo/commands/edit.py
@@ -2,7 +2,7 @@ import logging
 import os
 import sys
 
-from onyo.lib import Repo, InvalidOnyoRepoError
+from onyo.lib import Repo, OnyoInvalidRepoError
 from onyo.utils import (
     run_cmd,
     edit_file
@@ -53,7 +53,7 @@ def edit(args, onyo_root):
         # This is so "onyo edit" can be used to fix an existing problem. This has
         # benefits over just simply using `vim`, etc directly, as "onyo edit" will
         # validate the contents of the file before saving and committing.
-    except InvalidOnyoRepoError:
+    except OnyoInvalidRepoError:
         sys.exit(1)
 
     # check and set paths

--- a/onyo/commands/fsck.py
+++ b/onyo/commands/fsck.py
@@ -1,6 +1,6 @@
 import sys
 
-from onyo.lib import Repo, InvalidOnyoRepoError
+from onyo.lib import Repo, OnyoInvalidRepoError
 
 
 def fsck(args, onyo_root):
@@ -22,5 +22,5 @@ def fsck(args, onyo_root):
     try:
         repo = Repo(onyo_root)
         repo.fsck()
-    except InvalidOnyoRepoError:
+    except OnyoInvalidRepoError:
         sys.exit(1)

--- a/onyo/commands/history.py
+++ b/onyo/commands/history.py
@@ -4,7 +4,7 @@ import shutil
 import sys
 from pathlib import Path
 
-from onyo.lib import Repo, InvalidOnyoRepoError
+from onyo.lib import Repo, OnyoInvalidRepoError
 from onyo.utils import get_config_value
 
 logging.basicConfig()
@@ -74,7 +74,7 @@ def history(args, onyo_root):
     try:
         repo = Repo(onyo_root)
         repo.fsck(['asset-yaml'])
-    except InvalidOnyoRepoError:
+    except OnyoInvalidRepoError:
         sys.exit(1)
 
     # get the command and path

--- a/onyo/commands/mkdir.py
+++ b/onyo/commands/mkdir.py
@@ -1,79 +1,6 @@
-import logging
 import sys
-from pathlib import Path, PurePath
 
-from onyo.lib import Repo, OnyoInvalidRepoError
-from onyo.utils import is_protected_path
-
-logging.basicConfig()
-log = logging.getLogger('onyo')
-
-
-def run_mkdir(onyo_root, new_dir, repo):
-    """
-    Recursively create a directory containing an .anchor file. Stage (but do not
-    commit) the .anchor file.
-
-    Returns True on success.
-    """
-    # create the full path tree
-    Path(onyo_root, new_dir).mkdir(parents=True, exist_ok=True)
-
-    # create the anchor files and add to git
-    loop_dir = onyo_root
-    for d in PurePath(new_dir).parts:
-        loop_dir = Path(loop_dir, d)
-        anchor_file = Path(loop_dir, '.anchor')
-
-        anchor_file.touch(exist_ok=True)
-        repo._git(['add', anchor_file.resolve()])
-
-    return True
-
-
-def sanitize_dirs(directories, onyo_root):
-    """
-    Check and normalize a list of directories. If any exist, print and error.
-
-    Returns a list of normed directories on success.
-    """
-    dirs_to_create = []
-    error_exist = []
-    error_path_protected = []
-
-    for d in directories:
-        full_dir = Path(onyo_root, d).resolve()
-
-        # check if it exists
-        if full_dir.exists():
-            error_exist.append(d)
-            continue
-
-        # protected paths
-        if is_protected_path(full_dir):
-            error_path_protected.append(d)
-            continue
-
-        # TODO: ideally, this would return a list of normed paths, relative to
-        # the root of the onyo repository (not to be confused with onyo_root).
-        # This would allow commit messages that are consistent regardless of
-        # where onyo is invoked from.
-        norm_dir = str(full_dir.relative_to(onyo_root))
-        dirs_to_create.append(norm_dir)
-
-    # exit
-    if error_exist:
-        log.error("No directories created. The following already exist:")
-        log.error('\n'.join(error_exist))
-        sys.exit(1)
-
-    if error_path_protected:
-        log.error("The following paths are protected by onyo:")
-        log.error('\n'.join(error_path_protected))
-        log.error("\nExiting. No directories were created.")
-        sys.exit(1)
-
-    return dirs_to_create
+from onyo.lib import Repo, OnyoInvalidRepoError, OnyoProtectedPathError
 
 
 def mkdir(args, onyo_root):
@@ -81,12 +8,11 @@ def mkdir(args, onyo_root):
     Create ``directory``\(s). Intermediate directories will be created as needed
     (i.e. parent and child directories can be created in one call).
 
-    Onyo creates an empty ``.anchor`` file in directories, to force git to track
-    directories even when they are empty.
+    An empty ``.anchor`` file is added to each directory, to ensure that git
+    tracks it even when empty.
 
-    If the directory already exists, Onyo will throw an error. When multiple
-    directories are passed to Onyo, all will be checked before attempting to
-    create them.
+    If the directory already exists, or the path is protected, Onyo will throw
+    an error. All checks are performed before creating directories.
     """
     try:
         repo = Repo(onyo_root)
@@ -94,8 +20,7 @@ def mkdir(args, onyo_root):
     except OnyoInvalidRepoError:
         sys.exit(1)
 
-    dir_list = sanitize_dirs(args.directory, onyo_root)
-    for d in dir_list:
-        run_mkdir(onyo_root, d, repo)
-
-    repo._git(['commit', '-m', 'new directory(s): ' + ', '.join(dir_list)])
+    try:
+        repo.mkdir(args.directory)
+    except (FileExistsError, OnyoProtectedPathError):
+        sys.exit(1)

--- a/onyo/commands/mkdir.py
+++ b/onyo/commands/mkdir.py
@@ -2,7 +2,7 @@ import logging
 import sys
 from pathlib import Path, PurePath
 
-from onyo.lib import Repo, InvalidOnyoRepoError
+from onyo.lib import Repo, OnyoInvalidRepoError
 from onyo.utils import is_protected_path
 
 logging.basicConfig()
@@ -91,7 +91,7 @@ def mkdir(args, onyo_root):
     try:
         repo = Repo(onyo_root)
         repo.fsck()
-    except InvalidOnyoRepoError:
+    except OnyoInvalidRepoError:
         sys.exit(1)
 
     dir_list = sanitize_dirs(args.directory, onyo_root)

--- a/onyo/commands/mv.py
+++ b/onyo/commands/mv.py
@@ -203,4 +203,4 @@ def mv(args, onyo_root):
     # mv and commit
     repo._git(['mv'] + paths_to_mv + [args.destination])
     # TODO: can this commit message be made more helpful?
-    repo._git(['commit', '-m', 'moved asset(s)\n\n' + '\n'.join(paths_to_mv)])
+    repo.commit('moved asset(s)', paths_to_mv)

--- a/onyo/commands/mv.py
+++ b/onyo/commands/mv.py
@@ -3,7 +3,7 @@ import re
 import sys
 from pathlib import Path
 
-from onyo.lib import Repo, InvalidOnyoRepoError
+from onyo.lib import Repo, OnyoInvalidRepoError
 from onyo.utils import is_protected_path
 
 logging.basicConfig()
@@ -181,7 +181,7 @@ def mv(args, onyo_root):
     try:
         repo = Repo(onyo_root)
         repo.fsck()
-    except InvalidOnyoRepoError:
+    except OnyoInvalidRepoError:
         sys.exit(1)
 
     # sanitize and validate arguments

--- a/onyo/commands/new.py
+++ b/onyo/commands/new.py
@@ -3,7 +3,7 @@ import sys
 import shutil
 from pathlib import Path
 
-from onyo.lib import Repo, InvalidOnyoRepoError
+from onyo.lib import Repo, OnyoInvalidRepoError
 from onyo.utils import (
     generate_faux_serial,
     get_config_value,
@@ -138,7 +138,7 @@ def new(args, onyo_root):
     try:
         repo = Repo(onyo_root)
         repo.fsck()
-    except InvalidOnyoRepoError:
+    except OnyoInvalidRepoError:
         sys.exit(1)
 
     # set and check paths, identify template

--- a/onyo/commands/rm.py
+++ b/onyo/commands/rm.py
@@ -2,7 +2,7 @@ import logging
 import sys
 from pathlib import Path
 
-from onyo.lib import Repo, InvalidOnyoRepoError
+from onyo.lib import Repo, OnyoInvalidRepoError
 from onyo.utils import is_protected_path
 
 logging.basicConfig()
@@ -70,7 +70,7 @@ def rm(args, onyo_root):
     try:
         repo = Repo(onyo_root)
         repo.fsck()
-    except InvalidOnyoRepoError:
+    except OnyoInvalidRepoError:
         sys.exit(1)
 
     paths_to_rm = sanitize_paths(args.path, onyo_root)

--- a/onyo/commands/rm.py
+++ b/onyo/commands/rm.py
@@ -88,4 +88,4 @@ def rm(args, onyo_root):
     # rm and commit
     repo._git(['rm', '-r'] + paths_to_rm)
     # TODO: can this commit message be made more helpful?
-    repo._git(['commit', '-m', 'deleted asset(s)\n\n' + '\n'.join(paths_to_rm)])
+    repo.commit('deleted asset(s)', paths_to_rm)

--- a/onyo/commands/set.py
+++ b/onyo/commands/set.py
@@ -213,8 +213,8 @@ def set(args, onyo_root):
     for file in files_to_change:
         set_value(os.path.join(onyo_root, file), file, args.keys, onyo_root)
         # add any changes
-        repo._git(['add', file])
+        repo.add(file)
 
     files_staged = [str(x) for x in repo.files_staged]
     if files_staged:
-        repo._git(['commit', '-m', 'set values.\n\n' + '\n'.join(files_staged)])
+        repo.commit('set values', files_staged)

--- a/onyo/commands/set.py
+++ b/onyo/commands/set.py
@@ -5,7 +5,7 @@ import yaml
 import glob
 from ruamel.yaml import YAML  # pyre-ignore[21]
 
-from onyo.lib import Repo, InvalidOnyoRepoError
+from onyo.lib import Repo, OnyoInvalidRepoError
 from onyo.utils import (
     run_cmd,
     get_git_root,
@@ -187,7 +187,7 @@ def set(args, onyo_root):
         repo = Repo(onyo_root)
         # don't run onyo fsck, so values can be set for correcting assets.
         # TODO: really?
-    except InvalidOnyoRepoError:
+    except OnyoInvalidRepoError:
         sys.exit(1)
 
     # get all files in which the values should be set/changed

--- a/onyo/commands/tree.py
+++ b/onyo/commands/tree.py
@@ -5,7 +5,7 @@ import sys
 from onyo.utils import (
     run_cmd
 )
-from onyo.lib import Repo, InvalidOnyoRepoError
+from onyo.lib import Repo, OnyoInvalidRepoError
 
 logging.basicConfig()
 log = logging.getLogger('onyo')
@@ -53,7 +53,7 @@ def tree(args, onyo_root):
     try:
         repo = Repo(onyo_root)
         repo.fsck(['asset-yaml'])
-    except InvalidOnyoRepoError:
+    except OnyoInvalidRepoError:
         sys.exit(1)
 
     # check sources

--- a/onyo/lib/__init__.py
+++ b/onyo/lib/__init__.py
@@ -1,6 +1,6 @@
-from .onyo import Repo, InvalidOnyoRepoError
+from .onyo import Repo, OnyoInvalidRepoError
 
 __all__ = [
     'Repo',
-    'InvalidOnyoRepoError'
+    'OnyoInvalidRepoError'
 ]

--- a/onyo/lib/__init__.py
+++ b/onyo/lib/__init__.py
@@ -1,6 +1,7 @@
-from .onyo import Repo, OnyoInvalidRepoError
+from .onyo import Repo, OnyoInvalidRepoError, OnyoProtectedPathError
 
 __all__ = [
     'Repo',
-    'OnyoInvalidRepoError'
+    'OnyoInvalidRepoError',
+    'OnyoProtectedPathError',
 ]

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -19,6 +19,10 @@ class OnyoInvalidRepoError(Exception):
     """Thrown if the repository is invalid."""
 
 
+class OnyoProtectedPathError(Exception):
+    """Thrown if path is protected (.anchor, .git/, .onyo/)."""
+
+
 class Repo:
     """
     """

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -15,7 +15,7 @@ logging.basicConfig()
 log = logging.getLogger('onyo')
 
 
-class InvalidOnyoRepoError(Exception):
+class OnyoInvalidRepoError(Exception):
     """Thrown if the repository is invalid."""
 
 
@@ -133,12 +133,12 @@ class Repo:
             root = self._git(['rev-parse', '--show-toplevel'], cwd=self._opdir).strip()
         except subprocess.CalledProcessError:
             log.error(f"'{self._opdir}' is not a Git repository.")
-            raise InvalidOnyoRepoError(f"'{self._opdir}' is not a Git repository.")
+            raise OnyoInvalidRepoError(f"'{self._opdir}' is not a Git repository.")
 
         root = Path(root)
         if not Path(root, '.onyo').is_dir():
             log.error(f"'{root}' is not an Onyo repository.")
-            raise InvalidOnyoRepoError(f"'{self._opdir}' is not an Onyo repository.")
+            raise OnyoInvalidRepoError(f"'{self._opdir}' is not an Onyo repository.")
 
         # TODO: check .onyo/config, etc
 
@@ -201,7 +201,7 @@ class Repo:
 
             if not all_tests[key]():
                 log.debug(f"'{key}' failed")
-                raise InvalidOnyoRepoError(f"'{self._opdir}' failed fsck test '{key}'")
+                raise OnyoInvalidRepoError(f"'{self._opdir}' failed fsck test '{key}'")
 
             log.debug(f"'{key}' succeeded")
 

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -156,7 +156,7 @@ class Repo:
         """
         """
         if cwd is None:
-            cwd = self.root
+            cwd = self.opdir
 
         log.debug(f"Running 'git {args}'")
         ret = subprocess.run(["git"] + args,

--- a/tests/lib/test_Repo.py
+++ b/tests/lib/test_Repo.py
@@ -3,7 +3,7 @@ import subprocess
 from pathlib import Path
 
 from onyo import commands  # noqa: F401
-from onyo.lib import Repo, InvalidOnyoRepoError
+from onyo.lib import Repo, OnyoInvalidRepoError
 import pytest
 
 
@@ -43,7 +43,7 @@ def test_Repo_instantiate_invalid_path():
 
 def test_Repo_instantiate_empty_dir():
     Path('empty-dir').mkdir()
-    with pytest.raises(InvalidOnyoRepoError):
+    with pytest.raises(OnyoInvalidRepoError):
         Repo('empty-dir')
 
 
@@ -51,14 +51,14 @@ def test_Repo_instantiate_git_no_onyo():
     ret = subprocess.run(['git', 'init', 'git-no-onyo'])
     assert ret.returncode == 0
 
-    with pytest.raises(InvalidOnyoRepoError):
+    with pytest.raises(OnyoInvalidRepoError):
         Repo('git-no-onyo')
 
 
 def test_Repo_instantiate_onyo_no_git():
     Path('onyo-no-git/.onyo').mkdir(parents=True)
 
-    with pytest.raises(InvalidOnyoRepoError):
+    with pytest.raises(OnyoInvalidRepoError):
         Repo('onyo-no-git')
 
 

--- a/tests/lib/test_Repo_add.py
+++ b/tests/lib/test_Repo_add.py
@@ -1,0 +1,235 @@
+import logging
+import subprocess
+from pathlib import Path
+
+from onyo import commands  # noqa: F401
+from onyo.lib import Repo
+import pytest
+
+
+def test_onyo_init():
+    ret = subprocess.run(["onyo", "init"])
+    assert ret.returncode == 0
+
+
+def test_add_simple_str(caplog):
+    caplog.set_level(logging.INFO, logger='onyo')
+    repo = Repo('.')
+
+    # test
+    Path('simple-str').touch()
+    repo.add('simple-str')
+    assert Path('simple-str') in repo.files_staged
+
+    # cleanup
+    repo.commit('commit')
+
+
+def test_add_simple_Path(caplog):
+    caplog.set_level(logging.INFO, logger='onyo')
+    repo = Repo('.')
+
+    # test
+    Path('simple-Path').touch()
+    repo.add(Path('simple-Path'))
+    assert Path('simple-Path') in repo.files_staged
+
+    # cleanup
+    repo.commit('commit')
+
+
+def test_add_list_str(caplog):
+    caplog.set_level(logging.INFO, logger='onyo')
+    repo = Repo('.')
+
+    # test
+    Path('list-one').touch()
+    Path('list-two').touch()
+    Path('list-three').touch()
+    repo.add(['list-one', 'list-two', 'list-three'])
+    assert Path('list-one') in repo.files_staged
+    assert Path('list-two') in repo.files_staged
+    assert Path('list-three') in repo.files_staged
+
+    # cleanup
+    repo.commit('commit')
+
+
+def test_add_list_Path(caplog):
+    caplog.set_level(logging.INFO, logger='onyo')
+    repo = Repo('.')
+
+    # test
+    Path('list-Path-one').touch()
+    Path('list-Path-two').touch()
+    Path('list-Path-three').touch()
+    repo.add({Path('list-Path-one'), 'list-Path-two', Path('list-Path-three')})
+    assert Path('list-Path-one') in repo.files_staged
+    assert Path('list-Path-two') in repo.files_staged
+    assert Path('list-Path-three') in repo.files_staged
+
+    # cleanup
+    repo.commit('commit')
+
+
+def test_add_list_mixed(caplog):
+    caplog.set_level(logging.INFO, logger='onyo')
+    repo = Repo('.')
+
+    # test
+    Path('list-mix-one-str').touch()
+    Path('list-mix-two-Path').touch()
+    Path('list-mix-three-str').touch()
+    repo.add(['list-mix-one-str', Path('list-mix-two-Path'), 'list-mix-three-str'])
+    assert Path('list-mix-one-str') in repo.files_staged
+    assert Path('list-mix-two-Path') in repo.files_staged
+    assert Path('list-mix-three-str') in repo.files_staged
+
+    # cleanup
+    repo.commit('commit')
+
+
+def test_add_set_str(caplog):
+    caplog.set_level(logging.INFO, logger='onyo')
+    repo = Repo('.')
+
+    # test
+    Path('set-one').touch()
+    Path('set-two').touch()
+    Path('set-three').touch()
+    repo.add({'set-one', 'set-two', 'set-three'})
+    assert Path('set-one') in repo.files_staged
+    assert Path('set-two') in repo.files_staged
+    assert Path('set-three') in repo.files_staged
+
+    # cleanup
+    repo.commit('commit')
+
+
+def test_add_set_Path(caplog):
+    caplog.set_level(logging.INFO, logger='onyo')
+    repo = Repo('.')
+
+    # test
+    Path('set-Path-one').touch()
+    Path('set-Path-two').touch()
+    Path('set-Path-three').touch()
+    repo.add({Path('set-Path-one'), 'set-Path-two', Path('set-Path-three')})
+    assert Path('set-Path-one') in repo.files_staged
+    assert Path('set-Path-two') in repo.files_staged
+    assert Path('set-Path-three') in repo.files_staged
+
+    # cleanup
+    repo.commit('commit')
+
+
+def test_add_set_mixed(caplog):
+    caplog.set_level(logging.INFO, logger='onyo')
+    repo = Repo('.')
+
+    # test
+    Path('set-mix-one-Path').touch()
+    Path('set-mix-two-str').touch()
+    Path('set-mix-three-Path').touch()
+    repo.add({Path('set-mix-one-Path'), 'set-mix-two-str', Path('set-mix-three-Path')})
+    assert Path('set-mix-one-Path') in repo.files_staged
+    assert Path('set-mix-two-str') in repo.files_staged
+    assert Path('set-mix-three-Path') in repo.files_staged
+
+    # cleanup
+    repo.commit('commit')
+
+
+def test_add_spaces_file(caplog):
+    caplog.set_level(logging.INFO, logger='onyo')
+    repo = Repo('.')
+
+    # test
+    Path('s p a c e s').touch()
+    repo.add('s p a c e s')
+    assert Path('s p a c e s') in repo.files_staged
+
+    # cleanup
+    repo.commit('commit')
+
+
+def test_add_dir(caplog):
+    caplog.set_level(logging.INFO, logger='onyo')
+    repo = Repo('.')
+
+    # test
+    Path('dir-one').mkdir()
+    Path('dir-two').mkdir()
+    Path('dir-one/child-one-A').touch()
+    Path('dir-one/child-one-B').touch()
+    Path('dir-two/child-two-A').touch()
+    Path('dir-two/child-two-B').touch()
+
+    repo.add(['dir-one', 'dir-two'])
+    assert Path('dir-one/child-one-A') in repo.files_staged
+    assert Path('dir-one/child-one-B') in repo.files_staged
+    assert Path('dir-two/child-two-A') in repo.files_staged
+    assert Path('dir-two/child-two-B') in repo.files_staged
+
+    # cleanup
+    repo.commit('commit')
+
+
+def test_add_spaces_dir(caplog):
+    caplog.set_level(logging.INFO, logger='onyo')
+    repo = Repo('.')
+
+    # test
+    Path('s p a/c e s').mkdir(parents=True)
+    Path('s p a/c e s/child-A').touch()
+    repo.add('s p a')
+    assert Path('s p a/c e s/child-A') in repo.files_staged
+
+    # cleanup
+    repo.commit('commit')
+
+
+def test_add_repeat(caplog):
+    caplog.set_level(logging.INFO, logger='onyo')
+    repo = Repo('.')
+
+    # test
+    Path('repeat-A').touch()
+    Path('repeat-B').touch()
+    Path('repeat-C').touch()
+    repo.add(['repeat-A', 'repeat-B', 'repeat-A', 'repeat-C'])
+    assert Path('repeat-A') in repo.files_staged
+    assert Path('repeat-B') in repo.files_staged
+    assert Path('repeat-C') in repo.files_staged
+
+    # cleanup
+    repo.commit('commit')
+
+
+def test_add_unchanged(caplog):
+    caplog.set_level(logging.INFO, logger='onyo')
+    repo = Repo('.')
+
+    # setup
+    Path('unchanged').touch()
+    repo.add('unchanged')
+    repo.commit('commit')
+
+    # test
+    repo.add('unchanged')
+
+
+def test_add_missing(caplog):
+    caplog.set_level(logging.INFO, logger='onyo')
+    repo = Repo('.')
+
+    # test
+    Path('missing-A').touch()
+    Path('missing-C').touch()
+    with pytest.raises(FileNotFoundError):
+        repo.add(['missing-A', 'missing-B', 'missing-C'])
+    assert Path('missing-A') not in repo.files_staged
+    assert Path('missing-B') not in repo.files_staged
+    assert Path('missing-C') not in repo.files_staged
+
+    # no commit

--- a/tests/lib/test_Repo_commit.py
+++ b/tests/lib/test_Repo_commit.py
@@ -1,0 +1,150 @@
+import logging
+import subprocess
+from pathlib import Path
+
+from onyo import commands  # noqa: F401
+from onyo.lib import Repo
+import pytest
+
+
+def last_commit_message() -> str:
+    ret = subprocess.run(['git', 'log', '-1', '--pretty=format:%B'],
+                         capture_output=True, text=True)
+    return ret.stdout
+
+
+def test_onyo_init():
+    ret = subprocess.run(["onyo", "init"])
+    assert ret.returncode == 0
+
+
+def test_commit_str(caplog):
+    caplog.set_level(logging.INFO, logger='onyo')
+    repo = Repo('.')
+
+    # setup
+    Path('str').touch()
+    repo.add('str')
+
+    # test
+    repo.commit('single string')
+    msg = last_commit_message()
+    assert 'single string\n' == msg
+
+
+def test_commit_int(caplog):
+    caplog.set_level(logging.INFO, logger='onyo')
+    repo = Repo('.')
+
+    # setup
+    Path('int').touch()
+    repo.add('int')
+
+    # test
+    repo.commit(525600)
+    msg = last_commit_message()
+    assert '525600\n' == msg
+
+
+def test_commit_multi_str(caplog):
+    caplog.set_level(logging.INFO, logger='onyo')
+    repo = Repo('.')
+
+    # setup
+    Path('multi-str').touch()
+    repo.add('multi-str')
+
+    # test
+    repo.commit('multiple', 'strings', 'another')
+    msg = last_commit_message()
+    assert 'multiple\n\n' + 'strings\n\n' + 'another\n' == msg
+
+
+def test_commit_multi_str_Path(caplog):
+    caplog.set_level(logging.INFO, logger='onyo')
+    repo = Repo('.')
+
+    # setup
+    Path('multi-str-Path').touch()
+    repo.add('multi-str-Path')
+
+    # test
+    repo.commit('changed:', 'I HAVE REASONS', Path('multi-str-Path'))
+    msg = last_commit_message()
+    assert 'changed:\n\n' + 'I HAVE REASONS\n\n' + 'multi-str-Path\n' == msg
+
+
+def test_commit_multi_str_list(caplog):
+    caplog.set_level(logging.INFO, logger='onyo')
+    repo = Repo('.')
+
+    # setup
+    Path('multi-str-list').touch()
+    repo.add('multi-str-list')
+
+    # test
+    repo.commit('changed:', 'I HAVE REASONS', ['one', 'two', 'three'])
+    msg = last_commit_message()
+    assert 'changed:\n\n' + 'I HAVE REASONS\n\n' + 'one\ntwo\nthree\n' == msg
+
+
+def test_commit_multi_str_set(caplog):
+    caplog.set_level(logging.INFO, logger='onyo')
+    repo = Repo('.')
+
+    # setup
+    Path('multi-str-set').touch()
+    repo.add('multi-str-set')
+
+    # test
+    repo.commit('changed:', 'I HAVE REASONS', {'one', 'two', 'three'})
+    msg = last_commit_message()
+    assert 'changed:\n\n' + 'I HAVE REASONS\n\n' in msg
+    # sets are unordered
+    assert 'one\n' in msg
+    assert 'two\n' in msg
+    assert 'three\n' in msg
+
+
+def test_commit_multi_str_list_Path(caplog):
+    caplog.set_level(logging.INFO, logger='onyo')
+    repo = Repo('.')
+
+    # setup
+    Path('multi-str-list-Path').touch()
+    repo.add('multi-str-list-Path')
+
+    # test
+    repo.commit('changed:', 'I HAVE REASONS', [Path('one'), Path('two'), Path('three')])
+    msg = last_commit_message()
+    assert 'changed:\n\n' + 'I HAVE REASONS\n\n' + 'one\ntwo\nthree\n' == msg
+
+
+def test_commit_multi_str_set_Path(caplog):
+    caplog.set_level(logging.INFO, logger='onyo')
+    repo = Repo('.')
+
+    # setup
+    Path('multi-str-set-Path').touch()
+    repo.add('multi-str-set-Path')
+
+    # test
+    repo.commit('changed:', 'I HAVE REASONS', {Path('one'), Path('two'), Path('three')})
+    msg = last_commit_message()
+    assert 'changed:\n\n' + 'I HAVE REASONS\n\n' in msg
+    # sets are unordered
+    assert 'one\n' in msg
+    assert 'two\n' in msg
+    assert 'three\n' in msg
+
+
+def test_commit_nothing(caplog):
+    caplog.set_level(logging.INFO, logger='onyo')
+    repo = Repo('.')
+
+    # test
+    with pytest.raises(subprocess.CalledProcessError):
+        repo.commit('We believe in nothing Lebowski!')
+
+    msg = last_commit_message()
+    assert 'We believe in nothing Lebowski!' not in msg

--- a/tests/lib/test_Repo_fsck.py
+++ b/tests/lib/test_Repo_fsck.py
@@ -55,7 +55,7 @@ def test_fsck_anchors_populated(caplog):
     caplog.set_level(logging.INFO, logger='onyo')
 
     dirs = ['a', 'b', 'c', 'd']
-    files = ['README', 'a/1', 'a/2', 'b/3', 'b/4', 'c/5', 'c/6', 'd/7', 'd/8']
+    files = ['README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'c/f_5', 'c/f_6', 'd/f_7', 'd/f_8']
 
     # setup repo
     populate_test_repo('fsck-anchors-populated', dirs, files)
@@ -73,7 +73,7 @@ def test_fsck_anchors_missing(caplog):
     caplog.set_level(logging.INFO, logger='onyo')
 
     dirs = ['a', 'b', 'c', 'd', 'r/e/c/u/r/s/i/v/e']
-    files = ['README', 'a/1', 'a/2', 'b/3', 'b/4', 'c/5', 'c/6', 'd/7', 'd/8']
+    files = ['README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'c/f_5', 'c/f_6', 'd/f_7', 'd/f_8']
     anchors_to_remove = ['a/.anchor', 'r/e/c/.anchor', 'r/e/c/u/r/s/i/v/.anchor']
 
     # setup repo
@@ -115,7 +115,7 @@ def test_fsck_unique_assets_populated(caplog):
     caplog.set_level(logging.INFO, logger='onyo')
 
     dirs = ['a', 'b', 'c', 'd']
-    files = ['README', 'a/1', 'a/2', 'b/3', 'b/4', 'c/5', 'c/6', 'd/7', 'd/8']
+    files = ['README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'c/f_5', 'c/f_6', 'd/f_7', 'd/f_8']
 
     # setup repo
     populate_test_repo('fsck-unique-assets-populated', dirs, files)
@@ -133,8 +133,8 @@ def test_fsck_unique_assets_conflict(caplog):
     caplog.set_level(logging.INFO, logger='onyo')
 
     dirs = ['a', 'b', 'c', 'd', 'r/e/c/u/r/s/i/v/e']
-    files = ['README', 'a/1', 'a/2', 'b/3', 'b/4', 'r/e/c/5', 'r/e/c/u/r/6', 'r/e/c/u/r/s/i/v/e/7']
-    assets_to_conflict = ['b/1', 'r/e/c/3', 'r/e/c/u/r/s/i/v/e/5']
+    files = ['README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'r/e/c/f_5', 'r/e/c/u/r/f_6', 'r/e/c/u/r/s/i/v/e/f_7']
+    assets_to_conflict = ['b/f_1', 'r/e/c/f_3', 'r/e/c/u/r/s/i/v/e/f_5']
 
     # setup repo
     populate_test_repo('fsck-unique-assets-conflict', dirs, files)
@@ -178,7 +178,7 @@ def test_fsck_yaml_populated(caplog):
     caplog.set_level(logging.INFO, logger='onyo')
 
     dirs = ['a', 'b', 'c', 'd']
-    files = ['README', 'a/1', 'a/2', 'b/3', 'b/4', 'c/5', 'c/6', 'd/7', 'd/8']
+    files = ['README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'c/f_5', 'c/f_6', 'd/f_7', 'd/f_8']
 
     # setup repo
     populate_test_repo('fsck-yaml-populated', dirs, files)
@@ -196,8 +196,8 @@ def test_fsck_yaml_invalid(caplog):
     caplog.set_level(logging.INFO, logger='onyo')
 
     dirs = ['a', 'b', 'c', 'd', 'r/e/c/u/r/s/i/v/e']
-    files = ['README', 'a/1', 'a/2', 'b/3', 'b/4', 'r/e/c/5', 'r/e/c/u/r/6', 'r/e/c/u/r/s/i/v/e/7']
-    files_to_mangle = ['a/1', 'r/e/c/5', 'r/e/c/u/r/s/i/v/e/7']
+    files = ['README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'r/e/c/f_5', 'r/e/c/u/r/f_6', 'r/e/c/u/r/s/i/v/e/f_7']
+    files_to_mangle = ['a/f_1', 'r/e/c/f_5', 'r/e/c/u/r/s/i/v/e/f_7']
 
     # setup repo
     populate_test_repo('fsck-yaml-invalid', dirs, files)
@@ -240,7 +240,7 @@ def test_fsck_clean_tree_populated(caplog):
     caplog.set_level(logging.INFO, logger='onyo')
 
     dirs = ['a', 'b', 'c', 'd']
-    files = ['README', 'a/1', 'a/2', 'b/3', 'b/4', 'c/5', 'c/6', 'd/7', 'd/8']
+    files = ['README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'c/f_5', 'c/f_6', 'd/f_7', 'd/f_8']
 
     # setup repo
     populate_test_repo('fsck-clean-tree-populated', dirs, files)
@@ -258,8 +258,8 @@ def test_fsck_clean_tree_changed(caplog):
     caplog.set_level(logging.INFO, logger='onyo')
 
     dirs = ['a', 'b', 'c', 'd']
-    files = ['README', 'a/1', 'a/2', 'b/3', 'b/4', 'c/5', 'c/6', 'd/7', 'd/8']
-    files_to_change = ['a/1', 'b/3']
+    files = ['README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'c/f_5', 'c/f_6', 'd/f_7', 'd/f_8']
+    files_to_change = ['a/f_1', 'b/f_3']
 
     # setup repo
     populate_test_repo('fsck-clean-tree-changed', dirs, files)
@@ -284,8 +284,8 @@ def test_fsck_clean_tree_staged(caplog):
     caplog.set_level(logging.INFO, logger='onyo')
 
     dirs = ['a', 'b', 'c', 'd']
-    files = ['README', 'a/1', 'a/2', 'b/3', 'b/4', 'c/5', 'c/6', 'd/7', 'd/8']
-    files_to_stage = ['a/1', 'b/3']
+    files = ['README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'c/f_5', 'c/f_6', 'd/f_7', 'd/f_8']
+    files_to_stage = ['a/f_1', 'b/f_3']
 
     # setup repo
     populate_test_repo('fsck-clean-tree-staged', dirs, files)
@@ -313,8 +313,8 @@ def test_fsck_clean_tree_untracked(caplog):
     caplog.set_level(logging.INFO, logger='onyo')
 
     dirs = ['a', 'b', 'c', 'd']
-    files = ['README', 'a/1', 'a/2', 'b/3', 'b/4', 'c/5', 'c/6', 'd/7', 'd/8']
-    files_to_be_untracked = ['LICENSE', 'd/9']
+    files = ['README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'c/f_5', 'c/f_6', 'd/f_7', 'd/f_8']
+    files_to_be_untracked = ['LICENSE', 'd/f_9']
 
     # setup repo
     populate_test_repo('fsck-clean-tree-untracked', dirs, files)

--- a/tests/lib/test_Repo_fsck.py
+++ b/tests/lib/test_Repo_fsck.py
@@ -83,7 +83,7 @@ def test_fsck_anchors_missing(caplog):
 
     # remove anchors
     repo._git(['rm'] + anchors_to_remove)
-    repo._git(['commit', '-m', 'remove anchors'])
+    repo.commit('remove anchors')
 
     # test
     with pytest.raises(OnyoInvalidRepoError):
@@ -145,8 +145,8 @@ def test_fsck_unique_assets_conflict(caplog):
     for i in assets_to_conflict:
         Path(i).touch()
 
-    repo._git(['add'] + assets_to_conflict)
-    repo._git(['commit', '-m', 'add conflicts'])
+    repo.add(assets_to_conflict)
+    repo.commit('add conflicts')
 
     # test
     with pytest.raises(OnyoInvalidRepoError):
@@ -208,8 +208,8 @@ def test_fsck_yaml_invalid(caplog):
     for i in files_to_mangle:
         Path(i).write_text('dsfs: sdf: sdf:dd ad123e')
 
-    repo._git(['add'] + files_to_mangle)
-    repo._git(['commit', '-m', 'mangle files'])
+    repo.add(files_to_mangle)
+    repo.commit('mangle files')
 
     # test
     with pytest.raises(OnyoInvalidRepoError):

--- a/tests/lib/test_Repo_fsck.py
+++ b/tests/lib/test_Repo_fsck.py
@@ -4,7 +4,7 @@ import subprocess
 from pathlib import Path
 
 from onyo import commands  # noqa: F401
-from onyo.lib import Repo, InvalidOnyoRepoError
+from onyo.lib import Repo, OnyoInvalidRepoError
 import pytest
 
 
@@ -86,7 +86,7 @@ def test_fsck_anchors_missing(caplog):
     repo._git(['commit', '-m', 'remove anchors'])
 
     # test
-    with pytest.raises(InvalidOnyoRepoError):
+    with pytest.raises(OnyoInvalidRepoError):
         repo.fsck(['anchors'])
 
     # check log
@@ -149,7 +149,7 @@ def test_fsck_unique_assets_conflict(caplog):
     repo._git(['commit', '-m', 'add conflicts'])
 
     # test
-    with pytest.raises(InvalidOnyoRepoError):
+    with pytest.raises(OnyoInvalidRepoError):
         repo.fsck(['asset-unique'])
 
     # check log
@@ -212,7 +212,7 @@ def test_fsck_yaml_invalid(caplog):
     repo._git(['commit', '-m', 'mangle files'])
 
     # test
-    with pytest.raises(InvalidOnyoRepoError):
+    with pytest.raises(OnyoInvalidRepoError):
         repo.fsck(['asset-yaml'])
 
     # check log
@@ -271,7 +271,7 @@ def test_fsck_clean_tree_changed(caplog):
         Path(i).write_text('New contents')
 
     # test
-    with pytest.raises(InvalidOnyoRepoError):
+    with pytest.raises(OnyoInvalidRepoError):
         repo.fsck(['clean-tree'])
 
     # check log
@@ -300,7 +300,7 @@ def test_fsck_clean_tree_staged(caplog):
     assert ret.returncode == 0
 
     # test
-    with pytest.raises(InvalidOnyoRepoError):
+    with pytest.raises(OnyoInvalidRepoError):
         repo.fsck(['clean-tree'])
 
     # check log
@@ -326,7 +326,7 @@ def test_fsck_clean_tree_untracked(caplog):
         Path(i).touch()
 
     # test
-    with pytest.raises(InvalidOnyoRepoError):
+    with pytest.raises(OnyoInvalidRepoError):
         repo.fsck(['clean-tree'])
 
     # check log

--- a/tests/lib/test_Repo_mkdir.py
+++ b/tests/lib/test_Repo_mkdir.py
@@ -1,0 +1,312 @@
+import logging
+import subprocess
+from pathlib import Path
+
+from onyo import commands  # noqa: F401
+from onyo.lib import Repo, OnyoProtectedPathError
+import pytest
+
+
+def anchored_dir(directory):
+    """
+    Returns True if a directory exists and contains an .anchor file.
+    Otherwise it returns False.
+    """
+    if Path(directory).is_dir() and Path(directory, '.anchor').is_file():
+        return True
+
+    return False
+
+
+def test_onyo_init():
+    ret = subprocess.run(["onyo", "init"])
+    assert ret.returncode == 0
+
+
+def test_mkdir_simple(caplog):
+    caplog.set_level(logging.INFO, logger='onyo')
+    repo = Repo('.')
+
+    # test
+    repo.mkdir('simple')
+    assert anchored_dir('simple')
+
+
+def test_mkdir_recursive(caplog):
+    caplog.set_level(logging.INFO, logger='onyo')
+    repo = Repo('.')
+
+    # test
+    repo.mkdir('r/e/c/u/r/s/i/v/e')
+    assert anchored_dir('r')
+    assert anchored_dir('r/e')
+    assert anchored_dir('r/e/c')
+    assert anchored_dir('r/e/c/u')
+    assert anchored_dir('r/e/c/u/r')
+    assert anchored_dir('r/e/c/u/r/s')
+    assert anchored_dir('r/e/c/u/r/s/i')
+    assert anchored_dir('r/e/c/u/r/s/i/v')
+    assert anchored_dir('r/e/c/u/r/s/i/v/e')
+
+
+def test_mkdir_spaces(caplog):
+    caplog.set_level(logging.INFO, logger='onyo')
+    repo = Repo('.')
+
+    # single
+    repo.mkdir('s p a c e s')
+    assert anchored_dir('s p a c e s')
+
+    # nested spaces
+    repo.mkdir('s p a/c e s')
+    assert anchored_dir('s p a/c e s')
+
+    for d in [' ', 's', 'p', 'a', 'c', 'e', 's']:
+        assert not Path(d).exists()
+        assert not Path('s p a', d).exists()
+
+
+def test_mkdir_relative(caplog):
+    caplog.set_level(logging.INFO, logger='onyo')
+    repo = Repo('.')
+
+    # test
+    repo.mkdir('simple/../relative')
+    assert anchored_dir('relative')
+
+
+def test_mkdir_multiple_dirs(caplog):
+    caplog.set_level(logging.INFO, logger='onyo')
+    repo = Repo('.')
+
+    # test
+    repo.mkdir(['one', 'two', 'three'])
+    assert anchored_dir('one')
+    assert anchored_dir('two')
+    assert anchored_dir('three')
+
+
+def test_mkdir_overlapping(caplog):
+    caplog.set_level(logging.INFO, logger='onyo')
+    repo = Repo('.')
+
+    # test
+    repo.mkdir(['overlap/one', 'overlap/two', 'overlap/three'])
+    assert anchored_dir('overlap/one')
+    assert anchored_dir('overlap/two')
+    assert anchored_dir('overlap/three')
+    assert not Path('overlap/overlap').exists()
+    assert not Path('overlap/one/overlap').exists()
+    assert not Path('overlap/two/overlap').exists()
+    assert not Path('overlap/three/overlap').exists()
+
+
+def test_mkdir_path(caplog):
+    caplog.set_level(logging.INFO, logger='onyo')
+    repo = Repo('.')
+
+    # single
+    repo.mkdir(Path('Path'))
+    assert anchored_dir('Path')
+
+    # multiple
+    repo.mkdir([Path('Path-one'), Path('Path-two')])
+    assert anchored_dir('Path-one')
+    assert anchored_dir('Path-two')
+
+
+def test_mkdir_path_str_mixed(caplog):
+    caplog.set_level(logging.INFO, logger='onyo')
+    repo = Repo('.')
+
+    # test
+    repo.mkdir([Path('mixed-Path-one'), 'mixed-str-two'])
+    assert anchored_dir('mixed-Path-one')
+    assert anchored_dir('mixed-str-two')
+
+
+def test_mkdir_protected(caplog):
+    caplog.set_level(logging.INFO, logger='onyo')
+    repo = Repo('.')
+
+    # dir named .anchor
+    with pytest.raises(OnyoProtectedPathError):
+        repo.mkdir('protected/.anchor')
+    assert not Path('protected/.anchor').exists()
+    assert 'protected/.anchor' in caplog.text
+
+    # dir named .git
+    with pytest.raises(OnyoProtectedPathError):
+        repo.mkdir('protected/.git')
+    assert not Path('protected/.git').exists()
+    assert 'protected/.git' in caplog.text
+
+    # inside of .git
+    with pytest.raises(OnyoProtectedPathError):
+        repo.mkdir('.git/protected')
+    assert not Path('.git/protected').exists()
+    assert '.git/protected' in caplog.text
+
+    # dir named .onyo
+    with pytest.raises(OnyoProtectedPathError):
+        repo.mkdir('protected/.onyo')
+    assert not Path('protected/.onyo').exists()
+    assert 'protected/.onyo' in caplog.text
+
+    # inside of .onyo
+    with pytest.raises(OnyoProtectedPathError):
+        repo.mkdir('.onyo/protected')
+    assert not Path('.onyo/protected').exists()
+    assert '.onyo/protected' in caplog.text
+
+
+def test_mkdir_protected_mixed(caplog):
+    caplog.set_level(logging.INFO, logger='onyo')
+    repo = Repo('.')
+
+    # test
+    with pytest.raises(OnyoProtectedPathError):
+        repo.mkdir(['valid-one', 'protected/.anchor', 'valid-two'])
+    assert not Path('valid-one').exists()
+    assert not Path('valid-two').exists()
+    assert not Path('protected/.anchor').exists()
+
+    with pytest.raises(OnyoProtectedPathError):
+        repo.mkdir(['valid-one', '.onyo/protected', 'valid-two'])
+    assert not Path('valid-one').exists()
+    assert not Path('valid-two').exists()
+    assert not Path('.onyo/protected').exists()
+
+    # check logs
+    assert 'valid-one' not in caplog.text
+    assert 'valid-two' not in caplog.text
+    assert 'protected/.anchor' in caplog.text
+    assert '.onyo/protected' in caplog.text
+
+
+def test_mkdir_exists_dir(caplog):
+    caplog.set_level(logging.INFO, logger='onyo')
+    repo = Repo('.')
+
+    # setup
+    repo.mkdir('exists-dir')
+
+    # test
+    with pytest.raises(FileExistsError):
+        repo.mkdir('exists-dir')
+
+    assert anchored_dir('exists-dir')
+    assert not anchored_dir('exists-dir/exists-dir')
+
+    # check log
+    assert 'exists-dir' in caplog.text
+
+
+def test_mkdir_exists_file(caplog):
+    caplog.set_level(logging.INFO, logger='onyo')
+    repo = Repo('.')
+
+    # setup
+    Path('exists-file').touch()
+    repo.add('exists-file')
+    repo.commit('add exists-file')
+
+    # test
+    with pytest.raises(FileExistsError):
+        repo.mkdir('exists-file')
+
+    assert not anchored_dir('exists-file')
+    assert Path('exists-file').is_file()
+
+    # check log
+    assert 'exists-file' in caplog.text
+
+
+def test_mkdir_exists_recursive_dir(caplog):
+    caplog.set_level(logging.INFO, logger='onyo')
+    repo = Repo('.')
+
+    # setup
+    repo.mkdir('exists-r-dir/r/e/c/u/r/s/i/v/e')
+
+    # test
+    with pytest.raises(FileExistsError):
+        repo.mkdir('exists-r-dir/r/e/c/u/r/s/i/v/e')
+
+    # they should be untouched
+    assert anchored_dir('exists-r-dir/r')
+    assert anchored_dir('exists-r-dir/r/e')
+    assert anchored_dir('exists-r-dir/r/e/c')
+    assert anchored_dir('exists-r-dir/r/e/c/u')
+    assert anchored_dir('exists-r-dir/r/e/c/u/r')
+    assert anchored_dir('exists-r-dir/r/e/c/u/r/s')
+    assert anchored_dir('exists-r-dir/r/e/c/u/r/s/i')
+    assert anchored_dir('exists-r-dir/r/e/c/u/r/s/i/v')
+    assert anchored_dir('exists-r-dir/r/e/c/u/r/s/i/v/e')
+
+    assert not anchored_dir('exists-r-dir/r/r')
+    assert not anchored_dir('exists-r-dir/r/e/e')
+    assert not anchored_dir('exists-r-dir/r/e/c/c')
+    assert not anchored_dir('exists-r-dir/r/e/c/u/u')
+    assert not anchored_dir('exists-r-dir/r/e/c/u/r/r')
+    assert not anchored_dir('exists-r-dir/r/e/c/u/r/s/s')
+    assert not anchored_dir('exists-r-dir/r/e/c/u/r/s/i/i')
+    assert not anchored_dir('exists-r-dir/r/e/c/u/r/s/i/v/v')
+    assert not anchored_dir('exists-r-dir/r/e/c/u/r/s/i/v/e/e')
+
+    # check log
+    assert 'exists-r-dir/r/e/c/u/r/s/i/v/e' in caplog.text
+
+
+def test_mkdir_exists_recursive_file(caplog):
+    caplog.set_level(logging.INFO, logger='onyo')
+    repo = Repo('.')
+
+    # setup
+    repo.mkdir('exists-r-file/r/e/c/u/r/s/i/v/e')
+    Path('exists-r-file/r/e/c/u/r/s/exists-r-file').touch()
+    repo.add('exists-r-file/r/e/c/u/r/s/exists-r-file')
+    repo.commit('add exists-r-file')
+
+    # test
+    with pytest.raises(FileExistsError):
+        repo.mkdir('exists-r-file/r/e/c/u/r/s/exists-r-file')
+
+    assert not anchored_dir('exists-r-file/r/e/c/u/r/s/exists-r-file')
+    assert Path('exists-r-file/r/e/c/u/r/s/exists-r-file').is_file()
+
+    # they should be untouched
+    assert anchored_dir('exists-r-file/r')
+    assert anchored_dir('exists-r-file/r/e')
+    assert anchored_dir('exists-r-file/r/e/c')
+    assert anchored_dir('exists-r-file/r/e/c/u')
+    assert anchored_dir('exists-r-file/r/e/c/u/r')
+    assert anchored_dir('exists-r-file/r/e/c/u/r/s')
+    assert anchored_dir('exists-r-file/r/e/c/u/r/s/i')
+    assert anchored_dir('exists-r-file/r/e/c/u/r/s/i/v')
+    assert anchored_dir('exists-r-file/r/e/c/u/r/s/i/v/e')
+
+    # check log
+    assert 'exists-r-file/r/e/c/u/r/s/exists-r-file' in caplog.text
+
+
+def test_mkdir_exists_mixed(caplog):
+    caplog.set_level(logging.INFO, logger='onyo')
+    repo = Repo('.')
+
+    # setup
+    repo.mkdir('exists-mixed')
+
+    # test
+    with pytest.raises(FileExistsError):
+        repo.mkdir(['valid-one', 'exists-mixed', 'valid-two'])
+    assert not Path('valid-one').exists()
+    assert not Path('valid-two').exists()
+    assert not Path('exists-mixed/valid-one').exists()
+    assert not Path('exists-mixed/valid-two').exists()
+    assert anchored_dir('exists-mixed')
+
+    # check logs
+    assert 'valid-one' not in caplog.text
+    assert 'valid-two' not in caplog.text
+    assert 'exists-mixed' in caplog.text


### PR DESCRIPTION
Notable changes:

- introduce `Repo().add()` (with tests)
- introduce `Repo().commit()` (with tests)
- introduce `Repo().mkdir()` (with tests)
- convert `mkdir` to use `Repo().mkdir()`
- convert most commands to use `add()` and `commit()`

Tests for the command `mkdir` have been left intact. Those (along with the others) will eventually be reduced and simplified to focus on the user experience (output, prompts, exit codes, etc) rather than the functionality (which is well covered in the method tests). However, it does not make sense to begin this effort yet until the rework of the logging system happens.