### PR TITLE
CLI: use new syntax from #286 for set/unset

### DIFF
--- a/demo/generate_demo_repo.sh
+++ b/demo/generate_demo_repo.sh
@@ -128,11 +128,11 @@ onyo mv -y warehouse/laptop_microsoft_surface.oq782j "ethics/Achilles Book"
 
 # specify number of USB type A ports on all laptops
 # TODO: use --filter
-onyo set -y USB_A=2 */laptop_*.* */*/laptop_*.*
+onyo set -y --keys USB_A=2 --path */laptop_*.* */*/laptop_*.*
 
 # specify the number of USB ports (type A and C) on MacBooks
 # TODO: use --filter
-onyo set -y USB_A=2 USB_C=1 */laptop_apple_macbook.* */*/laptop_apple_macbook.*
+onyo set -y --keys USB_A=2 USB_C=1 --path */laptop_apple_macbook.* */*/laptop_apple_macbook.*
 
 # add three newly purchased laptops; shell brace-expansion can be very useful
 onyo new -y RAM=8GB display=13.3 USB_A=2 USB_C=1 \
@@ -146,7 +146,7 @@ onyo new -y warehouse/headphones_apple_airpods.uzl8e1
 onyo mv -y warehouse/monitor_dell_PH123.86JZho warehouse/laptop_apple_macbook.oiw629 warehouse/headphones_apple_airpods.uzl8e1 "accounting/Bingo Bob"
 
 # the broken laptop has been repaired (bad RAM, which has also been increased)
-onyo set -y RAM=32GB repair/laptop_lenovo_thinkpad.owh8e2
+onyo set -y --keys RAM=32GB --path repair/laptop_lenovo_thinkpad.owh8e2
 onyo mv -y repair/laptop_lenovo_thinkpad.owh8e2 warehouse
 
 # Max's laptop is old; retire it and replace with a new one

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -1210,12 +1210,11 @@ class Repo:
     #
     # UNSET
     #
-    def unset(self, paths: Iterable[Union[Path, str]], values: str,
+    def unset(self, paths: Iterable[Union[Path, str]], keys: list[str],
               dryrun: bool, quiet: bool, depth: Union[int]) -> str:
 
         # set and unset should select assets exactly the same way
         assets_to_unset = self._set_sanitize(paths, depth)
-        keys = values.split(',')
 
         if any([key in ["type", "make", "model", "serial"] for key in keys]):
             log.error("Can't unset pseudo keys (name fields are required).")

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -173,7 +173,7 @@ def setup_parser():
     )
     subcmds.metavar = '<command>'
     #
-    # subcommand cat
+    # subcommand "cat"
     #
     cmd_cat = subcmds.add_parser(
         'cat',
@@ -462,7 +462,7 @@ def setup_parser():
         help='key-value pairs to set in assets; multiple pairs can be separated by commas (e.g. key=value,key2=value2)'
     )
     #
-    # subcommand shell-completion
+    # subcommand "shell-completion"
     #
     cmd_shell_completion = subcmds.add_parser(
         'shell-completion',

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -567,18 +567,20 @@ def setup_parser():
         help='respond "yes" to any prompts'
     )
     cmd_unset.add_argument(
-        'keys',
+        '-k', '--keys',
+        required=True,
         metavar="KEYS",
+        nargs='+',
         type=str,
-        help='keys to unset in assets; multiple values can be separated by commas (e.g. key,key2,key3)'
+        help='keys to unset in assets; multiple keys can be given (e.g. key key2 key3)'
     )
     cmd_unset.add_argument(
-        'path',
-        metavar='PATH',
-        default='.',
+        '-p', '--path',
+        default=".",
+        metavar="PATH",
         nargs='*',
         type=path,
-        help='assets or directories for which to set values'
+        help='assets or directories for which to unset values'
     )
     return parser
 

--- a/tests/commands/test_set.py
+++ b/tests/commands/test_set.py
@@ -28,7 +28,7 @@ def test_set(repo: Repo, asset: str, set_values: list[str]) -> None:
     """
     Test that `onyo set KEY=VALUE <asset>` updates contents of assets.
     """
-    ret = subprocess.run(['onyo', 'set', '--yes'] + set_values + [asset], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', *set_values, '--path', asset], capture_output=True, text=True)
 
     # verify output
     assert "The following assets will be changed:" in ret.stdout
@@ -49,7 +49,7 @@ def test_set_interactive(repo: Repo, asset: str, set_values: list[str]) -> None:
     """
     Test that `onyo set KEY=VALUE <asset>` updates contents of assets.
     """
-    ret = subprocess.run(['onyo', 'set'] + set_values + [asset], input='y', capture_output=True, text=True)
+    ret = subprocess.run(['onyo', 'set', '--keys', *set_values, '--path', asset], input='y', capture_output=True, text=True)
 
     # verify output
     assert "The following assets will be changed:" in ret.stdout
@@ -71,7 +71,7 @@ def test_set_multiple_assets(repo: Repo, set_values: list[str]) -> None:
     Test that `onyo set KEY=VALUE <asset>` can update the contents of multiple
     assets in a single call.
     """
-    ret = subprocess.run(['onyo', 'set', '--yes'] + set_values + assets, capture_output=True, text=True)
+    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', *set_values, '--path', *assets], capture_output=True, text=True)
 
     # verify output
     assert "The following assets will be changed:" in ret.stdout
@@ -98,7 +98,7 @@ def test_set_error_non_existing_assets(repo: Repo, no_assets: list[str]) -> None
     - non-existing assets in directories
     - one non-existing asset in a list of existing ones
     """
-    ret = subprocess.run(['onyo', 'set', 'key=value'] + no_assets, capture_output=True, text=True)
+    ret = subprocess.run(['onyo', 'set', '--keys', 'key=value', '--path', *no_assets], capture_output=True, text=True)
 
     # verify output and the state of the repository
     assert not ret.stdout
@@ -114,7 +114,7 @@ def test_set_with_dot_recursive(repo: Repo, set_values: list[str]) -> None:
     Test that when `onyo set KEY=VALUE .` is called from the repository root,
     onyo selects all assets in the complete repo recursively.
     """
-    ret = subprocess.run(['onyo', 'set', '--yes'] + set_values + ["."], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', *set_values, '--path', "."], capture_output=True, text=True)
 
     # verify that output mentions every asset
     assert "The following assets will be changed:" in ret.stdout
@@ -136,7 +136,7 @@ def test_set_without_path(repo: Repo, set_values: list[str]) -> None:
     Test that `onyo set KEY=VALUE` without a given path selects all assets in
     the repository, beginning with cwd.
     """
-    ret = subprocess.run(['onyo', 'set', '--yes'] + set_values, capture_output=True, text=True)
+    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', *set_values], capture_output=True, text=True)
 
     # verify that output contains one line per asset
     assert "The following assets will be changed:" in ret.stdout
@@ -160,7 +160,7 @@ def test_set_recursive_directories(repo: Repo, directory: str, set_values: list[
     Test that `onyo set KEY=VALUE <directory>` updates contents of assets
     correctly.
     """
-    ret = subprocess.run(['onyo', 'set', '--yes'] + set_values + [directory], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', *set_values, '--path', directory], capture_output=True, text=True)
 
     # verify output
     assert "The following assets will be changed:" in ret.stdout
@@ -183,7 +183,7 @@ def test_set_discard_changes_single_assets(repo: Repo, asset: str, set_values: l
     """
     Test that `onyo set` discards changes for assets successfully.
     """
-    ret = subprocess.run(['onyo', 'set'] + set_values + [asset], input='n', capture_output=True, text=True)
+    ret = subprocess.run(['onyo', 'set', '--keys', *set_values, '--path', asset], input='n', capture_output=True, text=True)
 
     # verify output for just dot, should be all in onyo root, but not recursive
     assert "The following assets will be changed:" in ret.stdout
@@ -205,7 +205,7 @@ def test_set_discard_changes_recursive(repo: Repo) -> None:
     Test that `onyo set` discards changes for all assets successfully.
     """
     set_values = "key=discard"
-    ret = subprocess.run(['onyo', 'set', set_values], input='n', capture_output=True, text=True)
+    ret = subprocess.run(['onyo', 'set', '--keys', set_values], input='n', capture_output=True, text=True)
 
     # verify output for just dot, should be all in onyo root, but not recursive
     assert "The following assets will be changed:" in ret.stdout
@@ -229,7 +229,7 @@ def test_set_yes_flag(repo: Repo, asset: str, set_values: list[str]) -> None:
     """
     Test that `onyo set --yes KEY=VALUE <asset>` updates assets without prompt.
     """
-    ret = subprocess.run(['onyo', 'set', '--yes'] + set_values + [asset], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', *set_values, '--path', asset], capture_output=True, text=True)
 
     # verify output
     assert "The following assets will be changed:" in ret.stdout
@@ -254,7 +254,7 @@ def test_set_quiet_without_yes_flag(repo: Repo) -> None:
     Test that `onyo set --quiet KEY=VALUE <asset>` errors correctly without the
     --yes flag.
     """
-    ret = subprocess.run(['onyo', 'set', '--quiet', "mode=single", asset], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', 'set', '--quiet', '--keys', "mode=single", '--path', asset], capture_output=True, text=True)
 
     # verify output
     assert not ret.stdout
@@ -273,7 +273,7 @@ def test_set_quiet_flag(repo: Repo, asset: str, set_values: list[str]) -> None:
     Test that `onyo set --quiet --yes KEY=VALUE <asset>` works correctly without
     output and user-response.
     """
-    ret = subprocess.run(['onyo', 'set', '--yes', '--quiet'] + set_values + [asset], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', 'set', '--yes', '--quiet', '--keys', *set_values, '--path', asset], capture_output=True, text=True)
 
     # verify that output is completely empty
     assert not ret.stdout
@@ -295,7 +295,8 @@ def test_set_dryrun_flag(repo: Repo, set_values: list[str]) -> None:
     Test that `onyo set --dry-run KEY=VALUE <asset>` displays correct
     diff-output without actually changing any assets.
     """
-    ret = subprocess.run(['onyo', 'set', '--dry-run'] + set_values + assets, capture_output=True, text=True)
+    ret = subprocess.run(['onyo', 'set', '--dry-run', '--keys', *set_values,
+                          '--path', *assets], capture_output=True, text=True)
 
     # verify output
     assert "The following assets will be changed:" in ret.stdout
@@ -335,14 +336,14 @@ def test_set_depth_flag(repo: Repo, set_values: list[str]) -> None:
     - changing all assets if --depth is deeper then deepest sub-directory
       without error (e.g. deepest folder is 6, but --depth 8 is called)
     """
-    ret = subprocess.run(['onyo', 'set', '--depth', '-1'] + set_values, capture_output=True, text=True)
+    ret = subprocess.run(['onyo', 'set', '--depth', '-1', '--keys', *set_values], capture_output=True, text=True)
     # verify output for invalid --depth
     assert not ret.stdout
     assert "depth values must be positive, but is -1" in ret.stderr
     assert ret.returncode == 1
     repo.fsck()
 
-    ret = subprocess.run(['onyo', 'set', '--depth', '0'] + set_values, input='n', capture_output=True, text=True)
+    ret = subprocess.run(['onyo', 'set', '--depth', '0', '--keys', *set_values], input='n', capture_output=True, text=True)
     # verify output for --depth 0
     assert "laptop_macbook_pro.0" in ret.stdout
     assert "dir1/laptop_macbook_pro.1" not in ret.stdout
@@ -350,7 +351,7 @@ def test_set_depth_flag(repo: Repo, set_values: list[str]) -> None:
     assert ret.returncode == 0
     repo.fsck()
 
-    ret = subprocess.run(['onyo', 'set', '--depth', '1'] + set_values, input='n', capture_output=True, text=True)
+    ret = subprocess.run(['onyo', 'set', '--depth', '1', '--keys', *set_values], input='n', capture_output=True, text=True)
     # verify output for --depth 1
     assert "laptop_macbook_pro.0" in ret.stdout
     assert "dir1/laptop_macbook_pro.1" in ret.stdout
@@ -359,7 +360,7 @@ def test_set_depth_flag(repo: Repo, set_values: list[str]) -> None:
     assert ret.returncode == 0
     repo.fsck()
 
-    ret = subprocess.run(['onyo', 'set', '--depth', '3'] + set_values, input='n', capture_output=True, text=True)
+    ret = subprocess.run(['onyo', 'set', '--depth', '3', '--keys', *set_values], input='n', capture_output=True, text=True)
     # verify output for --depth 3
     assert "laptop_macbook_pro.0" in ret.stdout
     assert "dir1/laptop_macbook_pro.1" in ret.stdout
@@ -369,7 +370,7 @@ def test_set_depth_flag(repo: Repo, set_values: list[str]) -> None:
     assert ret.returncode == 0
     repo.fsck()
 
-    ret = subprocess.run(['onyo', 'set', '--depth', '6'] + set_values, input='n', capture_output=True, text=True)
+    ret = subprocess.run(['onyo', 'set', '--depth', '6', '--keys', *set_values], input='n', capture_output=True, text=True)
     # verify output for --depth 6 (maximum depth) contains all files
     assert "laptop_macbook_pro.0" in ret.stdout
     assert "dir1/laptop_macbook_pro.1" in ret.stdout
@@ -381,7 +382,7 @@ def test_set_depth_flag(repo: Repo, set_values: list[str]) -> None:
     assert ret.returncode == 0
     repo.fsck()
 
-    ret = subprocess.run(['onyo', 'set', '--depth', '10'] + set_values, input='n', capture_output=True, text=True)
+    ret = subprocess.run(['onyo', 'set', '--depth', '10', '--keys', *set_values], input='n', capture_output=True, text=True)
     # verify output for --depth bigger then folder depth without error
     assert "laptop_macbook_pro.0" in ret.stdout
     assert "dir1/laptop_macbook_pro.1" in ret.stdout
@@ -402,7 +403,7 @@ def test_add_new_key_to_existing_content(repo: Repo, asset: str) -> None:
     different `KEY`, and adds it without overwriting existing values.
     """
     set_1 = "change=one"
-    ret = subprocess.run(['onyo', 'set', '--yes', set_1, asset], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', set_1, '--path', asset], capture_output=True, text=True)
 
     # verify output
     assert "The following assets will be changed:" in ret.stdout
@@ -414,7 +415,7 @@ def test_add_new_key_to_existing_content(repo: Repo, asset: str) -> None:
 
     # call again and add a different KEY, without overwriting existing contents
     set_2 = "different=key"
-    ret = subprocess.run(['onyo', 'set', '--yes', set_2, asset], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', set_2, '--path', asset], capture_output=True, text=True)
 
     # verify output
     assert "The following assets will be changed:" in ret.stdout
@@ -442,7 +443,7 @@ def test_set_overwrite_key(repo: Repo, asset: str) -> None:
     different VALUE for the same KEY, and overwrites existing values correctly.
     """
     set_value = "value=original"
-    ret = subprocess.run(['onyo', 'set', '--yes', set_value, asset], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', set_value, '--path', asset], capture_output=True, text=True)
 
     # verify output
     assert "The following assets will be changed:" in ret.stdout
@@ -454,7 +455,7 @@ def test_set_overwrite_key(repo: Repo, asset: str) -> None:
 
     # call again with same key, but different value
     set_value_2 = "value=updated"
-    ret = subprocess.run(['onyo', 'set', '--yes', set_value_2, asset], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', set_value_2, '--path', asset], capture_output=True, text=True)
 
     # verify output
     assert "The following assets will be changed:" in ret.stdout
@@ -479,7 +480,7 @@ def test_setting_new_values_if_some_values_already_set(repo: Repo, asset: str) -
     the correct output if called multiple times, and that the output is correct.
     """
     set_values = "change=one"
-    ret = subprocess.run(['onyo', 'set', '--yes', set_values, asset], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', set_values, '--path', asset], capture_output=True, text=True)
 
     # verify output
     assert "The following assets will be changed:" in ret.stdout
@@ -491,7 +492,7 @@ def test_setting_new_values_if_some_values_already_set(repo: Repo, asset: str) -
     # call with two values, one of which is already set and should not appear
     # again in the output.
     set_values = ["change=one", "different=key"]
-    ret = subprocess.run(['onyo', 'set', '--yes'] + set_values + [asset], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', *set_values, '--path', asset], capture_output=True, text=True)
 
     # verify output
     assert "The following assets will be changed:" in ret.stdout
@@ -520,7 +521,7 @@ def test_values_already_set(repo: Repo, asset: str, set_values: list[str]) -> No
     if called again with same valid values the command does display the correct
     info message without error, and the repository stays in a clean state.
     """
-    ret = subprocess.run(['onyo', 'set', '--yes'] + set_values + [asset], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', *set_values, '--path', asset], capture_output=True, text=True)
 
     # verify output
     assert "The following assets will be changed:" in ret.stdout
@@ -531,7 +532,7 @@ def test_values_already_set(repo: Repo, asset: str, set_values: list[str]) -> No
     assert ret.returncode == 0
 
     # call `onyo set` again with the same values
-    ret = subprocess.run(['onyo', 'set', '--yes'] + set_values + [asset], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', *set_values, '--path', asset], capture_output=True, text=True)
 
     # verify second output
     assert "The values are already set. No assets updated." in ret.stdout
@@ -559,7 +560,8 @@ def test_set_update_name_fields(repo: Repo, asset: str, set_values: list[str]) -
     faux serials can be set and name fields are recognized and can be updated
     when they are `onyo set` together with a list of content fields.
     """
-    ret = subprocess.run(['onyo', 'set', '--yes', '--rename'] + set_values + [asset], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', 'set', '--yes', '--rename', '--keys', *set_values,
+                          '--path', asset], capture_output=True, text=True)
 
     # verify output
     assert "The following assets will be changed:" in ret.stdout
@@ -583,7 +585,8 @@ def test_update_many_faux_serial_numbers(repo: Repo) -> None:
     """
     # remember old assets before renaming
     old_asset_names = repo.assets
-    ret = subprocess.run(['onyo', 'set', '--yes', '--rename', 'serial=faux'] + list(assets), capture_output=True, text=True)
+    ret = subprocess.run(['onyo', 'set', '--yes', '--rename', '--keys',
+                          'serial=faux', '--path', *assets], capture_output=True, text=True)
 
     # verify output
     assert "The following assets will be changed:" in ret.stdout

--- a/tests/demo/reference_git_log.txt
+++ b/tests/demo/reference_git_log.txt
@@ -1,28 +1,28 @@
-commit 59fe24a906abadc8a3b64a3acfc5aba9fbf14325
+commit 17db8fbee2ed19f56489872c88d0948d9048fad7
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
     rm: 'management/Max Mustermann'
 
-commit 09de0124150fbcc7d028776ff5a7e3b940620993
+commit 7ee4a9df9e9ea6f642db2a426635bddf1b0b9c66
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
     mv: 'management/Max Mustermann/headphones_apple_airpods.7h8f04','management/Max Mustermann/laptop_apple_macbook.uef82b3' -> warehouse
 
-commit 831eed2b5e58faa663880fbd40551c013d8ac4e7
+commit 0177b277690b9af1c3d735961556b4935c268c39
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
     mv: 'warehouse/laptop_lenovo_thinkpad.owh8e2' -> ethics/Theo Turtle
 
-commit d6c40e0da880edb1312578177d489e47edca7496
+commit e52813efd6a23c01a991dddf4fa554399f759435
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
     mkdir: 'ethics/Theo Turtle'
 
-commit c4974b20047a3eada3680a7652bb59d31f6aefa3
+commit 422aa403bd2cfb6976e06d6e8155948d6a381959
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -30,43 +30,43 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     
     management/Alice Wonder/laptop_apple_macbook.83hd0
 
-commit 6f4aee6304ce452ed8056280cebbdd69f689fce5
+commit 6c2cb42b954ade164574072eda54f487bafd6d46
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
     mkdir: 'management/Alice Wonder'
 
-commit 974f275fec14a5d9a57244d3da3777d938340183
+commit a1872e05f45468f8ca0f5a72fde5159de90184e6
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
     mv: 'ethics/Max Mustermann' -> management
 
-commit b0c022aefa9416514b2bf63843555d1eaff811c1
+commit e6ee18036caaf79912d844efd817689ce8ce7acb
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
     mkdir: 'management'
 
-commit 212f83eeba2f17d8334350076c434122fe33b0e1
+commit 4270a74e482137da979401bd4f7eee2cf4b9cbe3
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
     mv: 'warehouse/laptop_apple_macbook.uef82b3' -> ethics/Max Mustermann
 
-commit 43774ccdd6134fdb2705f484b8b1aca2a1f448ad
+commit f8216b61d4a8a790a1bc59a5b93a6db9a828838d
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
     mv: 'ethics/Max Mustermann/laptop_apple_macbook.9r32he' -> recycling
 
-commit 9dc33836fdf99d984755718d99b20ff8f049f26a
+commit b237953eb07678f3ebdcc99975c058eff966486b
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
     mv: 'repair/laptop_lenovo_thinkpad.owh8e2' -> warehouse
 
-commit 17e82eeee783476f45434b106ced046f79f389a0
+commit 4e27505f9deb42ce14e6e0ca00b1dc04a78b0ed8
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -74,13 +74,13 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     
     repair/laptop_lenovo_thinkpad.owh8e2
 
-commit 4fc3e2855d4497e038365eda73172424c8c18827
+commit 4f24e1e0911cb90a809c093a88b0e5b764682946
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
     mv: 'warehouse/monitor_dell_PH123.86JZho','warehouse/laptop_apple_macbook.oiw629','warehouse/headphones_apple_airpods.uzl8e1' -> accounting/Bingo Bob
 
-commit 459fc04f425e937cfa4a03f575965ab7def39b88
+commit 7a7bca0def75f65b096bc1e53416f8ce4b0ef5b8
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -88,7 +88,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     
     warehouse/headphones_apple_airpods.uzl8e1
 
-commit 20a33df3756a9a48a5ea4b852f4ea4cd074843fa
+commit 12fbfcef4cfad6de252b2b15ae3e18be75cbfe84
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -96,7 +96,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     
     warehouse/laptop_apple_macbook.oiw629
 
-commit 5271d6c561e7c55ba533ac1daf77eeccb8c7988c
+commit 1c7ac8df18b2ad9fae7a95285d6329c13e100690
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -104,13 +104,13 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     
     warehouse/monitor_dell_PH123.86JZho
 
-commit 31cf383f569fa9c09b1f982948bf9e0ed8efd2ea
+commit e2c0b30692b0e44c42120344eb94fa472a1fcdc5
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
     mkdir: 'accounting/Bingo Bob'
 
-commit 3ac909efba16ec6f87595302c6319f6cf3d664d6
+commit 5d1ebd1c2db951a402dab94db2d7952bfd91c0ad
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -120,7 +120,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     warehouse/laptop_apple_macbook.9il2b4
     warehouse/laptop_apple_macbook.uef82b3
 
-commit 950b7329e2762cd76110cc493d72a5904aac8dea
+commit 9796347d25bf31668fad536fb238a83665bfdf67
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -129,7 +129,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     ethics/Max Mustermann/laptop_apple_macbook.9r32he
     warehouse/laptop_apple_macbook.9r5qlk
 
-commit d297115b79fa41f073a0945460a5ea4bb1edb513
+commit 9f259958c06955af947b3be27e80419d2d908ca1
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 


### PR DESCRIPTION
This probably still breaks, since the demo needs to be updated.

The main changes introduced in this PR:
- new syntax for set/unset in `main.py` like discussed in #286 
  - this is not closed, since it still needs to happen with the implementation of `onyo get`
- updates tests for set/unset with new syntax
- updates `repo.py` for the new parsing (no splitting at comma anymore)

Close #116 