### PR TITLE
TST/BF: add demo repo generation to the test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Onyo
 
 ![Build Status](https://github.com/psyinfra/onyo/actions/workflows/tests.yaml/badge.svg)
-![Demo Status](https://github.com/psyinfra/onyo/actions/workflows/deploy_demo.yaml/badge.svg)
-[![Documentation Status](https://readthedocs.org/projects/onyo/badge/?version=latest)](https://onyo.readthedocs.io/en/latest/?badge=latest)
+[![Demo Status](https://github.com/psyinfra/onyo/actions/workflows/deploy_demo.yaml/badge.svg)](https://github.com/psyinfra/onyo-demo/)
+[![Documentation Status](https://readthedocs.org/projects/onyo/badge/?version=latest)](https://onyo.readthedocs.io/en/latest/)
 [![codecov](https://codecov.io/gh/psyinfra/onyo/branch/main/graph/badge.svg?token=Z0VGYCHHAR)](https://codecov.io/gh/psyinfra/onyo)
 [![License: ISC](https://img.shields.io/badge/License-ISC-blueviolet.svg)](https://opensource.org/licenses/ISC)
 

--- a/demo/generate_demo_repo.sh
+++ b/demo/generate_demo_repo.sh
@@ -5,12 +5,14 @@
 # This script generates a demo Onyo repository.
 # It is not meant to be comprehensive, but should cover a wide range of Onyo's
 # functionality.
+set -e
 
 ############
 ## Variables
 ############
-readonly VERSION=0.0.1
+readonly VERSION=1.0.0
 readonly SCRIPT_NAME=${0##*/}
+readonly SCRIPT_DIR=$(dirname $(realpath -e "$0"))
 DEMO_DIR=''
 
 # set reproducible commit hashes
@@ -79,7 +81,6 @@ esac
 ######
 # MAIN
 ######
-ONYO_REPO_DIR=$(pwd)
 cd "$DEMO_DIR"
 
 # initialize a repository
@@ -92,7 +93,7 @@ onyo mkdir repair
 
 # import some existing hardware
 # TSV files can be very useful when adding large amounts of assets
-onyo new -y --tsv "$ONYO_REPO_DIR/demo/inventory.tsv"
+onyo new -y --tsv "${SCRIPT_DIR}/inventory.tsv"
 
 # add a set of newly bought assets
 onyo new -y RAM=8GB display=13.3 warehouse/laptop_apple_macbook.9r32he

--- a/demo/generate_demo_repo.sh
+++ b/demo/generate_demo_repo.sh
@@ -18,10 +18,10 @@ DEMO_DIR=''
 # set reproducible commit hashes
 export GIT_AUTHOR_NAME='Yoko Onyo'
 export GIT_AUTHOR_EMAIL='yoko@onyo.org'
-export GIT_AUTHOR_DATE='2023-01-01T00:00:00'
+export GIT_AUTHOR_DATE='2023-01-01 00:00:00 +0100'
 export GIT_COMMITTER_NAME='Yoko Onyo'
 export GIT_COMMITTER_EMAIL='yoko@onyo.org'
-export GIT_COMMITTER_DATE='2023-01-01T00:00:00'
+export GIT_COMMITTER_DATE='2023-01-01 00:00:00 +0100'
 
 
 ############

--- a/onyo/commands/edit.py
+++ b/onyo/commands/edit.py
@@ -132,12 +132,12 @@ def edit(args, opdir: str) -> None:
             print(f"'{asset}' not updated.")
 
     # commit changes
-    files_staged = repo.files_staged
-    if files_staged:
+    staged = sorted(repo.files_staged)
+    if staged:
         print(repo._diff_changes())
         if request_user_response("Save changes? No discards all changes. (y/n) "):
-            repo.commit('edit asset(s).', files_staged)
+            repo.commit('edit asset(s).', staged)
         else:
             repo._git(['restore', '--source=HEAD', '--staged', '--worktree'] +
-                      [str(file) for file in files_staged])
+                      [str(file) for file in staged])
             print('No assets updated.')

--- a/onyo/commands/new.py
+++ b/onyo/commands/new.py
@@ -248,7 +248,7 @@ def new(args, opdir: str) -> None:
     # they are build, their values are set, and they where opened to edit
 
     # print diff-like output and remember new directories and assets
-    staged = repo.files_staged
+    staged = sorted(repo.files_staged)
     changes = []
     if staged:
         print("The following will be created:")

--- a/onyo/commands/set.py
+++ b/onyo/commands/set.py
@@ -63,16 +63,16 @@ def set(args, opdir: str) -> None:
         sys.exit(0)
 
     # commit or discard changes
-    files_staged = repo.files_staged
-    if files_staged:
+    staged = sorted(repo.files_staged)
+    if staged:
         if args.yes or request_user_response("Update assets? (y/n) "):
-            repo.commit('set values', files_staged)
+            repo.commit('set values', staged)
         else:
-            repo._git(['restore', '--source=HEAD', '--staged', '--worktree'] + [str(file) for file in files_staged])
+            repo._git(['restore', '--source=HEAD', '--staged', '--worktree'] + [str(file) for file in staged])
             # when names were changed, the first restoring just brings
             # back the name, but leaves working-tree unclean
-            files_staged = repo.files_staged
-            if files_staged:
-                repo._git(['restore', '--source=HEAD', '--staged', '--worktree'] + [str(file) for file in files_staged])
+            staged = repo.files_staged
+            if staged:
+                repo._git(['restore', '--source=HEAD', '--staged', '--worktree'] + [str(file) for file in staged])
             if not args.quiet:
                 print("No assets updated.")

--- a/onyo/commands/unset.py
+++ b/onyo/commands/unset.py
@@ -58,16 +58,16 @@ def unset(args, opdir: str) -> None:
         sys.exit(0)
 
     # commit or discard changes
-    files_staged = repo.files_staged
-    if files_staged:
+    staged = sorted(repo.files_staged)
+    if staged:
         if args.yes or request_user_response("Update assets? (y/n) "):
-            repo.commit('remove key(s)', files_staged)
+            repo.commit('remove key(s)', staged)
         else:
-            repo._git(['restore', '--source=HEAD', '--staged', '--worktree'] + [str(file) for file in files_staged])
+            repo._git(['restore', '--source=HEAD', '--staged', '--worktree'] + [str(file) for file in staged])
             # when names were changed, the first restoring just brings
             # back the name, but leaves working-tree unclean
-            files_staged = repo.files_staged
-            if files_staged:
-                repo._git(['restore', '--source=HEAD', '--staged', '--worktree'] + [str(file) for file in files_staged])
+            staged = repo.files_staged
+            if staged:
+                repo._git(['restore', '--source=HEAD', '--staged', '--worktree'] + [str(file) for file in staged])
             if not args.quiet:
                 print("No assets updated.")

--- a/tests/demo/reference_git_log.txt
+++ b/tests/demo/reference_git_log.txt
@@ -1,0 +1,305 @@
+commit 59fe24a906abadc8a3b64a3acfc5aba9fbf14325
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    rm: 'management/Max Mustermann'
+
+commit 09de0124150fbcc7d028776ff5a7e3b940620993
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    mv: 'management/Max Mustermann/headphones_apple_airpods.7h8f04','management/Max Mustermann/laptop_apple_macbook.uef82b3' -> warehouse
+
+commit 831eed2b5e58faa663880fbd40551c013d8ac4e7
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    mv: 'warehouse/laptop_lenovo_thinkpad.owh8e2' -> ethics/Theo Turtle
+
+commit d6c40e0da880edb1312578177d489e47edca7496
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    mkdir: 'ethics/Theo Turtle'
+
+commit c4974b20047a3eada3680a7652bb59d31f6aefa3
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    new asset(s)
+    
+    management/Alice Wonder/laptop_apple_macbook.83hd0
+
+commit 6f4aee6304ce452ed8056280cebbdd69f689fce5
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    mkdir: 'management/Alice Wonder'
+
+commit 974f275fec14a5d9a57244d3da3777d938340183
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    mv: 'ethics/Max Mustermann' -> management
+
+commit b0c022aefa9416514b2bf63843555d1eaff811c1
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    mkdir: 'management'
+
+commit 212f83eeba2f17d8334350076c434122fe33b0e1
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    mv: 'warehouse/laptop_apple_macbook.uef82b3' -> ethics/Max Mustermann
+
+commit 43774ccdd6134fdb2705f484b8b1aca2a1f448ad
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    mv: 'ethics/Max Mustermann/laptop_apple_macbook.9r32he' -> recycling
+
+commit 9dc33836fdf99d984755718d99b20ff8f049f26a
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    mv: 'repair/laptop_lenovo_thinkpad.owh8e2' -> warehouse
+
+commit 17e82eeee783476f45434b106ced046f79f389a0
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    set values
+    
+    repair/laptop_lenovo_thinkpad.owh8e2
+
+commit 4fc3e2855d4497e038365eda73172424c8c18827
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    mv: 'warehouse/monitor_dell_PH123.86JZho','warehouse/laptop_apple_macbook.oiw629','warehouse/headphones_apple_airpods.uzl8e1' -> accounting/Bingo Bob
+
+commit 459fc04f425e937cfa4a03f575965ab7def39b88
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    new asset(s)
+    
+    warehouse/headphones_apple_airpods.uzl8e1
+
+commit 20a33df3756a9a48a5ea4b852f4ea4cd074843fa
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    new asset(s)
+    
+    warehouse/laptop_apple_macbook.oiw629
+
+commit 5271d6c561e7c55ba533ac1daf77eeccb8c7988c
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    new asset(s)
+    
+    warehouse/monitor_dell_PH123.86JZho
+
+commit 31cf383f569fa9c09b1f982948bf9e0ed8efd2ea
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    mkdir: 'accounting/Bingo Bob'
+
+commit 3ac909efba16ec6f87595302c6319f6cf3d664d6
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    new asset(s)
+    
+    warehouse/laptop_apple_macbook.73b2cn
+    warehouse/laptop_apple_macbook.9il2b4
+    warehouse/laptop_apple_macbook.uef82b3
+
+commit 950b7329e2762cd76110cc493d72a5904aac8dea
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    set values
+    
+    ethics/Max Mustermann/laptop_apple_macbook.9r32he
+    warehouse/laptop_apple_macbook.9r5qlk
+
+commit d297115b79fa41f073a0945460a5ea4bb1edb513
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    set values
+    
+    admin/Karl Krebs/laptop_apple_macbookpro.9sdjwa
+    ethics/Achilles Book/laptop_microsoft_surface.oq782j
+    ethics/Max Mustermann/laptop_apple_macbook.9r32he
+    repair/laptop_apple_macbookpro.dd082o
+    repair/laptop_apple_macbookpro.j7tbkk
+    repair/laptop_lenovo_thinkpad.owh8e2
+    warehouse/laptop_apple_macbook.9r5qlk
+    warehouse/laptop_apple_macbookpro.0io4ff
+    warehouse/laptop_apple_macbookpro.1eic93
+    warehouse/laptop_lenovo_thinkpad.iu7h6d
+
+commit fd3989e6edeeb20199b16cdb5661579940eb35df
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    mv: 'warehouse/laptop_microsoft_surface.oq782j' -> ethics/Achilles Book
+
+commit 859d18db3b0226ba0698a2c55433c782b2066fc2
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    mv: 'ethics/Achilles Book/laptop_lenovo_thinkpad.owh8e2' -> repair
+
+commit 8c0048d75b55215ed58bb3728006069e7506faaf
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    mv: 'warehouse/headphones_JBL_pro.e98t2p' -> ethics/Achilles Book
+
+commit efdbe45e66efed5d4259c67a636c81ddd3652e9e
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    mv: 'warehouse/laptop_lenovo_thinkpad.owh8e2' -> ethics/Achilles Book
+
+commit d9fc7ca1b2b73861a1927e3d8bb42e30b49d2ab8
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    mv: 'warehouse/headphones_apple_airpods.7h8f04' -> ethics/Max Mustermann
+
+commit 4fc84dba00752224271e4ed05e7b02857860a9c8
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    mv: 'warehouse/laptop_apple_macbook.9r32he' -> ethics/Max Mustermann
+
+commit 936cb2f59521ab9578aba30dff937b9ddafbe83b
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    mkdir: 'ethics/Max Mustermann','ethics/Achilles Book'
+
+commit 24d753b7c5fa463b6023683a97e4b646874ae7b8
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    rm: 'warehouse/headphones_JBL_pro.ph9527'
+
+commit d8fe50b9d6f2ce437bf795760f2d360a3e7570ef
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    new asset(s)
+    
+    warehouse/headphones_JBL_pro.ph9527
+
+commit da15c4811cd43f711eb349424324e287d737fbcc
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    new asset(s)
+    
+    warehouse/headphones_JBL_pro.e98t2p
+
+commit a35676a1596130ce647773b1d597382e30410628
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    new asset(s)
+    
+    warehouse/headphones_JBL_pro.325gtt
+
+commit 37e6c7149bc3b2257aa9139ab7c47bf155cc1f50
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    new asset(s)
+    
+    warehouse/headphones_apple_airpods.7h8f04
+
+commit 43429776e405fcc947edace09adc3adc07b36aa2
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    new asset(s)
+    
+    warehouse/laptop_microsoft_surface.oq782j
+
+commit 4a98097422fc01c8023fb658c7adc707358b0759
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    new asset(s)
+    
+    warehouse/laptop_lenovo_thinkpad.iu7h6d
+
+commit b07f93d2207d12686cca9a5a2c02d7a51a10c315
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    new asset(s)
+    
+    warehouse/laptop_lenovo_thinkpad.owh8e2
+
+commit 400ecbf0a519ddc8d51b371a36327e9916e63646
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    new asset(s)
+    
+    warehouse/laptop_apple_macbook.9r5qlk
+
+commit 24adf54ce2be39b989aaf14ccb6c099a10249ea6
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    new asset(s)
+    
+    warehouse/laptop_apple_macbook.9r32he
+
+commit e4fb5e4049072bb87fe6ad7bb8f087437d16cd54
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    new asset(s)
+    
+    admin
+    admin/Karl Krebs
+    admin/Karl Krebs/laptop_apple_macbookpro.9sdjwa
+    repair/laptop_apple_macbookpro.dd082o
+    repair/laptop_apple_macbookpro.j7tbkk
+    warehouse/laptop_apple_macbookpro.0io4ff
+    warehouse/laptop_apple_macbookpro.1eic93
+
+commit 6b23571d64706f7d2a50243b99ee2348072c33ec
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    mkdir: 'repair'
+
+commit cd79db4e2db1a66e289879397a298585e7960a36
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    mkdir: 'recycling'
+
+commit 6e08b4f7772ec0f1c8dc78e70becde606a33f95a
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    mkdir: 'warehouse'
+
+commit 3f3a4c4f97a5c6d6aa281730cea439ab5878d4fa
+Author: Yoko Onyo <yoko@onyo.org>
+Date:   Sun Jan 1 00:00:00 2023 +0100
+
+    Initialize as an Onyo repository

--- a/tests/demo/test_generate_demo_repo.py
+++ b/tests/demo/test_generate_demo_repo.py
@@ -1,0 +1,22 @@
+import subprocess
+from pathlib import Path
+
+
+def test_generate_demo_repo(tmp_path, request):
+    """
+    Generate an Onyo demo repository, and compare it against the git log of
+    another known-good-demo-repo.
+    """
+    script = Path(request.path.parent.parent.parent, 'demo/', 'generate_demo_repo.sh')
+
+    ret = subprocess.run([script, tmp_path],
+                         capture_output=True, text=True)
+    assert ret.returncode == 0
+
+    #
+    # compare the git log of the freshly-generated-repo against the reference
+    #
+    ret = subprocess.run(['git', '-C', tmp_path, 'log'],
+                         capture_output=True, text=True)
+    assert ret.returncode == 0
+    assert ret.stdout == Path(request.path.parent, 'reference_git_log.txt').read_text()


### PR DESCRIPTION
The main changes in this PR are:
- add the onyo demo repo to the tests (#263)
- make commit message content reproducible (#274)

For the commit messages, I considered changing `Repo.files_staged` to a list. However, other properties would also need to be updated, to maintain consistency.

Furthermore, I felt that a list would arguably be misleading, as the order returned by `git` is merely alphabetized, rather the order in which files were staged.

Thus, I decided to keep the properties as `set`s, and make the change where it's needed: the commit message.