### PR TITLE
NF/RF: mv -> Repo.mv() ; add tests

### DIFF
--- a/onyo/commands/mv.py
+++ b/onyo/commands/mv.py
@@ -1,181 +1,19 @@
-import logging
-import re
 import sys
-from pathlib import Path
-
-from onyo.lib import Repo, OnyoInvalidRepoError
-from onyo.utils import is_protected_path
-
-logging.basicConfig()
-log = logging.getLogger('onyo')
+from onyo.lib import Repo, OnyoInvalidRepoError, OnyoProtectedPathError
 
 
-def move_mode(destination, sources, onyo_root):
-    """
-    `mv` can be used to either move or rename a file/directory. The mode is not
-    explicitly declared by the user, and must be inferred from the arguments.
-
-    Returns True if "move" mode and False if not.
-    """
-    # can only rename one item
-    if len(sources) > 1:
-        return True
-
-    if Path(onyo_root, destination).resolve().is_dir():
-        return True
-
-    return False
-
-
-def rename_mode(destination, sources, onyo_root):
-    """
-    Returns True if "rename" mode and False if not.
-
-    The inverse of `move_mode()`. See its docstring for more information.
-    """
-    return not move_mode(destination, sources, onyo_root)
-
-
-def sanity_check_destination(destination, sources, onyo_root):
-    """
-    Perform a sanity check on the destination. This includes protected paths,
-    conflicts, and other pathological scenarios.
-
-    Returns True on success and exits with an error message on failure.
-    """
-    error_path_conflict = []
-    dest_path = Path(onyo_root, destination).resolve()
-
-    if rename_mode(destination, sources, onyo_root):
-        """
-        Rename mode checks
-        """
-        # target cannot already exist
-        if dest_path.exists():
-            log.error(f"The destination '{dest_path}' exists and would conflict.")
-            log.error("\nExiting. Nothing was moved.")
-            sys.exit(1)
-
-        # parent must exist
-        if not dest_path.parent.exists():
-            log.error(f"The destination '{dest_path.parent}' does not exist.")
-            log.error("\nExiting. Nothing was moved.")
-            sys.exit(1)
-
-        # renaming files is not allowed
-        source = Path(sources[0])
-        if source.is_file() and source.name != dest_path.name:
-            log.error(f"Cannot rename asset '{source.name}' to '{dest_path.name}'.")
-            log.error("Use 'onyo set' to rename assets.")
-            log.error("\nExiting. Nothing was moved.")
-            sys.exit(1)
-    else:
-        """
-        Move mode checks
-        """
-        # dest must exist
-        if not dest_path.exists():
-            log.error(f"The destination '{destination}' does not exist.")
-            log.error("\nExiting. Nothing was moved.")
-            sys.exit(1)
-
-        # dest must be a directory
-        if not dest_path.is_dir():
-            log.error(f"The destination '{destination}' is not a directory.")
-            log.error("\nExiting. Nothing was moved.")
-            sys.exit(1)
-
-    """
-    Common checks
-    """
-    # protected paths
-    if is_protected_path(dest_path):
-        log.error(f"The destination '{destination}' is protected by onyo.")
-        log.error("\nExiting. Nothing was moved.")
-        sys.exit(1)
-
-    # check for conflicts and generic insanity
-    for s in sources:
-        src_path = Path(s).resolve()
-        new_path = Path(dest_path, src_path.name).resolve()
-
-        # cannot move into self
-        if src_path in new_path.parents:
-            log.error(f"Cannot move '{s}' into itself.")
-            log.error("\nExiting. Nothing was moved.")
-            sys.exit(1)
-
-        # target paths cannot already exist
-        if new_path.exists():
-            error_path_conflict.append(s)
-            continue
-
-    if error_path_conflict:
-        log.error("The following destinations exist and would conflict:")
-        log.error('\n'.join(error_path_conflict))
-        log.error("\nExiting. Nothing was moved.")
-        sys.exit(1)
-
-    return True
-
-
-def sanitize_sources(sources, onyo_root):
-    """
-    Check and normalize a list of paths. If any do not exist, or are protected
-    paths (.anchor, .git, .onyo), then they will be printed and exit with error.
-
-    Returns a list of normed source paths on success.
-    """
-    paths_to_mv = []
-    error_path_absent = []
-    error_path_protected = []
-
-    # validate sources
-    for s in sources:
-        src_path = Path(onyo_root, s).resolve()
-
-        # paths must exist
-        if not src_path.exists():
-            error_path_absent.append(s)
-            continue
-
-        # protected paths
-        if is_protected_path(src_path):
-            error_path_protected.append(s)
-            continue
-
-        # TODO: ideally, this would return a list of normed paths, relative to
-        # the root of the onyo repository (not to be confused with onyo_root).
-        # This would allow commit messages that are consistent regardless of
-        # where onyo is invoked from.
-        norm_path = str(src_path.relative_to(onyo_root))
-        paths_to_mv.append(norm_path)
-
-    if error_path_absent:
-        log.error("The following paths do not exist:")
-        log.error('\n'.join(error_path_absent))
-        log.error("\nExiting. Nothing was moved.")
-        sys.exit(1)
-
-    if error_path_protected:
-        log.error("The following paths are protected by onyo:")
-        log.error('\n'.join(error_path_protected))
-        log.error("\nExiting. Nothing was moved.")
-        sys.exit(1)
-
-    return paths_to_mv
-
-
-def mv(args, onyo_root):
+def mv(args, onyo_root: str) -> None:
     """
     Move ``source``\(s) (assets or directories) to the ``destination``
     directory, or rename a ``source`` directory to ``destination``.
 
     Files cannot be renamed using ``onyo mv``. To do so, use ``onyo set``.
     """
+    repo = None
+
     # check flags
     if args.quiet and not args.yes:
-        log.error("The --quiet flag requires --yes.")
+        print('The --quiet flag requires --yes.', file=sys.stderr)
         sys.exit(1)
 
     try:
@@ -184,23 +22,23 @@ def mv(args, onyo_root):
     except OnyoInvalidRepoError:
         sys.exit(1)
 
-    # sanitize and validate arguments
-    paths_to_mv = sanitize_sources(args.source, onyo_root)
-    sanity_check_destination(args.destination, args.source, onyo_root)
-
     if not args.quiet:
