### PR TITLE
DEMO: generate and deploy demo

### DIFF
--- a/.github/workflows/deploy_demo.yaml
+++ b/.github/workflows/deploy_demo.yaml
@@ -1,0 +1,49 @@
+name: Deploy Onyo Demo
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+  workflow_run:
+    workflows: Onyo Tests
+    branches: main
+    types: completed
+
+jobs:
+  deploy:
+    # check workflow result, as "complete" is triggered regardless of the result
+    # of the previous workflow
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    environment: demo
+    concurrency: demo
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: git config
+        run: |
+          git config --global user.email "yoko@onyo.org"
+          git config --global user.name "Yoko Onyo"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+      - name: Generate and publish a fresh demo repository
+        env:
+          ONYO_DEMO_ACCESS_TOKEN: ${{ secrets.ONYO_DEMO_ACCESS_TOKEN }}
+        run: |
+          printf '\ngenerate a fresh demo repository\n'
+          demo/generate_demo_repo.sh /tmp/fresh_demo
+
+          printf '\nmake sure we are on the main branch\n'
+          git -C /tmp/fresh_demo checkout -B main
+
+          printf '\nset the location of the demo repo\n'
+          git -C /tmp/fresh_demo remote add origin https://aqw:${ONYO_DEMO_ACCESS_TOKEN}@github.com/psyinfra/onyo-demo
+
+          printf '\npush to onyo-demo\n'
+          git -C /tmp/fresh_demo push --force --set-upstream origin main

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,7 +21,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: git config
       run: |
-        git config --global user.email "onyo@example.com"
+        git config --global user.email "yoko@onyo.org"
         git config --global user.name "Yoko Onyo"
     - name: Install dependencies
       run: |
@@ -31,7 +31,7 @@ jobs:
     - name: flake8 linting
       run: |
         flake8
-    - name: Pyre type checking
+    - name: Pyre type-checking
       run: |
         pyre --noninteractive check
     - name: Test with pytest and collect coverage


### PR DESCRIPTION
This adds a workflow to run after the tests on `main` to generate the demo repository and force push it to `psyinfra/onyo-demo`.

It uses a fine-grained personal access token associated with my account. Unfortunately, it is limited to 1 year, so it will need to be updated. It is added to the "environment" for the `onyo` repository.

I considered adding a worflow directly to the `onyo-demo` repository, and trigger it from the `onyo` repo workflow. The goal of this was to avoid the need for an access token for the push, but the trigger still requires an access token, so it didn't solve anything.