### PR TITLE
NF/TST: add `repo(init=bool)`, and assorted test modernization

### DIFF
--- a/onyo/commands/init.py
+++ b/onyo/commands/init.py
@@ -1,60 +1,13 @@
-import logging
 import sys
-import shutil
 from pathlib import Path
-import git
-
-logging.basicConfig()
-log = logging.getLogger('onyo')
+from onyo import Repo
 
 
-def get_skel_dir():
-    """
-    Return the path of the skel/ dir in the onyo module directory.
-    """
-    onyo_module_dir = Path(__file__).resolve().parent.parent
-    skel = Path(onyo_module_dir, 'skel')
-    return skel
-
-
-def sanitize_dir(directory, opdir):
-    """
-    Check the directory for viability as an init target.
-
-    Returns the absolute path on success.
-    """
-    full_dir = Path(opdir)
-    if directory:
-        full_dir = Path(opdir, directory)
-
-    # sanity checks
-    # already an .onyo repo
-    dot_onyo = full_dir.joinpath('.onyo')
-    if dot_onyo.is_dir():
-        log.error(f"'{dot_onyo}' already exists. Exiting.")
-        sys.exit(1)
-
-    # target is a file, etc
-    if full_dir.exists() and not full_dir.is_dir():
-        log.error(f"'{full_dir}' exists but is not a directory. Exiting.")
-        sys.exit(1)
-
-    # make sure parent exists
-    if not full_dir.is_dir():
-        parent_dir = full_dir.parent
-        if not parent_dir.is_dir():
-            log.error(f"'{parent_dir}' does not exist. Exiting.")
-            sys.exit(1)
-
-    abs_dir = str(full_dir.resolve())
-    return abs_dir
-
-
-def init(args, opdir):
+def init(args, opdir: str) -> None:
     """
     Initialize an Onyo repository. The directory will be initialized as a git
-    repository (if it is not one already), the ``.onyo/`` directory created
-    (containing default config files, templates, etc), and everything committed.
+    repository (if it is not one already), the ``.onyo/`` directory created and
+    populated with config files, templates, etc. Everything will be committed.
 
     The current working directory will be initialized if neither ``directory``
     nor the ``onyo -C <dir>`` option are specified.
@@ -62,24 +15,14 @@ def init(args, opdir):
     Running ``onyo init`` on an existing repository is safe. It will not
     overwrite anything; it will exit with an error.
     """
-    target_dir = sanitize_dir(args.directory, opdir)
-    Path(target_dir).mkdir(exist_ok=True)
+    target_dir = Path(opdir)
+    if args.directory:
+        if Path(args.directory).is_absolute():
+            target_dir = Path(args.directory)
+        else:
+            target_dir = Path(opdir, args.directory)
 
     try:
-        repo = git.Repo(target_dir)
-        log.info(target_dir + " has a git repository.")
-    except git.exc.InvalidGitRepositoryError:
-        repo = git.Repo.init(target_dir)
-
-    # populate .onyo dir
-    skel = get_skel_dir()
-    dot_onyo = Path(target_dir, ".onyo")
-    shutil.copytree(skel, dot_onyo)
-
-    # add and commit
-    repo.git.add('.onyo/')
-    repo.git.commit(m='initialize onyo repository')
-
-    # print success
-    abs_dot_onyo = str(dot_onyo.resolve())
-    print(f'Initialized Onyo repository in {abs_dot_onyo}')
+        Repo(target_dir, init=True)
+    except (FileExistsError, FileNotFoundError):
+        sys.exit(1)

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -817,7 +817,12 @@ class Repo:
         if length < 4:
             # 62^4 is ~14.7 million combinations. Which is the lowest acceptable
             # risk of collisions between independent checkouts of a repo.
