### PR TITLE
Normalize "user response" for all commands ; add flags `--yes` and `--quiet` to `onyo mkdir`

### DIFF
--- a/demo/generate_demo_repo.sh
+++ b/demo/generate_demo_repo.sh
@@ -87,9 +87,9 @@ cd "$DEMO_DIR"
 onyo init
 
 # setup basic directory structure
-onyo mkdir warehouse
-onyo mkdir recycling
-onyo mkdir repair
+onyo mkdir --yes warehouse
+onyo mkdir --yes recycling
+onyo mkdir --yes repair
 
 # import some existing hardware
 # TSV files can be very useful when adding large amounts of assets
@@ -113,7 +113,7 @@ onyo new -y --path warehouse/headphones_JBL_pro.ph9527
 onyo rm -y warehouse/headphones_JBL_pro.ph9527
 
 # a few new users join
-onyo mkdir "ethics/Max Mustermann" "ethics/Achilles Book"
+onyo mkdir --yes "ethics/Max Mustermann" "ethics/Achilles Book"
 
 # assign equipment to Max and Achilles
 onyo mv -y warehouse/laptop_apple_macbook.9r32he "ethics/Max Mustermann"
@@ -139,7 +139,7 @@ onyo new -y --keys RAM=8GB display=13.3 USB_A=2 USB_C=1 \
     --path warehouse/laptop_apple_macbook.{uef82b3,9il2b4,73b2cn}
 
 # Bingo Bob was hired; and new hardware was purchased for him
-onyo mkdir "accounting/Bingo Bob"
+onyo mkdir --yes "accounting/Bingo Bob"
 onyo new -y --keys display=22.0 --path warehouse/monitor_dell_PH123.86JZho
 onyo new -y --keys RAM=8GB display=13.3 USB_A=2 --path warehouse/laptop_apple_macbook.oiw629
 onyo new -y --path warehouse/headphones_apple_airpods.uzl8e1
@@ -154,13 +154,13 @@ onyo mv -y ethics/Max\ Mustermann/laptop_apple_macbook.9r32he recycling
 onyo mv -y warehouse/laptop_apple_macbook.uef82b3 ethics/Max\ Mustermann/
 
 # a new group is created ("management"); transfer people to their new group
-onyo mkdir "management"
+onyo mkdir --yes "management"
 onyo mv -y "ethics/Max Mustermann" management
-onyo mkdir "management/Alice Wonder"
+onyo mkdir --yes "management/Alice Wonder"
 onyo new -y --keys RAM=8GB display=13.3 USB_A=2 --path "management/Alice Wonder/laptop_apple_macbook.83hd0"
 
 # Theo joins; assign them a laptop from the warehouse
-onyo mkdir "ethics/Theo Turtle"
+onyo mkdir --yes "ethics/Theo Turtle"
 onyo mv -y warehouse/laptop_lenovo_thinkpad.owh8e2 "ethics/Theo Turtle"
 
 # Max retired; return all of his hardware and delete his directory

--- a/onyo/commands/mkdir.py
+++ b/onyo/commands/mkdir.py
@@ -1,6 +1,7 @@
 import sys
 
 from onyo import Repo, OnyoInvalidRepoError, OnyoProtectedPathError
+from onyo.commands.edit import request_user_response
 
 
 def mkdir(args, opdir):
@@ -22,7 +23,18 @@ def mkdir(args, opdir):
 
     try:
         repo.mkdir(args.directory)
-        repo.commit(repo.generate_commit_message(message=args.message,
-                                                 cmd="mkdir"))
     except (FileExistsError, OnyoProtectedPathError):
         sys.exit(1)
+
+    # commit changes
+    staged = sorted(repo.files_staged)
+    if not args.quiet:
+        print("The following directories will be created:")
+        print(repo._n_join(staged))
+    if args.yes or request_user_response("Save changes? No discards all changes. (y/n) "):
+        repo.commit(repo.generate_commit_message(message=args.message,
+                                                 cmd="mkdir"))
+    else:
+        repo.restore()
+        if not args.quiet:
+            print('No assets updated.')

