### PR TITLE
NF: Repo() methods should stage changes

### DIFF
--- a/onyo/commands/mkdir.py
+++ b/onyo/commands/mkdir.py
@@ -1,4 +1,5 @@
 import sys
+from pathlib import Path
 
 from onyo.lib import Repo, OnyoInvalidRepoError, OnyoProtectedPathError
 
@@ -22,5 +23,6 @@ def mkdir(args, opdir):
 
     try:
         repo.mkdir(args.directory)
+        repo.commit('mkdir: ' + ','.join(["'{}'".format(Path(opdir, x).resolve().relative_to(repo.root)) for x in args.directory]))
     except (FileExistsError, OnyoProtectedPathError):
         sys.exit(1)

--- a/onyo/commands/mv.py
+++ b/onyo/commands/mv.py
@@ -1,4 +1,6 @@
 import sys
+from pathlib import Path
+
 from onyo.lib import Repo, OnyoInvalidRepoError, OnyoProtectedPathError
 
 
@@ -40,5 +42,8 @@ def mv(args, opdir: str) -> None:
 
     try:
         repo.mv(args.source, args.destination)
-    except (FileExistsError, FileNotFoundError, NotADirectoryError, OnyoProtectedPathError, ValueError):
+        repo.commit('mv: ' +
+                    ','.join(["'{}'".format(Path(opdir, x).resolve().relative_to(repo.root)) for x in args.source]) +
+                    ' -> ' + str(Path(opdir, args.destination).resolve().relative_to(repo.root)))
+    except (FileExistsError, FileNotFoundError, OnyoProtectedPathError, ValueError):
         sys.exit(1)

--- a/onyo/commands/rm.py
+++ b/onyo/commands/rm.py
@@ -1,4 +1,5 @@
 import sys
+from pathlib import Path
 
 from onyo.lib import Repo, OnyoInvalidRepoError, OnyoProtectedPathError
 
@@ -41,5 +42,6 @@ def rm(args, opdir: str) -> None:
 
     try:
         repo.rm(args.path)
+        repo.commit('rm: ' + ','.join(["'{}'".format(Path(opdir, x).resolve().relative_to(repo.root)) for x in args.path]))
     except (FileNotFoundError, OnyoProtectedPathError):
         sys.exit(1)

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -398,8 +398,6 @@ class Repo:
             a.touch(exist_ok=True)
 
         self.add(anchors)
