### PR TITLE
WIP: TST/RF: assorted cleanup

### DIFF
--- a/onyo/commands/cat.py
+++ b/onyo/commands/cat.py
@@ -8,7 +8,7 @@ logging.basicConfig()
 log = logging.getLogger('onyo')
 
 
-def sanitize_paths(paths, onyo_root):
+def sanitize_paths(paths, opdir):
     """
     Check and normalize a list of paths. If paths do not exist or are not files,
     print paths and exit with error.
@@ -19,7 +19,7 @@ def sanitize_paths(paths, onyo_root):
 
     for p in paths:
         # TODO: This is wrong when an absolute path is provided
-        full_path = Path(onyo_root, p).resolve()
+        full_path = Path(opdir, p).resolve()
 
         # path must exist
         if not full_path.exists():
@@ -48,18 +48,18 @@ def sanitize_paths(paths, onyo_root):
     return paths_to_cat
 
 
-def cat(args, onyo_root):
+def cat(args, opdir):
     """
     Print the contents of ``asset``\(s) to the terminal without parsing or
     validating the contents.
     """
     try:
-        repo = Repo(onyo_root)
+        repo = Repo(opdir)
         repo.fsck(['asset-yaml'])
     except OnyoInvalidRepoError:
         sys.exit(1)
 
-    paths_to_cat = sanitize_paths(args.asset, onyo_root)
+    paths_to_cat = sanitize_paths(args.asset, opdir)
 
     # open file and print to stdout
     for path in paths_to_cat:

--- a/onyo/commands/config.py
+++ b/onyo/commands/config.py
@@ -39,7 +39,7 @@ def sanitize_args(git_config_args):
     return git_config_args
 
 
-def config(args, onyo_root):
+def config(args, opdir):
     """
     Set, query, and unset Onyo repository configuration options. These options
     are stored in ``.onyo/config`` (which is tracked by git) and are shared with
@@ -71,7 +71,7 @@ def config(args, onyo_root):
         $ onyo config onyo.core.editor "vim"
     """
     try:
-        repo = Repo(onyo_root)
+        repo = Repo(opdir)
         repo.fsck(['asset-yaml'])
     except OnyoInvalidRepoError:
         sys.exit(1)

--- a/onyo/commands/edit.py
+++ b/onyo/commands/edit.py
@@ -11,13 +11,13 @@ logging.basicConfig()
 log = logging.getLogger('onyo')
 
 
-def get_editor(onyo_root: Path) -> str:
+def get_editor(repo_root: Path) -> str:
     """
     Returns the editor, progressing through git, onyo, $EDITOR, and finally
     fallback to "nano".
     """
     # onyo config and git config
-    editor = get_config_value('onyo.core.editor', onyo_root)
+    editor = get_config_value('onyo.core.editor', repo_root)
 
     # $EDITOR environment variable
     if not editor:
@@ -111,7 +111,7 @@ def sanitize_assets(assets: list[str], repo: Repo) -> list[Path]:
     return valid_assets
 
 
-def edit(args, onyo_root: str) -> None:
+def edit(args, opdir: str) -> None:
     """
     Open the ``asset`` file(s) using the editor specified by "onyo.core.editor",
     the environment variable ``EDITOR``, or ``nano`` (as a final fallback).
@@ -125,7 +125,7 @@ def edit(args, onyo_root: str) -> None:
     """
     repo = None
     try:
-        repo = Repo(onyo_root)
+        repo = Repo(opdir)
         # "onyo fsck" is intentionally not run here.
         # This is so "onyo edit" can be used to fix an existing problem. This has
         # benefits over just simply using `vim`, etc directly, as "onyo edit" will

--- a/onyo/commands/fsck.py
+++ b/onyo/commands/fsck.py
@@ -3,7 +3,7 @@ import sys
 from onyo.lib import Repo, OnyoInvalidRepoError
 
 
-def fsck(args, onyo_root):
+def fsck(args, opdir):
     """
     Run a suite of checks to verify the integrity and validity of an Onyo
     repository and its contents.