--- a/onyo/commands/mv.py
+++ b/onyo/commands/mv.py
@@ -1,6 +1,7 @@
 import sys
 
 from onyo import Repo, OnyoInvalidRepoError, OnyoProtectedPathError
+from onyo.commands.edit import request_user_response
 
 
 def mv(args, opdir: str) -> None:
@@ -33,11 +34,9 @@ def mv(args, opdir: str) -> None:
         print('The following will be moved:\n' +
               '\n'.join(f"'{x[0]}' -> '{x[1]}'" for x in dryrun_list))
 
-        if not args.yes:
-            response = input('Move assets? (y/N) ')
-            if response not in ['y', 'Y', 'yes']:
-                print('Nothing was moved.')
-                sys.exit(0)
+        if not args.yes and not request_user_response("Save changes? No discards all changes. (y/n) "):
+            print('Nothing was moved.')
+            sys.exit(0)
 
     try:
         repo.mv(args.source, args.destination)

--- a/onyo/commands/rm.py
+++ b/onyo/commands/rm.py
@@ -1,6 +1,7 @@
 import sys
 
 from onyo import Repo, OnyoInvalidRepoError, OnyoProtectedPathError
+from onyo.commands.edit import request_user_response
 
 
 def rm(args, opdir: str) -> None:
@@ -33,11 +34,9 @@ def rm(args, opdir: str) -> None:
         print('The following will be deleted:\n' +
               '\n'.join(dryrun_list))
 
-        if not args.yes:
-            response = input('Delete assets? (y/N) ')
-            if response not in ['y', 'Y', 'yes']:
-                print('Nothing was deleted.')
-                sys.exit(0)
+        if not args.yes and not request_user_response("Save changes? No discards all changes. (y/n) "):
+            print('Nothing was deleted.')
+            sys.exit(0)
 
     try:
         repo.rm(args.path)

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -202,7 +202,7 @@ def setup_parser():
         nargs=1,
         action='append',
         type=str,
