### PR TITLE
RF: `Repo.valid_name()`

### DIFF
--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -901,38 +901,21 @@ class Repo:
             log.error(f"The path is protected by onyo: '{asset}'")
             raise ValueError(f"Input contains multiple '{file[0].name}'")
 
-    def valid_name(self, asset: Path) -> bool:
+    def valid_name(self, asset: Union[Path, str]) -> bool:
         """
-        Verify that an asset name fits into the asset name scheme of onyo:
+        Verify that an asset name complies with the name scheme:
         <type>_<make>_<model>.<serial>
-        Where the fields type, make, and model do not allow the characters '.'
-        and '_' to be part of the field, and no field is allowed to be empty.
+        Where the fields type, make, and model do not allow '.' or '_', serial
+        permits all characters, and no field can be empty.
 
         Returns True for valid asset names, and False if invalid.
         """
-        # verify that a dot exists
-        if "." not in asset.name:
-            log.error("Asset names must have a '.'")
-            return False
+        asset = Path(asset)
 
-        # split fields
         try:
-            # reverse order, because re reads from right to left and splits,
-            # and this way '.' and '_' are in serial field
-            [serial, model, make, type] = re.findall('(.*)\.(.*)_(.*)_(.*)', asset.name[::-1])[0]
+            re.findall('(^[^._]+?)_([^._]+?)_([^._]+?)\.(.+)', asset.name)[0]
         except (ValueError, IndexError):
-            log.error(f"'{asset.name}' must be in the format '<type>_<make>_<model>.<serial>'")
-            return False
-
-        # check against special characters in fields 'type', 'make', 'model'
-        # if '_' in type or '.' in type or '_' in make or '.' in make or '_' in model or '.' in model:
-        if any('.' in x or '_' in x for x in [type, make, model]):
-            log.error(f"'{asset.name}' must be in the format '<type>_<make>_<model>.<serial>'")
-            return False
-
-        # none of the fields is allowed to be empty
-        if not all([type, make, model, serial]):
-            log.error("The fields 'type', 'make', 'model' and 'serial' are not allowed to be empty.")
+            log.info(f"'{asset.name}' must be in the format '<type>_<make>_<model>.<serial>'")
             return False
 
         return True

--- a/tests/commands/test_new.py
+++ b/tests/commands/test_new.py
@@ -601,3 +601,31 @@ def test_tsv_error_template_does_not_exist(repo: Repo) -> None:
     # verify that no new assets were created and the repository is still clean
     assert len(repo.assets) == 0
     repo.fsck()
+
+
+variants = ['laptop_apple_macbookpro_0',
+            'lap top _ app le _ mac book pro_ 0',
+            'laptop_ap.ple_macbookpro.0',
+            'lap_top_apple_macbookpro.0',
+            'laptop-apple-macbookpro.0',
+            '_apple_macbookpro.0',
+            'laptop__macbookpro.0',
+            'laptop_apple_.0',
+            'laptop_apple_macbookpro.'
+            ]
+@pytest.mark.parametrize('variant', variants)
+def test_error_namescheme(repo: Repo, variant: str) -> None:
+    """
+    Test that `onyo new` prints correct errors for different invalid names:
+    - '.' in another field as serial number
+    - Additional '_' in one of the early fields
+    - instead of '_' using '-' to divide fields
+    """
+    ret = subprocess.run(['onyo', 'new', variant], capture_output=True, text=True)
+    assert not ret.stdout
+    assert ret.returncode == 1
+    assert "must be in the format '<type>_<make>_<model>.<serial>'" in ret.stderr
+
+    # verify that no new assets were created and the repository state is clean
+    assert len(repo.assets) == 0
+    repo.fsck()

--- a/tests/lib/test_Repo_new.py
+++ b/tests/lib/test_Repo_new.py
@@ -31,8 +31,6 @@ def test_generate_faux_serials_invalid_length(repo, variant):
     """
     Fewer than 4 character in the serial is invalid.
     """
-    # faux serial numbers must have at least length 1 and the function raises
-    # ValueError:
     with pytest.raises(ValueError):
         repo.generate_faux_serials(*variant)
 
@@ -44,8 +42,6 @@ def test_generate_faux_serials_invalid_number(repo, variant):
     """
     Number of serials must be greater than 0.
     """
-    # faux serial numbers must have at least length 1 and the function raises
-    # ValueError:
     with pytest.raises(ValueError):
         repo.generate_faux_serials(*variant)
 
@@ -57,8 +53,6 @@ def test_generate_faux_serials_invalid_length_and_number(repo, variant):
     """
     Both length and number are invalid.
     """
-    # faux serial numbers must have at least length 1 and the function raises
-    # ValueError:
     with pytest.raises(ValueError):
         repo.generate_faux_serials(*variant)
 

--- a/tests/lib/test_Repo_new.py
+++ b/tests/lib/test_Repo_new.py
@@ -1,6 +1,5 @@
 import random
 import pytest
-import subprocess
 
 from onyo.lib import Repo
 
