### PR TITLE
TST/RF: leverage pytest features

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,6 @@
 [flake8]
-ignore=E501, W504, W605
+ignore = E501, W504, W605
+per-file-ignores =
+    tests/*test_*.py:E302
 exclude =
     build/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
         sudo apt-get install -y zsh
     - name: flake8 linting
       run: |
-        flake8 $(find . -type f -name "*.py")
+        flake8
     - name: Pyre type checking
       run: |
         pyre --noninteractive check

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ REPO_ROOT=$PWD pytest -vv --cov
 
 Linting uses both flake8 and Pyre.
 ```
-flake8 $(find . -type f -name "*.py")
-pyre --noninteractive check
+flake8
+pyre check
 ```
 
 ### Documentation

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -434,6 +434,6 @@ class Repo:
                       '\n'.join(error_path_protected) + '\n' +
                       '\nNo directories were created.')
             raise OnyoProtectedPathError('The following paths are protected by onyo:\n' +
-                                         '\n'.join(error_exist))
+                                         '\n'.join(error_path_protected))
 
         return dirs_to_create

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -364,7 +364,7 @@ class Repo:
     #
     # MKDIR
     #
-    def mkdir(self, directories: Union[list[Union[Path, str]], Path, str]) -> None:
+    def mkdir(self, directories: Union[Iterable[Union[Path, str]], Path, str]) -> None:
         """
         Create ``directory``\(s). Intermediate directories will be created as
         needed (i.e. parent and child directories can be created in one call).
@@ -375,7 +375,7 @@ class Repo:
         If a directory already exists, or the path is protected, an exception
         will be raised. All checks are performed before creating directories.
         """
-        if not isinstance(directories, list):
+        if not isinstance(directories, (list, set)):
             directories = [directories]
 
         dirs = self._mkdir_sanitize(directories)
@@ -395,7 +395,7 @@ class Repo:
         # paths should be relative to root in commit messages
         self.commit('mkdir: ' + ', '.join(["'{}'".format(x.relative_to(self.root)) for x in dirs]))
 
-    def _mkdir_sanitize(self, dirs: list) -> set[Path]:
+    def _mkdir_sanitize(self, dirs: Iterable[Union[Path, str]]) -> set[Path]:
         """
         Check and normalize a list of directories.
 
@@ -404,7 +404,7 @@ class Repo:
         error_exist = []
         error_path_protected = []
         dirs_to_create = set()
-        # TODO: the set() neatly avoids creating the dame dir twice. Intentional?
+        # TODO: the set() neatly avoids creating the same dir twice. Intentional?
 
         for d in dirs:
             full_dir = Path(self.opdir, d).resolve()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+markers =
+    repo_dirs: populate a repo with dirs; for use with the "repo" fixture
+    repo_files: populate a repo with files (parent dirs are automatically created); for use with the "repo" fixture
+addopts =
+    --strict-markers

--- a/tests/commands/test_config.py
+++ b/tests/commands/test_config.py
@@ -1,4 +1,5 @@
 import subprocess
+from pathlib import Path
 
 
 def test_onyo_init():
@@ -6,23 +7,21 @@ def test_onyo_init():
     assert ret.returncode == 0
 
 
-def test_config_set(helpers):
+def test_config_set():
     ret = subprocess.run(["onyo", "config", "onyo.test.set", "set-test"],
                          capture_output=True, text=True)
     assert ret.returncode == 0
     assert not ret.stdout
     assert not ret.stderr
-    assert helpers.string_in_file('set =', '.onyo/config')
-    assert helpers.string_in_file('= set-test', '.onyo/config')
+    assert 'set =' in Path('.onyo/config').read_text()
+    assert '= set-test' in Path('.onyo/config').read_text()
 
 
-def test_config_get_onyo(helpers):
+def test_config_get_onyo():
     # set
     ret = subprocess.run(["onyo", "config", "onyo.test.get-onyo", "get-onyo-test"],
                          capture_output=True, text=True)
     assert ret.returncode == 0
-    assert helpers.string_in_file('get-onyo =', '.onyo/config')
-    assert helpers.string_in_file('= get-onyo-test', '.onyo/config')
 
     # get
     ret = subprocess.run(["onyo", "config", "--get", "onyo.test.get-onyo"],
@@ -33,12 +32,10 @@ def test_config_get_onyo(helpers):
 
 
 # onyo should not alter git config's output (newline, etc)
-def test_config_get_pristine(helpers):
+def test_config_get_pristine():
     ret = subprocess.run(["onyo", "config", "onyo.test.get-pristine", "get-pristine-test"],
                          capture_output=True, text=True)
     assert ret.returncode == 0
-    assert helpers.string_in_file('get-pristine =', '.onyo/config')
-    assert helpers.string_in_file('= get-pristine-test', '.onyo/config')
 
     # git config's output
     ret = subprocess.run(["git", "config", "-f", ".onyo/config", "onyo.test.get-pristine"],
@@ -56,8 +53,8 @@ def test_config_get_pristine(helpers):
     assert ret.stdout == git_config_output
 
 
-def test_config_get_empty(helpers):
-    assert not helpers.string_in_file('onyo.test.not-exist', '.onyo/config')
+def test_config_get_empty():
+    assert 'onyo.test.not-exist' not in Path('.onyo/config').read_text()
 
     ret = subprocess.run(["onyo", "config", "--get", "onyo.test.not-exist"],
                          capture_output=True, text=True)
@@ -66,13 +63,11 @@ def test_config_get_empty(helpers):
     assert not ret.stderr
 
 
-def test_config_unset(helpers):
+def test_config_unset():
     # set
     ret = subprocess.run(["onyo", "config", "onyo.test.unset", "unset-test"],
                          capture_output=True, text=True)
     assert ret.returncode == 0
-    assert helpers.string_in_file('unset =', '.onyo/config')
-    assert helpers.string_in_file('= unset-test', '.onyo/config')
 
     # unset
     ret = subprocess.run(["onyo", "config", "--unset", "onyo.test.unset"],
@@ -80,8 +75,8 @@ def test_config_unset(helpers):
     assert ret.returncode == 0
     assert not ret.stdout
     assert not ret.stderr
-    assert not helpers.string_in_file('unset =', '.onyo/config')
-    assert not helpers.string_in_file('= unset-test', '.onyo/config')
+    assert 'unset =' not in Path('.onyo/config').read_text()
+    assert '= unset-test' not in Path('.onyo/config').read_text()
 
     # get
     ret = subprocess.run(["onyo", "config", "--get", "onyo.test.unset"],
@@ -114,13 +109,13 @@ def test_config_forbidden_flags():
         assert flag in ret.stderr
 
 
-def test_config_bubble_retcode(helpers):
+def test_config_bubble_retcode():
     """
     Bubble up git-config's retcodes.
     According to the git config manpage, attempting to unset an option which
     does not exist exits with "5".
     """
-    assert not helpers.string_in_file('onyo.test.not-exist', '.onyo/config')
+    assert 'onyo.test.not-exist' not in Path('.onyo/config').read_text()
 
     ret = subprocess.run(["onyo", "config", "--unset", "onyo.test.not-exist"],
                          capture_output=True, text=True)

--- a/tests/commands/test_history.py
+++ b/tests/commands/test_history.py
@@ -31,7 +31,7 @@ def test_onyo_init():
     assert ret.returncode == 0
 
 
-def test_history_noninteractive(helpers):
+def test_history_noninteractive():
     ret = subprocess.run(["onyo", "history", "-I"],
                          capture_output=True, text=True)
     assert ret.returncode == 0
@@ -39,7 +39,7 @@ def test_history_noninteractive(helpers):
     assert not ret.stderr
 
 
-def test_history_noninteractive_file(helpers):
+def test_history_noninteractive_file():
     ret = subprocess.run(["onyo", "history", "-I", "a"],
                          capture_output=True, text=True)
     assert ret.returncode == 0
@@ -47,7 +47,7 @@ def test_history_noninteractive_file(helpers):
     assert not ret.stderr
 
 
-def test_history_noninteractive_dir(helpers):
+def test_history_noninteractive_dir():
     ret = subprocess.run(["onyo", "history", "-I", "subdir/"],
                          capture_output=True, text=True)
     assert ret.returncode == 0
@@ -55,7 +55,7 @@ def test_history_noninteractive_dir(helpers):
     assert not ret.stderr
 
 
-def test_history_noninteractive_spaces(helpers):
+def test_history_noninteractive_spaces():
     ret = subprocess.run(["onyo", "history", "-I", "s p a c e s/"],
                          capture_output=True, text=True)
     assert ret.returncode == 0
@@ -70,7 +70,7 @@ def test_history_noninteractive_spaces(helpers):
     assert not ret.stderr
 
 
-def test_history_noninteractive_not_exist(helpers):
+def test_history_noninteractive_not_exist():
     ret = subprocess.run(["onyo", "history", "-I", "does_not_exist"],
                          capture_output=True, text=True)
     assert ret.returncode == 1
@@ -85,7 +85,7 @@ def test_history_noninteractive_not_exist(helpers):
     assert ret.stderr
 
 
-def test_history_noninteractive_too_many_args(helpers):
+def test_history_noninteractive_too_many_args():
     ret = subprocess.run(["onyo", "history", "-I", "a", "subdir/b"],
                          capture_output=True, text=True)
     assert ret.returncode != 0
@@ -95,7 +95,7 @@ def test_history_noninteractive_too_many_args(helpers):
 
 # NOTE: interactive cannot be tested directly, as onyo detects whether it's
 #       connected to a TTY.
-def test_history_interactive_fallback(helpers):
+def test_history_interactive_fallback():
     ret = subprocess.run(["onyo", "history", "subdir/b"],
                          capture_output=True, text=True)
     assert ret.returncode == 0
@@ -104,9 +104,9 @@ def test_history_interactive_fallback(helpers):
 
 
 # Error when no config flag is found
-def test_history_config_unset(helpers):
+def test_history_config_unset():
     # git is already unset
-    assert not helpers.string_in_file('onyo.history.non-interactive', '.git/config')
+    assert 'onyo.history.non-interactive' not in Path('.git/config').read_text()
     # unset onyo
     ret = subprocess.run(["onyo", "config", "--unset", "onyo.history.non-interactive"],
                          capture_output=True, text=True)
@@ -120,9 +120,9 @@ def test_history_config_unset(helpers):
     assert ret.stderr
 
 
-def test_history_config_invalid(helpers):
+def test_history_config_invalid():
     # git is already unset
-    assert not helpers.string_in_file('onyo.history.non-interactive', '.git/config')
+    assert 'onyo.history.non-interactive' not in Path('.git/config').read_text()
     # set to invalid
     ret = subprocess.run(["onyo", "config", "onyo.history.non-interactive", "does-not-exist-in-path"],
                          capture_output=True, text=True)
@@ -138,7 +138,7 @@ def test_history_config_invalid(helpers):
 
 # Reconfigure the history command to tickle some other functionality we're
 # interested in.
-def test_history_fake_noninteractive_stdout(helpers):
+def test_history_fake_noninteractive_stdout():
     ret = subprocess.run(["onyo", "config", "onyo.history.non-interactive", "/bin/printf"],
                          capture_output=True, text=True)
     assert ret.returncode == 0
@@ -158,7 +158,7 @@ def test_history_fake_noninteractive_stdout(helpers):
     assert not ret.stderr
 
 
-def test_history_fake_noninteractive_stderr(helpers):
+def test_history_fake_noninteractive_stderr():
     ret = subprocess.run(["onyo", "config", "onyo.history.non-interactive", "/bin/printf >&2"],
                          capture_output=True, text=True)
     assert ret.returncode == 0
@@ -178,7 +178,7 @@ def test_history_fake_noninteractive_stderr(helpers):
     assert Path(ret.stderr).resolve() == Path('s p a/c e s/1 2').resolve()
 
 
-def test_history_fake_noninteractive_bubble_exit_code(helpers):
+def test_history_fake_noninteractive_bubble_exit_code():
     # success
     ret = subprocess.run(["onyo", "config", "onyo.history.non-interactive", "/bin/true"],
                          capture_output=True, text=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,17 +86,6 @@ class Helpers:
         return chain.from_iterable(combinations(s, r) for r in range(len(s) + 1))
 
     @staticmethod
-    def string_in_file(string, file):
-        """
-        Test whether a string is in a file.
-        """
-        with open(file) as f:
-            if string in f.read():
-                return True
-
-        return False
-
-    @staticmethod
     def populate_repo(path: str, dirs: list = [], files: list = []) -> None:
         """
         Create and initialize a folder, and build a directory and file

--- a/tests/lib/test_Repo_add.py
+++ b/tests/lib/test_Repo_add.py
@@ -1,235 +1,191 @@
-import logging
-import subprocess
 from pathlib import Path
-
-from onyo import commands  # noqa: F401
-from onyo.lib import Repo
 import pytest
 
 
-def test_onyo_init():
-    ret = subprocess.run(["onyo", "init"])
-    assert ret.returncode == 0
-
-
-def test_add_simple_str(caplog):
-    caplog.set_level(logging.INFO, logger='onyo')
-    repo = Repo('.')
-
-    # test
-    Path('simple-str').touch()
-    repo.add('simple-str')
-    assert Path('simple-str') in repo.files_staged
-
-    # cleanup
-    repo.commit('commit')
-
-
-def test_add_simple_Path(caplog):
-    caplog.set_level(logging.INFO, logger='onyo')
-    repo = Repo('.')
+variants = {
+    'str': 'single-file',
+    'Path': Path('single-file'),
+    'list-str': ['single-file'],
+    'list-Path': [Path('single-file')],
+    'set-str': {'single-file'},
+    'set-Path': {Path('single-file')},
+}
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_add_args_single_file(repo, variant):
+    """
+    Single file across types.
+    """
+    Path('single-file').touch()
 
     # test
-    Path('simple-Path').touch()
-    repo.add(Path('simple-Path'))
-    assert Path('simple-Path') in repo.files_staged
-
-    # cleanup
-    repo.commit('commit')
+    repo.add(variant)
+    assert Path('single-file') in repo.files_staged
 
 
-def test_add_list_str(caplog):
-    caplog.set_level(logging.INFO, logger='onyo')
-    repo = Repo('.')
-
-    # test
-    Path('list-one').touch()
-    Path('list-two').touch()
-    Path('list-three').touch()
-    repo.add(['list-one', 'list-two', 'list-three'])
-    assert Path('list-one') in repo.files_staged
-    assert Path('list-two') in repo.files_staged
-    assert Path('list-three') in repo.files_staged
-
-    # cleanup
-    repo.commit('commit')
-
-
-def test_add_list_Path(caplog):
-    caplog.set_level(logging.INFO, logger='onyo')
-    repo = Repo('.')
+variants = {  # pyre-ignore[9]
+    'list-str': ['one', 'two', 'three'],
+    'list-Path': [Path('one'), Path('two'), Path('three')],
+    'list-mixed': ['one', Path('two'), 'three'],
+    'set-str': {'one', 'two', 'three'},
+    'set-Path': {Path('one'), Path('two'), Path('three')},
+    'set-mixed': {Path('one'), 'two', Path('three')},
+}
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_add_args_multi_file(repo, variant):
+    """
+    Multiple files across types.
+    """
+    Path('one').touch()
+    Path('two').touch()
+    Path('three').touch()
 
     # test
-    Path('list-Path-one').touch()
-    Path('list-Path-two').touch()
-    Path('list-Path-three').touch()
-    repo.add({Path('list-Path-one'), 'list-Path-two', Path('list-Path-three')})
-    assert Path('list-Path-one') in repo.files_staged
-    assert Path('list-Path-two') in repo.files_staged
-    assert Path('list-Path-three') in repo.files_staged
-
-    # cleanup
-    repo.commit('commit')
+    repo.add(variant)
+    assert Path('one') in repo.files_staged
+    assert Path('two') in repo.files_staged
+    assert Path('three') in repo.files_staged
 
 
-def test_add_list_mixed(caplog):
-    caplog.set_level(logging.INFO, logger='onyo')
-    repo = Repo('.')
-
-    # test
-    Path('list-mix-one-str').touch()
-    Path('list-mix-two-Path').touch()
-    Path('list-mix-three-str').touch()
-    repo.add(['list-mix-one-str', Path('list-mix-two-Path'), 'list-mix-three-str'])
-    assert Path('list-mix-one-str') in repo.files_staged
-    assert Path('list-mix-two-Path') in repo.files_staged
-    assert Path('list-mix-three-str') in repo.files_staged
-
-    # cleanup
-    repo.commit('commit')
-
-
-def test_add_set_str(caplog):
-    caplog.set_level(logging.INFO, logger='onyo')
-    repo = Repo('.')
+variants = {
+    'str': 'single-dir',
+    'Path': Path('single-dir'),
+    'list-str': ['single-dir'],
+    'list-Path': [Path('single-dir')],
+    'set-str': {'single-dir'},
+    'set-Path': {Path('single-dir')},
+}
+@pytest.mark.repo_dirs('single-dir')
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_add_args_single_dir(repo, variant):
+    """
+    Single directory across types.
+    """
+    Path('single-dir/file').touch()
 
     # test
-    Path('set-one').touch()
-    Path('set-two').touch()
-    Path('set-three').touch()
-    repo.add({'set-one', 'set-two', 'set-three'})
-    assert Path('set-one') in repo.files_staged
-    assert Path('set-two') in repo.files_staged
-    assert Path('set-three') in repo.files_staged
-
-    # cleanup
-    repo.commit('commit')
+    repo.add(variant)
+    assert Path('single-dir/file') in repo.files_staged
 
 
-def test_add_set_Path(caplog):
-    caplog.set_level(logging.INFO, logger='onyo')
-    repo = Repo('.')
-
-    # test
-    Path('set-Path-one').touch()
-    Path('set-Path-two').touch()
-    Path('set-Path-three').touch()
-    repo.add({Path('set-Path-one'), 'set-Path-two', Path('set-Path-three')})
-    assert Path('set-Path-one') in repo.files_staged
-    assert Path('set-Path-two') in repo.files_staged
-    assert Path('set-Path-three') in repo.files_staged
-
-    # cleanup
-    repo.commit('commit')
-
-
-def test_add_set_mixed(caplog):
-    caplog.set_level(logging.INFO, logger='onyo')
-    repo = Repo('.')
+variants = {  # pyre-ignore[9]
+    'list-str': ['one', 'two', 'three'],
+    'list-Path': [Path('one'), Path('two'), Path('three')],
+    'list-mixed': ['one', Path('two'), 'three'],
+    'set-str': {'one', 'two', 'three'},
+    'set-Path': {Path('one'), Path('two'), Path('three')},
+    'set-mixed': {Path('one'), 'two', Path('three')},
+}
+@pytest.mark.repo_dirs('one', 'two', 'three')
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_add_args_multi_dir(repo, variant):
+    """
+    Multiple directories across types.
+    """
+    Path('one/file-one-A').touch()
+    Path('one/file-one-B').touch()
+    Path('two/file-two-A').touch()
+    Path('two/file-two-B').touch()
+    Path('three/file-three-A').touch()
+    Path('three/file-three-B').touch()
 
     # test
-    Path('set-mix-one-Path').touch()
-    Path('set-mix-two-str').touch()
-    Path('set-mix-three-Path').touch()
-    repo.add({Path('set-mix-one-Path'), 'set-mix-two-str', Path('set-mix-three-Path')})
-    assert Path('set-mix-one-Path') in repo.files_staged
-    assert Path('set-mix-two-str') in repo.files_staged
-    assert Path('set-mix-three-Path') in repo.files_staged
+    repo.add(variant)
+    for i in variant:
+        assert Path(f'{i}/file-{i}-A') in repo.files_staged
+        assert Path(f'{i}/file-{i}-B') in repo.files_staged
 
-    # cleanup
-    repo.commit('commit')
+    assert len(variant) * 2 == len(repo.files_staged)
 
 
-def test_add_spaces_file(caplog):
-    caplog.set_level(logging.INFO, logger='onyo')
-    repo = Repo('.')
-
-    # test
-    Path('s p a c e s').touch()
-    repo.add('s p a c e s')
-    assert Path('s p a c e s') in repo.files_staged
-
-    # cleanup
-    repo.commit('commit')
-
-
-def test_add_dir(caplog):
-    caplog.set_level(logging.INFO, logger='onyo')
-    repo = Repo('.')
+variants = {  # pyre-ignore[9]
+    'top': {'dirs': 'r', 'num': 4},
+    'deep': {'dirs': 'r/e/c/u/r/s/i/v/e', 'num': 2},
+    'overlap-same': {'dirs': ['r/e/c/u/r', 'r/e/c/u/r/s/i/v/e'], 'num': 2},
+    'overlap-more': {'dirs': ['r/e', 'r/e/c/u/r/s/i/v/e'], 'num': 4},
+}
+@pytest.mark.repo_dirs('r/e/c/u/r/s/i/v/e')
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_add_dir_recursive(repo, variant):
+    """
+    Recursive directories
+    """
+    Path('r/e/c/child-r-A').touch()
+    Path('r/e/c/child-r-B').touch()
+    Path('r/e/c/u/r/s/i/v/e/child-r-A').touch()
+    Path('r/e/c/u/r/s/i/v/e/child-r-B').touch()
 
     # test
-    Path('dir-one').mkdir()
-    Path('dir-two').mkdir()
-    Path('dir-one/child-one-A').touch()
-    Path('dir-one/child-one-B').touch()
-    Path('dir-two/child-two-A').touch()
-    Path('dir-two/child-two-B').touch()
-
-    repo.add(['dir-one', 'dir-two'])
-    assert Path('dir-one/child-one-A') in repo.files_staged
-    assert Path('dir-one/child-one-B') in repo.files_staged
-    assert Path('dir-two/child-two-A') in repo.files_staged
-    assert Path('dir-two/child-two-B') in repo.files_staged
-
-    # cleanup
-    repo.commit('commit')
+    repo.add(variant['dirs'])
+    assert variant['num'] == len(repo.files_staged)
 
 
-def test_add_spaces_dir(caplog):
-    caplog.set_level(logging.INFO, logger='onyo')
-    repo = Repo('.')
+variants = {
+    'single': ['o n e'],
+    'multi': ['o n e', 't w o', 'd i r/t h r e e'],
+}
+@pytest.mark.repo_dirs('d i r')
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_add_spaces(repo, variant):
+    """
+    Spaces.
+    """
+    Path('o n e').touch()
+    Path('t w o').touch()
+    Path('d i r/t h r e e').touch()
 
     # test
-    Path('s p a/c e s').mkdir(parents=True)
-    Path('s p a/c e s/child-A').touch()
-    repo.add('s p a')
-    assert Path('s p a/c e s/child-A') in repo.files_staged
-
-    # cleanup
-    repo.commit('commit')
+    repo.add(variant)
+    for i in variant:
+        assert Path(i) in repo.files_staged
+    assert len(variant) == len(repo.files_staged)
 
 
-def test_add_repeat(caplog):
-    caplog.set_level(logging.INFO, logger='onyo')
-    repo = Repo('.')
-
-    # test
-    Path('repeat-A').touch()
-    Path('repeat-B').touch()
-    Path('repeat-C').touch()
-    repo.add(['repeat-A', 'repeat-B', 'repeat-A', 'repeat-C'])
-    assert Path('repeat-A') in repo.files_staged
-    assert Path('repeat-B') in repo.files_staged
-    assert Path('repeat-C') in repo.files_staged
-
-    # cleanup
-    repo.commit('commit')
-
-
-def test_add_unchanged(caplog):
-    caplog.set_level(logging.INFO, logger='onyo')
-    repo = Repo('.')
-
-    # setup
-    Path('unchanged').touch()
-    repo.add('unchanged')
-    repo.commit('commit')
+def test_add_repeat(repo):
+    """
+    Repeated target paths are OK.
+    """
+    Path('repeat-one').touch()
+    Path('two').touch()
+    Path('three').touch()
 
     # test
-    repo.add('unchanged')
+    repo.add(['repeat-one', 'two', 'repeat-one', 'three'])
+    assert Path('repeat-one') in repo.files_staged
+    assert Path('two') in repo.files_staged
+    assert Path('three') in repo.files_staged
 
 
-def test_add_missing(caplog):
-    caplog.set_level(logging.INFO, logger='onyo')
-    repo = Repo('.')
+variants = {
+    'file': 'unchanged-file',
+    'dir': 'unchanged-dir',
+    'mixed': ['unchanged-file', 'unchanged-dir'],
+}
+@pytest.mark.repo_dirs('unchanged-dir')
+@pytest.mark.repo_files('unchanged-file')
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_add_unchanged(repo, variant):
+    """
+    Unchanged targets.
+    """
+    repo.add(variant)
+    assert not repo.files_staged
+
+
+variants = {
+    'root': ['one', 'not-exist', 'dir/three'],
+    'subdir': ['one', 'two', 'dir/not-exist'],
+}
+@pytest.mark.repo_dirs('dir')
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_add_not_exist(repo, variant):
+    """
+    Targets that don't exist.
+    """
+    Path('one').touch()
+    Path('two').touch()
+    Path('dir/three').touch()
 
     # test
-    Path('missing-A').touch()
-    Path('missing-C').touch()
     with pytest.raises(FileNotFoundError):
-        repo.add(['missing-A', 'missing-B', 'missing-C'])
-    assert Path('missing-A') not in repo.files_staged
-    assert Path('missing-B') not in repo.files_staged
-    assert Path('missing-C') not in repo.files_staged
-
-    # no commit
+        repo.add(variant)
+    assert not repo.files_staged

--- a/tests/lib/test_Repo_fsck.py
+++ b/tests/lib/test_Repo_fsck.py
@@ -1,57 +1,57 @@
 import logging
-import os
-import subprocess
 from pathlib import Path
 
 from onyo import commands  # noqa: F401
-from onyo.lib import Repo, OnyoInvalidRepoError
+from onyo.lib import OnyoInvalidRepoError
 import pytest
 
 
-def test_fsck_anchors_empty(caplog, helpers):
+#
+# Generic
+#
+variants = [
+    'anchors',
+    'asset-unique',
+    'asset-yaml',
+    'clean-tree',
+]
+@pytest.mark.parametrize('variant', variants)
+def test_fsck_empty(caplog, repo, variant):
     caplog.set_level(logging.INFO, logger='onyo')
-
-    # setup repo
-    helpers.populate_repo('fsck-anchors-empty')
-    os.chdir('fsck-anchors-empty')
-    repo = Repo('.')
 
     # test
-    repo.fsck(['anchors'])
+    repo.fsck([variant])
 
     # check log
-    # TODO: assert 'anchors' in caplog.text
+    # TODO: assert variant in caplog.text
 
 
-def test_fsck_anchors_populated(caplog, helpers):
+variants = [
+    'anchors',
+    'asset-unique',
+    'asset-yaml',
+    'clean-tree',
+]
+@pytest.mark.repo_files('README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'c/f_5', 'c/f_6', 'd/f_7', 'd/f_8')
+@pytest.mark.parametrize('variant', variants)
+def test_fsck_populated(caplog, repo, variant):
     caplog.set_level(logging.INFO, logger='onyo')
-
-    dirs = ['a', 'b', 'c', 'd']
-    files = ['README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'c/f_5', 'c/f_6', 'd/f_7', 'd/f_8']
-
-    # setup repo
-    helpers.populate_repo('fsck-anchors-populated', dirs, files)
-    os.chdir('fsck-anchors-populated')
-    repo = Repo('.')
 
     # test
-    repo.fsck(['anchors'])
+    repo.fsck([variant])
 
     # check log
-    # TODO: assert 'anchors' in caplog.text
+    # TODO: assert variant in caplog.text
 
 
-def test_fsck_anchors_missing(caplog, helpers):
+#
+# Anchors
+#
+@pytest.mark.repo_dirs('r/e/c/u/r/s/i/v/e')
+@pytest.mark.repo_files('README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'c/f_5', 'c/f_6', 'd/f_7', 'd/f_8')
+def test_fsck_anchors_missing(caplog, repo):
     caplog.set_level(logging.INFO, logger='onyo')
-
-    dirs = ['a', 'b', 'c', 'd', 'r/e/c/u/r/s/i/v/e']
-    files = ['README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'c/f_5', 'c/f_6', 'd/f_7', 'd/f_8']
     anchors_to_remove = ['a/.anchor', 'r/e/c/.anchor', 'r/e/c/u/r/s/i/v/.anchor']
-
-    # setup repo
-    helpers.populate_repo('fsck-anchors-missing', dirs, files)
-    os.chdir('fsck-anchors-missing')
-    repo = Repo('.')
 
     # remove anchors
     repo._git(['rm'] + anchors_to_remove)
@@ -68,52 +68,15 @@ def test_fsck_anchors_missing(caplog, helpers):
     assert len(anchors_to_remove) == caplog.text.count('/.anchor')
 
 
-def test_fsck_unique_assets_empty(caplog, helpers):
+#
+# Asset-Unique
+#
+@pytest.mark.repo_files('README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'r/e/c/f_5', 'r/e/c/u/r/f_6', 'r/e/c/u/r/s/i/v/e/f_7')
+def test_fsck_unique_assets_conflict(caplog, repo):
     caplog.set_level(logging.INFO, logger='onyo')
-
-    # setup repo
-    helpers.populate_repo('fsck-unique-assets-empty')
-    os.chdir('fsck-unique-assets-empty')
-    repo = Repo('.')
-
-    # test
-    repo.fsck(['asset-unique'])
-
-    # check log
-    # TODO: assert 'asset-unique' in caplog.text
-
-
-def test_fsck_unique_assets_populated(caplog, helpers):
-    caplog.set_level(logging.INFO, logger='onyo')
-
-    dirs = ['a', 'b', 'c', 'd']
-    files = ['README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'c/f_5', 'c/f_6', 'd/f_7', 'd/f_8']
-
-    # setup repo
-    helpers.populate_repo('fsck-unique-assets-populated', dirs, files)
-    os.chdir('fsck-unique-assets-populated')
-    repo = Repo('.')
-
-    # test
-    repo.fsck(['asset-unique'])
-
-    # check log
-    # TODO: assert 'asset-unique' in caplog.text
-
-
-def test_fsck_unique_assets_conflict(caplog, helpers):
-    caplog.set_level(logging.INFO, logger='onyo')
-
-    dirs = ['a', 'b', 'c', 'd', 'r/e/c/u/r/s/i/v/e']
-    files = ['README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'r/e/c/f_5', 'r/e/c/u/r/f_6', 'r/e/c/u/r/s/i/v/e/f_7']
     assets_to_conflict = ['b/f_1', 'r/e/c/f_3', 'r/e/c/u/r/s/i/v/e/f_5']
 
-    # setup repo
-    helpers.populate_repo('fsck-unique-assets-conflict', dirs, files)
-    os.chdir('fsck-unique-assets-conflict')
-    repo = Repo('.')
-
-    # mangle files
+    # conflict some asset names
     for i in assets_to_conflict:
         Path(i).touch()
 
@@ -131,50 +94,13 @@ def test_fsck_unique_assets_conflict(caplog, helpers):
         assert 2 == caplog.text.count(Path(i).name)
 
 
-def test_fsck_yaml_empty(caplog, helpers):
+#
+# Asset-YAML
+#
+@pytest.mark.repo_files('README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'r/e/c/f_5', 'r/e/c/u/r/f_6', 'r/e/c/u/r/s/i/v/e/f_7')
+def test_fsck_yaml_invalid(caplog, repo):
     caplog.set_level(logging.INFO, logger='onyo')
-
-    # setup repo
-    helpers.populate_repo('fsck-yaml-empty')
-    os.chdir('fsck-yaml-empty')
-    repo = Repo('.')
-
-    # test
-    repo.fsck(['asset-yaml'])
-
-    # check log
-    # TODO: assert 'asset-yaml' in caplog.text
-
-
-def test_fsck_yaml_populated(caplog, helpers):
-    caplog.set_level(logging.INFO, logger='onyo')
-
-    dirs = ['a', 'b', 'c', 'd']
-    files = ['README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'c/f_5', 'c/f_6', 'd/f_7', 'd/f_8']
-
-    # setup repo
-    helpers.populate_repo('fsck-yaml-populated', dirs, files)
-    os.chdir('fsck-yaml-populated')
-    repo = Repo('.')
-
-    # test
-    repo.fsck(['asset-yaml'])
-
-    # check log
-    # TODO: assert 'asset-yaml' in caplog.text
-
-
-def test_fsck_yaml_invalid(caplog, helpers):
-    caplog.set_level(logging.INFO, logger='onyo')
-
-    dirs = ['a', 'b', 'c', 'd', 'r/e/c/u/r/s/i/v/e']
-    files = ['README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'r/e/c/f_5', 'r/e/c/u/r/f_6', 'r/e/c/u/r/s/i/v/e/f_7']
     files_to_mangle = ['a/f_1', 'r/e/c/f_5', 'r/e/c/u/r/s/i/v/e/f_7']
-
-    # setup repo
-    helpers.populate_repo('fsck-yaml-invalid', dirs, files)
-    os.chdir('fsck-yaml-invalid')
-    repo = Repo('.')
 
     # mangle files
     for i in files_to_mangle:
@@ -193,50 +119,13 @@ def test_fsck_yaml_invalid(caplog, helpers):
         assert i in caplog.text
 
 
-def test_fsck_clean_tree_empty(caplog, helpers):
+#
+# Clean-Tree
+#
+@pytest.mark.repo_files('README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'c/f_5', 'c/f_6', 'd/f_7', 'd/f_8')
+def test_fsck_clean_tree_changed(caplog, repo):
     caplog.set_level(logging.INFO, logger='onyo')
-
-    # setup repo
-    helpers.populate_repo('fsck-clean-tree-empty')
-    os.chdir('fsck-clean-tree-empty')
-    repo = Repo('.')
-
-    # test
-    repo.fsck(['clean-tree'])
-
-    # check log
-    # TODO: assert 'clean-tree' in caplog.text
-
-
-def test_fsck_clean_tree_populated(caplog, helpers):
-    caplog.set_level(logging.INFO, logger='onyo')
-
-    dirs = ['a', 'b', 'c', 'd']
-    files = ['README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'c/f_5', 'c/f_6', 'd/f_7', 'd/f_8']
-
-    # setup repo
-    helpers.populate_repo('fsck-clean-tree-populated', dirs, files)
-    os.chdir('fsck-clean-tree-populated')
-    repo = Repo('.')
-
-    # test
-    repo.fsck(['clean-tree'])
-
-    # check log
-    # TODO: assert 'clean-tree' in caplog.text
-
-
-def test_fsck_clean_tree_changed(caplog, helpers):
-    caplog.set_level(logging.INFO, logger='onyo')
-
-    dirs = ['a', 'b', 'c', 'd']
-    files = ['README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'c/f_5', 'c/f_6', 'd/f_7', 'd/f_8']
     files_to_change = ['a/f_1', 'b/f_3']
-
-    # setup repo
-    helpers.populate_repo('fsck-clean-tree-changed', dirs, files)
-    os.chdir('fsck-clean-tree-changed')
-    repo = Repo('.')
 
     # change files
     for i in files_to_change:
@@ -252,24 +141,16 @@ def test_fsck_clean_tree_changed(caplog, helpers):
         assert i in caplog.text
 
 
-def test_fsck_clean_tree_staged(caplog, helpers):
+@pytest.mark.repo_files('README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'c/f_5', 'c/f_6', 'd/f_7', 'd/f_8')
+def test_fsck_clean_tree_staged(caplog, repo):
     caplog.set_level(logging.INFO, logger='onyo')
-
-    dirs = ['a', 'b', 'c', 'd']
-    files = ['README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'c/f_5', 'c/f_6', 'd/f_7', 'd/f_8']
     files_to_stage = ['a/f_1', 'b/f_3']
-
-    # setup repo
-    helpers.populate_repo('fsck-clean-tree-staged', dirs, files)
-    os.chdir('fsck-clean-tree-staged')
-    repo = Repo('.')
 
     # change and stage files
     for i in files_to_stage:
         Path(i).write_text('New contents')
 
-    ret = subprocess.run(['git', 'add'] + files_to_stage)
-    assert ret.returncode == 0
+    repo.add(files_to_stage)
 
     # test
     with pytest.raises(OnyoInvalidRepoError):
@@ -281,17 +162,10 @@ def test_fsck_clean_tree_staged(caplog, helpers):
         assert i in caplog.text
 
 
-def test_fsck_clean_tree_untracked(caplog, helpers):
+@pytest.mark.repo_files('README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'c/f_5', 'c/f_6', 'd/f_7', 'd/f_8')
+def test_fsck_clean_tree_untracked(caplog, repo):
     caplog.set_level(logging.INFO, logger='onyo')
-
-    dirs = ['a', 'b', 'c', 'd']
-    files = ['README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'c/f_5', 'c/f_6', 'd/f_7', 'd/f_8']
     files_to_be_untracked = ['LICENSE', 'd/f_9']
-
-    # setup repo
-    helpers.populate_repo('fsck-clean-tree-untracked', dirs, files)
-    os.chdir('fsck-clean-tree-untracked')
-    repo = Repo('.')
 
     # create untracked files
     for i in files_to_be_untracked:

--- a/tests/lib/test_Repo_mkdir.py
+++ b/tests/lib/test_Repo_mkdir.py
@@ -1,9 +1,7 @@
-import logging
-import subprocess
 from pathlib import Path
 
 from onyo import commands  # noqa: F401
-from onyo.lib import Repo, OnyoProtectedPathError
+from onyo.lib import OnyoProtectedPathError
 import pytest
 
 
@@ -18,25 +16,70 @@ def anchored_dir(directory):
     return False
 
 
-def test_onyo_init():
-    ret = subprocess.run(["onyo", "init"])
-    assert ret.returncode == 0
+variants = {
+    'str': 'one',
+    'Path': Path('one'),
+    'list-str': ['one'],
+    'list-Path': [Path('one')],
+    'set-str': {'one'},
+    'set-Path': {Path('one')},
+}
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_mkdir_single(repo, variant):
+    """
+    Single directory across types.
+    """
+    repo.mkdir(variant)
+    assert anchored_dir('one')
+
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])
 
 
-def test_mkdir_simple(caplog):
-    caplog.set_level(logging.INFO, logger='onyo')
-    repo = Repo('.')
+variants = {  # pyre-ignore[9]
+    'list-str': ['one', 'two', 'three'],
+    'list-Path': [Path('one'), Path('two'), Path('three')],
+    'list-mixed': ['one', Path('two'), 'three'],
+    'set-str': {'one', 'two', 'three'},
+    'set-Path': {Path('one'), Path('two'), Path('three')},
+    'set-mixed': {Path('one'), 'two', Path('three')},
+}
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_mkdir_multi(repo, variant):
+    """
+    Multiple directories across types.
+    """
+    repo.mkdir(variant)
+    assert anchored_dir('one')
+    assert anchored_dir('two')
+    assert anchored_dir('three')
 
-    # test
-    repo.mkdir('simple')
-    assert anchored_dir('simple')
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])
 
 
-def test_mkdir_recursive(caplog):
-    caplog.set_level(logging.INFO, logger='onyo')
-    repo = Repo('.')
+variants = {
+    'single': ['o n e'],
+    'multi': ['o n e', 't w o', 't h r e e'],
+    'subdir': ['s p a/c e s'],
+}
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_mkdir_spaces(repo, variant):
+    """
+    Spaces.
+    """
+    repo.mkdir(variant)
+    for i in variant:
+        assert anchored_dir(i)
 
-    # test
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])
+
+
+def test_mkdir_recursive(repo):
+    """
+    Recursive directories.
+    """
     repo.mkdir('r/e/c/u/r/s/i/v/e')
     assert anchored_dir('r')
     assert anchored_dir('r/e')
@@ -48,50 +91,19 @@ def test_mkdir_recursive(caplog):
     assert anchored_dir('r/e/c/u/r/s/i/v')
     assert anchored_dir('r/e/c/u/r/s/i/v/e')
 
-
-def test_mkdir_spaces(caplog):
-    caplog.set_level(logging.INFO, logger='onyo')
-    repo = Repo('.')
-
-    # single
-    repo.mkdir('s p a c e s')
-    assert anchored_dir('s p a c e s')
-
-    # nested spaces
-    repo.mkdir('s p a/c e s')
-    assert anchored_dir('s p a/c e s')
-
-    for d in [' ', 's', 'p', 'a', 'c', 'e', 's']:
-        assert not Path(d).exists()
-        assert not Path('s p a', d).exists()
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])
 
 
-def test_mkdir_relative(caplog):
-    caplog.set_level(logging.INFO, logger='onyo')
-    repo = Repo('.')
+variants = {
+    'implicit': ['overlap/one', 'overlap/two', 'overlap/three'],
+    'explicit': ['overlap', 'overlap/one', 'overlap/two', 'overlap/three']
+}
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_mkdir_overlap(repo, variant):
+    repo.mkdir(variant)
 
-    # test
-    repo.mkdir('simple/../relative')
-    assert anchored_dir('relative')
-
-
-def test_mkdir_multiple_dirs(caplog):
-    caplog.set_level(logging.INFO, logger='onyo')
-    repo = Repo('.')
-
-    # test
-    repo.mkdir(['one', 'two', 'three'])
-    assert anchored_dir('one')
-    assert anchored_dir('two')
-    assert anchored_dir('three')
-
-
-def test_mkdir_overlapping(caplog):
-    caplog.set_level(logging.INFO, logger='onyo')
-    repo = Repo('.')
-
-    # test
-    repo.mkdir(['overlap/one', 'overlap/two', 'overlap/three'])
+    assert anchored_dir('overlap')
     assert anchored_dir('overlap/one')
     assert anchored_dir('overlap/two')
     assert anchored_dir('overlap/three')
@@ -100,223 +112,127 @@ def test_mkdir_overlapping(caplog):
     assert not Path('overlap/two/overlap').exists()
     assert not Path('overlap/three/overlap').exists()
 
-    # test
-    repo.mkdir(['double-o', 'double-o/one', 'double-o/two', 'double-o/three'])
-    assert anchored_dir('double-o/one')
-    assert anchored_dir('double-o/two')
-    assert anchored_dir('double-o/three')
-    assert not Path('double-o/double-o').exists()
-    assert not Path('double-o/one/double-o').exists()
-    assert not Path('double-o/two/double-o').exists()
-    assert not Path('double-o/three/double-o').exists()
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])
 
 
-def test_mkdir_path(caplog):
-    caplog.set_level(logging.INFO, logger='onyo')
-    repo = Repo('.')
-
-    # single
-    repo.mkdir(Path('Path'))
-    assert anchored_dir('Path')
-
-    # multiple
-    repo.mkdir([Path('Path-one'), Path('Path-two')])
-    assert anchored_dir('Path-one')
-    assert anchored_dir('Path-two')
-
-
-def test_mkdir_path_str_mixed(caplog):
-    caplog.set_level(logging.INFO, logger='onyo')
-    repo = Repo('.')
-
-    # test
-    repo.mkdir([Path('mixed-Path-one'), 'mixed-str-two'])
-    assert anchored_dir('mixed-Path-one')
-    assert anchored_dir('mixed-str-two')
-
-
-def test_mkdir_protected(caplog):
-    caplog.set_level(logging.INFO, logger='onyo')
-    repo = Repo('.')
-
-    # dir named .anchor
+variants = [  # pyre-ignore[9]
+    '.onyo/protected',
+    '.git/protected',
+    'protected/.git',
+    'protected/.onyo',
+    'one/.anchor',
+]
+@pytest.mark.parametrize('variant', variants)
+def test_mkdir_protected(repo, variant):
+    """
+    Protected paths.
+    """
     with pytest.raises(OnyoProtectedPathError):
-        repo.mkdir('protected/.anchor')
-    assert not Path('protected/.anchor').exists()
-    assert 'protected/.anchor' in caplog.text
+        repo.mkdir(variant)
 
-    # dir named .git
+    assert not Path(variant).exists()
+
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])
+
+
+variants = [  # pyre-ignore[9]
+    '.onyo/protected',
+    '.git/protected',
+    'protected/.git',
+    'protected/.onyo',
+    'one/.anchor',
+]
+@pytest.mark.parametrize('variant', variants)
+def test_mkdir_protected_mixed(repo, variant, caplog):
+    """
+    Protected paths.
+    """
     with pytest.raises(OnyoProtectedPathError):
-        repo.mkdir('protected/.git')
-    assert not Path('protected/.git').exists()
-    assert 'protected/.git' in caplog.text
+        repo.mkdir(['valid-one', variant, 'valid-two'])
 
-    # inside of .git
-    with pytest.raises(OnyoProtectedPathError):
-        repo.mkdir('.git/protected')
-    assert not Path('.git/protected').exists()
-    assert '.git/protected' in caplog.text
-
-    # dir named .onyo
-    with pytest.raises(OnyoProtectedPathError):
-        repo.mkdir('protected/.onyo')
-    assert not Path('protected/.onyo').exists()
-    assert 'protected/.onyo' in caplog.text
-
-    # inside of .onyo
-    with pytest.raises(OnyoProtectedPathError):
-        repo.mkdir('.onyo/protected')
-    assert not Path('.onyo/protected').exists()
-    assert '.onyo/protected' in caplog.text
-
-
-def test_mkdir_protected_mixed(caplog):
-    caplog.set_level(logging.INFO, logger='onyo')
-    repo = Repo('.')
-
-    # test
-    with pytest.raises(OnyoProtectedPathError):
-        repo.mkdir(['valid-one', 'protected/.anchor', 'valid-two'])
     assert not Path('valid-one').exists()
     assert not Path('valid-two').exists()
-    assert not Path('protected/.anchor').exists()
+    assert not Path(variant).exists()
 
-    with pytest.raises(OnyoProtectedPathError):
-        repo.mkdir(['valid-one', '.onyo/protected', 'valid-two'])
-    assert not Path('valid-one').exists()
-    assert not Path('valid-two').exists()
-    assert not Path('.onyo/protected').exists()
-
-    # check logs
+    # check log
     assert 'valid-one' not in caplog.text
     assert 'valid-two' not in caplog.text
-    assert 'protected/.anchor' in caplog.text
-    assert '.onyo/protected' in caplog.text
+    assert variant in caplog.text
+
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])
 
 
-def test_mkdir_exists_dir(caplog):
-    caplog.set_level(logging.INFO, logger='onyo')
-    repo = Repo('.')
-
-    # setup
-    repo.mkdir('exists-dir')
-
-    # test
+variants = [  # pyre-ignore[9]
+    'exists-dir',
+    'subdir/exists-dir',
+]
+@pytest.mark.repo_dirs('exists-dir', 'subdir/exists-dir')
+@pytest.mark.parametrize('variant', variants)
+def test_mkdir_exists_dir(repo, variant, caplog):
+    """
+    TODO
+    """
     with pytest.raises(FileExistsError):
-        repo.mkdir('exists-dir')
+        repo.mkdir(variant)
 
+    assert anchored_dir(variant)
+    assert not anchored_dir(f'{variant}/{variant}')
+
+    # check log
+    assert variant in caplog.text
+
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])
+
+
+variants = [  # pyre-ignore[9]
+    'exists-file',
+    'subdir/exists-subfile',
+]
+@pytest.mark.repo_files('exists-file', 'subdir/exists-subfile')
+@pytest.mark.parametrize('variant', variants)
+def test_mkdir_exists_file(repo, variant, caplog):
+    """
+    TODO
+    """
+    with pytest.raises(FileExistsError):
+        repo.mkdir(variant)
+
+    assert Path(variant).is_file()
+
+    # check log
+    assert variant in caplog.text
+
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])
+
+
+variants = [  # pyre-ignore[9]
+    'exists-file',
+    'exists-dir',
+]
+@pytest.mark.repo_dirs('exists-dir')
+@pytest.mark.repo_files('exists-file')
+@pytest.mark.parametrize('variant', variants)
+def test_mkdir_exists_mixed(repo, variant, caplog):
+    """
+    TODO
+    """
+    with pytest.raises(FileExistsError):
+        repo.mkdir(['valid-one', variant, 'valid-two'])
+
+    assert not Path('valid-one').exists()
+    assert not Path('valid-two').exists()
+    assert Path('exists-file').exists()
     assert anchored_dir('exists-dir')
-    assert not anchored_dir('exists-dir/exists-dir')
 
     # check log
-    assert 'exists-dir' in caplog.text
-
-
-def test_mkdir_exists_file(caplog):
-    caplog.set_level(logging.INFO, logger='onyo')
-    repo = Repo('.')
-
-    # setup
-    Path('exists-file').touch()
-    repo.add('exists-file')
-    repo.commit('add exists-file')
-
-    # test
-    with pytest.raises(FileExistsError):
-        repo.mkdir('exists-file')
-
-    assert not anchored_dir('exists-file')
-    assert Path('exists-file').is_file()
-
-    # check log
-    assert 'exists-file' in caplog.text
-
-
-def test_mkdir_exists_recursive_dir(caplog):
-    caplog.set_level(logging.INFO, logger='onyo')
-    repo = Repo('.')
-
-    # setup
-    repo.mkdir('exists-r-dir/r/e/c/u/r/s/i/v/e')
-
-    # test
-    with pytest.raises(FileExistsError):
-        repo.mkdir('exists-r-dir/r/e/c/u/r/s/i/v/e')
-
-    # they should be untouched
-    assert anchored_dir('exists-r-dir/r')
-    assert anchored_dir('exists-r-dir/r/e')
-    assert anchored_dir('exists-r-dir/r/e/c')
-    assert anchored_dir('exists-r-dir/r/e/c/u')
-    assert anchored_dir('exists-r-dir/r/e/c/u/r')
-    assert anchored_dir('exists-r-dir/r/e/c/u/r/s')
-    assert anchored_dir('exists-r-dir/r/e/c/u/r/s/i')
-    assert anchored_dir('exists-r-dir/r/e/c/u/r/s/i/v')
-    assert anchored_dir('exists-r-dir/r/e/c/u/r/s/i/v/e')
-
-    assert not anchored_dir('exists-r-dir/r/r')
-    assert not anchored_dir('exists-r-dir/r/e/e')
-    assert not anchored_dir('exists-r-dir/r/e/c/c')
-    assert not anchored_dir('exists-r-dir/r/e/c/u/u')
-    assert not anchored_dir('exists-r-dir/r/e/c/u/r/r')
-    assert not anchored_dir('exists-r-dir/r/e/c/u/r/s/s')
-    assert not anchored_dir('exists-r-dir/r/e/c/u/r/s/i/i')
-    assert not anchored_dir('exists-r-dir/r/e/c/u/r/s/i/v/v')
-    assert not anchored_dir('exists-r-dir/r/e/c/u/r/s/i/v/e/e')
-
-    # check log
-    assert 'exists-r-dir/r/e/c/u/r/s/i/v/e' in caplog.text
-
-
-def test_mkdir_exists_recursive_file(caplog):
-    caplog.set_level(logging.INFO, logger='onyo')
-    repo = Repo('.')
-
-    # setup
-    repo.mkdir('exists-r-file/r/e/c/u/r/s/i/v/e')
-    Path('exists-r-file/r/e/c/u/r/s/exists-r-file').touch()
-    repo.add('exists-r-file/r/e/c/u/r/s/exists-r-file')
-    repo.commit('add exists-r-file')
-
-    # test
-    with pytest.raises(FileExistsError):
-        repo.mkdir('exists-r-file/r/e/c/u/r/s/exists-r-file')
-
-    assert not anchored_dir('exists-r-file/r/e/c/u/r/s/exists-r-file')
-    assert Path('exists-r-file/r/e/c/u/r/s/exists-r-file').is_file()
-
-    # they should be untouched
-    assert anchored_dir('exists-r-file/r')
-    assert anchored_dir('exists-r-file/r/e')
-    assert anchored_dir('exists-r-file/r/e/c')
-    assert anchored_dir('exists-r-file/r/e/c/u')
-    assert anchored_dir('exists-r-file/r/e/c/u/r')
-    assert anchored_dir('exists-r-file/r/e/c/u/r/s')
-    assert anchored_dir('exists-r-file/r/e/c/u/r/s/i')
-    assert anchored_dir('exists-r-file/r/e/c/u/r/s/i/v')
-    assert anchored_dir('exists-r-file/r/e/c/u/r/s/i/v/e')
-
-    # check log
-    assert 'exists-r-file/r/e/c/u/r/s/exists-r-file' in caplog.text
-
-
-def test_mkdir_exists_mixed(caplog):
-    caplog.set_level(logging.INFO, logger='onyo')
-    repo = Repo('.')
-
-    # setup
-    repo.mkdir('exists-mixed')
-
-    # test
-    with pytest.raises(FileExistsError):
-        repo.mkdir(['valid-one', 'exists-mixed', 'valid-two'])
-    assert not Path('valid-one').exists()
-    assert not Path('valid-two').exists()
-    assert not Path('exists-mixed/valid-one').exists()
-    assert not Path('exists-mixed/valid-two').exists()
-    assert anchored_dir('exists-mixed')
-
-    # check logs
     assert 'valid-one' not in caplog.text
     assert 'valid-two' not in caplog.text
-    assert 'exists-mixed' in caplog.text
+    assert variant in caplog.text
+
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
 import pytest
-
+from pathlib import Path
 from onyo import commands  # noqa: F401
 from onyo import utils
 
@@ -11,23 +11,23 @@ def test_onyo_init():
     assert ret.returncode == 0
 
 
-def test_get_config_value_git(helpers):
+def test_get_config_value_git():
     ret = subprocess.run(["git", "config", "onyo.test.get-git", "get-git-test"],
                          capture_output=True, text=True)
     assert ret.returncode == 0
-    assert helpers.string_in_file('get-git =', '.git/config')
-    assert helpers.string_in_file('= get-git-test', '.git/config')
+    assert 'get-git =' in Path('.git/config').read_text()
+    assert '= get-git-test' in Path('.git/config').read_text()
 
     onyo_root = './'
     assert utils.get_config_value('onyo.test.get-git', onyo_root) == 'get-git-test'
 
 
-def test_get_config_value_onyo(helpers):
+def test_get_config_value_onyo():
     ret = subprocess.run(["onyo", "config", "onyo.test.get-onyo", "get-onyo-test"],
                          capture_output=True, text=True)
     assert ret.returncode == 0
-    assert helpers.string_in_file('get-onyo =', '.onyo/config')
-    assert helpers.string_in_file('= get-onyo-test', '.onyo/config')
+    assert 'get-onyo =' in Path('.onyo/config').read_text()
+    assert '= get-onyo-test' in Path('.onyo/config').read_text()
 
     onyo_root = './'
     assert utils.get_config_value('onyo.test.get-onyo', onyo_root) == 'get-onyo-test'
@@ -69,7 +69,7 @@ def test_get_editor_onyo():
     assert ret.returncode == 0
 
 
-def test_get_config_value_envvar(helpers):
+def test_get_config_value_envvar():
     """
     Get the editor from $EDITOR.
     """


### PR DESCRIPTION
This leverages many new (to this codebase) pytest features.

Most notably, the introduction of a `repo` fixture. This fixture:
- creates a new repository in a temporary directory
- `cd`s into the dir
- returns a handle to the repo

Furthermore, it will populate the repository by looking for the following markers:
- repo_dirs()
- repo_files()
  - files automatically have their parent dirs created.
 
Parameterization is now used, reducing repetitive tests.

All of this works towards:
- the eventual retirement of `change_cwd_to_sandbox`, `clean_sandboxes`, and `populate_repo`.
- parallel execution of tests
- randomization of test order

The modernizing in the PR is limited to the newer portions of the tests. The rest will be addressed as work continues to bring more functionality into the `Repo` class.