### PR TITLE
NF/RF: rm -> Repo.rm() (and a few unrelated tests)

### DIFF
--- a/onyo/commands/rm.py
+++ b/onyo/commands/rm.py
@@ -1,70 +1,20 @@
-import logging
 import sys
-from pathlib import Path
 
-from onyo.lib import Repo, OnyoInvalidRepoError
-from onyo.utils import is_protected_path
-
-logging.basicConfig()
-log = logging.getLogger('onyo')
+from onyo.lib import Repo, OnyoInvalidRepoError, OnyoProtectedPathError
 
 
-def sanitize_paths(paths, onyo_root):
-    """
-    Check and normalize a list of paths. If any do not exist, or are protected
-    paths (.anchor, .git, .onyo), then they will be printed and exit with error.
-
-    Returns a list of normed paths on success.
-    """
-    paths_to_rm = []
-    error_path_absent = []
-    error_path_protected = []
-
-    for p in paths:
-        full_path = Path(onyo_root, p).resolve()
-
-        # paths must exist
-        if not full_path.exists():
-            error_path_absent.append(p)
-            continue
-
-        # protected paths
-        if is_protected_path(full_path):
-            error_path_protected.append(p)
-            continue
-
-        # TODO: ideally, this would return a list of normed paths, relative to
-        # the root of the onyo repository (not to be confused with onyo_root).
-        # This would allow commit messages that are consistent regardless of
-        # where onyo is invoked from.
-        norm_path = str(full_path.relative_to(onyo_root))
-        paths_to_rm.append(norm_path)
-
-    if error_path_absent:
-        log.error("The following paths do not exist:")
-        log.error('\n'.join(error_path_absent))
-        log.error("\nExiting. Nothing was deleted.")
-        sys.exit(1)
-
-    if error_path_protected:
-        log.error("The following paths are protected by onyo:")
-        log.error('\n'.join(error_path_protected))
-        log.error("\nExiting. Nothing was deleted.")
-        sys.exit(1)
-
-    return paths_to_rm
-
-
-def rm(args, onyo_root):
+def rm(args, onyo_root: str) -> None:
     """
     Delete ``asset``\(s) and ``directory``\(s).
 
-    A complete list of all files and directories to delete will be presented
-    first, and the user prompted for confirmation.
+    A list of all files and directories to delete will be presented, and the
+    user prompted for confirmation.
     """
+    repo = None
+
     # check flags
     if args.quiet and not args.yes:
-        log.error("The --quiet flag requires --yes.")
+        print('The --quiet flag requires --yes.', file=sys.stderr)
         sys.exit(1)
 
     try:
@@ -73,19 +23,23 @@ def rm(args, onyo_root):
     except OnyoInvalidRepoError:
         sys.exit(1)
 
-    paths_to_rm = sanitize_paths(args.path, onyo_root)
-
     if not args.quiet:
-        print("The following assets and directories will be deleted:")
-        print("\n".join(paths_to_rm))
+        dryrun_list = None
+        try:
+            dryrun_list = repo.rm(args.path, dryrun=True)
+        except (FileNotFoundError, OnyoProtectedPathError):
+            sys.exit(1)
+
+        print('The following will be deleted:\n' +
+              '\n'.join(dryrun_list))
 
         if not args.yes:
-            response = input("Delete assets? (y/N) ")
+            response = input('Delete assets? (y/N) ')
             if response not in ['y', 'Y', 'yes']:
-                log.info("Nothing was deleted.")
+                print('Nothing was deleted.')
                 sys.exit(0)
 
-    # rm and commit
-    repo._git(['rm', '-r'] + paths_to_rm)
-    # TODO: can this commit message be made more helpful?
-    repo.commit('deleted asset(s)', paths_to_rm)
+    try:
+        repo.rm(args.path)
+    except (FileNotFoundError, OnyoProtectedPathError):
+        sys.exit(1)

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -199,6 +199,9 @@ class Repo:
 
         messages = []
         for i in args:
+            if not i:
+                raise ValueError('commit messages cannot be empty')
+
             messages.append('-m')
             if isinstance(i, (list, set)):
                 messages.append('\n'.join([str(x) for x in i]))