@@ -61,63 +60,3 @@ def test_generate_faux_serials_invalid_length_and_number(repo, variant):
     # ValueError:
     with pytest.raises(ValueError):
         repo.generate_faux_serials(*variant)
-
-
-variants = ['laptop_apple_macbookpro_0',
-            'lap top _ app le _ mac book pro_ 0']
-@pytest.mark.parametrize('variant', variants)
-def test_error_invalid_namescheme_no_dot(repo: Repo, variant: str) -> None:
-    """
-    Test that `onyo new` prints correct errors for different invalid names if
-    the '.' is missing in the asset name.
-    """
-    ret = subprocess.run(['onyo', 'new', variant], capture_output=True, text=True)
-    assert not ret.stdout
-    assert ret.returncode == 1
-    assert "Asset names must have a '.'" in ret.stderr
-
-    # verify that no new assets were created and the repository state is clean
-    assert len(repo.assets) == 0
-    repo.fsck()
-
-
-variants = ['laptop_ap.ple_macbookpro.0',
-            'lap_top_apple_macbookpro.0',
-            'laptop-apple-macbookpro.0']
-@pytest.mark.parametrize('variant', variants)
-def test_error_invalid_namescheme_wrong_format(repo: Repo, variant: str) -> None:
-    """
-    Test that `onyo new` prints correct errors for different invalid names:
-    - '.' in another field as serial number
-    - Additional '_' in one of the early fields
-    - instead of '_' using '-' to divide fields
-    """
-    ret = subprocess.run(['onyo', 'new', variant], capture_output=True, text=True)
-    assert not ret.stdout
-    assert ret.returncode == 1
-    assert "must be in the format '<type>_<make>_<model>.<serial>'" in ret.stderr
-
-    # verify that no new assets were created and the repository state is clean
-    assert len(repo.assets) == 0
-    repo.fsck()
-
-
-variants = ['_apple_macbookpro.0',
-            'laptop__macbookpro.0',
-            'laptop_apple_.0',
-            'laptop_apple_macbookpro.'
-            ]
-@pytest.mark.parametrize('variant', variants)
-def test_error_invalid_namescheme_empty_fields(repo: Repo, variant: str) -> None:
-    """
-    Test the correct error if a name field ('type', 'make', 'model', 'serial')
-    is empty, while the format (e.g. needed '_' and '.' exist) is correct.
-    """
-    ret = subprocess.run(['onyo', 'new', variant], capture_output=True, text=True)
-    assert not ret.stdout
-    assert ret.returncode == 1
-    assert "The fields 'type', 'make', 'model' and 'serial' are not allowed to be empty." in ret.stderr
-
-    # verify that no new assets were created and the repository state is clean
-    assert len(repo.assets) == 0
-    repo.fsck()

--- a/tests/lib/test_Repo_new.py
+++ b/tests/lib/test_Repo_new.py
@@ -1,5 +1,6 @@
 import random
 import pytest
+from pathlib import Path
 
 from onyo.lib import Repo
 
@@ -60,3 +61,40 @@ def test_generate_faux_serials_invalid_length_and_number(repo, variant):
     # ValueError:
     with pytest.raises(ValueError):
         repo.generate_faux_serials(*variant)
+
+
+variants = ['laptop_apple_macbookpro_0',  # no .
+            'laptop-apple-macbookpro.0',  # no _
+            'laptop-apple-macbookpro-0',  # no _ or -
+            'laptop_ap.ple_macbookpro.0',  # . can only be in serial field
+            'lap_top_apple_macbookpro.0',  # too many fields (_)
+            '__.',  # all fields are empty
+            '_apple_macbookpro.0',  # empty type
+            'laptop__macbookpro.0',  # empty make
+            'laptop_apple_.0',  # empty model
+            'laptop_apple_macbookpro.'  # empty serial
+            ]
+@pytest.mark.parametrize('variant', variants)
+def test_valid_name_error(repo: Repo, variant: str) -> None:
+    """
+    Test `Repo.valid_name()` against invalid asset names.
+    """
+    for asset in [variant, Path(variant)]:
+        valid = repo.valid_name(asset)
+        assert isinstance(valid, bool)
+        assert not valid
+
+
+variants = ['laptop_apple_macbookpro.serial123',  # normal
+            'lap top_app le_mac book.ser ial',  # spaces are allowed
+            'laptop_apple_macbookpro.serial_a.b_c.d'  # serial allows any characters
+            ]
+@pytest.mark.parametrize('variant', variants)
+def test_valid_name(repo: Repo, variant: str) -> None:
+    """
+    Test `Repo.valid_name()` against valid asset names --- including weird ones.
+    """
+    for asset in [variant, Path(variant)]:
+        valid = repo.valid_name(asset)
+        assert isinstance(valid, bool)
+        assert valid


### PR DESCRIPTION
This PR:

- moves `onyo new` tests under `tests/commands`
- adds tests for `Repo.valid_name()`
- refactors `Repo.valid_name()` to simplify it and accept both `str` and `Path`