-        help='Use the given <msg> as the commit message (rather than the default). If multiple -m options are given, their values are concatenated as separate paragraphs'
+        help='Use the given MESSAGE as the commit message (rather than the default). If multiple -m options are given, their values are concatenated as separate paragraphs'
     )
     cmd_edit.add_argument(
         '-q', '--quiet',
@@ -293,7 +293,7 @@ def setup_parser():
         nargs=1,
         action='append',
         type=str,
-        help='Use the given <msg> as the commit message (rather than the default). If multiple -m options are given, their values are concatenated as separate paragraphs'
+        help='Use the given MESSAGE as the commit message (rather than the default). If multiple -m options are given, their values are concatenated as separate paragraphs'
     )
     cmd_mkdir.add_argument(
         '-q', '--quiet',
@@ -332,7 +332,7 @@ def setup_parser():
         nargs=1,
         action='append',
         type=str,
-        help='Use the given <msg> as the commit message (rather than the default). If multiple -m options are given, their values are concatenated as separate paragraphs'
+        help='Use the given MESSAGE as the commit message (rather than the default). If multiple -m options are given, their values are concatenated as separate paragraphs'
     )
     cmd_mv.add_argument(
         '-q', '--quiet',
@@ -377,7 +377,7 @@ def setup_parser():
         nargs=1,
         action='append',
         type=str,
-        help='Use the given <msg> as the commit message (rather than the default). If multiple -m options are given, their values are concatenated as separate paragraphs'
+        help='Use the given MESSAGE as the commit message (rather than the default). If multiple -m options are given, their values are concatenated as separate paragraphs'
     )
     cmd_new.add_argument(
         '-t', '--template',
@@ -440,7 +440,7 @@ def setup_parser():
         nargs=1,
         action='append',
         type=str,
-        help='Use the given <msg> as the commit message (rather than the default). If multiple -m options are given, their values are concatenated as separate paragraphs'
+        help='Use the given MESSAGE as the commit message (rather than the default). If multiple -m options are given, their values are concatenated as separate paragraphs'
     )
     cmd_rm.add_argument(
         '-q', '--quiet',
@@ -487,7 +487,7 @@ def setup_parser():
         nargs=1,
         action='append',
         type=str,
-        help='Use the given <msg> as the commit message (rather than the default). If multiple -m options are given, their values are concatenated as separate paragraphs'
+        help='Use the given MESSAGE as the commit message (rather than the default). If multiple -m options are given, their values are concatenated as separate paragraphs'
     )
     cmd_set.add_argument(
         '-n', "--dry-run",
@@ -593,7 +593,7 @@ def setup_parser():
         nargs=1,
         action='append',
         type=str,
-        help='Use the given <msg> as the commit message (rather than the default). If multiple -m options are given, their values are concatenated as separate paragraphs'
+        help='Use the given MESSAGE as the commit message (rather than the default). If multiple -m options are given, their values are concatenated as separate paragraphs'
     )
     cmd_unset.add_argument(
         '-n', "--dry-run",

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -296,6 +296,20 @@ def setup_parser():
         help='Use the given <msg> as the commit message (rather than the default). If multiple -m options are given, their values are concatenated as separate paragraphs'
     )
     cmd_mkdir.add_argument(
+        '-q', '--quiet',
+        required=False,
+        default=False,
+        action='store_true',
+        help='silence messages to stdout; requires the --yes flag'
+    )
+    cmd_mkdir.add_argument(
+        '-y', '--yes',
+        required=False,
+        default=False,
+        action='store_true',
+        help='respond "yes" to any prompts'
+    )
+    cmd_mkdir.add_argument(
         'directory',
         metavar='DIR',
         nargs='+',

--- a/tests/commands/test_mv.py
+++ b/tests/commands/test_mv.py
@@ -24,7 +24,7 @@ def test_mv_interactive_missing_y(repo: Repo) -> None:
     """
     ret = subprocess.run(['onyo', 'mv', 'subdir/laptop_apple_macbook.abc123', './'], capture_output=True, text=True)
     assert ret.returncode == 1
-    assert "Move assets? (y/N) " in ret.stdout
+    assert "Save changes? No discards all changes. (y/n) " in ret.stdout
     assert ret.stderr
 
     assert Path('subdir/laptop_apple_macbook.abc123').exists()
@@ -39,7 +39,7 @@ def test_mv_interactive_abort(repo: Repo) -> None:
     """
     ret = subprocess.run(['onyo', 'mv', 'subdir/laptop_apple_macbook.abc123', './'], input='n', capture_output=True, text=True)
     assert ret.returncode == 0
-    assert "Move assets? (y/N) " in ret.stdout
+    assert "Save changes? No discards all changes. (y/n) " in ret.stdout
     assert not ret.stderr
 
     assert Path('subdir/laptop_apple_macbook.abc123').exists()
@@ -54,7 +54,7 @@ def test_mv_interactive(repo: Repo) -> None:
     """
     ret = subprocess.run(['onyo', 'mv', 'subdir/laptop_apple_macbook.abc123', './'], input='y', capture_output=True, text=True)
     assert ret.returncode == 0
-    assert "Move assets? (y/N) " in ret.stdout
+    assert "Save changes? No discards all changes. (y/n) " in ret.stdout
     assert not ret.stderr
 
     assert not Path('subdir/laptop_apple_macbook.abc123').exists()
@@ -99,7 +99,7 @@ def test_mv_yes(repo: Repo) -> None:
     ret = subprocess.run(['onyo', 'mv', '--yes', 'subdir/laptop_apple_macbook.abc123', './'], capture_output=True, text=True)
     assert ret.returncode == 0
     assert "The following will be moved:" in ret.stdout
-    assert "Move assets? (y/N) " not in ret.stdout
+    assert "Save changes? No discards all changes. (y/n) " not in ret.stdout
     assert not ret.stderr
 
     assert not Path('subdir/laptop_apple_macbook.abc123').exists()

--- a/tests/commands/test_onyo.py
+++ b/tests/commands/test_onyo.py
@@ -11,7 +11,8 @@ variants = [
 @pytest.mark.repo_dirs('just-a-dir')
 @pytest.mark.parametrize('variant', variants)
 def test_onyo_debug(repo, variant):
-    ret = subprocess.run(['onyo', variant, 'mkdir', f'flag{variant}'], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', variant, 'mkdir', '--yes', f'flag{variant}'],
+                         capture_output=True, text=True)
     assert ret.returncode == 0
     assert 'DEBUG:onyo' in ret.stderr
 

--- a/tests/commands/test_rm.py
+++ b/tests/commands/test_rm.py
@@ -24,7 +24,7 @@ def test_rm_interactive_missing_y(repo: Repo) -> None:
     """
     ret = subprocess.run(['onyo', 'rm', *assets], capture_output=True, text=True)
     assert ret.returncode == 1
-    assert "Delete assets? (y/N) " in ret.stdout
+    assert "Save changes? No discards all changes. (y/n) " in ret.stdout
     assert ret.stderr
 
     # verify no changes were made and the repository is in a clean state
@@ -40,7 +40,7 @@ def test_rm_interactive_abort(repo: Repo) -> None:
     """
     ret = subprocess.run(['onyo', 'rm', *assets], input='n', capture_output=True, text=True)
     assert ret.returncode == 0
-    assert "Delete assets? (y/N) " in ret.stdout
+    assert "Save changes? No discards all changes. (y/n) " in ret.stdout
     assert not ret.stderr
 
     # verify no changes were made and the repository is in a clean state
@@ -57,7 +57,7 @@ def test_rm_interactive(repo: Repo, asset: str) -> None:
     """
     ret = subprocess.run(['onyo', 'rm', asset], input='y', capture_output=True, text=True)
     assert ret.returncode == 0
-    assert "Delete assets? (y/N) " in ret.stdout
+    assert "Save changes? No discards all changes. (y/n) " in ret.stdout
     assert not ret.stderr
 
     # verify deleting was successful and the repository is in a clean state

--- a/tests/lib/test_Repo.py
+++ b/tests/lib/test_Repo.py
@@ -425,7 +425,7 @@ def test_Repo_opdir_child(tmp_path):
     ret = subprocess.run(['onyo', 'init', 'opdir-child'])
     assert ret.returncode == 0
     os.chdir('opdir-child')
-    ret = subprocess.run(['onyo', 'mkdir', '1/2/3/4/5/6'])
+    ret = subprocess.run(['onyo', 'mkdir', '--yes', '1/2/3/4/5/6'])
     assert ret.returncode == 0
 
     # test
@@ -480,7 +480,7 @@ def test_Repo_root_child(tmp_path):
     ret = subprocess.run(['onyo', 'init', 'root-child'])
     assert ret.returncode == 0
     os.chdir('root-child')
-    ret = subprocess.run(['onyo', 'mkdir', '1/2/3/4/5/6'])
+    ret = subprocess.run(['onyo', 'mkdir', '--yes', '1/2/3/4/5/6'])
     assert ret.returncode == 0
 
     # test


### PR DESCRIPTION
**Changes:**
This adds the flags `--yes` and `--quiet` to `onyo mkdir`, and uses the same function for the "user response" for the commands `mkdir`, `mv` and `rm` that is already used in the commands `edit`, `new`, `set` and `unset`.
Thereby, all committing commands (except init and config) response now in a more unified way.

The PR updates tests (including output), and the demo were `onyo mkdir --yes` is used, and adds new tests for the added flags and user responses.

**FYI:**
The `user_response()` will create a need to update the commands later, when we move the interactive functions to another place, and yet I still think this PR will prepare the move, since just the import line has to be changed later, not the code of the `mkdir()` function itself.

I removed some unneeded tests (e.g. 'overlap/three' adds nothing new, if the folders 'overlap/one' and 'overlap/two'
already exist). I think we should remove unneeded tests like this to make room e.g. for tests with special characters, and to have more overlap between the functionalities of the commands and the API.