### PR TITLE
TST: remove pypy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', 'pypy3.9']
+        python-version: ['3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
It takes ~5x longer to run, and burns up minutes that we could use for better purposes.

I considered adding macOS, but at a 10x premium, that means we have 200 minutes of tests per month.  And that's just macOS, and not including the other 3 platforms.