-        # paths should be relative to root in commit messages
-        self.commit('mkdir: ' + ', '.join(["'{}'".format(x.relative_to(self.root)) for x in dirs]))
 
     def _mkdir_sanitize(self, dirs: Iterable[Union[Path, str]]) -> set[Path]:
         """
@@ -466,12 +464,7 @@ class Repo:
         if dryrun:
             ret = self._git(['mv', '--dry-run'] + [str(x) for x in src_paths] + [str(dest_path)])
         else:
-            # mv and commit
             ret = self._git(['mv'] + [str(x) for x in src_paths] + [str(dest_path)])
-            # TODO: should `mv` commit? (mkdir() does, add() doesn't)
-            # TODO: can this commit message be made more helpful?
-            # TODO: relative to self.root
-            self.commit('moved asset(s)', src_paths)
 
         # TODO: change this to info
         log.debug('The following will be moved:\n' +
@@ -683,10 +676,6 @@ class Repo:
         else:
             # rm and commit
             ret = self._git(['rm', '-r'] + [str(x) for x in paths_to_rm])
-            # TODO: should `rm` commit? (mkdir() does, add() doesn't)
-            # TODO: can this commit message be made more helpful?
-            # TODO: relative to self.root
-            self.commit('deleted asset(s)', paths_to_rm)
 
         # TODO: change this to info
         log.debug('The following will be deleted:\n' +

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,13 +48,14 @@ def repo(tmp_path, monkeypatch, request):
     # populate the repo
     if dirs:
         repo_.mkdir(dirs)
+        repo_.commit('populate dirs for tests', dirs)
 
     for i in files:
         i.touch()
 
     if files:
         repo_.add(files)
-        repo_.commit('populated for tests', files)
+        repo_.commit('populate files for tests', files)
 
     # cd into repo; to ease testing
     monkeypatch.chdir(repo_path)
@@ -151,6 +152,7 @@ class Helpers:
         # dirs
         if dirs:
             repo.mkdir(dirs)
+            repo.commit('populate dirs for tests', dirs)
 
         # files
         if files:
@@ -158,4 +160,4 @@ class Helpers:
                 Path(path, i).touch()
 
             repo.add(files)
-            repo.commit('populated for tests', files)
+            repo.commit('populate files for tests', files)

--- a/tests/lib/test_Repo_mkdir.py
+++ b/tests/lib/test_Repo_mkdir.py
@@ -31,8 +31,13 @@ def test_mkdir_single(repo, variant):
     repo.mkdir(variant)
     assert anchored_dir('one')
 
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
+    # everything should be staged
+    assert not repo.files_changed
+    assert repo.files_staged
+    assert not repo.files_untracked
+
+    # check anchors
+    repo.fsck(['anchors'])
 
 
 variants = {  # pyre-ignore[9]
@@ -53,8 +58,13 @@ def test_mkdir_multi(repo, variant):
     assert anchored_dir('two')
     assert anchored_dir('three')
 
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
+    # everything should be staged
+    assert not repo.files_changed
+    assert repo.files_staged
+    assert not repo.files_untracked
+
+    # check anchors
+    repo.fsck(['anchors'])
 
 
 variants = {
@@ -71,8 +81,13 @@ def test_mkdir_spaces(repo, variant):
     for i in variant:
         assert anchored_dir(i)
 
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
+    # everything should be staged
+    assert not repo.files_changed
+    assert repo.files_staged
+    assert not repo.files_untracked
+
+    # check anchors
+    repo.fsck(['anchors'])
 
 
 def test_mkdir_recursive(repo):
@@ -90,8 +105,13 @@ def test_mkdir_recursive(repo):
     assert anchored_dir('r/e/c/u/r/s/i/v')
     assert anchored_dir('r/e/c/u/r/s/i/v/e')
 
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
+    # everything should be staged
+    assert not repo.files_changed
+    assert repo.files_staged
+    assert not repo.files_untracked
+
+    # check anchors
+    repo.fsck(['anchors'])
 
 
 variants = {
@@ -111,8 +131,13 @@ def test_mkdir_overlap(repo, variant):
     assert not Path('overlap/two/overlap').exists()
     assert not Path('overlap/three/overlap').exists()
 
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
+    # everything should be staged
+    assert not repo.files_changed
+    assert repo.files_staged
+    assert not repo.files_untracked
+
+    # check anchors
+    repo.fsck(['anchors'])
 
 
 variants = [  # pyre-ignore[9]
@@ -132,8 +157,13 @@ def test_mkdir_protected(repo, variant):
 
     assert not Path(variant).exists()
 
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
+    # nothing should be changed
+    assert not repo.files_changed
+    assert not repo.files_staged
+    assert not repo.files_untracked
+
+    # check anchors
+    repo.fsck(['anchors'])
 
 
 variants = [  # pyre-ignore[9]
@@ -155,13 +185,18 @@ def test_mkdir_protected_mixed(repo, variant, caplog):
     assert not Path('valid-two').exists()
     assert not Path(variant).exists()
 
+    # nothing should be changed
+    assert not repo.files_changed
+    assert not repo.files_staged
+    assert not repo.files_untracked
+
     # check log
     assert 'valid-one' not in caplog.text
     assert 'valid-two' not in caplog.text
     assert variant in caplog.text
 
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
+    # check anchors
+    repo.fsck(['anchors'])
 
 
 variants = [  # pyre-ignore[9]
@@ -172,7 +207,7 @@ variants = [  # pyre-ignore[9]
 @pytest.mark.parametrize('variant', variants)
 def test_mkdir_exists_dir(repo, variant, caplog):
     """
-    TODO
+    Cannot re-create an existing directory.
     """
     with pytest.raises(FileExistsError):
         repo.mkdir(variant)
@@ -180,11 +215,16 @@ def test_mkdir_exists_dir(repo, variant, caplog):
     assert anchored_dir(variant)
     assert not anchored_dir(f'{variant}/{variant}')
 
+    # nothing should be changed
+    assert not repo.files_changed
+    assert not repo.files_staged
+    assert not repo.files_untracked
+
     # check log
     assert variant in caplog.text
 
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
+    # check anchors
+    repo.fsck(['anchors'])
 
 
 variants = [  # pyre-ignore[9]
@@ -195,18 +235,23 @@ variants = [  # pyre-ignore[9]
 @pytest.mark.parametrize('variant', variants)
 def test_mkdir_exists_file(repo, variant, caplog):
     """
