### PR TITLE
TST: Modernize remaining old-style tests

### DIFF
--- a/tests/commands/test_config.py
+++ b/tests/commands/test_config.py
@@ -2,12 +2,7 @@ import subprocess
 from pathlib import Path
 
 
-def test_onyo_init():
-    ret = subprocess.run(["onyo", "init"])
-    assert ret.returncode == 0
-
-
-def test_config_set():
+def test_config_set(repo):
     ret = subprocess.run(["onyo", "config", "onyo.test.set", "set-test"],
                          capture_output=True, text=True)
     assert ret.returncode == 0
@@ -17,7 +12,7 @@ def test_config_set():
     assert '= set-test' in Path('.onyo/config').read_text()
 
 
-def test_config_get_onyo():
+def test_config_get_onyo(repo):
     # set
     ret = subprocess.run(["onyo", "config", "onyo.test.get-onyo", "get-onyo-test"],
                          capture_output=True, text=True)
@@ -31,8 +26,10 @@ def test_config_get_onyo():
     assert not ret.stderr
 
 
-# onyo should not alter git config's output (newline, etc)
-def test_config_get_pristine():
+def test_config_get_pristine(repo):
+    """
+    onyo should not alter git config's output (newline, etc)
+    """
     ret = subprocess.run(["onyo", "config", "onyo.test.get-pristine", "get-pristine-test"],
                          capture_output=True, text=True)
     assert ret.returncode == 0
@@ -53,7 +50,7 @@ def test_config_get_pristine():
     assert ret.stdout == git_config_output
 
 