@@ -20,7 +20,7 @@ def fsck(args, onyo_root):
       the validation rulesets defined in ``.onyo/validation/``.
     """
     try:
-        repo = Repo(onyo_root)
+        repo = Repo(opdir)
         repo.fsck()
     except OnyoInvalidRepoError:
         sys.exit(1)

--- a/onyo/commands/history.py
+++ b/onyo/commands/history.py
@@ -11,17 +11,17 @@ logging.basicConfig()
 log = logging.getLogger('onyo')
 
 
-def sanitize_path(path, onyo_root):
+def sanitize_path(path, opdir):
     """
-    Checks a path relative to onyo_root. If it does not exist, it will print
-    an error and exit.
+    Checks a path relative to opdir. If it does not exist, it will print an
+    error and exit.
 
     Returns an absolute path on success.
     """
     if not path:
         path = './'
 
-    full_path = Path(onyo_root, path).resolve()
+    full_path = Path(opdir, path).resolve()
 
     # check if path exists
     if not full_path.exists():
@@ -32,7 +32,7 @@ def sanitize_path(path, onyo_root):
     return full_path
 
 
-def get_history_cmd(interactive, onyo_root):
+def get_history_cmd(interactive, repo_root):
     """
     Get the command used to display history. The appropriate one is selected
     according to the interactive mode, and basic checks are performed for
@@ -46,7 +46,7 @@ def get_history_cmd(interactive, onyo_root):
     if not interactive or not sys.stdout.isatty():
         config_name = 'onyo.history.non-interactive'
 
-    history_cmd = get_config_value(config_name, onyo_root)
+    history_cmd = get_config_value(config_name, repo_root)
     if not history_cmd:
         log.error(f"'{config_name}' is unset and is required to display history.")
         log.error("Please see 'onyo config --help' for information about how to set it. Exiting.")
@@ -61,7 +61,7 @@ def get_history_cmd(interactive, onyo_root):
     return history_cmd
 
 
-def history(args, onyo_root):
+def history(args, opdir):
     """
     Display the history of an ``asset`` or ``directory``.
 
@@ -72,19 +72,19 @@ def history(args, onyo_root):
     The commands to display history are configurable using ``onyo config``.
     """
     try:
-        repo = Repo(onyo_root)
+        repo = Repo(opdir)
         repo.fsck(['asset-yaml'])
     except OnyoInvalidRepoError:
         sys.exit(1)
 
     # get the command and path
-    history_cmd = get_history_cmd(args.interactive, onyo_root)
-    path = sanitize_path(args.path, onyo_root)
+    history_cmd = get_history_cmd(args.interactive, repo.root)
+    path = sanitize_path(args.path, opdir)
 
     # run it
     orig_cwd = os.getcwd()
     try:
-        os.chdir(onyo_root)
+        os.chdir(opdir)
         status = os.system(f"{history_cmd} '{path}'")
     except:  # noqa: E722
         pass

--- a/onyo/commands/init.py
+++ b/onyo/commands/init.py
@@ -17,15 +17,15 @@ def get_skel_dir():
     return skel
 
 
-def sanitize_dir(directory, onyo_root):
+def sanitize_dir(directory, opdir):
     """
     Check the directory for viability as an init target.
 
     Returns the absolute path on success.
     """
-    full_dir = Path(onyo_root)
+    full_dir = Path(opdir)
     if directory:
-        full_dir = Path(onyo_root, directory)
+        full_dir = Path(opdir, directory)
 
     # sanity checks
     # already an .onyo repo
@@ -50,7 +50,7 @@ def sanitize_dir(directory, onyo_root):
     return abs_dir
 
 
-def init(args, onyo_root):
+def init(args, opdir):
     """
     Initialize an Onyo repository. The directory will be initialized as a git
     repository (if it is not one already), the ``.onyo/`` directory created
@@ -62,7 +62,7 @@ def init(args, onyo_root):
     Running ``onyo init`` on an existing repository is safe. It will not
     overwrite anything; it will exit with an error.
     """
-    target_dir = sanitize_dir(args.directory, onyo_root)
+    target_dir = sanitize_dir(args.directory, opdir)
     Path(target_dir).mkdir(exist_ok=True)
 
     try:

--- a/onyo/commands/mkdir.py
+++ b/onyo/commands/mkdir.py
@@ -3,7 +3,7 @@ import sys
 from onyo.lib import Repo, OnyoInvalidRepoError, OnyoProtectedPathError
 
 
-def mkdir(args, onyo_root):
+def mkdir(args, opdir):
     """
     Create ``directory``\(s). Intermediate directories will be created as needed
     (i.e. parent and child directories can be created in one call).
@@ -15,7 +15,7 @@ def mkdir(args, onyo_root):
     an error. All checks are performed before creating directories.
     """
     try:
-        repo = Repo(onyo_root)
+        repo = Repo(opdir)
         repo.fsck()
     except OnyoInvalidRepoError:
         sys.exit(1)

--- a/onyo/commands/mv.py
+++ b/onyo/commands/mv.py
@@ -2,7 +2,7 @@ import sys
 from onyo.lib import Repo, OnyoInvalidRepoError, OnyoProtectedPathError
 
 
-def mv(args, onyo_root: str) -> None:
+def mv(args, opdir: str) -> None:
     """
     Move ``source``\(s) (assets or directories) to the ``destination``
     directory, or rename a ``source`` directory to ``destination``.
@@ -17,7 +17,7 @@ def mv(args, onyo_root: str) -> None:
         sys.exit(1)
 
     try:
-        repo = Repo(onyo_root)
+        repo = Repo(opdir)
         repo.fsck()
     except OnyoInvalidRepoError:
         sys.exit(1)

--- a/onyo/commands/new.py
+++ b/onyo/commands/new.py
@@ -133,7 +133,7 @@ def sanitize_paths(directory, template, repo):
     return [directory, template]
 
 
-def new(args, onyo_root):
+def new(args, opdir):
     """
     Creates a new ``asset`` in ``directory``. The command opens a dialog that
     asks for the field names defined by the asset name scheme, and after
@@ -143,7 +143,7 @@ def new(args, onyo_root):
     its YAML syntax and based on the rules in ``.onyo/validation/``.
     """
     try:
-        repo = Repo(onyo_root)
+        repo = Repo(opdir)
         repo.fsck()
     except OnyoInvalidRepoError:
         sys.exit(1)

--- a/onyo/commands/rm.py
+++ b/onyo/commands/rm.py
@@ -3,7 +3,7 @@ import sys
 from onyo.lib import Repo, OnyoInvalidRepoError, OnyoProtectedPathError
 
 
-def rm(args, onyo_root: str) -> None:
+def rm(args, opdir: str) -> None:
     """
     Delete ``asset``\(s) and ``directory``\(s).
 
@@ -18,7 +18,7 @@ def rm(args, onyo_root: str) -> None:
         sys.exit(1)
 
     try:
-        repo = Repo(onyo_root)
+        repo = Repo(opdir)
         repo.fsck()
     except OnyoInvalidRepoError:
         sys.exit(1)

--- a/onyo/commands/set.py
+++ b/onyo/commands/set.py
@@ -4,9 +4,6 @@ import sys
 from ruamel.yaml import YAML  # pyre-ignore[21]
 
 from onyo.lib import Repo, OnyoInvalidRepoError
-from onyo.utils import (
-    get_git_root
-)
 
 logging.basicConfig()
 log = logging.getLogger('onyo')
@@ -84,7 +81,7 @@ def diff_changes(file_list, keys, opdir):
             asset_changed = asset_changed + "\n+\t" + key + ": " + str(keys[key])
         if asset_changed:
             if opdir in file:
-                output_str = output_str + "\n" + os.path.relpath(file, get_git_root(opdir)) + asset_changed
+                output_str = output_str + "\n" + os.path.relpath(file, opdir) + asset_changed
             else:
                 output_str = output_str + "\n" + file + asset_changed
     return output_str

--- a/onyo/commands/shell_completion.py
+++ b/onyo/commands/shell_completion.py
@@ -430,7 +430,7 @@ compdef _onyo onyo
         return case
 
 