--- a/tests/lib/test_Repo_commit.py
+++ b/tests/lib/test_Repo_commit.py
@@ -79,9 +79,36 @@ def test_commit_set(repo, variant):
     assert 'three\n' in msg
 
 
-def test_commit_nothing(repo):
+def test_commit_nothing_staged(repo):
     with pytest.raises(subprocess.CalledProcessError):
         repo.commit('We believe in nothing Lebowski!')
 
     msg = last_commit_message()
     assert 'We believe in nothing Lebowski!' not in msg
+
+
+variants = {  # pyre-ignore[9]
+    'empty': (),
+    'str': (''),
+    'list': ([]),
+    'set': (set()),
+    'title-None': ('title', None),
+    'title-str': ('title', ''),
+    'title-list': ('title', []),
+    'title-set': ('title', set()),
+}
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_commit_empty_message(repo, variant):
+    Path('valid').touch()
+    repo.add('valid')
+    repo.commit('valid commit')
+
+    Path('file').touch()
+    repo.add('file')
+
+    # test
+    with pytest.raises(ValueError):
+        repo.commit(*variant)
+
+    msg = last_commit_message()
+    assert 'valid commit\n' == msg

--- a/tests/lib/test_Repo_fsck.py
+++ b/tests/lib/test_Repo_fsck.py
@@ -44,6 +44,39 @@ def test_fsck_populated(caplog, repo, variant):
     # TODO: assert variant in caplog.text
 
 
+variants = [
+    '',
+    'does-not-exist'
+]
+@pytest.mark.parametrize('variant', variants)
+def test_fsck_invalid_test(caplog, repo, variant):
+    caplog.set_level(logging.INFO, logger='onyo')
+
+    # test
+    with pytest.raises(ValueError):
+        repo.fsck([variant])
+
+    # check log
+    # TODO: assert variant in caplog.text
+
+
+def test_fsck_all(caplog, repo):
+    """
+    Default is to run all tests.
+    """
+    caplog.set_level(logging.INFO, logger='onyo')
+
+    # test
+    repo.fsck()
+
+    # check log
+    # TODO: assert 'anchors' in caplog.text
+    # TODO: assert 'asset-unique' in caplog.text
+    # TODO: assert 'asset-validate' in caplog.text
+    # TODO: assert 'asset-yaml' in caplog.text
+    # TODO: assert 'clean-tree' in caplog.text
+
+
 #
 # Anchors
 #