-    TODO
+    Target directory cannot be a file.
     """
     with pytest.raises(FileExistsError):
         repo.mkdir(variant)
 
     assert Path(variant).is_file()
 
+    # nothing should be changed
+    assert not repo.files_changed
+    assert not repo.files_staged
+    assert not repo.files_untracked
+
     # check log
     assert variant in caplog.text
 
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
+    # check anchors
+    repo.fsck(['anchors'])
 
 
 variants = [  # pyre-ignore[9]
@@ -218,7 +263,7 @@ variants = [  # pyre-ignore[9]
 @pytest.mark.parametrize('variant', variants)
 def test_mkdir_exists_mixed(repo, variant, caplog):
     """
-    TODO
+    Target directories must not exist.
     """
     with pytest.raises(FileExistsError):
         repo.mkdir(['valid-one', variant, 'valid-two'])
@@ -228,10 +273,15 @@ def test_mkdir_exists_mixed(repo, variant, caplog):
     assert Path('exists-file').exists()
     assert anchored_dir('exists-dir')
 
+    # nothing should be changed
+    assert not repo.files_changed
+    assert not repo.files_staged
+    assert not repo.files_untracked
+
     # check log
     assert 'valid-one' not in caplog.text
     assert 'valid-two' not in caplog.text
     assert variant in caplog.text
 
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
+    # check anchors
+    repo.fsck(['anchors'])

--- a/tests/lib/test_Repo_mv.py
+++ b/tests/lib/test_Repo_mv.py
@@ -29,12 +29,14 @@ def test_missing_parent(repo, variant, caplog):
     assert not Path('does').exists()
     assert 'does not exist' in caplog.text
 
+    # nothing should be changed
+    assert not repo.files_changed
+    assert not repo.files_staged
+    assert not repo.files_untracked
+
     # check log
     assert 'move mode' not in caplog.text
     assert 'rename mode' not in caplog.text
-
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
 
 
 #
@@ -67,11 +69,13 @@ def test_rename_types_dir(repo, variant, caplog):
     assert not Path('dir').exists()
     assert Path('dir.rename').exists()
 
+    # everything should be staged
+    assert not repo.files_changed
+    assert repo.files_staged
+    assert not repo.files_untracked
+
     # check log
     assert 'move mode' not in caplog.text
-
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
 
 
 variants = {  # pyre-ignore[9]
@@ -98,12 +102,14 @@ def test_rename_src_not_exist(repo, variant, caplog):
     assert not dest.exists()
     assert dest.parent.exists()
 
+    # nothing should be changed
+    assert not repo.files_changed
+    assert not repo.files_staged
+    assert not repo.files_untracked
+
     # check log
     assert 'move mode' not in caplog.text
     assert 'source paths do not exist' in caplog.text
-
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
 
 
 variants = {  # pyre-ignore[9]
@@ -128,11 +134,13 @@ def test_rename_dir(repo, variant, caplog):
     assert not Path(variant[0]).exists()
     assert Path(variant[1]).exists()
 
+    # everything should be staged
+    assert not repo.files_changed
+    assert repo.files_staged
+    assert not repo.files_untracked
+
     # check log
     assert 'move mode' not in caplog.text
-
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
 
 
 variants = {  # pyre-ignore[9]
@@ -157,12 +165,14 @@ def test_rename_file(repo, variant, caplog):
     assert Path(variant[0]).is_file()
     assert not Path(variant[1]).exists()
 
+    # nothing should be changed
+    assert not repo.files_changed
+    assert not repo.files_staged
+    assert not repo.files_untracked
+
     # check log
     assert 'move mode' not in caplog.text
     assert 'Cannot rename asset' in caplog.text
-
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
 
 
 variants = {  # pyre-ignore[9]
@@ -193,12 +203,14 @@ def test_rename_conflict_file(repo, variant, caplog):
     assert src.exists()
     assert dest.is_file()
 
+    # nothing should be changed
+    assert not repo.files_changed
+    assert not repo.files_staged
+    assert not repo.files_untracked
+
     # check log
     assert 'move mode' not in caplog.text
     assert 'cannot be a file' in caplog.text
-
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
 
 
 variants = {  # pyre-ignore[9]
@@ -222,12 +234,14 @@ def test_rename_dir_into_self(repo, variant, caplog):
     assert src.is_dir()
     assert not dest.exists()
 
+    # nothing should be changed
+    assert not repo.files_changed
+    assert not repo.files_staged
+    assert not repo.files_untracked
+
     # check log
     assert 'move mode' not in caplog.text
     assert 'into itself' in caplog.text
-
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
 
 
 variants = {  # pyre-ignore[9]
@@ -263,11 +277,13 @@ def test_rename_protected(repo, variant, caplog):
     assert Path(variant[0]).exists()
     assert not Path(variant[1]).exists()
 
+    # nothing should be changed
+    assert not repo.files_changed
+    assert not repo.files_staged
+    assert not repo.files_untracked
+
     # check log
     assert 'move mode' not in caplog.text
-
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
 
 
 #
@@ -300,11 +316,13 @@ def test_move_types_dir(repo, variant, caplog):
     assert not Path('src-dir').exists()
     assert Path('dest-dir', 'src-dir').exists()
 
+    # everything should be staged
+    assert not repo.files_changed
+    assert repo.files_staged
+    assert not repo.files_untracked
+
     # check log
     assert 'rename mode' not in caplog.text
-
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
 
 
 variants = {  # pyre-ignore[9]
@@ -335,11 +353,13 @@ def test_move_types_file(repo, variant, caplog):
     assert not Path('src-file').exists()
     assert Path('dest-dir', 'src-file').exists()
 
+    # everything should be staged
+    assert not repo.files_changed
+    assert repo.files_staged
+    assert not repo.files_untracked
+
     # check log
     assert 'rename mode' not in caplog.text
-
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
 
 
 variants = {  # pyre-ignore[9]
@@ -374,11 +394,13 @@ def test_move_types_mixed(repo, variant, caplog):
         assert src.parent.exists()
         assert Path('dest-dir', src.name).exists()
 
+    # everything should be staged
+    assert not repo.files_changed
+    assert repo.files_staged
+    assert not repo.files_untracked
+
     # check log
     assert 'rename mode' not in caplog.text
-
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
 
 
 variants = {  # pyre-ignore[9]
@@ -414,11 +436,13 @@ def test_move_single_implicit(repo, variant, caplog):
     assert src.parent.exists()
     assert Path(dest, src.name).exists()
 
+    # everything should be staged
+    assert not repo.files_changed
+    assert repo.files_staged
+    assert not repo.files_untracked
+
     # check log
     assert 'rename mode' not in caplog.text
-
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
 
 
 variants = {  # pyre-ignore[9]
@@ -453,11 +477,13 @@ def test_move_single_explicit(repo, variant, caplog):
     assert src.parent.exists()
     assert dest.exists()
 
+    # everything should be staged
+    assert not repo.files_changed
+    assert repo.files_staged
+    assert not repo.files_untracked
+
     # check log
     assert 'rename mode' not in caplog.text
-
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
 
 
 variants = {  # pyre-ignore[9]
@@ -493,11 +519,13 @@ def test_move_multiple(repo, variant, caplog):
         assert src.parent.exists()
         assert Path(dest, src.name).exists()
 
+    # everything should be staged
+    assert not repo.files_changed
+    assert repo.files_staged
+    assert not repo.files_untracked
+
     # check log
     assert 'rename mode' not in caplog.text
-
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
 
 
 variants = {  # pyre-ignore[9]
@@ -548,11 +576,13 @@ def test_move_protected(repo, variant, caplog):
         assert not Path(dest, 'one').exists()
         assert not Path(dest, 'three').exists()
 
+    # nothing should be changed
+    assert not repo.files_changed
+    assert not repo.files_staged
+    assert not repo.files_untracked
+
     # check log
     assert 'rename mode' not in caplog.text
-
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
 
 
 variants = {  # pyre-ignore[9]
@@ -586,12 +616,14 @@ def test_move_src_not_exist(repo, variant, caplog):
     assert Path('exist-file-1').exists()
     assert Path('exist-dir-3').exists()
 
+    # nothing should be changed
+    assert not repo.files_changed
+    assert not repo.files_staged
+    assert not repo.files_untracked
+
     # check log
     assert 'rename mode' not in caplog.text
     assert 'source paths do not exist' in caplog.text
-
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
 
 
 variants = {  # pyre-ignore[9]
@@ -621,12 +653,14 @@ def test_move_dest_not_exist(repo, variant, caplog):
         assert src.exists()
         assert not Path(dest, src.name).exists()
 
+    # nothing should be changed
+    assert not repo.files_changed
+    assert not repo.files_staged
+    assert not repo.files_untracked
+
     # check log
     assert 'rename mode' not in caplog.text
     assert 'does not exist' in caplog.text
-
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
 
 
 variants = {  # pyre-ignore[9]
@@ -654,12 +688,14 @@ def test_move_into_self(repo, variant, caplog):
         assert src.exists()
         assert not Path(dest, src.name).exists()
 
+    # nothing should be changed
+    assert not repo.files_changed
+    assert not repo.files_staged
+    assert not repo.files_untracked
+
     # check log
     assert 'rename mode' not in caplog.text
     assert 'into itself' in caplog.text
-
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
 
 
 variants = {  # pyre-ignore[9]
@@ -691,12 +727,14 @@ def test_move_name_conflict(repo, variant, caplog):
         assert src.exists()
         assert not Path(dest, src.name, src.name).exists()
 
+    # nothing should be changed
+    assert not repo.files_changed
+    assert not repo.files_staged
+    assert not repo.files_untracked
+
     # check log
     assert 'rename mode' not in caplog.text
     assert 'destinations exist and would conflict' or 'cannot be a file' in caplog.text
-
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
 
 
 variants = {  # pyre-ignore[9]
@@ -725,9 +763,11 @@ def test_move_dest_must_be_dir(repo, variant, caplog):
 
     assert dest.is_file()
 
+    # nothing should be changed
+    assert not repo.files_changed
+    assert not repo.files_staged
+    assert not repo.files_untracked
+
     # check log
     assert 'rename mode' not in caplog.text
     assert 'cannot be a file' in caplog.text
-
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])

--- a/tests/lib/test_Repo_rm.py
+++ b/tests/lib/test_Repo_rm.py
@@ -22,8 +22,13 @@ def test_rm_args_single_file(repo, variant):
     assert not Path('single-file').exists()
     assert Path('untouched').exists()
 
-    # make sure everything is clean
-    repo.fsck(['clean-tree'])
+    # everything should be staged
+    assert not repo.files_changed
+    assert repo.files_staged
+    assert not repo.files_untracked
+
+    # check anchors
+    repo.fsck(['anchors'])
 
 
 variants = {
@@ -44,8 +49,13 @@ def test_rm_args_single_dir(repo, variant):
     assert not Path('single-dir').exists()
     assert Path('untouched').exists()
 
-    # make sure everything is clean
-    repo.fsck(['clean-tree'])
+    # everything should be staged
+    assert not repo.files_changed
+    assert repo.files_staged
+    assert not repo.files_untracked
+
+    # check anchors
+    repo.fsck(['anchors'])
 
 
 variants = {  # pyre-ignore[9]
@@ -68,8 +78,13 @@ def test_rm_args_multi_file(repo, variant):
     assert not Path('three').exists()
     assert Path('untouched').exists()
 
-    # make sure everything is clean
-    repo.fsck(['clean-tree'])
+    # everything should be staged
+    assert not repo.files_changed
+    assert repo.files_staged
+    assert not repo.files_untracked
+
+    # check anchors
+    repo.fsck(['anchors'])
 
 
 variants = {  # pyre-ignore[9]
@@ -92,8 +107,13 @@ def test_rm_args_multi_dir(repo, variant):
     assert not Path('three').exists()
     assert Path('untouched').exists()
 
-    # make sure everything is clean
-    repo.fsck(['clean-tree'])
+    # everything should be staged
+    assert not repo.files_changed
+    assert repo.files_staged
+    assert not repo.files_untracked
+
+    # check anchors
+    repo.fsck(['anchors'])
 
 
 variants = [  # pyre-ignore[9]
@@ -111,8 +131,13 @@ def test_rm_not_exist(repo, variant):
 
     assert Path('subdir').exists()
 
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
+    # nothing should be changed
+    assert not repo.files_changed
+    assert not repo.files_staged
+    assert not repo.files_untracked
+
+    # check anchors
+    repo.fsck(['anchors'])
 
 
 variants = [  # pyre-ignore[9]
@@ -132,8 +157,13 @@ def test_rm_not_exist_mixed(repo, variant):
     assert Path('two').exists()
     assert Path('subdir').exists()
 
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
+    # nothing should be changed
+    assert not repo.files_changed
+    assert not repo.files_staged
+    assert not repo.files_untracked
+
+    # check anchors
+    repo.fsck(['anchors'])
 
 
 variants = [  # pyre-ignore[9]
@@ -154,8 +184,13 @@ def test_rm_protected(repo, variant):
 
     assert Path(variant).exists()
 
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
+    # nothing should be changed
+    assert not repo.files_changed
+    assert not repo.files_staged
+    assert not repo.files_untracked
+
+    # check anchors
+    repo.fsck(['anchors'])
 
 
 variants = [  # pyre-ignore[9]
@@ -178,8 +213,13 @@ def test_rm_protected_mixed(repo, variant):
     assert Path('valid-two').exists()
     assert Path(variant).exists()
 
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
+    # nothing should be changed
+    assert not repo.files_changed
+    assert not repo.files_staged
+    assert not repo.files_untracked
+
+    # check anchors
+    repo.fsck(['anchors'])
 
 
 @pytest.mark.repo_dirs('repeat-dir', 'dir-two', 'dir-three')
@@ -200,8 +240,13 @@ def test_rm_repeat(repo):
     assert not Path('dir-two').exists()
     assert not Path('dir-three').exists()
 
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
+    # everything should be staged
+    assert not repo.files_changed
+    assert repo.files_staged
+    assert not repo.files_untracked
+
+    # check anchors
+    repo.fsck(['anchors'])
 
 
 @pytest.mark.repo_files('overlap/one', 'overlap/two', 'overlap/three')
@@ -212,8 +257,13 @@ def test_rm_overlap(repo):
     repo.rm(['overlap/one', 'overlap', 'overlap/three'])
     assert not Path('overlap').exists()
 
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
+    # everything should be staged
+    assert not repo.files_changed
+    assert repo.files_staged
+    assert not repo.files_untracked
+
+    # check anchors
+    repo.fsck(['anchors'])
 
 
 @pytest.mark.repo_files('s p a/c e s/1 2', 's p a/c e s/3 4')
@@ -230,8 +280,13 @@ def test_rm_spaces(repo):
     assert not Path('s p a/c e s/').exists()
     assert Path('s p a/').exists()
 
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
+    # everything should be staged
+    assert not repo.files_changed
+    assert repo.files_staged
+    assert not repo.files_untracked
+
+    # check anchors
+    repo.fsck(['anchors'])
 
 
 @pytest.mark.repo_dirs('r/e/c/u/r/s/i/v/e')
@@ -252,8 +307,13 @@ def test_rm_subdirs(repo):
     assert not Path('r/e/c/u/r').is_dir()
     assert Path('r/e/c/u').is_dir()
 
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
+    # everything should be staged
+    assert not repo.files_changed
+    assert repo.files_staged
+    assert not repo.files_untracked
+
+    # check anchors
+    repo.fsck(['anchors'])
 
 
 @pytest.mark.repo_dirs('r/e/c/u/r/s/i/v/e')
@@ -267,8 +327,13 @@ def test_rm_dryrun(repo):
     assert Path('two/b').is_file()
     assert Path('r').is_dir()
 
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
+    # nothing should be changed
+    assert not repo.files_changed
+    assert not repo.files_staged
+    assert not repo.files_untracked
+
+    # check anchors
+    repo.fsck(['anchors'])
 
 
 @pytest.mark.repo_dirs('dir/subdir')
@@ -288,5 +353,10 @@ def test_rm_return_value(repo):
     assert 'dir/.anchor' in ret
     assert 'dir/subdir/.anchor' in ret
 
-    # make sure everything is clean
-    repo.fsck(['anchors', 'clean-tree'])
+    # nothing should be changed
+    assert not repo.files_changed
+    assert not repo.files_staged
+    assert not repo.files_untracked
+
+    # check anchors
+    repo.fsck(['anchors'])


### PR DESCRIPTION
This updates the following to stage changes and not commit them:

- `mkdir()`
- `mv()`
- `rm()`

Note, this only changes the methods. The /commands/ have been updated to commit the changes.

This also updates the tests to check the new behavior.