-def shell_completion(args, onyo_root):
+def shell_completion(args, opdir):
     """
     Display a shell script for tab completion for Onyo.
 

--- a/onyo/commands/tree.py
+++ b/onyo/commands/tree.py
@@ -18,20 +18,20 @@ def build_tree_cmd(directory):
     return "tree \"" + directory + "\""
 
 
-def prepare_arguments(sources, onyo_root):
+def prepare_arguments(sources, opdir):
     problem_str = ""
     list_of_sources = []
     # just a single path?
     single_source = "".join(sources)
     if os.path.isdir(single_source):
         return [single_source]
-    elif os.path.isdir(os.path.join(onyo_root, single_source)):
-        return [os.path.join(onyo_root, single_source)]
+    elif os.path.isdir(os.path.join(opdir, single_source)):
+        return [os.path.join(opdir, single_source)]
     # build paths
     for source in sources:
         current_source = source
         if not os.path.exists(current_source):
-            current_source = os.path.join(onyo_root, source)
+            current_source = os.path.join(opdir, source)
         # check if path exists
         if not os.path.exists(current_source):
             problem_str = problem_str + "\n" + source + " does not exist."
@@ -45,19 +45,19 @@ def prepare_arguments(sources, onyo_root):
     return list_of_sources
 
 
-def tree(args, onyo_root):
+def tree(args, opdir):
     """
     List the assets and directories in ``directory`` using the ``tree``
     program.
     """
     try:
-        repo = Repo(onyo_root)
+        repo = Repo(opdir)
         repo.fsck(['asset-yaml'])
     except OnyoInvalidRepoError:
         sys.exit(1)
 
     # check sources
-    list_of_sources = prepare_arguments(args.directory, onyo_root)
+    list_of_sources = prepare_arguments(args.directory, opdir)
     # build and run commands
     for source in list_of_sources:
         tree_command = build_tree_cmd(source)

--- a/onyo/commands/tree.py
+++ b/onyo/commands/tree.py
@@ -1,54 +1,43 @@
 import logging
 import os
 import sys
+from pathlib import Path
 
-from onyo.utils import (
-    run_cmd
-)
 from onyo.lib import Repo, OnyoInvalidRepoError
 
 logging.basicConfig()
 log = logging.getLogger('onyo')
 
 
-def build_tree_cmd(directory):
-    if not os.path.isdir(directory):
-        log.error(directory + " does not exist.")
-        sys.exit(1)
-    return "tree \"" + directory + "\""
-
-
-def prepare_arguments(sources, opdir):
-    problem_str = ""
-    list_of_sources = []
-    # just a single path?
-    single_source = "".join(sources)
-    if os.path.isdir(single_source):
-        return [single_source]
-    elif os.path.isdir(os.path.join(opdir, single_source)):
-        return [os.path.join(opdir, single_source)]
-    # build paths
-    for source in sources:
-        current_source = source
-        if not os.path.exists(current_source):
-            current_source = os.path.join(opdir, source)
-        # check if path exists
-        if not os.path.exists(current_source):
-            problem_str = problem_str + "\n" + source + " does not exist."
-        elif not os.path.isdir(current_source):
-            problem_str = problem_str + "\n" + source + " is not a directory."
-        else:
-            list_of_sources.append(current_source)
-    if problem_str != "":
-        log.error(problem_str)
-        sys.exit(1)
-    return list_of_sources
-
-
-def tree(args, opdir):
+def sanitize_directories(directories: list, opdir: str) -> str:
     """
