### PR TITLE
BF: allow special characters

### DIFF
--- a/onyo/commands/edit.py
+++ b/onyo/commands/edit.py
@@ -1,10 +1,11 @@
 import logging
 import os
 import sys
-
-from onyo import Repo, OnyoInvalidRepoError
 from pathlib import Path
+from shlex import quote
+
 from ruamel.yaml import YAML, scanner  # pyre-ignore[21]
+from onyo import Repo, OnyoInvalidRepoError
 
 logging.basicConfig()
 log = logging.getLogger('onyo')
@@ -42,8 +43,7 @@ def edit_asset(editor: str, asset: Path) -> bool:
     if the user wants to discard the changes.
     """
     while True:
-        os.system(f'{editor} "{asset}"')
-
+        os.system(f'{editor} {quote(str(asset))}')
         try:
             YAML(typ='rt').load(asset)
             # TODO: add asset validity here

--- a/onyo/commands/history.py
+++ b/onyo/commands/history.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import sys
 from pathlib import Path
+from shlex import quote
 
 from onyo import Repo, OnyoInvalidRepoError
 
@@ -84,7 +85,7 @@ def history(args, opdir):
     orig_cwd = os.getcwd()
     try:
         os.chdir(opdir)
-        status = os.system(f"{history_cmd} '{path}'")
+        status = os.system(f"{history_cmd} {quote(str(path))}")
     except:  # noqa: E722
         pass
     finally:

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -126,7 +126,7 @@ class Repo:
         Return a set of all files in the repository (except under .git).
         """
         log.debug('Acquiring list of files')
-        files = {Path(x) for x in self._git(['ls-files']).splitlines() if x}
+        files = {Path(x) for x in self._git(['ls-files', '-z']).split('\0') if x}
         return files
 
     def _get_files_changed(self) -> set[Path]:
@@ -134,7 +134,7 @@ class Repo:
         Return a set of all unstaged changes in the repository.
         """
         log.debug('Acquiring list of changed files')
-        changed = {Path(x) for x in self._git(['diff', '--name-only']).splitlines() if x}
+        changed = {Path(x) for x in self._git(['diff', '-z', '--name-only']).split('\0') if x}
         return changed
 
     def _get_files_staged(self) -> set[Path]:
@@ -142,7 +142,7 @@ class Repo:
         Return a set of all staged changes in the repository.
         """
         log.debug('Acquiring list of staged files')
-        staged = {Path(x) for x in self._git(['diff', '--name-only', '--staged']).splitlines() if x}
+        staged = {Path(x) for x in self._git(['diff', '--name-only', '-z', '--staged']).split('\0') if x}
         return staged
 
     def _get_files_untracked(self) -> set[Path]:
@@ -150,7 +150,7 @@ class Repo:
         Return a set of all untracked files in the repository.
         """
         log.debug('Acquiring list of untracked files')
-        untracked = {Path(x) for x in self._git(['ls-files', '--others', '--exclude-standard']).splitlines() if x}
+        untracked = {Path(x) for x in self._git(['ls-files', '-z', '--others', '--exclude-standard']).split('\0') if x}
         return untracked
 
     def _get_root(self) -> Path:


### PR DESCRIPTION
This PR fixes two bugs, both connected to certain special characters.

- Parsing of `git ls-files` output contains quotes if files have some special characters:
  - Use `git ls-files -z` to get list of files in `Repo._get_files()` without additional quotes
  - Update parsing of this list accordingly
  - close #277 

- `os.system` parses paths with spaces, quotes etc. differently then `subprocess.run`
  - replace `os.system` with `subprocess.run` for `onyo tree`
  - use `shlex.quote()` for giving paths as input to `os.system` 