### PR TITLE
TST: run tests on tmpfs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,7 +36,9 @@ jobs:
         pyre --noninteractive check
     - name: Test with pytest and collect coverage
       run: |
+        mkdir /tmp/onyo-tmpfs
+        sudo mount -t tmpfs -o size=1G tmpfs /tmp/onyo-tmpfs
         export REPO_ROOT=$PWD
-        pytest -vv --cov
+        pytest -vv --cov --basetemp=/tmp/onyo-tmpfs/run
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3


### PR DESCRIPTION
This should speed up the tests significantly by removing pretty much all IO overhead.