-    List the assets and directories in ``directory`` using the ``tree``
-    program.
+    Check a list of directories. If any do not exist or are a file, and error
+    will be printed.
+
+    Returns a string of the valid directories relative to opdir.
+    """
+    dirs = []
+    error_path = []
+
+    for d in directories:
+        full_path = Path(opdir, d)
+
+        if full_path.is_dir():
+            dirs.append(full_path.relative_to(opdir))
+        else:
+            error_path.append(d)
+
+    if error_path:
+        print('The following paths are not directories:\n' + '\n'.join(error_path),
+              file=sys.stderr)
+        sys.exit(1)
+
+    return ' '.join(str(x) for x in dirs)
+
+
+def tree(args, opdir: str) -> None:
+    """
+    List the assets and directories in ``directory`` using ``tree``.
     """
     try:
         repo = Repo(opdir)
@@ -56,10 +45,23 @@ def tree(args, opdir):
     except OnyoInvalidRepoError:
         sys.exit(1)
 
-    # check sources
-    list_of_sources = prepare_arguments(args.directory, opdir)
-    # build and run commands
-    for source in list_of_sources:
-        tree_command = build_tree_cmd(source)
-        output = run_cmd(tree_command)
-        print(output)
+    # sanitize the paths
+    dirs = sanitize_directories(args.directory, opdir)
+
+    # run it
+    status = int()
+    orig_cwd = os.getcwd()
+    try:
+        os.chdir(opdir)
+        status = os.system(f"tree {dirs}")
+    except:  # noqa: E722
+        pass
+    finally:
+        os.chdir(orig_cwd)
+
+    # covert the return status into a return code
+    returncode = os.waitstatus_to_exitcode(status)
+
+    # bubble up error retval
+    if returncode != 0:
+        exit(returncode)

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -117,6 +117,7 @@ def setup_parser():
     parser.add_argument(
         '-C',
         '--onyopath',
+        dest='opdir',
         metavar='DIR',
         required=False,
         default=os.getcwd(),
@@ -508,7 +509,7 @@ def main():
 
     # run the subcommand
     if subcmd_index:
-        args.run(args, args.onyopath)
+        args.run(args, args.opdir)
     else:
         parser.print_help()
         exit(1)

--- a/onyo/utils.py
+++ b/onyo/utils.py
@@ -1,48 +1,12 @@
-import subprocess
 import logging
 import os
-import sys
-import shlex
-import string
 import random
+import string
 from pathlib import Path
 from git import Repo, exc
 
 logging.basicConfig()
 log = logging.getLogger('onyo')
-
-
-def run_cmd(cmd, comment=""):
-    if comment != "":
-        run_process = subprocess.Popen(shlex.split(cmd) + [comment],
-                                       stdout=subprocess.PIPE,
-                                       stderr=subprocess.PIPE,
-                                       universal_newlines=True)
-    else:
-        run_process = subprocess.Popen(shlex.split(cmd),
-                                       stdout=subprocess.PIPE,
-                                       stderr=subprocess.PIPE,
-                                       universal_newlines=True)
-    run_output, run_error = run_process.communicate()
-    if (run_error != ""):
-        log.error(run_error)
-        sys.exit(1)
-    else:
-        log.debug(cmd + " " + comment)
-    return run_output
-
-
-def get_git_root(path):
-    # first checks if file is in git from current position
-    try:
-        git_repo = Repo(path, search_parent_directories=True)
-        git_root = git_repo.git.rev_parse("--show-toplevel")
-        if os.path.isdir(os.path.join(git_root, ".onyo")):
-            return git_root
-    except (exc.NoSuchPathError, exc.InvalidGitRepositoryError):
-        log.error(path + " is no onyo repository.")
-        sys.exit(1)
-        return git_root
 
 
 def generate_faux_serial(repo_root, faux_length=8):
@@ -67,10 +31,6 @@ def generate_faux_serial(repo_root, faux_length=8):
     while True in [faux in asset[1] for asset in list_of_assets]:
         faux = "faux" + ''.join(random.choices(alphanum, k=faux_length))
     return faux
-
-
-def build_git_add_cmd(directory, file):
-    return "git -C \"" + directory + "\" add \"" + file + "\""
 
 
 def get_config_value(name, repo_root):

--- a/onyo/utils.py
+++ b/onyo/utils.py
@@ -45,7 +45,7 @@ def get_git_root(path):
         return git_root
 
 
-def generate_faux_serial(onyo_root, faux_length=8):
+def generate_faux_serial(repo_root, faux_length=8):
     """
     Generate a unique faux serial number and verify that it does not appear in
     any other asset file name in any directory of the onyo repository.
@@ -62,7 +62,7 @@ def generate_faux_serial(onyo_root, faux_length=8):
     # generate a new faux serial number until a unique one (which is in no other
     # asset name in the repository) is found, then return it.
     alphanum = string.ascii_letters + string.digits