-        # use git's --dry-run to generate the proposed changes
-        ret = repo._git(['mv', '--dry-run'] + paths_to_mv + [args.destination])
-        print("The following will be moved:")
-        print('\n'.join("'{}' -> '{}'".format(*r) for r in re.findall('Renaming (.*) to (.*)', ret)))
+        dryrun_list = None
+        try:
+            dryrun_list = repo.mv(args.source, args.destination, dryrun=True)
+        except (FileExistsError, FileNotFoundError, NotADirectoryError, OnyoProtectedPathError, ValueError):
+            sys.exit(1)
+
+        print('The following will be moved:\n' +
+              '\n'.join(f"'{x[0]}' -> '{x[1]}'" for x in dryrun_list))
 
         if not args.yes:
-            response = input("Move assets? (y/N) ")
+            response = input('Move assets? (y/N) ')
             if response not in ['y', 'Y', 'yes']:
-                log.info("Nothing was moved.")
+                print('Nothing was moved.')
                 sys.exit(0)
 
-    # mv and commit
-    repo._git(['mv'] + paths_to_mv + [args.destination])
-    # TODO: can this commit message be made more helpful?
-    repo.commit('moved asset(s)', paths_to_mv)
+    try:
+        repo.mv(args.source, args.destination)
+    except (FileExistsError, FileNotFoundError, NotADirectoryError, OnyoProtectedPathError, ValueError):
+        sys.exit(1)

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -174,7 +174,7 @@ class Repo:
         Paths are relative to ``root.opdir``.
         """
         if isinstance(targets, (list, set)):
-            tgts = [str(x) for x in list(targets)]
+            tgts = [str(x) for x in targets]
         else:
             tgts = [str(targets)]
 

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -149,6 +149,15 @@ class Repo:
         return root
 
     #
+    # HELPERS
+    #
+    def _n_join(self, to_join: Iterable) -> str:
+        """
+        Convert an Iterable's contents to strings and join with newlines.
+        """
+        return '\n'.join([str(x) for x in to_join])
+
+    #
     # _git
     #
     def _git(self, args: list[str], *, cwd: Optional[Path] = None, raise_error: bool = True) -> str:
@@ -204,7 +213,7 @@ class Repo:
 
             messages.append('-m')
             if isinstance(i, (list, set)):
-                messages.append('\n'.join([str(x) for x in i]))
+                messages.append(self._n_join(i))
             else:
                 messages.append(str(i))
 
@@ -266,7 +275,7 @@ class Repo:
 
         if difference:
             log.warning('The following .anchor files are missing:\n' +
-                        '\n'.join({str(x) for x in difference}))
+                        self._n_join(difference))
             log.warning("Likely 'mkdir' was used to create the directory. Use 'onyo mkdir' instead.")
             # TODO: Prompt the user if they want Onyo to fix it.
 
@@ -287,15 +296,15 @@ class Repo:
 
             if changed:
                 log.error('Changes not staged for commit:\n' +
-                          '\n'.join(changed))
+                          self._n_join(changed))
 
             if staged:
                 log.error('Changes to be committed:\n' +
-                          '\n'.join(staged))
+                          self._n_join(staged))
 
             if untracked:
                 log.error('Untracked files:\n' +
-                          '\n'.join(untracked))
+                          self._n_join(untracked))
 
             log.error('Please commit all changes or add untracked files to .gitignore')
 
@@ -357,7 +366,7 @@ class Repo:
 
         if invalid_yaml:
             log.error('The following files fail YAML validation:\n' +
-                      '\n'.join(invalid_yaml))
+                      self._n_join(invalid_yaml))
 
             return False
 
@@ -426,17 +435,17 @@ class Repo:
         # errors
         if error_exist:
             log.error('The following paths already exist:\n' +
-                      '\n'.join(error_exist) + '\n' +
+                      self._n_join(error_exist) + '\n' +
                       'No directories were created.')
             raise FileExistsError('The following paths already exist:\n' +
-                                  '\n'.join(error_exist))
+                                  self._n_join(error_exist))
 
         if error_path_protected:
             log.error('The following paths are protected by onyo:\n' +
-                      '\n'.join(error_path_protected) + '\n' +
-                      '\nNo directories were created.')
+                      self._n_join(error_path_protected) + '\n' +
+                      'No directories were created.')
             raise OnyoProtectedPathError('The following paths are protected by onyo:\n' +
-                                         '\n'.join(error_path_protected))
+                                         self._n_join(error_path_protected))
 
         return dirs_to_create
 
@@ -506,7 +515,7 @@ class Repo:
         if error_path_protected:
             log.error('The following paths are protected by onyo:\n' +
                       '\n'.join(error_path_protected) + '\n' +
-                      '\nNo directories were created.')
+                      'No directories were created.')
             raise OnyoProtectedPathError('The following paths are protected by onyo:\n' +
                                          '\n'.join(error_path_protected))
 

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -450,6 +450,228 @@ class Repo:
         return dirs_to_create
 
     #
+    # MV
+    #
+    def mv(self, sources: Union[Iterable[Union[Path, str]], Path, str], destination: Union[Path, str], dryrun: bool = False) -> list[tuple[str, str]]:
+        """
+        Move ``source``\(s) (assets or directories) to the ``destination``
+        directory, or rename a ``source`` directory to ``destination``.
+
+        Files cannot be renamed using ``mv()``. To do so, use ``set()``.
+        """
+        if not isinstance(sources, (list, set)):
+            sources = [sources]
+        elif not isinstance(sources, list):
+            sources = list(sources)
+
+        # sanitize and validate arguments
+        src_paths = self._mv_sanitize_sources(sources)
+        dest_path = self._mv_sanitize_destination(sources, destination)
+
+        if dryrun:
+            ret = self._git(['mv', '--dry-run'] + [str(x) for x in src_paths] + [str(dest_path)])
+        else:
+            # mv and commit
+            ret = self._git(['mv'] + [str(x) for x in src_paths] + [str(dest_path)])
+            # TODO: should `mv` commit? (mkdir() does, add() doesn't)
+            # TODO: can this commit message be made more helpful?
+            # TODO: relative to self.root
+            self.commit('moved asset(s)', src_paths)
+
+        # TODO: change this to info
+        log.debug('The following will be moved:\n' +
+                  '\n'.join([str(x.relative_to(self.opdir)) for x in src_paths]))
+
+        # return a list of mv-ed assets
+        # TODO: is this relative to opdir or root? (should be opdir)
+        return [r for r in re.findall('Renaming (.*) to (.*)', ret)]
+
+    def _mv_move_mode(self, sources: list[Union[Path, str]], destination: Union[Path, str]) -> bool:
+        """
+        `mv()` can be used to either move or rename a file/directory. The mode
+        is not explicitly declared by the user, and must be inferred from the
+        arguments.
+
+        Returns True if "move" mode and False if not.
+        """
+        # can only rename one item
+        if len(sources) > 1:
+            return True
+
+        if Path(self.opdir, destination).resolve().is_dir():
+            return True
+
+        # explicitly restating the source name at the destination is a move
+        if Path(sources[0]).name == Path(destination).name and not Path(self.opdir, destination).resolve().exists():
+            return True
+
+        return False
+
+    def _mv_rename_mode(self, sources: list[Union[Path, str]], destination: Union[Path, str]) -> bool:
+        """
+        Returns True if "rename" mode and False if not.
+
+        The inverse of `move_mode()`. See its docstring for more information.
+        """
+        return not self._mv_move_mode(sources, destination)
+
+    def _mv_sanitize_destination(self, sources: list[Union[Path, str]], destination: Union[Path, str]) -> Path:
+        """
+        Perform a sanity check on the destination. This includes protected
+        paths, conflicts, and other pathological scenarios.
+
+        Returns an absolute Path on success.
+        """
+        error_path_conflict = []
+        dest_path = Path(self.opdir, destination).resolve()
+
+        """
+        Common checks
+        """
+        # protected paths
+        if is_protected_path(dest_path):
+            log.error('The following paths are protected by onyo:\n' +
+                      f'{dest_path}\n' +
+                      'Nothing was moved.')
+            raise OnyoProtectedPathError('The following paths are protected by onyo:\n' +
+                                         f'{dest_path}')
+
+        # destination cannot be a file
+        if dest_path.is_file():
+            # This intentionally raises FileExistsError rather than NotADirectoryError.
+            # It reduces the number of different exceptions that can be raised
+            # by `mv()`, and keeps the exception type unified with other similar
+            # situations (such as implicit conflict with the destination).
+            log.error(f"The destination '{dest_path}' cannot be a file.\n" +
+                      'Nothing was moved.')
+            raise FileExistsError(f"The destination '{dest_path}' cannot be a file.\n" +
+                                  'Nothing was moved.')
+
+        # check for conflicts and general insanity
+        for src in sources:
+            src_path = Path(self.opdir, src).resolve()
+            new_path = Path(dest_path, src_path.name).resolve()
+            if not dest_path.exists:
+                new_path = Path(dest_path).resolve()
+
+            # cannot rename/move into self
+            if src_path in new_path.parents:
+                log.error(f"Cannot move '{src}' into itself.\n" +
+                          "Nothing was moved.")
+                raise ValueError(f"Cannot move '{src}' into itself.\n" +
+                                 "Nothing was moved.")
+
+            # target paths cannot already exist
+            if new_path.exists():
+                error_path_conflict.append(new_path)
+                continue
+
+        if error_path_conflict:
+            log.error('The following destinations exist and would conflict:\n' +
+                      self._n_join(error_path_conflict) + '\n' +
+                      'Nothing was moved.')
+            raise FileExistsError('The following destination paths exist and would conflict.\n' +
+                                  self._n_join(error_path_conflict) + '\n' +
+                                  'Nothing was moved.')
+
+        # parent must exist
+        if not dest_path.parent.exists():
+            log.error(f"The destination '{dest_path.parent}' does not exist.\n" +
+                      "Nothing was moved.")
+            raise FileNotFoundError(f"The destination '{dest_path.parent}' does not exist.\n" +
+                                    "Nothing was moved.")
+
+        if self._mv_rename_mode(sources, destination):
+            """
+            Rename mode checks
+            """
+            log.debug("'mv' in rename mode")
+            # renaming files is not allowed
+            src_path = Path(self.opdir, sources[0]).resolve()
+            if src_path.is_file() and src_path.name != dest_path.name:
+                log.error(f"Cannot rename asset '{src_path.name}' to '{dest_path.name}'.\n" +
+                          "Use 'set()' to rename assets.\n" +
+                          "Nothing was moved.")
+                raise ValueError(f"Cannot rename asset '{src_path.name}' to '{dest_path.name}'.\n" +
+                                 "Use 'set()' to rename assets.\n" +
+                                 "Nothing was moved.")
+
+            # target cannot already exist
+            if dest_path.exists():
+                log.error(f"The destination '{dest_path}' exists and would conflict.\n" +
+                          "Nothing was moved.")
+                raise FileExistsError(f"The destination '{dest_path}' exists and would conflict.\n" +
+                                      "Nothing was moved.")
+        else:
+            """
+            Move mode checks
+            """
+            log.debug("'mv' in move mode")
+
+            # check if same name is specified as the destination
+            # (e.g. rename to same name is a move)
+            if src_path.name != dest_path.name:
+                # dest must exist
+                if not dest_path.exists():
+                    log.error(f"The destination '{destination}' does not exist.\n" +
+                              "Nothing was moved.")
+                    raise FileNotFoundError(f"The destination '{destination}' does not exist.\n" +
+                                            "Nothing was moved.")
+
+            # cannot move onto self
+            if src_path.is_file() and dest_path.is_file() and src_path.samefile(dest_path):
+                log.error(f"Cannot move '{src}' onto itself.\n" +
+                          "Nothing was moved.")
+                raise FileExistsError(f"Cannot move '{src}' onto itself.\n" +
+                                      "Nothing was moved.")
+
+        return dest_path
+
+    def _mv_sanitize_sources(self, sources: list[Union[Path, str]]) -> list[Path]:
+        """
+        Check and normalize a list of paths. If any do not exist, or are
+        protected paths (.anchor, .git, .onyo), then an exception will be
+        raised.
+
+        Returns a list of absolute Paths.
+        """
+        paths_to_mv = []
+        error_path_absent = []
+        error_path_protected = []
+
+        # validate sources
+        for src in sources:
+            full_path = Path(self.opdir, src).resolve()
+
+            # paths must exist
+            if not full_path.exists():
+                error_path_absent.append(src)
+                continue
+
+            # protected paths
+            if is_protected_path(full_path):
+                error_path_protected.append(src)
+                continue
+
+            paths_to_mv.append(full_path)
+
+        if error_path_absent:
+            log.error('The following source paths do not exist:\n' +
+                      self._n_join(error_path_absent) + '\n' +
+                      'Nothing was moved.')
+            raise FileNotFoundError('The following paths do not exist:\n' +
+                                    self._n_join(error_path_absent))
+
+        if error_path_protected:
+            log.error('The following paths are protected by onyo:\n' +
+                      self._n_join(error_path_protected) + '\n' +
+                      'Nothing was moved.')
+            raise OnyoProtectedPathError('The following paths are protected by onyo:\n' +
+                                         self._n_join(error_path_protected))
+
+        return paths_to_mv
+
+    #
     # RM
     #
     def rm(self, paths: Union[Iterable[Union[Path, str]], Path, str], dryrun: bool = False) -> list[str]:

--- a/tests/commands/test_mv.py
+++ b/tests/commands/test_mv.py
@@ -159,7 +159,7 @@ def test_mv_rename_file(helpers):
     ret = subprocess.run(['onyo', 'mv', '--yes', 'a', 'b'], capture_output=True, text=True)
     assert ret.returncode == 1
     assert not ret.stdout
-    assert 'exists and would conflict' in ret.stderr
+    assert 'cannot be a file' in ret.stderr
     assert Path('a').exists()
     assert Path('b').exists()
 
@@ -285,7 +285,7 @@ def test_mv_move_file(helpers):
     ret = subprocess.run(['onyo', 'mv', 'three/a', 'three/b', 'three/c'], capture_output=True, text=True)
     assert ret.returncode == 1
     assert not ret.stdout
-    assert 'is not a directory' in ret.stderr
+    assert 'cannot be a file' in ret.stderr
     assert Path('three/a').is_file()
     assert Path('three/b').is_file()
     assert Path('three/c').is_file()
@@ -294,7 +294,7 @@ def test_mv_move_file(helpers):
     ret = subprocess.run(['onyo', 'mv', 'three/f', 'three/f'], capture_output=True, text=True)
     assert ret.returncode == 1
     assert not ret.stdout
-    assert 'exists and would conflict' in ret.stderr
+    assert 'cannot be a file' in ret.stderr
     assert Path('three/f').is_file()
 
 

--- a/tests/lib/test_Repo_mv.py
+++ b/tests/lib/test_Repo_mv.py
@@ -1,0 +1,733 @@
+import logging
+from pathlib import Path
+import pytest
+from onyo import commands  # noqa: F401
+from onyo.lib import OnyoProtectedPathError
+
+
+#
+# GENERIC
+#
+variants = [
+    'src-dir',
+    'src-file',
+]
+@pytest.mark.repo_dirs('src-dir')
+@pytest.mark.repo_files('src-file')
+@pytest.mark.parametrize('variant', variants)
+def test_missing_parent(repo, variant, caplog):
+    """
+    Parent must exist. It is not possible to determine whether this is a rename
+    or a move.
+    """
+    caplog.set_level(logging.DEBUG, logger='onyo')
+
+    with pytest.raises(FileNotFoundError):
+        repo.mv(variant, 'does/not/exist/src.rename')
+
+    assert Path(variant).exists()
+    assert not Path('does').exists()
+    assert 'does not exist' in caplog.text
+
+    # check log
+    assert 'move mode' not in caplog.text
+    assert 'rename mode' not in caplog.text
+
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])
+
+
+#
+# RENAME
+#
+variants = {  # pyre-ignore[9]
+    'src-str-dest-str': ('dir', 'dir.rename'),
+    'src-Path-dest-str': (Path('dir'), 'dir.rename'),
+    'src-str-dest-Path': ('dir', Path('dir.rename')),
+    'src-Path-dest-Path': (Path('dir'), Path('dir.rename')),
+    'src-list-str-dest-str': (['dir'], 'dir.rename'),
+    'src-list-Path-dest-str': ([Path('dir')], 'dir.rename'),
+    'src-list-str-dest-Path': (['dir'], Path('dir.rename')),
+    'src-list-Path-dest-Path': ([Path('dir')], Path('dir.rename')),
+    'src-set-str-dest-str': ({'dir'}, 'dir.rename'),
+    'src-set-Path-dest-str': ({Path('dir')}, 'dir.rename'),
+    'src-set-str-dest-Path': ({'dir'}, Path('dir.rename')),
+    'src-set-Path-dest-Path': ({Path('dir')}, Path('dir.rename')),
+}
+@pytest.mark.repo_dirs('dir')
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_rename_types_dir(repo, variant, caplog):
+    """
+    Rename a directory across types.
+    """
+    caplog.set_level(logging.DEBUG, logger='onyo')
+
+    # test
+    repo.mv(*variant)
+    assert not Path('dir').exists()
+    assert Path('dir.rename').exists()
+
+    # check log
+    assert 'move mode' not in caplog.text
+
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])
+
+
+variants = {  # pyre-ignore[9]
+    'dest-cwd': ('does-not-exist', 'does-not-exist.rename'),
+    'dest-subdir': ('does-not-exist', 'dest-dir/does-not-exist.rename'),
+    'src-subdir-dest-cwd': ('src-dir/does-not-exist', 'does-not-exist.rename'),
+    'src-subdir-dest-subdir': ('src-dir/does-not-exist', 'dest-dir/does-not-exist.rename'),
+}
+@pytest.mark.repo_dirs('src-dir', 'dest-dir')
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_rename_src_not_exist(repo, variant, caplog):
+    """
+    Source paths must exist.
+    """
+    caplog.set_level(logging.DEBUG, logger='onyo')
+    src = Path(variant[0])
+    dest = Path(variant[1])
+
+    # test
+    with pytest.raises(FileNotFoundError):
+        repo.mv(*variant)
+
+    assert not src.exists()
+    assert not dest.exists()
+    assert dest.parent.exists()
+
+    # check log
+    assert 'move mode' not in caplog.text
+    assert 'source paths do not exist' in caplog.text
+
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])
+
+
+variants = {  # pyre-ignore[9]
+    'simple': ('src', 'src.rename'),
+    'into-subdir': ('src', 'subdir/src.rename'),
+    'out-of-subdir': ('subdir/src-two', 'src-two.rename'),
+    'spaces-source': ('s p a c e s', 'spaces'),
+    'spaces-dest': ('src', 's r c'),
+    'spaces-subdir-dest': ('src', 's p a c e s/s r c'),
+}
+@pytest.mark.repo_dirs('src', 'subdir/src-two', 's p a c e s')
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_rename_dir(repo, variant, caplog):
+    """
+    Renaming a directory is allowed.
+    """
+    caplog.set_level(logging.DEBUG, logger='onyo')
+
+    # test
+    repo.mv(*variant)
+
+    assert not Path(variant[0]).exists()
+    assert Path(variant[1]).exists()
+
+    # check log
+    assert 'move mode' not in caplog.text
+
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])
+
+
+variants = {  # pyre-ignore[9]
+    'simple': ('src', 'src.rename'),
+    'into-subdir': ('src', 'subdir/src.rename'),
+    'out-of-subdir': ('subdir/src-two', 'src-two.rename'),
+    'spaces-source': ('s p a c e s', 'spaces'),
+    'spaces-dest': ('src', 's r c'),
+}
+@pytest.mark.repo_files('src', 'existing-file', 'subdir/src-two', 's p a c e s')
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_rename_file(repo, variant, caplog):
+    """
+    Renaming a file is not allowed.
+    """
+    caplog.set_level(logging.DEBUG, logger='onyo')
+
+    # test
+    with pytest.raises(ValueError):
+        repo.mv(*variant)
+
+    assert Path(variant[0]).is_file()
+    assert not Path(variant[1]).exists()
+
+    # check log
+    assert 'move mode' not in caplog.text
+    assert 'Cannot rename asset' in caplog.text
+
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])
+
+
+variants = {  # pyre-ignore[9]
+    'dir-file': ('src-dir', 'existing-file-1'),
+    'file-file': ('src-file', 'existing-file-1'),
+    'dir-subfile': ('src-dir', 'subdir/existing-file-2'),
+    'file-subfile': ('src-file', 'subdir/existing-file-2'),
+}
+@pytest.mark.repo_dirs('src-dir')
+@pytest.mark.repo_files('src-file', 'existing-file-1', 'subdir/existing-file-2')
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_rename_conflict_file(repo, variant, caplog):
+    """
+    Renaming onto an existing file is not allowed.
+
+    This only tests renaming to conflicting file destinations because to
+    "rename" to an existing destination dir is actually the syntax for moving
+    the source into the destination dir.
+    """
+    caplog.set_level(logging.DEBUG, logger='onyo')
+    src = Path(variant[0])
+    dest = Path(variant[1])
+
+    # test
+    with pytest.raises(FileExistsError):
+        repo.mv(*variant)
+
+    assert src.exists()
+    assert dest.is_file()
+
+    # check log
+    assert 'move mode' not in caplog.text
+    assert 'cannot be a file' in caplog.text
+
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])
+
+
+variants = {  # pyre-ignore[9]
+    'root': ('./', 'root.rename'),
+    'dir': ('dir', 'dir/dir.rename'),
+}
+@pytest.mark.repo_dirs('dir')
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_rename_dir_into_self(repo, variant, caplog):
+    """
+    Renaming a directory into itself is not allowed.
+    """
+    caplog.set_level(logging.DEBUG, logger='onyo')
+    src = Path(variant[0])
+    dest = Path(variant[1])
+
+    # test
+    with pytest.raises(ValueError):
+        repo.mv(*variant)
+
+    assert src.is_dir()
+    assert not dest.exists()
+
+    # check log
+    assert 'move mode' not in caplog.text
+    assert 'into itself' in caplog.text
+
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])
+
+
+variants = {  # pyre-ignore[9]
+    'src-dir-git': ('.git', 'new-git'),
+    'src-dir-onyo': ('.onyo', 'new-onyo'),
+    'src-dir-git-subdir': ('.git/objects', 'new-objects'),
+    'src-dir-onyo-subdir': ('.onyo/templates', 'new-templates'),
+    'src-file-git': ('.git/config', 'new-git-config'),
+    'src-file-onyo': ('.onyo/config', 'new-onyo-config'),
+    'src-anchor': ('src-dir/.anchor', 'new-anchor'),
+    'dest-dir-git-subdir': ('src-dir', '.git/new-src'),
+    'dest-dir-onyo-subdir': ('src-dir', '.onyo/new-src'),
+    'dest-file-git': ('src-file', '.git/new-src'),
+    'dest-file-onyo': ('src-file', '.onyo/new-src'),
+    'dest-anchor-file': ('src-file', '.anchor'),
+    'dest-anchor-dir': ('src-dir', '.anchor'),
+    'inside-git': ('.git/config', '.git/new-config'),
+    'inside-onyo': ('.onyo/templates', '.onyo/new-templates'),
+}
+@pytest.mark.repo_files('src-file')
+@pytest.mark.repo_dirs('src-dir')
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_rename_protected(repo, variant, caplog):
+    """
+    Protected paths.
+    """
+    caplog.set_level(logging.DEBUG, logger='onyo')
+
+    # test
+    with pytest.raises(OnyoProtectedPathError):
+        repo.mv(*variant)
+
+    assert Path(variant[0]).exists()
+    assert not Path(variant[1]).exists()
+
+    # check log
+    assert 'move mode' not in caplog.text
+
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])
+
+
+#
+# MOVE
+#
+variants = {  # pyre-ignore[9]
+    'src-str-dest-str': ('src-dir', 'dest-dir'),
+    'src-Path-dest-str': (Path('src-dir'), 'dest-dir'),
+    'src-str-dest-Path': ('src-dir', Path('dest-dir')),
+    'src-Path-dest-Path': (Path('src-dir'), Path('dest-dir')),
+    'src-list-str-dest-str': (['src-dir'], 'dest-dir'),
+    'src-list-Path-dest-str': ([Path('src-dir')], 'dest-dir'),
+    'src-list-str-dest-Path': (['src-dir'], Path('dest-dir')),
+    'src-list-Path-dest-Path': ([Path('src-dir')], Path('dest-dir')),
+    'src-set-str-dest-str': ({'src-dir'}, 'dest-dir'),
+    'src-set-Path-dest-str': ({Path('src-dir')}, 'dest-dir'),
+    'src-set-str-dest-Path': ({'src-dir'}, Path('dest-dir')),
+    'src-set-Path-dest-Path': ({Path('src-dir')}, Path('dest-dir')),
+}
+@pytest.mark.repo_dirs('src-dir', 'dest-dir')
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_move_types_dir(repo, variant, caplog):
+    """
+    Move a directory across types.
+    """
+    caplog.set_level(logging.DEBUG, logger='onyo')
+
+    # test
+    repo.mv(*variant)
+    assert not Path('src-dir').exists()
+    assert Path('dest-dir', 'src-dir').exists()
+
+    # check log
+    assert 'rename mode' not in caplog.text
+
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])
+
+
+variants = {  # pyre-ignore[9]
+    'src-str-dest-str': ('src-file', 'dest-dir'),
+    'src-Path-dest-str': (Path('src-file'), 'dest-dir'),
+    'src-str-dest-Path': ('src-file', Path('dest-dir')),
+    'src-Path-dest-Path': (Path('src-file'), Path('dest-dir')),
+    'src-list-str-dest-str': (['src-file'], 'dest-dir'),
+    'src-list-Path-dest-str': ([Path('src-file')], 'dest-dir'),
+    'src-list-str-dest-Path': (['src-file'], Path('dest-dir')),
+    'src-list-Path-dest-Path': ([Path('src-file')], Path('dest-dir')),
+    'src-set-str-dest-str': ({'src-file'}, 'dest-dir'),
+    'src-set-Path-dest-str': ({Path('src-file')}, 'dest-dir'),
+    'src-set-str-dest-Path': ({'src-file'}, Path('dest-dir')),
+    'src-set-Path-dest-Path': ({Path('src-file')}, Path('dest-dir')),
+}
+@pytest.mark.repo_dirs('dest-dir')
+@pytest.mark.repo_files('src-file', 'dest-dir')
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_move_types_file(repo, variant, caplog):
+    """
+    Move a file across types.
+    """
+    caplog.set_level(logging.DEBUG, logger='onyo')
+
+    # test
+    repo.mv(*variant)
+    assert not Path('src-file').exists()
+    assert Path('dest-dir', 'src-file').exists()
+
+    # check log
+    assert 'rename mode' not in caplog.text
+
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])
+
+
+variants = {  # pyre-ignore[9]
+    'src-list-str-dest-str': (['src-dir-1', 'src-file-2', 'subdir/src-file-3'], 'dest-dir'),
+    'src-list-Path-dest-str': ([Path('src-dir-1'), Path('src-file-2'), Path('subdir/src-file-3')], 'dest-dir'),
+    'src-list-str-dest-Path': (['src-dir-1', 'src-file-2', 'subdir/src-file-3'], Path('dest-dir')),
+    'src-list-Path-dest-Path': ([Path('src-dir-1'), Path('src-file-2'), Path('subdir/src-file-3')], Path('dest-dir')),
+    'src-list-mixed-dest-str': ([Path('src-dir-1'), 'src-file-2', Path('subdir/src-file-3')], 'dest-dir'),
+    'src-list-mixed-dest-Path': (['src-dir-1', Path('src-file-2'), 'subdir/src-file-3'], Path('dest-dir')),
+    'src-set-str-dest-str': ({'src-dir-1', 'src-file-2', 'subdir/src-file-3'}, 'dest-dir'),
+    'src-set-Path-dest-str': ({Path('src-dir-1'), Path('src-file-2'), Path('subdir/src-file-3')}, 'dest-dir'),
+    'src-set-str-dest-Path': ({'src-dir-1', 'src-file-2', 'subdir/src-file-3'}, Path('dest-dir')),
+    'src-set-Path-dest-Path': ({Path('src-dir-1'), Path('src-file-2'), Path('subdir/src-file-3')}, Path('dest-dir')),
+    'src-set-mixed-dest-str': ({Path('src-dir-1'), 'src-file-2', Path('subdir/src-file-3')}, 'dest-dir'),
+    'src-set-mixed-dest-Path': ({'src-dir-1', Path('src-file-2'), 'subdir/src-file-3'}, Path('dest-dir')),
+}
+@pytest.mark.repo_dirs('src-dir-1', 'dest-dir')
+@pytest.mark.repo_files('src-file-2', 'subdir/src-file-3')
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_move_types_mixed(repo, variant, caplog):
+    """
+    Move multiple files and directories across types.
+    """
+    caplog.set_level(logging.DEBUG, logger='onyo')
+
+    # test
+    repo.mv(*variant)
+
+    for i in variant[0]:
+        src = Path(i)
+        assert not src.exists()
+        assert src.parent.exists()
+        assert Path('dest-dir', src.name).exists()
+
+    # check log
+    assert 'rename mode' not in caplog.text
+
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])
+
+
+variants = {  # pyre-ignore[9]
+    'src-dir-dest-dir': ('src-dir', 'dest-dir'),
+    'src-subdir-dest-dir': ('src-dir/src-subdir', 'dest-dir'),
+    'src-file-dest-dir': ('src-file', 'dest-dir'),
+    'src-subfile-dest-dir': ('srcdir/src-subfile', 'dest-dir'),
+    'src-dir-dest-subdir': ('src-dir', 'dest-dir/dest-subdir'),
+    'src-subdir-dest-subdir': ('src-dir/src-subdir', 'dest-dir/dest-subdir'),
+    'src-file-dest-subdir': ('src-file', 'dest-dir/dest-subdir'),
+    'src-subfile-dest-subdir': ('srcdir/src-subfile', 'dest-dir/dest-subdir'),
+    'src-file-spaces': ('s r c f i l e', 'dest-dir'),
+    'src-file-dest-spaces': ('src-file', 'd e s t/d i r'),
+    'src-spaces-dest-spaces': ('s r c f i l e', 'd e s t/d i r'),
+    'seems-explicit-but-isnt-dir': ('name-1', 'same/name-1'),
+    'seems-explicit-but-isnt-file': ('name-2', 'same/name-2'),
+}
+@pytest.mark.repo_dirs('src-dir/src-subdir', 'dest-dir/dest-subdir', 'd e s t/d i r', 'name-1', 'same/name-1', 'same/name-2')
+@pytest.mark.repo_files('src-file', 'srcdir/src-subfile', 's r c f i l e', 'name-2')
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_move_single_implicit(repo, variant, caplog):
+    """
+    Move a single item with an implicit destination name.
+    """
+    caplog.set_level(logging.DEBUG, logger='onyo')
+    src = Path(variant[0])
+    dest = Path(variant[1])
+
+    # test
+    repo.mv(*variant)
+
+    assert not src.exists()
+    assert src.parent.exists()
+    assert Path(dest, src.name).exists()
+
+    # check log
+    assert 'rename mode' not in caplog.text
+
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])
+
+
+variants = {  # pyre-ignore[9]
+    'src-dir-dest-dir': ('src-dir', 'dest-dir/src-dir'),
+    'src-subdir-dest-dir': ('src-dir/src-subdir', 'dest-dir/src-subdir'),
+    'src-file-dest-dir': ('src-file', 'dest-dir/src-file'),
+    'src-subfile-dest-dir': ('srcdir/src-subfile', 'dest-dir/src-subfile'),
+    'src-dir-dest-subdir': ('src-dir', 'dest-dir/dest-subdir/src-dir'),
+    'src-subdir-dest-subdir': ('src-dir/src-subdir', 'dest-dir/dest-subdir/src-subdir'),
+    'src-file-dest-subdir': ('src-file', 'dest-dir/dest-subdir/src-file'),
+    'src-subfile-dest-subdir': ('srcdir/src-subfile', 'dest-dir/dest-subdir/src-subfile'),
+    'src-file-spaces': ('s r c f i l e', 'dest-dir/s r c f i l e'),
+    'src-file-dest-spaces': ('src-file', 'd e s t/d i r/src-file'),
+    'src-spaces-dest-spaces': ('s r c f i l e', 'd e s t/d i r/s r c f i l e'),
+}
+@pytest.mark.repo_files('src-file', 'srcdir/src-subfile', 's r c f i l e')
+@pytest.mark.repo_dirs('src-dir/src-subdir', 'dest-dir/dest-subdir', 'd e s t/d i r')
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_move_single_explicit(repo, variant, caplog):
+    """
+    Move a single item with an explicit destination name that /matches/ the
+    source name (making it still a move, and not a rename).
+    """
+    caplog.set_level(logging.DEBUG, logger='onyo')
+    src = Path(variant[0])
+    dest = Path(variant[1])
+
+    # test
+    repo.mv(*variant)
+
+    assert not src.exists()
+    assert src.parent.exists()
+    assert dest.exists()
+
+    # check log
+    assert 'rename mode' not in caplog.text
+
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])
+
+
+variants = {  # pyre-ignore[9]
+    'src-files': (['file-1', 'file-2', 'file-3'], 'dest-dir'),
+    'src-dirs': (['dir-1', 'dir-2', 'dir-3'], 'dest-dir'),
+    'src-subfiles': (['srcdir/subfile-1', 'srcdir/subfile-2', 'srcdir/subfile-3'], 'dest-dir'),
+    'src-subdirs': (['srcdir/subdir-1', 'srcdir/subdir-2', 'srcdir/subdir-3'], 'dest-dir'),
+    'src-files-dest-subdir': (['file-1', 'file-2', 'file-3'], 'dest-dir/dest-subdir'),
+    'src-dirs-dest-subdir': (['dir-1', 'dir-2', 'dir-3'], 'dest-dir/dest-subdir'),
+    'src-subfiles-dest-subdir': (['srcdir/subfile-1', 'srcdir/subfile-2', 'srcdir/subfile-3'], 'dest-dir/dest-subdir'),
+    'src-subdirs-dest-subdir': (['srcdir/subdir-1', 'srcdir/subdir-2', 'srcdir/subdir-3'], 'dest-dir/dest-subdir'),
+    'mixed-files-dir': (['file-1', 'dir-2', 'file-3'], 'dest-dir'),
+    'mixed-depth': (['srcdir/subdir-1', 'file-2', 'file-3'], 'dest-dir/dest-subdir'),
+    'spaces': (['file-1', 'srcdir', 'f i l e'], 'd e s t/d i r/'),
+}
+@pytest.mark.repo_files('file-1', 'file-2', 'file-3', 'srcdir/subfile-1', 'srcdir/subfile-2', 'srcdir/subfile-3', 'f i l e')
+@pytest.mark.repo_dirs('dir-1', 'dir-2', 'dir-3', 'srcdir/subdir-1', 'srcdir/subdir-2', 'srcdir/subdir-3', 'dest-dir/dest-subdir', 'd e s t/d i r')
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_move_multiple(repo, variant, caplog):
+    """
+    Move multiple sources.
+    """
+    caplog.set_level(logging.DEBUG, logger='onyo')
+    dest = Path(variant[1])
+
+    # test
+    repo.mv(*variant)
+
+    sources = [variant[0]] if isinstance(variant[0], str) else variant[0]
+    for i in sources:
+        src = Path(i)
+        assert not src.exists()
+        assert src.parent.exists()
+        assert Path(dest, src.name).exists()
+
+    # check log
+    assert 'rename mode' not in caplog.text
+
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])
+
+
+variants = {  # pyre-ignore[9]
+    'src-dir-git': ('.git', 'dest-dir'),
+    'src-dir-onyo': ('.onyo', 'dest-dir'),
+    'src-dir-git-subdir': ('.git/objects', 'dest-dir'),
+    'src-dir-onyo-subdir': ('.onyo/templates', 'dest-dir'),
+    'src-file-git': ('.git/config', 'dest-dir'),
+    'src-file-onyo': ('.onyo/config', 'dest-dir'),
+    'src-anchor': ('src-dir/.anchor', './'),
+    'dest-dir-git': ('src-dir', '.git'),
+    'dest-dir-onyo': ('src-dir', '.onyo'),
+    'dest-dir-git-subdir': ('src-dir', '.git/objects'),
+    'dest-dir-onyo-subdir': ('src-dir', '.onyo/templates'),
+    'dest-file-git': ('src-file', '.git'),
+    'dest-file-onyo': ('src-file', '.onyo'),
+    'inside-git': ('.git/config', '.git/objects'),
+    'inside-onyo': ('.onyo/templates', '.onyo/validation'),
+}
+@pytest.mark.repo_files('src-file', 'one', 'three')
+@pytest.mark.repo_dirs('src-dir', 'dest-dir')
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_move_protected(repo, variant, caplog):
+    """
+    Protected paths.
+    """
+    caplog.set_level(logging.DEBUG, logger='onyo')
+    src = Path(variant[0])
+    dest = Path(variant[1])
+
+    # single
+    with pytest.raises(OnyoProtectedPathError):
+        repo.mv(*variant)
+
+    assert src.exists()
+    assert not Path(dest, src.name).exists()
+
+    # multiple
+    with pytest.raises(OnyoProtectedPathError):
+        repo.mv(['one', src, 'three'], dest)
+
+    assert Path('one').exists()
+    assert Path(src).exists()
+    assert Path('three').exists()
+
+    assert not Path(dest, src.name).exists()
+    if not dest.samefile('.'):
+        assert not Path(dest, 'one').exists()
+        assert not Path(dest, 'three').exists()
+
+    # check log
+    assert 'rename mode' not in caplog.text
+
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])
+
+
+variants = {  # pyre-ignore[9]
+    'dest-implicit': ('does-not-exist', 'dest-dir'),
+    'dest-explicit': ('does-not-exist', 'dest-dir/does-not-exist'),
+    'src-subdir-dest-implicit': ('dir/does-not-exist', 'dest-dir'),
+    'src-subdir-dest-explicit': ('dir/does-not-exist', 'dest-dir/does-not-exist'),
+    'multiple': (['does-not-exist-1', 'dir/does-not-exist-2'], 'dest-dir'),
+    'mixed': (['exist-file-1', 'does-not-exist-2', 'exist-dir-3'], 'dest-dir'),
+}
+@pytest.mark.repo_dirs('dir', 'dest-dir', 'exist-dir-3')
+@pytest.mark.repo_files('exist-file-1')
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_move_src_not_exist(repo, variant, caplog):
+    """
+    Source paths must exist.
+    """
+    caplog.set_level(logging.DEBUG, logger='onyo')
+    dest = Path(variant[1])
+
+    # test
+    with pytest.raises(FileNotFoundError):
+        repo.mv(*variant)
+
+    sources = [variant[0]] if isinstance(variant[0], str) else variant[0]
+    for i in sources:
+        src = Path(i)
+        if dest.exists():  # implicit mode
+            assert not Path(dest, src.name).exists()
+
+    assert Path('exist-file-1').exists()
+    assert Path('exist-dir-3').exists()
+
+    # check log
+    assert 'rename mode' not in caplog.text
+    assert 'source paths do not exist' in caplog.text
+
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])
+
+
+variants = {  # pyre-ignore[9]
+    'cwd': ({'file-1', 'src-dir/file-2', 'src-dir/subdir'}, 'does-not-exist'),
+    'subdir': ({'file-1', 'src-dir/file-2', 'src-dir/subdir'}, 'dest-dir/does-not-exist'),
+}
+@pytest.mark.repo_dirs('src-dir/subdir', 'dest-dir')
+@pytest.mark.repo_files('file-1', 'src-dir/file-2')
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_move_dest_not_exist(repo, variant, caplog):
+    """
+    Destination must exist in move mode with multiple sources.
+
+    The explicit form ('src-dir' -> 'does-not-exist/src-dir') is covered by the
+    missing parent checks.
+    """
+    caplog.set_level(logging.DEBUG, logger='onyo')
+    dest = Path(variant[1])
+
+    # test
+    with pytest.raises(FileNotFoundError):
+        repo.mv(*variant)
+
+    sources = [variant[0]] if isinstance(variant[0], str) else variant[0]
+    for i in sources:
+        src = Path(i)
+        assert src.exists()
+        assert not Path(dest, src.name).exists()
+
+    # check log
+    assert 'rename mode' not in caplog.text
+    assert 'does not exist' in caplog.text
+
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])
+
+
+variants = {  # pyre-ignore[9]
+    'implicit': ('dir', 'dir'),
+    'multiple': (['file-1', 'dir', 'file-3'], 'dir'),
+    'explicit': ('dir', 'dir/dir'),
+}
+@pytest.mark.repo_dirs('dir')
+@pytest.mark.repo_files('file-1', 'file-3')
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_move_into_self(repo, variant, caplog):
+    """
+    Cannot move a directory into itself.
+    """
+    caplog.set_level(logging.DEBUG, logger='onyo')
+    dest = Path(variant[1])
+
+    # test
+    with pytest.raises(ValueError):
+        repo.mv(*variant)
+
+    sources = [variant[0]] if isinstance(variant[0], str) else variant[0]
+    for i in sources:
+        src = Path(i)
+        assert src.exists()
+        assert not Path(dest, src.name).exists()
+
+    # check log
+    assert 'rename mode' not in caplog.text
+    assert 'into itself' in caplog.text
+
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])
+
+
+variants = {  # pyre-ignore[9]
+    'self-dir': ('conflict-dir', './'),
+    'self-file': ('conflict-file', './'),
+    'self-file-explicit': ('conflict-file', 'conflict-file'),
+    'cross-file-to-dir': ('conflict-cross-type', 'dir'),
+    'cross-dir-to-file': ('dir/conflict-cross-type', './'),
+    'cross-dir-to-file-explicit': ('dir/conflict-cross-type', './conflict-cross-type'),
+    'multiple': (['file-1', 'conflict-cross-type', 'dir-2'], 'dir'),
+}
+@pytest.mark.repo_dirs('conflict-dir', 'dir/conflict-dir', 'dir/conflict-cross-type', 'dir-2')
+@pytest.mark.repo_files('file-1', 'conflict-cross-type', 'conflict-file')
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_move_name_conflict(repo, variant, caplog):
+    """
+    Names of files/directories cannot conflict.
+    """
+    caplog.set_level(logging.DEBUG, logger='onyo')
+    dest = Path(variant[1])
+
+    # test
+    with pytest.raises(FileExistsError):
+        repo.mv(*variant)
+
+    sources = [variant[0]] if isinstance(variant[0], str) else variant[0]
+    for i in sources:
+        src = Path(i)
+        assert src.exists()
+        assert not Path(dest, src.name, src.name).exists()
+
+    # check log
+    assert 'rename mode' not in caplog.text
+    assert 'destinations exist and would conflict' or 'cannot be a file' in caplog.text
+
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])
+
+
+variants = {  # pyre-ignore[9]
+    'file': (['file-1', 'file-2', 'dir-1'], 'file-3'),
+    'subfile': (['file-1', 'file-2', 'dir-1'], 'subdir/file-4'),
+}
+@pytest.mark.repo_dirs('dir-1')
+@pytest.mark.repo_files('file-1', 'file-2', 'file-3', 'subdir/file-4')
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_move_dest_must_be_dir(repo, variant, caplog):
+    """
+    The destination must be a directory.
+    """
+    caplog.set_level(logging.DEBUG, logger='onyo')
+    dest = Path(variant[1])
+
+    # test
+    with pytest.raises(FileExistsError):
+        repo.mv(*variant)
+
+    sources = [variant[0]] if isinstance(variant[0], str) else variant[0]
+    for i in sources:
+        src = Path(i)
+        assert src.exists()
+        assert not Path(dest, src.name, src.name).exists()
+
+    assert dest.is_file()
+
+    # check log
+    assert 'rename mode' not in caplog.text
+    assert 'cannot be a file' in caplog.text
+
+    # make sure everything is clean
+    repo.fsck(['anchors', 'clean-tree'])

--- a/tests/lib/test_Repo_rm.py
+++ b/tests/lib/test_Repo_rm.py
@@ -206,7 +206,7 @@ def test_rm_repeat(repo):
 
 
 @pytest.mark.repo_files('overlap/one', 'overlap/two', 'overlap/three')
-def test_mkdir_overlap(repo):
+def test_rm_overlap(repo):
     """
     Overlapping targets.
     """
@@ -218,7 +218,7 @@ def test_mkdir_overlap(repo):
 
 
 @pytest.mark.repo_files('s p a/c e s/1 2', 's p a/c e s/3 4')
-def test_mkdir_spaces(repo):
+def test_rm_spaces(repo):
     """
     Spaces.
     """


### PR DESCRIPTION
Notable changes:

- introduce `Repo().mv()` (with tests)
- add a bunch of new tests, covering a lot of corner cases
- fix bugs around explicit move (`file-1` -> `subdir/file-1`)

As with the other conversion, the tests for the command `mv` have been left intact. They will be address later when the logging overhaul happens.