### PR TITLE
TST/RF: add populate_repo() helper

### DIFF
--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -381,7 +381,7 @@ class Repo:
         dirs = self._mkdir_sanitize(directories)
         # make dirs
         for d in dirs:
-            d.mkdir(parents=True)
+            d.mkdir(parents=True, exist_ok=True)
 
         # anchors
         anchors = {Path(i, '.anchor') for d in dirs

--- a/tests/commands/test_new.py
+++ b/tests/commands/test_new.py
@@ -1,43 +1,25 @@
 import subprocess
-import os
 from pathlib import Path
 
-test_dirs = ['simple',
-             's p a c e s',
-             's p a/c e s',
-             'r/e/c/u/r/s/i/v/e',
-             'relative',
-             'one',
-             'two',
-             'three',
-             'overlap/one',
-             'overlap/two',
-             'overlap/three',
-             'very/very/very/deep'
-             ]
 
-
-def populate_test_repo(path):
-    ret = subprocess.run(['onyo', 'init', path])
-    assert ret.returncode == 0
-
-    # enter repo
-    original_cwd = Path.cwd()
-    os.chdir(path)
-
-    # create dirs
-    ret = subprocess.run(['onyo', 'mkdir'] + test_dirs)
-    assert ret.returncode == 0
-
-    # return to home
-    os.chdir(original_cwd)
-
-
-def test_new_non_interactive():
-    populate_test_repo('./')
+def test_new_non_interactive(helpers):
+    dirs = ['simple',
+            's p a c e s',
+            's p a/c e s',
+            'r/e/c/u/r/s/i/v/e',
+            'relative',
+            'one',
+            'two',
+            'three',
+            'overlap/one',
+            'overlap/two',
+            'overlap/three'
+            ]
+    files = []
+    helpers.populate_repo('./', dirs, files)
 
     # create new asset for all different folders
-    for i, directory in enumerate(test_dirs):
+    for i, directory in enumerate(dirs):
         input_str = f'laptop\napple\nmacbookpro\n{i}'
         file = f'laptop_apple_macbookpro.{i}'
         ret = subprocess.run(['onyo', 'new', '--non-interactive', directory], input=input_str.encode())
@@ -47,10 +29,22 @@ def test_new_non_interactive():
 
 
 def test_new_non_interactive_with_faux():
+    dirs = ['simple',
+            's p a c e s',
+            's p a/c e s',
+            'r/e/c/u/r/s/i/v/e',
+            'relative',
+            'one',
+            'two',
+            'three',
+            'overlap/one',
+            'overlap/two',
+            'overlap/three'
+            ]
     # create new asset with faux for all different folders
-    for directory in test_dirs:
+    for d in dirs:
         input_str = 'laptop\napple\nmacbookpro\nfaux'
-        ret = subprocess.run(['onyo', 'new', '--non-interactive', directory], input=input_str.encode())
+        ret = subprocess.run(['onyo', 'new', '--non-interactive', d], input=input_str.encode())
 
         # since the faux are by nature changing, it does not check the existence
         # of the file, just that it exited for all directory names with success

--- a/tests/commands/test_rm.py
+++ b/tests/commands/test_rm.py
@@ -3,57 +3,12 @@ import subprocess
 from pathlib import Path
 
 
-def populate_test_repo(path):
-    create_dirs = ['simple',
-                   's p a c e s',
-                   's p a/c e s',
-                   'r/e/c/u/r/s/i/v/e',
-                   'relative',
-                   'one',
-                   'two',
-                   'three',
-                   'overlap/one',
-                   'overlap/two',
-                   'overlap/three'
-                   ]
+def test_rm_flags(helpers):
+    dirs = []
+    files = ['a', 'b', 'c']
 
-    ret = subprocess.run(['onyo', 'init', path])
-    assert ret.returncode == 0
-
-    # enter repo
-    original_cwd = Path.cwd()
-    os.chdir(path)
-
-    # create dirs
-    ret = subprocess.run(['onyo', 'mkdir'] + create_dirs)
-    assert ret.returncode == 0
-
-    # create files
-    Path('a').touch()
-    Path('b').touch()
-    Path('c').touch()
-    Path('one/d').touch()
-    Path('two/e').touch()
-    Path('three/f').touch()
-    Path('s p a c e s/g').touch()
-    Path('s p a c e s/h').touch()
-    Path('s p a c e s/i').touch()
-    Path('s p a/c e s/1 2').touch()
-    Path('s p a/c e s/3 4').touch()
-    Path('s p a/c e s/5 6').touch()
-
-    # add and commit
-    ret = subprocess.run(['git', 'add', '.'])
-    assert ret.returncode == 0
-    ret = subprocess.run(['git', 'commit', '-m', 'populated for tests'])
-    assert ret.returncode == 0
-
-    # return to home
-    os.chdir(original_cwd)
-
-
-def test_rm_flags():
-    populate_test_repo('flags')
+    # setup
+    helpers.populate_repo('flags', dirs, files)
     os.chdir('flags')
 
     # --quiet (requires --yes)
@@ -84,8 +39,12 @@ def test_rm_flags():
     assert not Path('c').is_file()
 
 
-def test_rm_cwd():
-    populate_test_repo('cwd')
+def test_rm_cwd(helpers):
+    dirs = ['simple']
+    files = ['a']
+
+    # setup
+    helpers.populate_repo('cwd', dirs, files)
     os.chdir('cwd')
 
     # file
@@ -99,8 +58,12 @@ def test_rm_cwd():
     assert not Path('simple').is_dir()
 
 
-def test_rm_cwd_multiple():
-    populate_test_repo('cwd_multiple')
+def test_rm_cwd_multiple(helpers):
+    dirs = ['one', 'two', 'three']
+    files = ['a', 'b', 'c', 'one/d', 'two/e', 'three/f']
+
+    # setup
+    helpers.populate_repo('cwd_multiple', dirs, files)
     os.chdir('cwd_multiple')
 
     # files
@@ -118,8 +81,12 @@ def test_rm_cwd_multiple():
     assert not Path('three').is_dir()
 
 
-def test_rm_nested():
-    populate_test_repo('nested')
+def test_rm_nested(helpers):
+    dirs = ['one', 'two', 'three', 'r/e/c/u/r/s/i/v/e']
+    files = ['a', 'b', 'c', 'one/d', 'two/e', 'three/f']
+
+    # setup
+    helpers.populate_repo('nested', dirs, files)
     os.chdir('nested')
 
     # files
@@ -137,8 +104,13 @@ def test_rm_nested():
     assert Path('r/e/c/u').is_dir()
 
 
-def test_rm_spaces():
-    populate_test_repo('spaces')
+def test_rm_spaces(helpers):
+    dirs = ['s p a c e s', 's p a/c e s']
+    files = ['s p a c e s/g', 's p a c e s/h', 's p a c e s/i',
+             's p a/c e s/1 2', 's p a/c e s/3 4', 's p a/c e s/5 6']
+
+    # setup
+    helpers.populate_repo('spaces', dirs, files)
     os.chdir('spaces')
 
     # files
@@ -156,8 +128,12 @@ def test_rm_spaces():
     assert not Path('s p a').is_dir()
 
 
-def test_rm_same_target():
-    populate_test_repo('same_target')
+def test_rm_same_target(helpers):
+    dirs = ['simple']
+    files = ['a']
+
+    # setup
+    helpers.populate_repo('same_target', dirs, files)
     os.chdir('same_target')
 
     # files
@@ -171,8 +147,12 @@ def test_rm_same_target():
     assert not Path('simple').is_dir()
 
 
-def test_rm_overlap():
-    populate_test_repo('overlap')
+def test_rm_overlap(helpers):
+    dirs = ['overlap/one', 'overlap/two', 'overlap/three']
+    files = []
+
+    # setup
+    helpers.populate_repo('overlap', dirs, files)
     os.chdir('overlap')
 
     ret = subprocess.run(['onyo', 'rm', '--yes', 'overlap/one', 'overlap', 'overlap/two'])
@@ -180,8 +160,12 @@ def test_rm_overlap():
     assert not Path('overlap').is_dir()
 
 
-def test_rm_protected():
-    populate_test_repo('protected')
+def test_rm_protected(helpers):
+    dirs = ['simple']
+    files = []
+
+    # setup
+    helpers.populate_repo('protected', dirs, files)
     os.chdir('protected')
 
     ret = subprocess.run(['onyo', 'rm', '--yes', '.onyo'])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,13 @@
 import os
 import shutil
+import subprocess
 from collections.abc import Iterable
 from itertools import chain, combinations
 from pathlib import Path
 from tempfile import gettempdir
+
+from onyo import commands  # noqa: F401
+from onyo.lib import Repo
 import pytest
 
 
@@ -91,3 +95,26 @@ class Helpers:
                 return True
 
         return False
+
+    @staticmethod
+    def populate_repo(path: str, dirs: list = [], files: list = []) -> None:
+        """
+        Create and initialize a folder, and build a directory and file
+        structure.
+        """
+        # setup repo
+        ret = subprocess.run(['onyo', 'init', path])
+        assert ret.returncode == 0
+        repo = Repo(path)
+
+        # dirs
+        if dirs:
+            repo.mkdir(dirs)
+
+        # files
+        if files:
+            for i in files:
+                Path(path, i).touch()
+
+            repo.add(files)
+            repo.commit('populated for tests', files)

--- a/tests/lib/test_Repo.py
+++ b/tests/lib/test_Repo.py
@@ -7,32 +7,6 @@ from onyo.lib import Repo, OnyoInvalidRepoError
 import pytest
 
 
-def populate_test_repo(path: str, dirs: list = [], files: list = []) -> None:
-    # setup repo
-    ret = subprocess.run(['onyo', 'init', path])
-    assert ret.returncode == 0
-
-    # enter repo
-    original_cwd = Path.cwd()
-    os.chdir(path)
-
-    # dirs
-    ret = subprocess.run(['onyo', 'mkdir'] + dirs)
-    assert ret.returncode == 0
-
-    # files
-    for i in files:
-        Path(i).touch()
-
-    ret = subprocess.run(['git', 'add'] + files)
-    assert ret.returncode == 0
-    ret = subprocess.run(['git', 'commit', '-m', 'populated for tests'])
-    assert ret.returncode == 0
-
-    # return to home
-    os.chdir(original_cwd)
-
-
 #
 # instantiation
 #
@@ -79,12 +53,12 @@ def test_Repo_instantiate_path():
 #
 # Repo.assets
 #
-def test_Repo_assets():
+def test_Repo_assets(helpers):
     dirs = ['a', 'b', 'c', 'd']
     files = ['README', 'a/1', 'a/2', 'b/3', 'b/4', 'c/5', 'c/6', 'd/7', 'd/8']
 
     # setup repo
-    populate_test_repo('assets', dirs, files)
+    helpers.populate_repo('assets', dirs, files)
     os.chdir('assets')
     repo = Repo('.')
 
@@ -115,12 +89,12 @@ def test_Repo_assets():
 #
 # Repo.dirs
 #
-def test_Repo_dirs():
+def test_Repo_dirs(helpers):
     dirs = ['a', 'b', 'c', 'd']
     files = ['README', 'a/1', 'a/2', 'b/3', 'b/4', 'c/5', 'c/6', 'd/7', 'd/8']
 
     # setup repo
-    populate_test_repo('dirs', dirs, files)
+    helpers.populate_repo('dirs', dirs, files)
     os.chdir('dirs')
     repo = Repo('.')
 
@@ -145,12 +119,12 @@ def test_Repo_dirs():
 #
 # Repo.files
 #
-def test_Repo_files():
+def test_Repo_files(helpers):
     dirs = ['a', 'b', 'c', 'd']
     files = ['README', 'a/1', 'a/2', 'b/3', 'b/4', 'c/5', 'c/6', 'd/7', 'd/8']
 
     # setup repo
-    populate_test_repo('files', dirs, files)
+    helpers.populate_repo('files', dirs, files)
     os.chdir('files')
     repo = Repo('.')
 
@@ -177,13 +151,13 @@ def test_Repo_files():
 #
 # Repo.files_changed
 #
-def test_Repo_files_changed():
+def test_Repo_files_changed(helpers):
     dirs = ['a', 'b', 'c', 'd']
     files = ['README', 'a/1', 'a/2', 'b/3', 'b/4', 'c/5', 'c/6', 'd/7', 'd/8']
     files_to_change = ['a/1', 'b/3']
 
     # setup repo
-    populate_test_repo('changed', dirs, files)
+    helpers.populate_repo('changed', dirs, files)
     os.chdir('changed')
     repo = Repo('.')
 
@@ -208,13 +182,13 @@ def test_Repo_files_changed():
 #
 # Repo.files_staged
 #
-def test_Repo_files_staged():
+def test_Repo_files_staged(helpers):
     dirs = ['a', 'b', 'c', 'd']
     files = ['README', 'a/1', 'a/2', 'b/3', 'b/4', 'c/5', 'c/6', 'd/7', 'd/8']
     files_to_stage = ['a/1', 'b/3']
 
     # setup repo
-    populate_test_repo('staged', dirs, files)
+    helpers.populate_repo('staged', dirs, files)
     os.chdir('staged')
     repo = Repo('.')
 
@@ -242,13 +216,13 @@ def test_Repo_files_staged():
 #
 # Repo.files_untracked
 #
-def test_Repo_files_untracked():
+def test_Repo_files_untracked(helpers):
     dirs = ['a', 'b', 'c', 'd']
     files = ['README', 'a/1', 'a/2', 'b/3', 'b/4', 'c/5', 'c/6', 'd/7', 'd/8']
     files_to_be_untracked = ['LICENSE', 'd/9']
 
     # setup repo
-    populate_test_repo('untracked', dirs, files)
+    helpers.populate_repo('untracked', dirs, files)
     os.chdir('untracked')
     repo = Repo('.')
 

--- a/tests/lib/test_Repo_fsck.py
+++ b/tests/lib/test_Repo_fsck.py
@@ -8,39 +8,11 @@ from onyo.lib import Repo, OnyoInvalidRepoError
 import pytest
 
 
-def populate_test_repo(path: str, dirs: list = [], files: list = []) -> None:
-    # setup repo
-    ret = subprocess.run(['onyo', 'init', path])
-    assert ret.returncode == 0
-
-    # enter repo
-    original_cwd = Path.cwd()
-    os.chdir(path)
-
-    # dirs
-    if dirs:
-        ret = subprocess.run(['onyo', 'mkdir'] + dirs)
-        assert ret.returncode == 0
-
-    # files
-    if files:
-        for i in files:
-            Path(i).touch()
-
-        ret = subprocess.run(['git', 'add'] + files)
-        assert ret.returncode == 0
-        ret = subprocess.run(['git', 'commit', '-m', 'populated for tests'])
-        assert ret.returncode == 0
-
-    # return to home
-    os.chdir(original_cwd)
-
-
-def test_fsck_anchors_empty(caplog):
+def test_fsck_anchors_empty(caplog, helpers):
     caplog.set_level(logging.INFO, logger='onyo')
 
     # setup repo
-    populate_test_repo('fsck-anchors-empty')
+    helpers.populate_repo('fsck-anchors-empty')
     os.chdir('fsck-anchors-empty')
     repo = Repo('.')
 
@@ -51,14 +23,14 @@ def test_fsck_anchors_empty(caplog):
     # TODO: assert 'anchors' in caplog.text
 
 
-def test_fsck_anchors_populated(caplog):
+def test_fsck_anchors_populated(caplog, helpers):
     caplog.set_level(logging.INFO, logger='onyo')
 
     dirs = ['a', 'b', 'c', 'd']
     files = ['README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'c/f_5', 'c/f_6', 'd/f_7', 'd/f_8']
 
     # setup repo
-    populate_test_repo('fsck-anchors-populated', dirs, files)
+    helpers.populate_repo('fsck-anchors-populated', dirs, files)
     os.chdir('fsck-anchors-populated')
     repo = Repo('.')
 
@@ -69,7 +41,7 @@ def test_fsck_anchors_populated(caplog):
     # TODO: assert 'anchors' in caplog.text
 
 
-def test_fsck_anchors_missing(caplog):
+def test_fsck_anchors_missing(caplog, helpers):
     caplog.set_level(logging.INFO, logger='onyo')
 
     dirs = ['a', 'b', 'c', 'd', 'r/e/c/u/r/s/i/v/e']
@@ -77,7 +49,7 @@ def test_fsck_anchors_missing(caplog):
     anchors_to_remove = ['a/.anchor', 'r/e/c/.anchor', 'r/e/c/u/r/s/i/v/.anchor']
 
     # setup repo
-    populate_test_repo('fsck-anchors-missing', dirs, files)
+    helpers.populate_repo('fsck-anchors-missing', dirs, files)
     os.chdir('fsck-anchors-missing')
     repo = Repo('.')
 
@@ -96,11 +68,11 @@ def test_fsck_anchors_missing(caplog):
     assert len(anchors_to_remove) == caplog.text.count('/.anchor')
 
 
-def test_fsck_unique_assets_empty(caplog):
+def test_fsck_unique_assets_empty(caplog, helpers):
     caplog.set_level(logging.INFO, logger='onyo')
 
     # setup repo
-    populate_test_repo('fsck-unique-assets-empty')
+    helpers.populate_repo('fsck-unique-assets-empty')
     os.chdir('fsck-unique-assets-empty')
     repo = Repo('.')
 
@@ -111,14 +83,14 @@ def test_fsck_unique_assets_empty(caplog):
     # TODO: assert 'asset-unique' in caplog.text
 
 
-def test_fsck_unique_assets_populated(caplog):
+def test_fsck_unique_assets_populated(caplog, helpers):
     caplog.set_level(logging.INFO, logger='onyo')
 
     dirs = ['a', 'b', 'c', 'd']
     files = ['README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'c/f_5', 'c/f_6', 'd/f_7', 'd/f_8']
 
     # setup repo
-    populate_test_repo('fsck-unique-assets-populated', dirs, files)
+    helpers.populate_repo('fsck-unique-assets-populated', dirs, files)
     os.chdir('fsck-unique-assets-populated')
     repo = Repo('.')
 
@@ -129,7 +101,7 @@ def test_fsck_unique_assets_populated(caplog):
     # TODO: assert 'asset-unique' in caplog.text
 
 
-def test_fsck_unique_assets_conflict(caplog):
+def test_fsck_unique_assets_conflict(caplog, helpers):
     caplog.set_level(logging.INFO, logger='onyo')
 
     dirs = ['a', 'b', 'c', 'd', 'r/e/c/u/r/s/i/v/e']
@@ -137,7 +109,7 @@ def test_fsck_unique_assets_conflict(caplog):
     assets_to_conflict = ['b/f_1', 'r/e/c/f_3', 'r/e/c/u/r/s/i/v/e/f_5']
 
     # setup repo
-    populate_test_repo('fsck-unique-assets-conflict', dirs, files)
+    helpers.populate_repo('fsck-unique-assets-conflict', dirs, files)
     os.chdir('fsck-unique-assets-conflict')
     repo = Repo('.')
 
@@ -159,11 +131,11 @@ def test_fsck_unique_assets_conflict(caplog):
         assert 2 == caplog.text.count(Path(i).name)
 
 
-def test_fsck_yaml_empty(caplog):
+def test_fsck_yaml_empty(caplog, helpers):
     caplog.set_level(logging.INFO, logger='onyo')
 
     # setup repo
-    populate_test_repo('fsck-yaml-empty')
+    helpers.populate_repo('fsck-yaml-empty')
     os.chdir('fsck-yaml-empty')
     repo = Repo('.')
 
@@ -174,14 +146,14 @@ def test_fsck_yaml_empty(caplog):
     # TODO: assert 'asset-yaml' in caplog.text
 
 
-def test_fsck_yaml_populated(caplog):
+def test_fsck_yaml_populated(caplog, helpers):
     caplog.set_level(logging.INFO, logger='onyo')
 
     dirs = ['a', 'b', 'c', 'd']
     files = ['README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'c/f_5', 'c/f_6', 'd/f_7', 'd/f_8']
 
     # setup repo
-    populate_test_repo('fsck-yaml-populated', dirs, files)
+    helpers.populate_repo('fsck-yaml-populated', dirs, files)
     os.chdir('fsck-yaml-populated')
     repo = Repo('.')
 
@@ -192,7 +164,7 @@ def test_fsck_yaml_populated(caplog):
     # TODO: assert 'asset-yaml' in caplog.text
 
 
-def test_fsck_yaml_invalid(caplog):
+def test_fsck_yaml_invalid(caplog, helpers):
     caplog.set_level(logging.INFO, logger='onyo')
 
     dirs = ['a', 'b', 'c', 'd', 'r/e/c/u/r/s/i/v/e']
@@ -200,7 +172,7 @@ def test_fsck_yaml_invalid(caplog):
     files_to_mangle = ['a/f_1', 'r/e/c/f_5', 'r/e/c/u/r/s/i/v/e/f_7']
 
     # setup repo
-    populate_test_repo('fsck-yaml-invalid', dirs, files)
+    helpers.populate_repo('fsck-yaml-invalid', dirs, files)
     os.chdir('fsck-yaml-invalid')
     repo = Repo('.')
 
@@ -221,11 +193,11 @@ def test_fsck_yaml_invalid(caplog):
         assert i in caplog.text
 
 
-def test_fsck_clean_tree_empty(caplog):
+def test_fsck_clean_tree_empty(caplog, helpers):
     caplog.set_level(logging.INFO, logger='onyo')
 
     # setup repo
-    populate_test_repo('fsck-clean-tree-empty')
+    helpers.populate_repo('fsck-clean-tree-empty')
     os.chdir('fsck-clean-tree-empty')
     repo = Repo('.')
 
@@ -236,14 +208,14 @@ def test_fsck_clean_tree_empty(caplog):
     # TODO: assert 'clean-tree' in caplog.text
 
 
-def test_fsck_clean_tree_populated(caplog):
+def test_fsck_clean_tree_populated(caplog, helpers):
     caplog.set_level(logging.INFO, logger='onyo')
 
     dirs = ['a', 'b', 'c', 'd']
     files = ['README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'c/f_5', 'c/f_6', 'd/f_7', 'd/f_8']
 
     # setup repo
-    populate_test_repo('fsck-clean-tree-populated', dirs, files)
+    helpers.populate_repo('fsck-clean-tree-populated', dirs, files)
     os.chdir('fsck-clean-tree-populated')
     repo = Repo('.')
 
@@ -254,7 +226,7 @@ def test_fsck_clean_tree_populated(caplog):
     # TODO: assert 'clean-tree' in caplog.text
 
 
-def test_fsck_clean_tree_changed(caplog):
+def test_fsck_clean_tree_changed(caplog, helpers):
     caplog.set_level(logging.INFO, logger='onyo')
 
     dirs = ['a', 'b', 'c', 'd']
@@ -262,7 +234,7 @@ def test_fsck_clean_tree_changed(caplog):
     files_to_change = ['a/f_1', 'b/f_3']
 
     # setup repo
-    populate_test_repo('fsck-clean-tree-changed', dirs, files)
+    helpers.populate_repo('fsck-clean-tree-changed', dirs, files)
     os.chdir('fsck-clean-tree-changed')
     repo = Repo('.')
 
@@ -280,7 +252,7 @@ def test_fsck_clean_tree_changed(caplog):
         assert i in caplog.text
 
 
-def test_fsck_clean_tree_staged(caplog):
+def test_fsck_clean_tree_staged(caplog, helpers):
     caplog.set_level(logging.INFO, logger='onyo')
 
     dirs = ['a', 'b', 'c', 'd']
@@ -288,7 +260,7 @@ def test_fsck_clean_tree_staged(caplog):
     files_to_stage = ['a/f_1', 'b/f_3']
 
     # setup repo
-    populate_test_repo('fsck-clean-tree-staged', dirs, files)
+    helpers.populate_repo('fsck-clean-tree-staged', dirs, files)
     os.chdir('fsck-clean-tree-staged')
     repo = Repo('.')
 
@@ -309,7 +281,7 @@ def test_fsck_clean_tree_staged(caplog):
         assert i in caplog.text
 
 
-def test_fsck_clean_tree_untracked(caplog):
+def test_fsck_clean_tree_untracked(caplog, helpers):
     caplog.set_level(logging.INFO, logger='onyo')
 
     dirs = ['a', 'b', 'c', 'd']
@@ -317,7 +289,7 @@ def test_fsck_clean_tree_untracked(caplog):
     files_to_be_untracked = ['LICENSE', 'd/f_9']
 
     # setup repo
-    populate_test_repo('fsck-clean-tree-untracked', dirs, files)
+    helpers.populate_repo('fsck-clean-tree-untracked', dirs, files)
     os.chdir('fsck-clean-tree-untracked')
     repo = Repo('.')
 

--- a/tests/lib/test_Repo_mkdir.py
+++ b/tests/lib/test_Repo_mkdir.py
@@ -100,6 +100,16 @@ def test_mkdir_overlapping(caplog):
     assert not Path('overlap/two/overlap').exists()
     assert not Path('overlap/three/overlap').exists()
 
+    # test
+    repo.mkdir(['double-o', 'double-o/one', 'double-o/two', 'double-o/three'])
+    assert anchored_dir('double-o/one')
+    assert anchored_dir('double-o/two')
+    assert anchored_dir('double-o/three')
+    assert not Path('double-o/double-o').exists()
+    assert not Path('double-o/one/double-o').exists()
+    assert not Path('double-o/two/double-o').exists()
+    assert not Path('double-o/three/double-o').exists()
+
 
 def test_mkdir_path(caplog):
     caplog.set_level(logging.INFO, logger='onyo')


### PR DESCRIPTION
This adds a helper, and simplifies some of the number of files and dirs being created by tests.

This drops overall test runtime by 15%. This is likely due to fewer subshells being spawned, and a reduction in overall work.

Also, I uncovered a bug in `mkdir` as part of the refactoring.