### PR TITLE
TST: run tests in random order

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setup(
             'flake8',
             'pyre-check',
             'pytest',
-            'pytest-cov'
+            'pytest-cov',
+            'pytest-randomly'
         ],
         'docs': [
             'sphinx>=4.3.0',

--- a/tests/commands/test_init.py
+++ b/tests/commands/test_init.py
@@ -36,4 +36,4 @@ def test_explicit(tmp_path):
     ret = subprocess.run(["onyo", "init", repo_path])
 
     assert ret.returncode == 0
-    assert fully_populated_dot_onyo()
+    assert fully_populated_dot_onyo(repo_path)


### PR DESCRIPTION
To ensure we don't accidentally introduce inter-test dependencies.