### PR TITLE
BF: shell-completion fixes

### DIFF
--- a/onyo/commands/shell_completion.py
+++ b/onyo/commands/shell_completion.py
@@ -340,11 +340,14 @@ compdef _onyo onyo
         # build exclude
         #
         # e.g.: '(- : *)'{{-h,--help}}'[display usage information]'
-        # TODO
+        # TODO: this section is naive. Real support should be added.
 
-        # always exclude for -h/--help
         if flag == '-h,--help':
+            # always exclude for -h/--help
             chunks['exclude'] = "(- : *)"
+        else:
+            # always exclude self; aka: don't allow repeats
+            chunks['exclude'] = "(" + flag.replace(',', ' ') + ")"
 
         #
         # build flag


### PR DESCRIPTION
This PR includes two fixes:

1) remove both forms of a flag from the suggestion list after its been used (previously, only the form used was removed)
2) prevents shell-completion from exploding with non-int nargs to flags

The fix for 2 is imperfect, but it gets the tests passing again for #282 and #290 

I have added a lengthy comment to the fix for 2. The proper solution is unclear to me, and may require posting to the ZSH mailing list.

Until then, users for query-style commands should do one of the following:
* use `--paths` before `--keys` (which has no idea of completion
* or use another flag (such as `--yes`) after `--paths`, which will then return to normal behavior