-    list_of_assets = get_list_of_assets(onyo_root)
+    list_of_assets = get_list_of_assets(repo_root)
     faux = "faux" + ''.join(random.choices(alphanum, k=faux_length))
     while True in [faux in asset[1] for asset in list_of_assets]:
         faux = "faux" + ''.join(random.choices(alphanum, k=faux_length))
@@ -73,7 +73,7 @@ def build_git_add_cmd(directory, file):
     return "git -C \"" + directory + "\" add \"" + file + "\""
 
 
-def get_config_value(name, onyo_root):
+def get_config_value(name, repo_root):
     """
     Get the value for a configuration option specified by `name`. git-config is
     checked first, as it is machine-local. The default order of git-config
@@ -82,7 +82,7 @@ def get_config_value(name, onyo_root):
     Returns a string with the config value on success. None otherwise.
     """
     value = None
-    repo = Repo(onyo_root)
+    repo = Repo(repo_root)
 
     # git-config (with its full stack of locations to check)
     try:
@@ -94,7 +94,7 @@ def get_config_value(name, onyo_root):
 
     # .onyo/config
     if not value:
-        dot_onyo_config = os.path.join(repo.git.rev_parse('--show-toplevel'), '.onyo/config')
+        dot_onyo_config = os.path.join(repo_root, '.onyo/config')
         try:
             value = repo.git.config('--get', name, f=dot_onyo_config)
             log.debug(f"onyo config acquired '{name}': '{value}'")
@@ -109,11 +109,11 @@ def get_config_value(name, onyo_root):
     return value
 
 
-def get_list_of_assets(repo_path):
+def get_list_of_assets(repo_root):
     """
     Return a list of all assets in an onyo repository.
     """