-            raise ValueError('The length of faux serial numbers must be greater than 4.')
+            raise ValueError('The length of faux serial numbers must be >= 4.')
+
+        if num < 1:
+            # 62^4 is ~14.7 million combinations. Which is the lowest acceptable
+            # risk of collisions between independent checkouts of a repo.
+            raise ValueError('The length of faux serial numbers must be >= 1.')
 
         alphanum = string.ascii_letters + string.digits
         faux_serials = set()

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ setup(
     packages=find_packages(),
     license='ISC',
     install_requires=[
-        'GitPython',
         'ruamel.yaml'
     ],
     extras_require={

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import subprocess
 from collections.abc import Iterable
 from itertools import chain, combinations
 from pathlib import Path
@@ -28,9 +27,7 @@ def repo(tmp_path, monkeypatch, request):
     files = set()
 
     # initialize repo
-    ret = subprocess.run(['onyo', 'init', repo_path])
-    assert ret.returncode == 0
-    repo_ = Repo(repo_path)
+    repo_ = Repo(repo_path, init=True)
 
     # collect files to populate the repo
     m = request.node.get_closest_marker('repo_files')
@@ -144,10 +141,8 @@ class Helpers:
         Create and initialize a folder, and build a directory and file
         structure.
         """
-        # setup repo
-        ret = subprocess.run(['onyo', 'init', path])
-        assert ret.returncode == 0
-        repo = Repo(path)
+        # init repo
+        repo = Repo(path, init=True)
 
         # dirs
         if dirs:

--- a/tests/lib/test_Repo_new.py
+++ b/tests/lib/test_Repo_new.py
@@ -3,8 +3,8 @@ import pytest
 
 
 # generate 50 random pairings of length and num.
-variants = {(length, num) for length in random.sample(range(4, 20), 10) for num in random.sample(range(1, 10000), 5)}
-@pytest.mark.parametrize('variant', variants)
+variants = {f'{length} x {num}': (length, num) for length in random.sample(range(4, 20), 10) for num in random.sample(range(1, 10000), 5)}
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
 def test_generate_faux_serials(repo, variant):
     """
     Generate a faux serial numbers of variable length and quantity.
@@ -22,12 +22,38 @@ def test_generate_faux_serials(repo, variant):
         assert len(i) == length + len('faux')
 
 
-# generate 20 invalid random pairings of length and num.
-variants = {(length, num) for length in range(0, 3) for num in random.sample(range(1, 10000), 5)}
-@pytest.mark.parametrize('variant', variants)
-def test_length_range_of_generate_faux_serials(repo, variant):
+# generate 30 invalid random pairings of length and num.
+variants = {f'{length} x {num}': (length, num) for length in range(-2, 4) for num in random.sample(range(1, 10000), 5)}
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_generate_faux_serials_invalid_length(repo, variant):
     """
     Fewer than 4 character in the serial is invalid.
+    """
+    # faux serial numbers must have at least length 1 and the function raises
+    # ValueError:
+    with pytest.raises(ValueError):
+        repo.generate_faux_serials(*variant)
+
+
+# generate 15 invalid random pairings of length and num.
+variants = {f'{length} x {num}': (length, num) for length in random.sample(range(4, 20), 5) for num in range(-2, 1)}
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_generate_faux_serials_invalid_number(repo, variant):
+    """
+    Number of serials must be greater than 0.
+    """
+    # faux serial numbers must have at least length 1 and the function raises
+    # ValueError:
+    with pytest.raises(ValueError):
+        repo.generate_faux_serials(*variant)
+
+
+# generate mutually invalid pairings of length and num.
+variants = {f'{length} x {num}': (length, num) for length in range(0, 4) for num in range(-2, 1)}
+@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
+def test_generate_faux_serials_invalid_length_and_number(repo, variant):
+    """
+    Both length and number are invalid.
     """
     # faux serial numbers must have at least length 1 and the function raises
     # ValueError:

--- a/tests/reference_output/C_absolute/init_test.txt
+++ b/tests/reference_output/C_absolute/init_test.txt
@@ -1,1 +1,2 @@
-Initialized Onyo repository in <replace>/.onyo
+INFO:onyo:Initialized empty Git repository in <replace>/.git/
+INFO:onyo:Initialized Onyo repository in <replace>/.onyo/

--- a/tests/reference_output/root_of_repo/init_test.txt
+++ b/tests/reference_output/root_of_repo/init_test.txt
@@ -1,1 +1,2 @@
-Initialized Onyo repository in <replace>/.onyo
+INFO:onyo:Initialized empty Git repository in <replace>/.git/
+INFO:onyo:Initialized Onyo repository in <replace>/.onyo/


### PR DESCRIPTION
This PR covers a variety of areas:

Notable changes:
- add `Repo(init=True)` with tests
- port `init` and test helpers to use `Repo(init=True)`
- drop GitPython as a dependency
- `generate_faux_serials()` will only generate > 0 serials
- expand and improve tests for `generate_faux_serials()`
- update tests for `history` and `cat` to use the `repo` fixture (and some other general modernization)

The test runtime is significantly reduced (~50%). I expected an improvement, but the extent is surprising. The new `init` codepath spawns fewer subshells, and GitPython was always slow in our benchmarks.

Locally:
- without coverage: 73 sec -> 38 sec (48% drop)
- with coverage: 120 sec -> 50 sec (59% drop)

On CI:
- `3.9`: 246 sec -> 110 sec (55% drop)
- `3.10`: 252 sec -> 123 sec (51% drop)
- `3.11`: 393 sec -> 320 sec (19% drop)