-def test_config_get_empty():
+def test_config_get_empty(repo):
     assert 'onyo.test.not-exist' not in Path('.onyo/config').read_text()
 
     ret = subprocess.run(["onyo", "config", "--get", "onyo.test.not-exist"],
@@ -63,7 +60,7 @@ def test_config_get_empty():
     assert not ret.stderr
 
 
-def test_config_unset():
+def test_config_unset(repo):
     # set
     ret = subprocess.run(["onyo", "config", "onyo.test.unset", "unset-test"],
                          capture_output=True, text=True)
@@ -86,7 +83,7 @@ def test_config_unset():
     assert not ret.stderr
 
 
-def test_config_help():
+def test_config_help(repo):
     """
     `onyo config --help` is shown and not `git config --help`.
     """
@@ -98,7 +95,7 @@ def test_config_help():
         assert not ret.stderr
 
 
-def test_config_forbidden_flags():
+def test_config_forbidden_flags(repo):
     """
     Flags that change the source of values are not allowed.
     """
@@ -109,7 +106,7 @@ def test_config_forbidden_flags():
         assert flag in ret.stderr
 
 
-def test_config_bubble_retcode():
+def test_config_bubble_retcode(repo):
     """
     Bubble up git-config's retcodes.
     According to the git config manpage, attempting to unset an option which
@@ -122,7 +119,7 @@ def test_config_bubble_retcode():
     assert ret.returncode == 5
 
 
-def test_config_bubble_stderr():
+def test_config_bubble_stderr(repo):
     """
     Bubble up git-config printing to stderr.
     """

--- a/tests/commands/test_init.py
+++ b/tests/commands/test_init.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 from pathlib import Path
 
@@ -21,84 +22,18 @@ def fully_populated_dot_onyo(directory=''):
     return True
 
 
-def test_cwd():
+def test_cwd(tmp_path):
+    os.chdir(tmp_path)
+
     ret = subprocess.run(["onyo", "init"])
+
     assert ret.returncode == 0
     assert fully_populated_dot_onyo()
 
 
-def test_child_exist():
-    Path('child_exist').mkdir()
-    ret = subprocess.run(["onyo", "init", 'child_exist'])
+def test_explicit(tmp_path):
+    repo_path = Path(tmp_path).resolve()
+    ret = subprocess.run(["onyo", "init", repo_path])
+
     assert ret.returncode == 0
-    assert fully_populated_dot_onyo('child_exist')
-
-
-def test_child_not_exist():
-    ret = subprocess.run(["onyo", "init", 'child_not_exist'])
-    assert ret.returncode == 0
-    assert fully_populated_dot_onyo('child_not_exist')
-
-
-def test_child_with_spaces_not_exist():
-    ret = subprocess.run(["onyo", "init", 'child with spaces not exist'])
-    assert ret.returncode == 0
-    assert fully_populated_dot_onyo('child with spaces not exist')
-
-
-def test_child_with_spaces_exist():
-    Path('child with spaces exist').mkdir()
-    ret = subprocess.run(["onyo", "init", 'child with spaces exist'])
-    assert ret.returncode == 0
-    assert fully_populated_dot_onyo('child with spaces exist')
-
-
-def test_fail_reinit_cwd():
-    ret = subprocess.run(["onyo", "init"])
-    assert ret.returncode == 1
-    # and nothing should be lost
     assert fully_populated_dot_onyo()
-
-
-def test_fail_reinit_child():
-    ret = subprocess.run(["onyo", "init", 'reinit_child'])
-    assert ret.returncode == 0
-    ret = subprocess.run(["onyo", "init", 'reinit_child'])
-    assert ret.returncode == 1
-    # and nothing should be lost
-    assert fully_populated_dot_onyo('reinit_child')
-
-
-def test_fail_init_file():
-    Path('file').touch()
-    ret = subprocess.run(["onyo", "init", 'file'])
-    assert ret.returncode == 1
-
-
-# target dir that is too deep
-def test_fail_missing_parent_dir():
-    ret = subprocess.run(["onyo", "init", 'missing/parent/dir'])
-    assert ret.returncode == 1
-    assert not fully_populated_dot_onyo('missing/parent/dir')
-
-
-# target dir that's already a git repo
-def test_child_exist_with_git():
-    # create git repo
-    ret = subprocess.run(['git', 'init', 'child_exist_with_git'])
-    assert ret.returncode == 0
-
-    ret = subprocess.run(["onyo", "init", 'child_exist_with_git'])
-    assert ret.returncode == 0
-    assert fully_populated_dot_onyo('child_exist_with_git')
-
-
-# target dir that contains non-git stuff
-def test_child_with_cruft():
-    Path('child_exist_with_cruft').mkdir()
-    Path('child_exist_with_cruft/such_cruft.txt').touch()
-
-    ret = subprocess.run(["onyo", "init", 'child_exist_with_cruft'])
-    assert ret.returncode == 0
-    assert fully_populated_dot_onyo('child_exist_with_cruft')
-    # TODO: assert that child_exist_with_cruft/such_cruft.txt is not committed.

--- a/tests/commands/test_mv.py
+++ b/tests/commands/test_mv.py
@@ -1,412 +1,94 @@
-import os
 import subprocess
 from pathlib import Path
+import pytest
 
+# These tests focus on functionality specific to the CLI for `onyo mv`.
+# Tests located in this file should not duplicate those testing `Repo.mv()`
+# directly.
 
-def test_mv_flags(helpers):
-    dirs = ['one', 'two', 'three']
-    files = ['a', 'b', 'c', 'one/d', 'two/e', 'three/f']
-
-    # setup repo
-    helpers.populate_repo('flags', dirs, files)
-    os.chdir('flags')
-
-    # --quiet (requires --yes)
-    ret = subprocess.run(['onyo', 'mv', '--quiet', 'a', 'a.quiet'], capture_output=True, text=True)
+#
+# FLAGS
+#
+@pytest.mark.repo_files('subdir/laptop_apple_macbook.abc123')
+def test_mv_interactive_missing_y(repo):
+    """
+    Default mode is interactive. It requires a "y" to approve.
+    """
+    ret = subprocess.run(['onyo', 'mv', 'subdir/laptop_apple_macbook.abc123', './'], capture_output=True, text=True)
     assert ret.returncode == 1
-    assert not Path('a.quiet').exists()
+    assert "Move assets? (y/N) " in ret.stdout
+    assert ret.stderr
+
+    assert Path('subdir/laptop_apple_macbook.abc123').exists()
+    assert not Path('laptop_apple_macbook.abc123').exists()
+
+
+@pytest.mark.repo_files('subdir/laptop_apple_macbook.abc123')
+def test_mv_interactive_abort(repo):
+    """
+    Default mode is interactive. Provide the "n" to abort.
+    """
+    ret = subprocess.run(['onyo', 'mv', 'subdir/laptop_apple_macbook.abc123', './'], input='n', capture_output=True, text=True)
+    assert ret.returncode == 0
+    assert "Move assets? (y/N) " in ret.stdout
+    assert not ret.stderr
+
+    assert Path('subdir/laptop_apple_macbook.abc123').exists()
+    assert not Path('laptop_apple_macbook.abc123').exists()
+
+
+@pytest.mark.repo_files('subdir/laptop_apple_macbook.abc123')
+def test_mv_interactive(repo):
+    """
+    Default mode is interactive. Provide the "y" to approve.
+    """
+    ret = subprocess.run(['onyo', 'mv', 'subdir/laptop_apple_macbook.abc123', './'], input='y', capture_output=True, text=True)
+    assert ret.returncode == 0
+    assert "Move assets? (y/N) " in ret.stdout
+    assert not ret.stderr
+
+    assert not Path('subdir/laptop_apple_macbook.abc123').exists()
+    assert Path('laptop_apple_macbook.abc123').exists()
+
+
+@pytest.mark.repo_files('subdir/laptop_apple_macbook.abc123')
+def test_mv_quiet_missing_yes(repo):
+    """
+    ``--quiet`` requires ``--yes``
+    """
+    ret = subprocess.run(['onyo', 'mv', '--quiet', 'subdir/laptop_apple_macbook.abc123', './'], capture_output=True, text=True)
+    assert ret.returncode == 1
     assert not ret.stdout
     assert ret.stderr
 
-    # --quiet with --yes success
-    ret = subprocess.run(['onyo', 'mv', '--quiet', '--yes', 'b', 'two'], capture_output=True, text=True)
+    assert Path('subdir/laptop_apple_macbook.abc123').exists()
+    assert not Path('laptop_apple_macbook.abc123').exists()
+
+
+@pytest.mark.repo_files('subdir/laptop_apple_macbook.abc123')
+def test_mv_quiet(repo):
+    """
+    ``--quiet`` requires ``--yes``
+    """
+    ret = subprocess.run(['onyo', 'mv', '--yes', '--quiet', 'subdir/laptop_apple_macbook.abc123', './'], capture_output=True, text=True)
     assert ret.returncode == 0
     assert not ret.stdout
     assert not ret.stderr
-    assert not Path('b').exists()
-    assert Path('two/b').is_file()
 
-    # --quiet with --yes failure
-    ret = subprocess.run(['onyo', 'mv', '--quiet', '--yes', 'does', 'not', 'exist'], capture_output=True, text=True)
-    assert ret.returncode == 1
-    assert not ret.stdout
-    assert ret.stderr
-    assert not Path('does').exists()
-    assert not Path('not').exists()
-    assert not Path('exist').exists()
+    assert not Path('subdir/laptop_apple_macbook.abc123').exists()
+    assert Path('laptop_apple_macbook.abc123').exists()
 
-    # --yes success
-    ret = subprocess.run(['onyo', 'mv', '--yes', 'c', 'three/c'], capture_output=True, text=True)
+
+@pytest.mark.repo_files('subdir/laptop_apple_macbook.abc123')
+def test_mv_yes(repo):
+    """
+    --yes removes any prompts and auto-approves the move.
+    """
+    ret = subprocess.run(['onyo', 'mv', '--yes', 'subdir/laptop_apple_macbook.abc123', './'], capture_output=True, text=True)
     assert ret.returncode == 0
-    assert ret.stdout
+    assert "The following will be moved:" in ret.stdout
+    assert "Move assets? (y/N) " not in ret.stdout
     assert not ret.stderr
-    assert not Path('c').exists()
-    assert Path('three/c').is_file()
 
-
-def test_mv_protected(helpers):
-    dirs = ['one', 'two', 'three']
-    files = ['a', 'b', 'c', 'one/d', 'two/e', 'three/f']
-
-    # setup repo
-    helpers.populate_repo('protected', dirs, files)
-    os.chdir('protected')
-
-    # cannot rename a file to .anchor
-    ret = subprocess.run(['onyo', 'mv', '--yes', 'one/.anchor', '.anchor'], capture_output=True, text=True)
-    assert ret.returncode == 1
-    assert not ret.stdout
-    assert 'protected by onyo' in ret.stderr
-    assert Path('one/.anchor').is_file()
-
-    # cannot rename a directory to .anchor
-    ret = subprocess.run(['onyo', 'mv', '--yes', 'three', '.anchor'], capture_output=True, text=True)
-    assert ret.returncode == 1
-    assert not ret.stdout
-    assert 'protected by onyo' in ret.stderr
-    assert not Path('.anchor').is_dir()
-
-    # cannot move file into .onyo
-    ret = subprocess.run(['onyo', 'mv', '--yes', 'three/f', '.onyo'], capture_output=True, text=True)
-    assert ret.returncode == 1
-    assert not ret.stdout
-    assert 'protected by onyo' in ret.stderr
-    assert Path('three/f').is_file()
-    assert not Path('.onyo/f').exists()
-
-    # cannot move file out of .onyo
-    ret = subprocess.run(['onyo', 'mv', '--yes', '.onyo/config', 'one'], capture_output=True, text=True)
-    assert ret.returncode == 1
-    assert not ret.stdout
-    assert 'protected by onyo' in ret.stderr
-    assert Path('.onyo/config').is_file()
-    assert not Path('one/config').exists()
-
-    # cannot move dir into .onyo
-    ret = subprocess.run(['onyo', 'mv', '--yes', 'three', '.onyo'], capture_output=True, text=True)
-    assert ret.returncode == 1
-    assert not ret.stdout
-    assert 'protected by onyo' in ret.stderr
-    assert Path('three').is_dir()
-    assert not Path('.onyo/three').is_dir()
-
-    # cannot move dir out of .onyo
-    ret = subprocess.run(['onyo', 'mv', '--yes', '.onyo/validation', 'three'], capture_output=True, text=True)
-    assert ret.returncode == 1
-    assert not ret.stdout
-    assert 'protected by onyo' in ret.stderr
-    assert Path('.onyo/validation').is_dir()
-    assert not Path('three/validation').exists()
-
-    # cannot move file into .git
-    ret = subprocess.run(['onyo', 'mv', '--yes', 'three/f', '.git'], capture_output=True, text=True)
-    assert ret.returncode == 1
-    assert not ret.stdout
-    assert 'protected by onyo' in ret.stderr
-    assert Path('three/f').is_file()
-    assert not Path('.git/f').exists()
-
-    # cannot move file out of .git
-    ret = subprocess.run(['onyo', 'mv', '--yes', '.git/config', 'one'], capture_output=True, text=True)
-    assert ret.returncode == 1
-    assert not ret.stdout
-    assert 'protected by onyo' in ret.stderr
-    assert Path('.git/config').is_file()
-    assert not Path('one/config').exists()
-
-    # cannot move dir into .git
-    ret = subprocess.run(['onyo', 'mv', '--yes', 'three', '.git'], capture_output=True, text=True)
-    assert ret.returncode == 1
-    assert not ret.stdout
-    assert 'protected by onyo' in ret.stderr
-    assert Path('three').is_dir()
-    assert not Path('.git/three').exists()
-
-    # cannot move dir out of .git
-    ret = subprocess.run(['onyo', 'mv', '--yes', '.git/refs', 'one'], capture_output=True, text=True)
-    assert ret.returncode == 1
-    assert not ret.stdout
-    assert 'protected by onyo' in ret.stderr
-    assert Path('.git/refs').is_dir()
-    assert not Path('one/refs').exists()
-
-
-def test_mv_rename_file(helpers):
-    dirs = ['one', 'two', 'three']
-    files = ['a', 'b', 'c', 'one/d', 'two/e', 'three/f']
-
-    # setup repo
-    helpers.populate_repo('rename_file', dirs, files)
-    os.chdir('rename_file')
-
-    # cannot rename a file
-    ret = subprocess.run(['onyo', 'mv', '--yes', 'a', 'a.rename'], capture_output=True, text=True)
-    assert ret.returncode == 1
-    assert not ret.stdout
-    assert ret.stderr
-    assert Path('a').exists()
-    assert not Path('a.rename').is_file()
-
-    # cannot rename a file
-    ret = subprocess.run(['onyo', 'mv', '--yes', 'a', 'one/a.rename'], capture_output=True, text=True)
-    assert ret.returncode == 1
-    assert not ret.stdout
-    assert ret.stderr
-    assert Path('a').exists()
-    assert not Path('one/a.rename').is_file()
-
-    # cannot rename a file onto an existing file
-    ret = subprocess.run(['onyo', 'mv', '--yes', 'a', 'b'], capture_output=True, text=True)
-    assert ret.returncode == 1
-    assert not ret.stdout
-    assert 'cannot be a file' in ret.stderr
-    assert Path('a').exists()
-    assert Path('b').exists()
-
-    # allowed: same name is not a rename
-    ret = subprocess.run(['onyo', 'mv', '--yes', 'b', 'two/b'], capture_output=True, text=True)
-    assert ret.returncode == 0
-    assert ret.stdout
-    assert not ret.stderr
-    assert not Path('b').exists()
-    assert Path('two/b').is_file()
-
-    # same name missing parent
-    ret = subprocess.run(['onyo', 'mv', '--yes', 'c', 'not-exist/c'], capture_output=True, text=True)
-    assert ret.returncode == 1
-    assert not ret.stdout
-    assert ret.stderr
-    assert Path('c').exists()
-    assert not Path('not-exist/c').is_file()
-
-
-def test_mv_rename_dir(helpers):
-    dirs = ['one', 'two', 'three', 'four', 's p a/c e s']
-    files = []
-
-    # setup repo
-    helpers.populate_repo('rename_dir', dirs, files)
-    os.chdir('rename_dir')
-
-    # simple
-    ret = subprocess.run(['onyo', 'mv', '--yes', 'one', 'one.newname'], capture_output=True, text=True)
-    assert ret.returncode == 0
-    assert ret.stdout
-    assert not ret.stderr
-    assert not Path('one').exists()
-    assert Path('one.newname').is_dir()
-
-    # rename into subdir
-    ret = subprocess.run(['onyo', 'mv', '--yes', 'two', 'four/two-rename'], capture_output=True, text=True)
-    assert ret.returncode == 0
-    assert ret.stdout
-    assert not ret.stderr
-    assert not Path('two').exists()
-    assert Path('four/two-rename').is_dir()
-
-    # same-name into subdir
-    ret = subprocess.run(['onyo', 'mv', '--yes', 'three', 'four/three'], capture_output=True, text=True)
-    assert ret.returncode == 0
-    assert ret.stdout
-    assert not ret.stderr
-    assert not Path('three').exists()
-    assert Path('four/three').is_dir()
-
-    # spaces
-    ret = subprocess.run(['onyo', 'mv', '--yes', 's p a/c e s', 'nospaces'], capture_output=True, text=True)
-    assert ret.returncode == 0
-    assert ret.stdout
-    assert not ret.stderr
-    assert not Path('s p a/c e s').exists()
-    assert Path('nospaces').is_dir()
-
-
-def test_mv_move_file(helpers):
-    dirs = ['s p a c e s', 's p a/c e s', 'one', 'two', 'three']
-    files = ['a', 'b', 'c', 'one/d', 'two/e', 'three/f', 's p a c e s/g',
-             's p a c e s/h', 's p a c e s/i', 's p a/c e s/1 2']
-
-    # setup repo
-    helpers.populate_repo('move_file', dirs, files)
-    os.chdir('move_file')
-
-    # NOTE: file names must be unique (otherwise fsck fails) and cannot be
-    # renamed. This is why there is no test for moving onto an existing file.
-
-    # single file
-    ret = subprocess.run(['onyo', 'mv', '--yes', 'a', 'one'], capture_output=True, text=True)
-    assert ret.returncode == 0
-    assert ret.stdout
-    assert not ret.stderr
-    assert not Path('a').exists()
-    assert Path('one/a').is_file()
-
-    # multiple files
-    ret = subprocess.run(['onyo', 'mv', '--yes', 'b', 'c', 'one'], capture_output=True, text=True)
-    assert ret.returncode == 0
-    assert ret.stdout
-    assert not ret.stderr
-    assert not Path('b').exists()
-    assert not Path('c').exists()
-    assert Path('one/b').is_file()
-    assert Path('one/c').is_file()
-
-    # many depths with spaces
-    ret = subprocess.run(['onyo', 'mv', '--yes', 'one/a', 'one/b', 'one/c', 'one/d', 'two/e', 's p a c e s/g', 's p a/c e s/1 2', 'three'],
-                         capture_output=True, text=True)
-    assert ret.returncode == 0
-    assert ret.stdout
-    assert not ret.stderr
-    assert not Path('one/a').exists()
-    assert not Path('one/b').exists()
-    assert not Path('one/c').exists()
-    assert not Path('one/d').exists()
-    assert not Path('two/e').exists()
-    assert not Path('s p a c e s/g').exists()
-    assert not Path('s p a/c e s/1 2').exists()
-    assert Path('three/a').is_file()
-    assert Path('three/b').is_file()
-    assert Path('three/c').is_file()
-    assert Path('three/d').is_file()
-    assert Path('three/e').is_file()
-    assert Path('three/g').is_file()
-    assert Path('three/1 2').is_file()
-
-    # destination must exist
-    ret = subprocess.run(['onyo', 'mv', 'three/a', 'three/b', 'not_exist'], capture_output=True, text=True)
-    assert ret.returncode == 1
-    assert not ret.stdout
-    assert 'does not exist' in ret.stderr
-    assert Path('three/a').is_file()
-    assert Path('three/b').is_file()
-    assert not Path('not_exist').exists()
-
-    # destination must be a directory
-    ret = subprocess.run(['onyo', 'mv', 'three/a', 'three/b', 'three/c'], capture_output=True, text=True)
-    assert ret.returncode == 1
-    assert not ret.stdout
-    assert 'cannot be a file' in ret.stderr
-    assert Path('three/a').is_file()
-    assert Path('three/b').is_file()
-    assert Path('three/c').is_file()
-
-    # cannot move onto self
-    ret = subprocess.run(['onyo', 'mv', 'three/f', 'three/f'], capture_output=True, text=True)
-    assert ret.returncode == 1
-    assert not ret.stdout
-    assert 'cannot be a file' in ret.stderr
-    assert Path('three/f').is_file()
-
-
-def test_mv_move_dir(helpers):
-    dirs = ['simple', 's p a c e s', 's p a/c e s', 'one', 'two', 'three', 'conflict', 'three/conflict']
-    files = []
-
-    # setup repo
-    helpers.populate_repo('move_dir', dirs, files)
-    os.chdir('move_dir')
-
-    # single dir
-    ret = subprocess.run(['onyo', 'mv', '--yes', 'simple', 'one'], capture_output=True, text=True)
-    assert ret.returncode == 0
-    assert ret.stdout
-    assert not ret.stderr
-    assert not Path('simple').exists()
-    assert Path('one/simple').is_dir()
-
-    # multiple dirs
-    ret = subprocess.run(['onyo', 'mv', '--yes', 'one', 'two', 'three'], capture_output=True, text=True)
-    assert ret.returncode == 0
-    assert ret.stdout
-    assert not ret.stderr
-    assert not Path('one').exists()
-    assert not Path('two').exists()
-    assert Path('three/one').is_dir()
-    assert Path('three/two').is_dir()
-
-    # many depths with spaces
-    ret = subprocess.run(['onyo', 'mv', '--yes', 'three/one', 'three/two', 's p a/c e s', 's p a c e s'],
-                         capture_output=True, text=True)
-    assert ret.returncode == 0
-    assert ret.stdout
-    assert not ret.stderr
-    assert not Path('three/one').exists()
-    assert not Path('three/two').exists()
-    assert not Path('s p a/c e s').exists()
-    assert Path('s p a c e s/one').is_dir()
-    assert Path('s p a c e s/two').is_dir()
-    assert Path('s p a c e s/c e s').is_dir()
-
-    # cannot move to conflict
-    ret = subprocess.run(['onyo', 'mv', '--yes', 'conflict', 'three'], capture_output=True, text=True)
-    assert ret.returncode == 1
-    assert not ret.stdout
-    assert 'destinations exist and would conflict' in ret.stderr
-    assert Path('conflict').is_dir()
-    assert Path('three/conflict').is_dir()
-    assert not Path('three/conflict/conflict').is_dir()
-
-    # cannot conflict to self
-    ret = subprocess.run(['onyo', 'mv', '--yes', 'three', './'], capture_output=True, text=True)
-    assert ret.returncode == 1
-    assert not ret.stdout
-    assert 'destinations exist and would conflict' in ret.stderr
-    assert Path('three').is_dir()
-
-    # cannot move into self implicitly
-    ret = subprocess.run(['onyo', 'mv', 'three', 'three'], capture_output=True, text=True)
-    assert ret.returncode == 1
-    assert not ret.stdout
-    assert "Cannot move 'three' into itself" in ret.stderr
-    assert Path('three').is_dir()
-    assert not Path('three/three').exists()
-
-    # cannot move into self explicitly
-    ret = subprocess.run(['onyo', 'mv', 'three', 'three/three'], capture_output=True, text=True)
-    assert ret.returncode == 1
-    assert not ret.stdout
-    assert "Cannot move 'three' into itself" in ret.stderr
-    assert Path('three').is_dir()
-    assert not Path('three/three').exists()
-
-    # cannot move into self explicitly
-    ret = subprocess.run(['onyo', 'mv', 'three', 'three/new_name'], capture_output=True, text=True)
-    assert ret.returncode == 1
-    assert not ret.stdout
-    assert "Cannot move 'three' into itself" in ret.stderr
-    assert Path('three').is_dir()
-    assert not Path('three/new_name').exists()
-
-    # destination dir must exist
-    ret = subprocess.run(['onyo', 'mv', 'three', 'not-exist/three'], capture_output=True, text=True)
-    assert ret.returncode == 1
-    assert not ret.stdout
-    assert ret.stderr
-    assert Path('three').is_dir()
-    assert not Path('not-exist').exists()
-
-
-def test_mv_move_mixed(helpers):
-    dirs = ['one', 'two', 's p a/c e s', 's p a c e s']
-    files = ['a', 'b', 'one/d', 'two/e', 's p a/c e s/1 2', 's p a c e s/g']
-
-    # setup repo
-    helpers.populate_repo('move_mixed', dirs, files)
-    os.chdir('move_mixed')
-
-    # many depths with spaces
-    ret = subprocess.run(['onyo', 'mv', '--yes', 'a', 'one', 'two', 's p a/c e s', 'b', 's p a c e s'],
-                         capture_output=True, text=True)
-    assert ret.returncode == 0
-    assert ret.stdout
-    assert not ret.stderr
-    assert not Path('a').exists()
-    assert not Path('one').exists()
-    assert not Path('two').exists()
-    assert not Path('s p a/c e s').exists()
-    assert not Path('b').exists()
-    assert Path('s p a c e s/a').is_file()
-    assert Path('s p a c e s/one').is_dir()
-    assert Path('s p a c e s/two').is_dir()
-    assert Path('s p a c e s/c e s').is_dir()
-    assert Path('s p a c e s/b').is_file()
+    assert not Path('subdir/laptop_apple_macbook.abc123').exists()
+    assert Path('laptop_apple_macbook.abc123').exists()

--- a/tests/commands/test_onyo.py
+++ b/tests/commands/test_onyo.py
@@ -1,36 +1,35 @@
 import subprocess
 from itertools import product
 
+import pytest
 
-def test_onyo_init():
-    ret = subprocess.run(["onyo", "init"])
+
+variants = [
+    '-d',
+    '--debug',
+]
+@pytest.mark.repo_dirs('just-a-dir')
+@pytest.mark.parametrize('variant', variants)
+def test_onyo_debug(repo, variant):
+    ret = subprocess.run(['onyo', variant, 'mkdir', f'flag{variant}'], capture_output=True, text=True)
     assert ret.returncode == 0
+    assert 'DEBUG:onyo' in ret.stderr
 
 
-def test_onyo_debug(helpers):
-    # populate repo, so there's something to be noisy about
-    ret = subprocess.run(['onyo', 'mkdir', 'just-a-dir'])
+variants = [
+    '-h',
+    '--help',
+]
+@pytest.mark.parametrize('variant', variants)
+def test_onyo_help(repo, variant):
+    ret = subprocess.run(['onyo', variant], capture_output=True, text=True)
     assert ret.returncode == 0
-
-    for i in ['-d', '--debug']:
-        full_cmd = ['onyo', i, 'mkdir', f'flag{i}']
-
-        ret = subprocess.run(full_cmd, capture_output=True, text=True)
-        assert ret.returncode == 0
-        assert 'DEBUG:onyo' in ret.stderr
+    assert 'usage: onyo [-h]' in ret.stdout
+    assert not ret.stderr
 
 
-def test_onyo_help(helpers):
-    for i in ['-h', '--help']:
-        full_cmd = ['onyo', i]
-
-        ret = subprocess.run(full_cmd, capture_output=True, text=True)
-        assert ret.returncode == 0
-        assert 'usage: onyo [-h]' in ret.stdout
-        assert not ret.stderr
-
-
-def test_onyo_without_subcommand(helpers):
+# TODO: this would be better if parametrized
+def test_onyo_without_subcommand(repo, helpers):
     """
     Test all possible combinations of flags for onyo, without any subcommand.
     """

--- a/tests/commands/test_rm.py
+++ b/tests/commands/test_rm.py
@@ -1,181 +1,88 @@
-import os
 import subprocess
 from pathlib import Path
+import pytest
 
+# These tests focus on functionality specific to the CLI for `onyo rm`.
+# Tests located in this file should not duplicate those testing `Repo.rm()`
+# directly.
 
-def test_rm_flags(helpers):
-    dirs = []
-    files = ['a', 'b', 'c']
-
-    # setup
-    helpers.populate_repo('flags', dirs, files)
-    os.chdir('flags')
-
-    # --quiet (requires --yes)
-    ret = subprocess.run(['onyo', 'rm', '--quiet', 'a'], capture_output=True, text=True)
+#
+# FLAGS
+#
+@pytest.mark.repo_files('laptop_apple_macbook.abc123')
+def test_rm_interactive_missing_y(repo):
+    """
+    Default mode is interactive. It requires a "y" to approve.
+    """
+    ret = subprocess.run(['onyo', 'rm', 'laptop_apple_macbook.abc123'], capture_output=True, text=True)
     assert ret.returncode == 1
-    assert Path('a').is_file()
+    assert "Delete assets? (y/N) " in ret.stdout
+    assert ret.stderr
+
+    assert Path('laptop_apple_macbook.abc123').exists()
+
+
+@pytest.mark.repo_files('laptop_apple_macbook.abc123')
+def test_rm_interactive_abort(repo):
+    """
+    Default mode is interactive. Provide the "n" to abort.
+    """
+    ret = subprocess.run(['onyo', 'rm', 'laptop_apple_macbook.abc123'], input='n', capture_output=True, text=True)
+    assert ret.returncode == 0
+    assert "Delete assets? (y/N) " in ret.stdout
+    assert not ret.stderr
+
+    assert Path('laptop_apple_macbook.abc123').exists()
+
+
+@pytest.mark.repo_files('laptop_apple_macbook.abc123')
+def test_rm_interactive(repo):
+    """
+    Default mode is interactive. Provide the "y" to approve.
+    """
+    ret = subprocess.run(['onyo', 'rm', 'laptop_apple_macbook.abc123'], input='y', capture_output=True, text=True)
+    assert ret.returncode == 0
+    assert "Delete assets? (y/N) " in ret.stdout
+    assert not ret.stderr
+
+    assert not Path('laptop_apple_macbook.abc123').exists()
+
+
+@pytest.mark.repo_files('laptop_apple_macbook.abc123')
+def test_rm_quiet_missing_yes(repo):
+    """
+    ``--quiet`` requires ``--yes``
+    """
+    ret = subprocess.run(['onyo', 'rm', '--quiet', 'laptop_apple_macbook.abc123'], capture_output=True, text=True)
+    assert ret.returncode == 1
     assert not ret.stdout
     assert ret.stderr
 
-    # --quiet with --yes success
-    ret = subprocess.run(['onyo', 'rm', '--quiet', '--yes', 'b'], capture_output=True, text=True)
+    assert Path('laptop_apple_macbook.abc123').exists()
+
+
+@pytest.mark.repo_files('laptop_apple_macbook.abc123')
+def test_rm_quiet(repo):
+    """
+    ``--quiet`` requires ``--yes``
+    """
+    ret = subprocess.run(['onyo', 'rm', '--yes', '--quiet', 'laptop_apple_macbook.abc123'], capture_output=True, text=True)
     assert ret.returncode == 0
     assert not ret.stdout
     assert not ret.stderr
-    assert not Path('b').is_file()
 
-    # --quiet with --yes failure
-    ret = subprocess.run(['onyo', 'rm', '--quiet', '--yes', 'does', 'not', 'exist'], capture_output=True, text=True)
-    assert ret.returncode == 1
-    assert not ret.stdout
-    assert ret.stderr
+    assert not Path('laptop_apple_macbook.abc123').exists()
 
-    # --yes success
-    ret = subprocess.run(['onyo', 'rm', '--yes', 'c'], capture_output=True, text=True)
+
+@pytest.mark.repo_files('laptop_apple_macbook.abc123')
+def test_rm_yes(repo):
+    """
+    --yes removes any prompts and auto-approves the deletion.
+    """
+    ret = subprocess.run(['onyo', 'rm', '--yes', 'laptop_apple_macbook.abc123'], capture_output=True, text=True)
     assert ret.returncode == 0
-    assert ret.stdout
+    assert "The following will be deleted:" in ret.stdout
+    assert "Remove assets? (y/N) " not in ret.stdout
     assert not ret.stderr
-    assert not Path('c').is_file()
 
-
-def test_rm_cwd(helpers):
-    dirs = ['simple']
-    files = ['a']
-
-    # setup
-    helpers.populate_repo('cwd', dirs, files)
-    os.chdir('cwd')
-
-    # file
-    ret = subprocess.run(['onyo', 'rm', '--yes', 'a'])
-    assert ret.returncode == 0
-    assert not Path('a').is_file()
-
-    # directory
-    ret = subprocess.run(['onyo', 'rm', '--yes', 'simple'])
-    assert ret.returncode == 0
-    assert not Path('simple').is_dir()
-
-
-def test_rm_cwd_multiple(helpers):
-    dirs = ['one', 'two', 'three']
-    files = ['a', 'b', 'c', 'one/d', 'two/e', 'three/f']
-
-    # setup
-    helpers.populate_repo('cwd_multiple', dirs, files)
-    os.chdir('cwd_multiple')
-
-    # files
-    ret = subprocess.run(['onyo', 'rm', '--yes', 'a', 'b', 'c'])
-    assert ret.returncode == 0
-    assert not Path('a').is_file()
-    assert not Path('b').is_file()
-    assert not Path('c').is_file()
-
-    # directories
-    ret = subprocess.run(['onyo', 'rm', '--yes', 'one', 'two', 'three'])
-    assert ret.returncode == 0
-    assert not Path('one').is_dir()
-    assert not Path('two').is_dir()
-    assert not Path('three').is_dir()
-
-
-def test_rm_nested(helpers):
-    dirs = ['one', 'two', 'three', 'r/e/c/u/r/s/i/v/e']
-    files = ['a', 'b', 'c', 'one/d', 'two/e', 'three/f']
-
-    # setup
-    helpers.populate_repo('nested', dirs, files)
-    os.chdir('nested')
-
-    # files
-    ret = subprocess.run(['onyo', 'rm', '--yes', 'one/d', 'two/e'])
-    assert ret.returncode == 0
-    assert not Path('one/d').is_file()
-    assert not Path('two/e').is_file()
-    assert Path('one').is_dir()
-    assert Path('two').is_dir()
-
-    # directories
-    ret = subprocess.run(['onyo', 'rm', '--yes', 'r/e/c/u/r'])
-    assert ret.returncode == 0
-    assert not Path('r/e/c/u/r').is_dir()
-    assert Path('r/e/c/u').is_dir()
-
-
-def test_rm_spaces(helpers):
-    dirs = ['s p a c e s', 's p a/c e s']
-    files = ['s p a c e s/g', 's p a c e s/h', 's p a c e s/i',
-             's p a/c e s/1 2', 's p a/c e s/3 4', 's p a/c e s/5 6']
-
-    # setup
-    helpers.populate_repo('spaces', dirs, files)
-    os.chdir('spaces')
-
-    # files
-    ret = subprocess.run(['onyo', 'rm', '--yes', 's p a/c e s/1 2', 's p a/c e s/3 4'])
-    assert ret.returncode == 0
-    assert not Path('s p a/c e s/1 2').is_file()
-    assert not Path('s p a/c e s/3 4').is_file()
-    assert Path('s p a/c e s/5 6').is_file()
-    assert Path('s p a/c e s/').is_dir()
-
-    # directories
-    ret = subprocess.run(['onyo', 'rm', '--yes', 's p a c e s', 's p a'])
-    assert ret.returncode == 0
-    assert not Path('s p a c e s').is_dir()
-    assert not Path('s p a').is_dir()
-
-
-def test_rm_same_target(helpers):
-    dirs = ['simple']
-    files = ['a']
-
-    # setup
-    helpers.populate_repo('same_target', dirs, files)
-    os.chdir('same_target')
-
-    # files
-    ret = subprocess.run(['onyo', 'rm', '--yes', 'a', 'a', 'a'])
-    assert ret.returncode == 0
-    assert not Path('a').is_file()
-
-    # directories
-    ret = subprocess.run(['onyo', 'rm', '--yes', 'simple', 'simple'])
-    assert ret.returncode == 0
-    assert not Path('simple').is_dir()
-
-
-def test_rm_overlap(helpers):
-    dirs = ['overlap/one', 'overlap/two', 'overlap/three']
-    files = []
-
-    # setup
-    helpers.populate_repo('overlap', dirs, files)
-    os.chdir('overlap')
-
-    ret = subprocess.run(['onyo', 'rm', '--yes', 'overlap/one', 'overlap', 'overlap/two'])
-    assert ret.returncode == 0
-    assert not Path('overlap').is_dir()
-
-
-def test_rm_protected(helpers):
-    dirs = ['simple']
-    files = []
-
-    # setup
-    helpers.populate_repo('protected', dirs, files)
-    os.chdir('protected')
-
-    ret = subprocess.run(['onyo', 'rm', '--yes', '.onyo'])
-    assert ret.returncode == 1
-    assert Path('.onyo').is_dir()
-
-    ret = subprocess.run(['onyo', 'rm', '--yes', '.git'])
-    assert ret.returncode == 1
-    assert Path('.git').is_dir()
-
-    ret = subprocess.run(['onyo', 'rm', '--yes', 'simple/.anchor'])
-    assert ret.returncode == 1
-    assert Path('simple/.anchor').is_file()
+    assert not Path('laptop_apple_macbook.abc123').exists()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,7 @@
 import os
-import shutil
 from collections.abc import Iterable
 from itertools import chain, combinations
 from pathlib import Path
-from tempfile import gettempdir
 
 from onyo import Repo
 import pytest
@@ -62,29 +60,6 @@ def repo(tmp_path, monkeypatch, request):
 
 
 @pytest.fixture(scope="function", autouse=True)
-def change_cwd_to_sandbox(request, monkeypatch):
-    """
-    Change the working directory to a "sandbox" that allows tests to run in
-    isolation, and not conflict with other tests.
-
-    This is located under /tmp in order to run isolated from the source git
-    repository (as the parent dirs are searched for a valid git repo).
-
-    The directory is named "/tmp/onyo-sandbox/<test-file-name>/".
-    For example: "/tmp/onyo-sandbox/test_mkdir.py/"
-
-    If the directory does not exist, it will be created.
-    """
-    tmp = gettempdir()
-    sandbox_test_dir = Path(tmp, 'onyo-sandbox', request.path.name)
-
-    # create the dir
-    sandbox_test_dir.mkdir(parents=True, exist_ok=True)
-    # cd
-    monkeypatch.chdir(sandbox_test_dir)
-
-
-@pytest.fixture(scope="function", autouse=True)
 def clean_env(request):
     """
     Ensure that $EDITOR is not inherited from the environment or other tests.
@@ -92,20 +67,6 @@ def clean_env(request):
     try:
         del os.environ['EDITOR']
     except KeyError:
-        pass
-
-
-@pytest.fixture(scope="session", autouse=True)
-def clean_sandboxes(request):
-    """
-    Ensure that 'tests/sandbox' is clean, and doesn't have remnants from
-    previous runs.
-    """
-    tmp = gettempdir()
-    sandbox_test_dir = Path(tmp, 'onyo-sandbox')
-    try:
-        shutil.rmtree(sandbox_test_dir)
-    except FileNotFoundError:
         pass
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,25 +134,3 @@ class Helpers:
         "powerset([1,2,3]) --> () (1,) (2,) (3,) (1,2) (1,3) (2,3) (1,2,3)"
         s = list(iterable)
         return chain.from_iterable(combinations(s, r) for r in range(len(s) + 1))
-
-    @staticmethod
-    def populate_repo(path: str, dirs: list = [], files: list = []) -> None:
-        """
-        Create and initialize a folder, and build a directory and file
-        structure.
-        """
-        # init repo
-        repo = Repo(path, init=True)
-
-        # dirs
-        if dirs:
-            repo.mkdir(dirs)
-            repo.commit('populate dirs for tests', dirs)
-
-        # files
-        if files:
-            for i in files:
-                Path(path, i).touch()
-
-            repo.add(files)
-            repo.commit('populate files for tests', files)


### PR DESCRIPTION
This PR modernizes the last portions of the test suite to allow dropping `populate_repo`, `clean_sandboxes()` and `change_cwd_to_sandbox()`.

It also removes redundant test functions from the `test/commands` dir that are already covered by the tests in `test/lib`.

This PR closes #251, #252, #253