--- a/tests/lib/test_Repo_rm.py
+++ b/tests/lib/test_Repo_rm.py
@@ -1,0 +1,293 @@
+from pathlib import Path
+
+from onyo import commands  # noqa: F401
+from onyo.lib import OnyoProtectedPathError
+import pytest
+
+
+variants = {
+    'str': 'single-file',
+    'Path': Path('single-file'),
+    'list-str': ['single-file'],
+    'list-Path': [Path('single-file')],
+    'set-str': {'single-file'},
+    'set-Path': {Path('single-file')},
+}
+@pytest.mark.repo_files('single-file', 'untouched')
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_rm_args_single_file(repo, variant):
+    """
+    Single file across types.
+    """
+    repo.rm(variant)
+    assert not Path('single-file').exists()
+    assert Path('untouched').exists()
+
+    # make sure everything is clean
+    repo.fsck(['clean-tree'])
+
+
+variants = {
+    'str': 'single-dir',
+    'Path': Path('single-dir'),
+    'list-str': ['single-dir'],
+    'list-Path': [Path('single-dir')],
+    'set-str': {'single-dir'},
+    'set-Path': {Path('single-dir')},
+}
+@pytest.mark.repo_dirs('single-dir', 'untouched')
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_rm_args_single_dir(repo, variant):
+    """
+    Single directory across types.
+    """
+    repo.rm(variant)
+    assert not Path('single-dir').exists()
+    assert Path('untouched').exists()
+
+    # make sure everything is clean
+    repo.fsck(['clean-tree'])
+
+
+variants = {  # pyre-ignore[9]
+    'list-str': ['one', 'two', 'three'],
+    'list-Path': [Path('one'), Path('two'), Path('three')],
+    'list-mixed': ['one', Path('two'), 'three'],
+    'set-str': {'one', 'two', 'three'},
+    'set-Path': {Path('one'), Path('two'), Path('three')},
+    'set-mixed': {Path('one'), 'two', Path('three')},
+}
+@pytest.mark.repo_files('one', 'two', 'three', 'untouched')
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_rm_args_multi_file(repo, variant):
+    """
+    Multiple files across types.
+    """
+    repo.rm(variant)
+    assert not Path('one').exists()
+    assert not Path('two').exists()
+    assert not Path('three').exists()
+    assert Path('untouched').exists()
+
+    # make sure everything is clean
+    repo.fsck(['clean-tree'])
+
+
+variants = {  # pyre-ignore[9]
+    'list-str': ['one', 'two', 'three'],
+    'list-Path': [Path('one'), Path('two'), Path('three')],
+    'list-mixed': ['one', Path('two'), 'three'],
+    'set-str': {'one', 'two', 'three'},
+    'set-Path': {Path('one'), Path('two'), Path('three')},
+    'set-mixed': {Path('one'), 'two', Path('three')},
+}
+@pytest.mark.repo_dirs('one', 'two', 'three', 'untouched')
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_rm_args_multi_dir(repo, variant):
+    """
+    Multiple directories across types.
+    """
+    repo.rm(variant)
+    assert not Path('one').exists()
+    assert not Path('two').exists()
+    assert not Path('three').exists()
+    assert Path('untouched').exists()
+
+    # make sure everything is clean
+    repo.fsck(['clean-tree'])
+
+
+variants = [  # pyre-ignore[9]
+    'not-exist',
+    'subdir/not-exist'
+]
+@pytest.mark.repo_dirs('subdir')
+@pytest.mark.parametrize('variant', variants)
+def test_rm_not_exist(repo, variant):
+    """
+    Targets must exist.
+    """
+    with pytest.raises(FileNotFoundError):
+        repo.rm(variant)
+
+    assert Path('subdir').exists()
+
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])
+
+
+variants = [  # pyre-ignore[9]
+    'not-exist',
+    'subdir/not-exist'
+]
+@pytest.mark.repo_dirs('one', 'two', 'subdir')
+@pytest.mark.parametrize('variant', variants)
+def test_rm_not_exist_mixed(repo, variant):
+    """
+    All targets must exist.
+    """
+    with pytest.raises(FileNotFoundError):
+        repo.rm(['one', variant, 'two'])
+
+    assert Path('one').exists()
+    assert Path('two').exists()
+    assert Path('subdir').exists()
+
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])
+
+
+variants = [  # pyre-ignore[9]
+    '.onyo',
+    '.git',
+    '.onyo/templates',
+    '.git/config',
+    'one/.anchor',
+]
+@pytest.mark.repo_dirs('one', 'untouched')
+@pytest.mark.parametrize('variant', variants)
+def test_rm_protected(repo, variant):
+    """
+    Protected paths.
+    """
+    with pytest.raises(OnyoProtectedPathError):
+        repo.rm(variant)
+
+    assert Path(variant).exists()
+
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])
+
+
+variants = [  # pyre-ignore[9]
+    '.onyo',
+    '.git',
+    '.onyo/templates',
+    '.git/config',
+    'dir/.anchor',
+]
+@pytest.mark.repo_dirs('valid-one', 'valid-two', 'dir')
+@pytest.mark.parametrize('variant', variants)
+def test_rm_protected_mixed(repo, variant):
+    """
+    Protected paths.
+    """
+    with pytest.raises(OnyoProtectedPathError):
+        repo.rm(['valid-one', variant, 'valid-two'])
+
+    assert Path('valid-one').exists()
+    assert Path('valid-two').exists()
+    assert Path(variant).exists()
+
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])
+
+
+@pytest.mark.repo_dirs('repeat-dir', 'dir-two', 'dir-three')
+@pytest.mark.repo_files('repeat-file', 'file-two', 'file-three')
+def test_rm_repeat(repo):
+    """
+    Repeated target paths are OK.
+    """
+    # files
+    repo.rm(['repeat-file', 'file-two', 'repeat-file', 'file-three'])
+    assert not Path('repeat-file').exists()
+    assert not Path('file-two').exists()
+    assert not Path('file-three').exists()
+
+    # directories
+    repo.rm(['repeat-dir', 'dir-two', 'dir-three', 'repeat-dir'])
+    assert not Path('repeat-dir').exists()
+    assert not Path('dir-two').exists()
+    assert not Path('dir-three').exists()
+
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])
+
+
+@pytest.mark.repo_files('overlap/one', 'overlap/two', 'overlap/three')
+def test_mkdir_overlap(repo):
+    """
+    Overlapping targets.
+    """
+    repo.rm(['overlap/one', 'overlap', 'overlap/three'])
+    assert not Path('overlap').exists()
+
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])
+
+
+@pytest.mark.repo_files('s p a/c e s/1 2', 's p a/c e s/3 4')
+def test_mkdir_spaces(repo):
+    """
+    Spaces.
+    """
+    repo.rm(['s p a/c e s/1 2', 's p a/c e s/3 4'])
+    assert not Path('s p a/c e s/1 2').exists()
+    assert not Path('s p a/c e s/3 4').exists()
+    assert Path('s p a/c e s/').exists()
+
+    repo.rm(['s p a/c e s/'])
+    assert not Path('s p a/c e s/').exists()
+    assert Path('s p a/').exists()
+
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])
+
+
+@pytest.mark.repo_dirs('r/e/c/u/r/s/i/v/e')
+@pytest.mark.repo_files('one/a', 'two/b')
+def test_rm_subdirs(repo):
+    """
+    Deleting directory contents should leave parent dir intact.
+    """
+    # files
+    repo.rm(['one/a', 'two/b'])
+    assert not Path('one/a').is_file()
+    assert not Path('two/b').is_file()
+    assert Path('one').is_dir()
+    assert Path('two').is_dir()
+
+    # directories
+    repo.rm('r/e/c/u/r')
+    assert not Path('r/e/c/u/r').is_dir()
+    assert Path('r/e/c/u').is_dir()
+
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])
+
+
+@pytest.mark.repo_dirs('r/e/c/u/r/s/i/v/e')
+@pytest.mark.repo_files('one/a', 'two/b')
+def test_rm_dryrun(repo):
+    """
+    Dry run should not delete anything.
+    """
+    repo.rm(['one/a', 'two/b', 'r'], dryrun=True)
+    assert Path('one/a').is_file()
+    assert Path('two/b').is_file()
+    assert Path('r').is_dir()
+
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])
+
+
+@pytest.mark.repo_dirs('dir/subdir')
+@pytest.mark.repo_files('one', 'two')
+def test_rm_return_value(repo):
+    """
+    Return list should contain all items/
+    """
+    ret = repo.rm(['one', 'two', 'dir'], dryrun=True)
+    assert ret
+    assert isinstance(ret, list)
+
+    # 2 files + 2 anchors
+    assert 4 == len(ret)
+    assert 'one' in ret
+    assert 'two' in ret
+    assert 'dir/.anchor' in ret
+    assert 'dir/subdir/.anchor' in ret
+
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])

--- a/tests/reference_output/C_absolute/delete_device.txt
+++ b/tests/reference_output/C_absolute/delete_device.txt
@@ -1,4 +1,4 @@
-The following assets and directories will be deleted:
+The following will be deleted:
 <replace>
 Delete assets? (y/N) 
 

--- a/tests/reference_output/root_of_repo/delete_device.txt
+++ b/tests/reference_output/root_of_repo/delete_device.txt
@@ -1,4 +1,4 @@
-The following assets and directories will be deleted:
+The following will be deleted:
 <replace>
 Delete assets? (y/N) 
 


### PR DESCRIPTION
Notable changes:

- introduce `Repo().rm()` (with tests)
- convert `rm` to use `Repo().rm()`
- add tests for a few corner cases in `fsck()` and `commit()`

As with the other conversion, the tests for the command `rm` have been left intact. They will be address later when the logging overhaul happens.