### PR TITLE
TST/BF: make test_history.py platform independent

### DIFF
--- a/tests/commands/test_history.py
+++ b/tests/commands/test_history.py
@@ -139,7 +139,7 @@ def test_history_config_invalid():
 # Reconfigure the history command to tickle some other functionality we're
 # interested in.
 def test_history_fake_noninteractive_stdout():
-    ret = subprocess.run(["onyo", "config", "onyo.history.non-interactive", "/bin/printf"],
+    ret = subprocess.run(["onyo", "config", "onyo.history.non-interactive", "/usr/bin/env printf"],
                          capture_output=True, text=True)
     assert ret.returncode == 0
 
@@ -159,7 +159,7 @@ def test_history_fake_noninteractive_stdout():
 
 
 def test_history_fake_noninteractive_stderr():
-    ret = subprocess.run(["onyo", "config", "onyo.history.non-interactive", "/bin/printf >&2"],
+    ret = subprocess.run(["onyo", "config", "onyo.history.non-interactive", "/usr/bin/env printf >&2"],
                          capture_output=True, text=True)
     assert ret.returncode == 0
 
@@ -180,7 +180,7 @@ def test_history_fake_noninteractive_stderr():
 
 def test_history_fake_noninteractive_bubble_exit_code():
     # success
-    ret = subprocess.run(["onyo", "config", "onyo.history.non-interactive", "/bin/true"],
+    ret = subprocess.run(["onyo", "config", "onyo.history.non-interactive", "/usr/bin/env true"],
                          capture_output=True, text=True)
     assert ret.returncode == 0
     ret = subprocess.run(["onyo", "history", "-I", "a"],


### PR DESCRIPTION
Change command calls from e.g. `/bin/printf` to `/usr/bin/env printf` to use tests platform independent.

`test_history.py` used built-in commands e.g. `/bin/printf`. These differ on macbooks (e.g. `/usr/bin/printf`) so the tests for the `onyo history` command failed on macOS.