-    return [[x[0][0], Path(x[0][0]).name] for x in Repo(repo_path).index.entries.items()
+    return [[x[0][0], Path(x[0][0]).name] for x in Repo(repo_root).index.entries.items()
             if not is_protected_path(x[0][0])]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,15 +15,13 @@ def repo(tmp_path, monkeypatch, request):
     """
     This fixture:
     - creates a new repository in a temporary directory
-    - `cd`s into the dir
+    - `cd`s into the repository
     - returns a handle to the repo
 
-    Furthermore, it will populate the repository by looking for the
-    following markers:
+    Furthermore, it will populate the repository using these markers:
     - repo_dirs()
     - repo_files()
-      - files automatically have their parent dirs created.
-
+      - parent directories of files are automatically created
     """
     repo_path = Path(tmp_path)
     dirs = set()
@@ -34,16 +32,17 @@ def repo(tmp_path, monkeypatch, request):
     assert ret.returncode == 0
     repo_ = Repo(repo_path)
 
-    # see if there's anything to populate the repo
+    # collect files to populate the repo
     m = request.node.get_closest_marker('repo_files')
     if m:
         files = {Path(repo_path, x) for x in m.args}
 
+    # collect dirs to populate the repo
     m = request.node.get_closest_marker('repo_dirs')
     if m:
         dirs = set(m.args)
 
-    # collect dirs for files too
+    # collect dirs from files list too
     dirs |= {x.parent for x in files if not x.parent.exists()}
 
     # populate the repo

--- a/tests/reference_output/C_absolute/test_tree_output.txt
+++ b/tests/reference_output/C_absolute/test_tree_output.txt
@@ -1,4 +1,4 @@
-<replace>/
+.
 ├── no user
 │   ├── laptop_apple_macbookpro.2
 │   └── laptop_apple_macbookpro.3

--- a/tests/reference_output/root_of_repo/test_tree_output.txt
+++ b/tests/reference_output/root_of_repo/test_tree_output.txt
@@ -1,4 +1,4 @@
-<replace>/
+.
 ├── no user
 │   ├── laptop_apple_macbookpro.2
 │   └── laptop_apple_macbookpro.3

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,50 +5,41 @@ import pytest
 from onyo import utils
 
 
-def test_onyo_init():
-    ret = subprocess.run(["onyo", "init"])
-    assert ret.returncode == 0
-
-
-def test_get_config_value_git():
+def test_get_config_value_git(repo):
     ret = subprocess.run(["git", "config", "onyo.test.get-git", "get-git-test"],
                          capture_output=True, text=True)
     assert ret.returncode == 0
     assert 'get-git =' in Path('.git/config').read_text()
     assert '= get-git-test' in Path('.git/config').read_text()
 
-    onyo_root = './'
-    assert utils.get_config_value('onyo.test.get-git', onyo_root) == 'get-git-test'
+    assert utils.get_config_value('onyo.test.get-git', repo.root) == 'get-git-test'
 
 
-def test_get_config_value_onyo():
+def test_get_config_value_onyo(repo):
     ret = subprocess.run(["onyo", "config", "onyo.test.get-onyo", "get-onyo-test"],
                          capture_output=True, text=True)
     assert ret.returncode == 0
     assert 'get-onyo =' in Path('.onyo/config').read_text()
     assert '= get-onyo-test' in Path('.onyo/config').read_text()
 
-    onyo_root = './'
-    assert utils.get_config_value('onyo.test.get-onyo', onyo_root) == 'get-onyo-test'
+    assert utils.get_config_value('onyo.test.get-onyo', repo.root) == 'get-onyo-test'
 
 
-def test_generate_faux_serials():
+def test_generate_faux_serials(repo):
     """
     Test the creation of unique serial numbers with the default length through
     calling the generate_faux_serial() function multiple times and comparing the
     generated faux serial numbers.
     """
-    onyo_root = './'
-
-    # technically, creating multiple faux serial numbers without actually
-    # creating assets might lead to duplicates. In practice, this should not
-    # happen if they are sufficiently long and random
-    faux = [utils.generate_faux_serial(onyo_root) for x in range(0, 100)]
+    # creating multiple faux serial numbers without actually creating assets
+    # might lead to duplicates. In practice, this should not happen if they are
+    # sufficiently long and random
+    faux = [utils.generate_faux_serial(repo.root) for x in range(0, 100)]
     assert len(faux) == len(set(faux))
     assert len(faux) > 0
 
 
-def test_length_range_of_generate_faux_serials():
+def test_length_range_of_generate_faux_serials(repo):
     """
     Create many faux serial numbers with different lengths over the range of
     allowed faux serial number lengths to test that the function returns faux
@@ -56,26 +47,24 @@ def test_length_range_of_generate_faux_serials():
     to verify that the appropriate error gets thrown. Because of the
     different lengths, they should all be different.
     """
-    onyo_root = './'
-
-    # test that faux serial numbers must have at least length 1 and the function
-    # raises the correct ValueError:
+    # faux serial numbers must have at least length 1 and the function raises
+    # ValueError:
     with pytest.raises(ValueError) as ret:
-        utils.generate_faux_serial(onyo_root, faux_length=0)
+        utils.generate_faux_serial(repo.root, faux_length=0)
     assert ret.type == ValueError
 
-    # test that faux serial numbers can't be requested longer than 37 and the
-    # function raises the correct ValueError:
+    # faux serial numbers can't be requested longer than 37 and the function
+    # raises ValueError:
     with pytest.raises(ValueError) as ret:
-        utils.generate_faux_serial(onyo_root, faux_length=38)
+        utils.generate_faux_serial(repo.root, faux_length=38)
     assert ret.type == ValueError
 
-    faux = [utils.generate_faux_serial(onyo_root, x) for x in range(1, 37)]
+    faux = [utils.generate_faux_serial(repo.root, x) for x in range(1, 37)]
     assert len(faux) == len(set(faux))
     assert len(faux) > 0
 
 
-def test_is_protected_path():
+def test_is_protected_path(repo):
     # simple
     assert utils.is_protected_path('.anchor')
     assert utils.is_protected_path('.git')


### PR DESCRIPTION
This is a collection of seeming-random, but actually interconnected changes.

Changed of note:
- quick-and-dirty modernization of `tree`. No thought was put into repo-ification, which also seems largely unneeded
- renaming of `onyo_root` to either `opdir` (which is what it usually means) or `repo_root` (which it sometimes means)
- update the `utils.py` tests to use the `repo` fixture and update some comments
- finally drop `run_cmd()`, `build_git_add_cmd()`, and `get_git_root()` from utils, as the above were the last consumers.