### PR TITLE
TST: add  `repo_contents` fixture to set values in assets; use fixture for `test_unset.py`

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,5 +2,6 @@
 markers =
     repo_dirs: populate a repo with dirs; for use with the "repo" fixture
     repo_files: populate a repo with files (parent dirs are automatically created); for use with the "repo" fixture
+    repo_contents: populate files of a repo with content; for use with the "repo" fixture
 addopts =
     --strict-markers

--- a/tests/commands/test_unset.py
+++ b/tests/commands/test_unset.py
@@ -8,32 +8,31 @@ files = ['laptop_apple_macbookpro',
          'lap top_ap ple_mac book pro']
 
 directories = ['.',
-               'simple',
                's p a c e s',
-               's p a/c e s',
                'r/e/c/u/r/s/i/v/e',
                'overlap/one',
                'overlap/two',
-               'very/very/very/deep']
+               'very/very/very/deep',
+               ]
 
 assets = [f"{d}/{f}.{i}" for f in files for i, d in enumerate(directories)]
 
+content_dict = {"one_key": "one_value",
+                "two_key": "two_value",
+                "three_key": "three_value"}
 
-@pytest.mark.repo_files(*assets)
+content_str = "\n".join([f"{elem}: {content_dict.get(elem)}"
+                         for elem in content_dict]) + "\n"
+
+contents = [[x, content_str] for x in assets]
+
+@pytest.mark.repo_contents(*contents)
 @pytest.mark.parametrize('asset', assets)
 def test_unset(repo: Repo, asset: str) -> None:
     """
     Test that `onyo unset KEY <asset>` removes keys from of assets.
     """
-    set_values = "key=value"
-    key = "key"
-
-    # TODO: find out if there is a faster way than `onyo set` for writing
-    # without leaving an unclean git tree
-    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', set_values, '--path', asset], capture_output=True, text=True)
-    assert ret.returncode == 0
-    assert "key: value" in Path.read_text(Path(asset))
-
+    key = list(content_dict.keys())[0]
     ret = subprocess.run(['onyo', 'unset', '--yes', '--keys', key, '--path', asset], capture_output=True, text=True)
 
     # verify output
@@ -44,52 +43,42 @@ def test_unset(repo: Repo, asset: str) -> None:
     assert ret.returncode == 0
 
     # verify changes, and the repository clean
-    assert "key: value" not in Path.read_text(Path(asset))
+    assert f"{key}: {content_dict.get(key)}" not in Path(asset).read_text()
     repo.fsck()
 
 
-@pytest.mark.repo_files(*assets)
+@pytest.mark.repo_contents(*contents)
 @pytest.mark.parametrize('asset', assets)
 def test_unset_interactive(repo: Repo, asset: str) -> None:
     """
     Test that `onyo unset KEY <asset>` removes keys from of assets.
     """
-    set_values = "key=value"
-    key = "key"
-
-    ret = subprocess.run(['onyo', 'set', '--keys', set_values, '--path', asset], input='y', capture_output=True, text=True)
-    assert ret.returncode == 0
-    assert "key: value" in Path.read_text(Path(asset))
-
+    key = list(content_dict.keys())[0]
     ret = subprocess.run(['onyo', 'unset', '--keys', key, '--path', asset], input='y', capture_output=True, text=True)
 
     # verify output
     assert "The following assets will be changed:" in ret.stdout
     assert "Update assets? (y/n) " in ret.stdout
     assert str(Path(asset)) in ret.stdout
-    assert f"-{key}" in ret.stdout
+    assert f"-{key}: {content_dict.get(key)}" in ret.stdout
     assert not ret.stderr
     assert ret.returncode == 0
 
     # verify changes, and the repository clean
-    assert "key: value" not in Path.read_text(Path(asset))
+    assert f"{key}: {content_dict.get(key)}" not in Path(asset).read_text()
     repo.fsck()
 
 
-@pytest.mark.repo_files(*assets)
+@pytest.mark.repo_contents(*contents)
 @pytest.mark.parametrize('asset', assets)
 def test_unset_subset_of_keys(repo: Repo, asset: str) -> None:
     """
     Test that `onyo unset KEY <asset>` removes just the keys specified from
     assets with many other keys.
     """
-    set_values = ["first=value", "key=value", "second=key"]
-    key = "key"
-    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', *set_values, '--path', asset], capture_output=True, text=True)
-    assert ret.returncode == 0
-
-    # test un-setting just a subset of the existing keys
-    ret = subprocess.run(['onyo', 'unset', '--yes', '--keys', key, '--path', asset], capture_output=True, text=True)
+    key = list(content_dict.keys())[0]
+    ret = subprocess.run(['onyo', 'unset', '--yes', '--keys', key, '--path', asset],
+                         capture_output=True, text=True)
 
     # verify output
     assert "The following assets will be changed:" in ret.stdout
@@ -100,60 +89,63 @@ def test_unset_subset_of_keys(repo: Repo, asset: str) -> None:
 
     # verify the right key is removed and the others still exist, and that the
     # repository is still in a clean state
-    contents = Path.read_text(Path(asset))
-    assert "key: value" not in contents
-    assert "first: value" in contents
-    assert "second: key" in contents
+    asset_contents = Path(asset).read_text()
+    assert f"{key}: {content_dict.get(key)}" not in asset_contents
+    for k in list(content_dict.keys())[1:]:
+        assert f"{k}: {content_dict.get(k)}" in asset_contents
     repo.fsck()
 
 
 @pytest.mark.repo_files(*assets)
 @pytest.mark.parametrize('asset', assets)
-def test_error_unset_non_existing_key(repo: Repo, asset: str) -> None:
+def test_unset_info_empty_asset(repo: Repo, asset: str) -> None:
     """
-    Test that `onyo unset KEY <asset>` prints the correct info without stopping
-    the command, when one of the KEYs does not exist.
-    Calls `onyo unset KEY <asset>` on an completely empty asset, and then
-    `onyo unset KEY1,KEY2 <asset>` on an asset containing KEY2, but not KEY1.
+    Test that `onyo unset --keys KEY --path ASSET` prints the correct info,
+    when one of the KEYs does not exist, because the given asset is empty.
     """
-    set_values = "existing=key"
     no_key = "non_existing"
 
     # test un-setting a non-existing key from an empty file
-    ret = subprocess.run(['onyo', 'unset', '--yes', '--keys', no_key, '--path', asset], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', 'unset', '--yes', '--keys', no_key,
+                          '--path', asset], capture_output=True, text=True)
+
+    # verify reaction of onyo
     assert "No assets containing the specified key(s) could be found. No assets updated." in ret.stdout
     assert f"Field {no_key} does not exist in " in ret.stderr
     assert ret.returncode == 0
-
-    # set key so the asset is not empty
-    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', set_values, '--path', asset], capture_output=True, text=True)
-    assert ret.returncode == 0
-
-    # test un-setting a non-existing key from an asset with other keys
-    ret = subprocess.run(['onyo', 'unset', '--yes', '--keys', 'non_existing',
-                          'existing', '--path', asset], capture_output=True, text=True)
-    assert "-existing: key" in ret.stdout
-    assert f"Field {no_key} does not exist in " in ret.stderr
-    assert ret.returncode == 0
-
-    # verify the other key got removed anyways, and the repository is clean
-    assert "existing: key" not in Path.read_text(Path(asset))
     repo.fsck()
 
 
-@pytest.mark.repo_files(*assets)
+@pytest.mark.repo_contents(*contents)
+@pytest.mark.parametrize('asset', assets)
+def test_unset_key_does_not_exist(repo: Repo, asset: str) -> None:
+    """
+    Test that `onyo unset --keys KEY --path ASSET` prints the correct info,
+    when one of the KEYs does not exist, but the asset is not empty.
+    """
+    no_key = "non_existing"
+
+    # test un-setting a non-existing key from an empty file
+    ret = subprocess.run(['onyo', 'unset', '--yes', '--keys', no_key,
+                          '--path', asset], capture_output=True, text=True)
+
+    # verify reaction of onyo
+    assert "No assets containing the specified key(s) could be found. No assets updated." in ret.stdout
+    assert f"Field {no_key} does not exist in " in ret.stderr
+    assert ret.returncode == 0
+    repo.fsck()
+
+
+@pytest.mark.repo_contents(*contents)
 def test_unset_multiple_assets(repo: Repo) -> None:
     """
-    Test that `onyo unset KEY <asset>` removes keys from of assets.
+    Test that `onyo unset --keys KEY --path ASSET` removes keys from of assets.
     """
-    set_values = "key=value"
-    key = "key"
+    key = list(content_dict.keys())[0]
 
-    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', set_values, '--path', *assets], capture_output=True, text=True)
-    assert ret.returncode == 0
-
-    # test unsetting multiple keys:
+    # test unsetting keys for multiple assets:
     ret = subprocess.run(['onyo', 'unset', '--yes', '--keys', key, '--path', *assets], capture_output=True, text=True)
+
     # verify output
     assert "The following assets will be changed:" in ret.stdout
     for asset in repo.assets:
@@ -163,7 +155,7 @@ def test_unset_multiple_assets(repo: Repo) -> None:
 
     # verify changes, and the repository clean
     for asset in repo.assets:
-        assert key not in Path.read_text(Path(asset))
+        assert key not in Path(asset).read_text()
     repo.fsck()
 
 
@@ -174,11 +166,13 @@ non_existing_assets = [["single_non_existing.asset"],
 @pytest.mark.parametrize('no_assets', non_existing_assets)
 def test_unset_error_non_existing_assets(repo: Repo, no_assets: list[str]) -> None:
     """
-    Test that `onyo unset KEY <asset>` errors correctly for non-existing assets
-    on root, in directories, or if an invalid asset name is in a list of
-    valid ones.
+    Test that `onyo unset --keys KEY --path ASSET` errors correctly for
+    non-existing assets on root, in directories, or if an invalid asset name is
+    in a list of valid ones.
     """
-    ret = subprocess.run(['onyo', 'unset', '--keys', 'key', '--path', *no_assets], capture_output=True, text=True)
+    key = list(content_dict.keys())[0]
+    ret = subprocess.run(['onyo', 'unset', '--keys', key, '--path', *no_assets],
+                         capture_output=True, text=True)
 
     # verify output
     assert not ret.stdout
@@ -187,139 +181,86 @@ def test_unset_error_non_existing_assets(repo: Repo, no_assets: list[str]) -> No
     repo.fsck()
 
 
-@pytest.mark.repo_files(*assets)
+@pytest.mark.repo_contents(*contents)
 def test_unset_with_dot(repo: Repo) -> None:
     """
-    Test that when `onyo unset KEY=VALUE .` is called from the
+    Test that when `onyo unset --keys KEY=VALUE --path .` is called from the
     repository root, onyo uses all assets in the completely repo recursively.
     """
-    key_values = "key=recursive"
-    key = "key"
+    key = list(content_dict.keys())[0]
+    ret = subprocess.run(['onyo', 'unset', '--yes', '--keys', key,
+                          '--path', "."], capture_output=True, text=True)
 
-    # set values:
-    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', key_values, '--path', "."], capture_output=True, text=True)
-    assert ret.stdout.count("+key: recursive") == len(assets)
-    assert not ret.stderr
-    assert ret.returncode == 0
-    repo.fsck()
-
-    # unset `key` again
-    ret = subprocess.run(['onyo', 'unset', '--yes', '--keys', key, '--path', "."], capture_output=True, text=True)
-
-    # verify that output contains one line per asset
     assert "The following assets will be changed:" in ret.stdout
-    # one time for every asset in the repository
-    assert ret.stdout.count("-key: recursive") == len(assets)
+    # verify that output contains one line per asset
+    assert ret.stdout.count(f"-{key}: {content_dict.get(key)}") == len(assets)
     assert not ret.stderr
     assert ret.returncode == 0
     repo.fsck()
 
 
-@pytest.mark.repo_files(*assets)
+@pytest.mark.repo_contents(*contents)
 def test_unset_without_path(repo: Repo) -> None:
     """
-    Test that `onyo unset KEY` without a given path argument selects all assets
-    recursively.
-
-    This uses first `onyo set` (and verifies success) to set all values, and
-    then a similar `onyo unset` call to remove the keys.
+    Test that `onyo unset --keys KEY` without a given path argument selects all
+    assets recursively.
     """
-    set_values = "key=cwd_recursive"
-    key = "key"
-
-    # first set values for all the assets, to make sure that really just the
-    # ones in root get removed, even if others with the same key exist
-    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', set_values, '--path', "."], capture_output=True, text=True)
-
-    # verify success
-    assert ret.stdout.count("+key: cwd_recursive") == len(assets)
-    assert not ret.stderr
-    assert ret.returncode == 0
-    repo.fsck()
-
-    # unset `key` again
-    ret = subprocess.run(['onyo', 'unset', '--yes', '--keys', key], capture_output=True, text=True)
+    key = list(content_dict.keys())[0]
+    ret = subprocess.run(['onyo', 'unset', '--yes', '--keys', key],
+                         capture_output=True, text=True)
 
     # verify the output
     assert "The following assets will be changed:" in ret.stdout
-    assert ret.stdout.count("-key: cwd_recursive") == len(assets)
+    assert ret.stdout.count(f"-{key}: {content_dict.get(key)}") == len(assets)
     assert not ret.stderr
     assert ret.returncode == 0
     repo.fsck()
 
 
-@pytest.mark.repo_files(*assets)
+@pytest.mark.repo_contents(*contents)
 @pytest.mark.parametrize('directory', directories)
 def test_unset_recursive_directories(repo: Repo, directory: str) -> None:
     """
-    Test that `onyo unset KEY <directory>` updates contents of
-    assets in <directory>.
-
-    This uses first `onyo set` (and verifies success) to set all values, and
-    then a similar `onyo unset` call to remove the keys.
+    Test that `onyo unset --keys KEY --path DIRECTORY` updates contents of
+    assets in DIRECTORY.
     """
-    set_values = "key=recursive_directories"
-    key = "key"
-    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', set_values, '--path', "."], capture_output=True, text=True)
-
-    # verify output
-    assert str(Path(directory)) in ret.stdout
-    assert not ret.stderr
-    assert ret.returncode == 0
-
-    # unset values
+    key = list(content_dict.keys())[0]
     ret = subprocess.run(['onyo', 'unset', '--yes', '--keys', key, '--path', directory], capture_output=True, text=True)
 
     # verify changes, and the repository clean
     # TODO: update this after solving #259
     repo_assets = repo.assets
     for asset in [asset for asset in Path(directory).iterdir() if asset in repo_assets]:
-        for value in set_values.split(","):
-            assert key not in Path.read_text(Path(asset))
-            assert "-key: recursive_directories" in ret.stdout
+        assert key not in Path(asset).read_text()
+        assert f"-{key}: {content_dict.get(key)}" in ret.stdout
     repo.fsck()
 
-@pytest.mark.repo_files(*assets)
+
+@pytest.mark.repo_contents(*contents)
 @pytest.mark.parametrize('asset', assets)
 def test_unset_discard_changes_single_assets(repo: Repo, asset: str) -> None:
     """
     Test that `onyo unset` discards changes for assets successfully.
     """
-    set_values = "key=discard_value"
-    key = "key"
-    ret = subprocess.run(['onyo', 'set', '--keys', set_values, '--path', asset], input='y', capture_output=True, text=True)
-
-    assert str(Path(asset)) in ret.stdout
-    assert "+key: discard_value" in ret.stdout
-    assert not ret.stderr
-    assert ret.returncode == 0
-
+    key = list(content_dict.keys())[0]
     # do an `onyo unset`, but answer "n" to discard the changes done by unset
     ret = subprocess.run(['onyo', 'unset', '--keys', key, '--path', asset], input='n', capture_output=True, text=True)
-    assert "-key: discard_value" in ret.stdout
+    assert f"-{key}: {content_dict.get(key)}" in ret.stdout
     assert "No assets updated." in ret.stdout
     assert not ret.stderr
     assert ret.returncode == 0
 
     # verify that the key was not removed
-    assert "key: discard_value" in Path.read_text(Path(asset))
+    assert f"{key}: {content_dict.get(key)}" in Path(asset).read_text()
     repo.fsck()
 
 
-@pytest.mark.repo_files(*assets)
+@pytest.mark.repo_contents(*contents)
 def test_unset_discard_changes_recursive(repo: Repo) -> None:
     """
     Test that `onyo unset` discards changes for all assets successfully.
     """
-    set_values = "key=discard"
-    key = "key"
-    ret = subprocess.run(['onyo', 'set', '--keys', set_values], input='y', capture_output=True, text=True)
-
-    # verify output for just dot, should be all in onyo root, but not recursive
-    assert ret.stdout.count("+key: discard") == len(repo.assets)
-    assert not ret.stderr
-    assert ret.returncode == 0
-
+    key = list(content_dict.keys())[0]
     # call `unset`, but discard changes
     ret = subprocess.run(['onyo', 'unset', '--keys', key], input='n', capture_output=True, text=True)
 
@@ -327,34 +268,30 @@ def test_unset_discard_changes_recursive(repo: Repo) -> None:
     assert "The following assets will be changed:" in ret.stdout
     assert "Update assets? (y/n) " in ret.stdout
     assert "No assets updated." in ret.stdout
-    assert ret.stdout.count("-key: discard") == len(repo.assets)
+    assert ret.stdout.count(f"-{key}: {content_dict.get(key)}") == len(repo.assets)
     assert not ret.stderr
     assert ret.returncode == 0
 
     # verify that the removal was not written but discarded
     repo_assets = repo.assets
     for asset in repo_assets:
-        assert "key: discard" in Path.read_text(asset)
+        assert f"{key}: {content_dict.get(key)}" in Path.read_text(asset)
     repo.fsck()
 
 
-@pytest.mark.repo_files(*assets)
+@pytest.mark.repo_contents(*contents)
 @pytest.mark.parametrize('asset', assets)
 def test_unset_yes_flag(repo: Repo, asset: str) -> None:
     """
     Test that `onyo unset --yes KEY <asset>` updates assets without prompt.
     """
-    set_values = "key=yes"
-    key = "key"
-    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', set_values, '--path', asset], capture_output=True, text=True)
-
-    # remove the key again
+    key = list(content_dict.keys())[0]
     ret = subprocess.run(['onyo', 'unset', '--yes', '--keys', key, '--path', asset], capture_output=True, text=True)
 
     # verify output
     assert "The following assets will be changed:" in ret.stdout
     assert str(Path(asset)) in ret.stdout
-    assert f"-{set_values.replace('=',': ')}" in ret.stdout
+    assert f"-{key}" in ret.stdout
     assert not ret.stderr
     assert ret.returncode == 0
 
@@ -362,7 +299,7 @@ def test_unset_yes_flag(repo: Repo, asset: str) -> None:
     assert "Update assets? (y/n) " not in ret.stdout
 
     # verify that the removal did happen, and the repository is still clean
-    assert "key" not in Path.read_text(Path(asset))
+    assert f"{key}" not in Path(asset).read_text()
     repo.fsck()
 
 
@@ -370,10 +307,11 @@ asset = 'simple/laptop_apple_macbookpro.0'
 @pytest.mark.repo_files(asset)
 def test_unset_quiet_without_yes_flag(repo: Repo) -> None:
     """
-    Test that `onyo unset --quiet KEY <asset>` errors correctly without
-    the --yes flag.
+    Test that `onyo unset --quiet --keys KEY --path ASSET` errors correctly
+    without the --yes flag.
     """
-    ret = subprocess.run(['onyo', 'unset', '--quiet', '--keys', 'dummy_key', '--path', asset], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', 'unset', '--quiet', '--keys', 'dummy_key',
+                          '--path', asset], capture_output=True, text=True)
 
     # verify output
     assert not ret.stdout
@@ -384,32 +322,29 @@ def test_unset_quiet_without_yes_flag(repo: Repo) -> None:
     repo.fsck()
 
 
-@pytest.mark.repo_files(*assets)
+@pytest.mark.repo_contents(*contents)
 @pytest.mark.parametrize('asset', assets)
 def test_unset_quiet_flag(repo: Repo, asset: str) -> None:
     """
-    Test that `onyo unset --quiet --yes KEY <asset>` works correctly without
-    output and user-response.
+    Test that `onyo unset --quiet --yes --keys KEY --path ASSET` works correctly
+    without output and user-response.
     """
-    set_values = "key=quiet"
-    ret = subprocess.run(['onyo', 'set', '--yes', '--quiet', '--keys', set_values, '--path', asset], capture_output=True, text=True)
-    assert not ret.stderr
-    assert ret.returncode == 0
-
-    ret = subprocess.run(['onyo', 'unset', '--yes', '--quiet', '--keys', 'key', '--path', asset], capture_output=True, text=True)
+    key = list(content_dict.keys())[0]
+    ret = subprocess.run(['onyo', 'unset', '--yes', '--quiet', '--keys', key,
+                          '--path', asset], capture_output=True, text=True)
     # verify that output is completely empty
     assert not ret.stdout
     assert not ret.stderr
     assert ret.returncode == 0
 
     # verify that asset contents are updated
-    assert "key" not in Path.read_text(Path(asset))
+    assert f"{key}" not in Path(asset).read_text()
 
     # verify that the repository is in a clean state
     repo.fsck()
 
 
-@pytest.mark.repo_files(*assets)
+@pytest.mark.repo_contents(*contents)
 @pytest.mark.parametrize('asset', assets)
 def test_unset_message_flag(repo: Repo, asset: str) -> None:
     """
@@ -417,18 +352,9 @@ def test_unset_message_flag(repo: Repo, asset: str) -> None:
     with one specified by the user containing different special characters.
     """
     msg = "I am here to test the --message flag with spe\"cial\\char\'acteஞrs!"
-    key_values = "key=quiet"
-
-    # first set values
-    ret = subprocess.run(['onyo', 'set', '--yes', '--quiet',
-                          '--keys', key_values, '--path', asset],
-                         capture_output=True, text=True)
-    assert not ret.stderr
-    assert ret.returncode == 0
-
-    # test "unset values" with --message
+    key = list(content_dict.keys())[0]
     ret = subprocess.run(['onyo', 'unset', '--yes', '--message', msg,
-                          '--keys', 'key', '--path', asset],
+                          '--keys', key, '--path', asset],
                          capture_output=True, text=True)
     assert ret.returncode == 0
     assert not ret.stderr
@@ -439,22 +365,17 @@ def test_unset_message_flag(repo: Repo, asset: str) -> None:
     repo.fsck()
 
 
-@pytest.mark.repo_files(*assets)
+@pytest.mark.repo_contents(*contents)
 def test_unset_dryrun_flag(repo: Repo) -> None:
     """
-    Test that `onyo unset --dry-run KEY <asset>` displays correct diff-output
-    without actually changing any assets.
+    Test that `onyo unset --dry-run --keys KEY --path ASSET` displays correct
+    diff-output without actually changing any assets.
     """
-    set_values = "key=dry-run"
-    key = "key"
-    # set values normally
-    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', set_values, '--path', *assets], capture_output=True, text=True)
-    assert not ret.stderr
-    assert ret.returncode == 0
-
+    key = list(content_dict.keys())[0]
     # do a dry-run with unset, to check if the diff is correct without actually
     # changing an asset
-    ret = subprocess.run(['onyo', 'unset', '--dry-run', '--keys', key, '--path', *assets], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', 'unset', '--dry-run', '--keys', key,
+                          '--path', *assets], capture_output=True, text=True)
 
     # verify output
     assert "The following assets will be changed:" in ret.stdout
@@ -468,20 +389,22 @@ def test_unset_dryrun_flag(repo: Repo) -> None:
     # the asset files are made
     for asset in assets:
         assert str(Path(asset)) in ret.stdout
-        assert "-key: dry-run" in ret.stdout
-        assert "key: dry-run" in Path.read_text(Path(asset))
+        assert f"-{key}: {content_dict.get(key)}" in ret.stdout
+        assert f"{key}: {content_dict.get(key)}" in Path(asset).read_text()
 
     # check that the repository is still clean
     repo.fsck()
 
 
-@pytest.mark.repo_files("laptop_macbook_pro.0",
-                        "dir1/laptop_macbook_pro.1",
-                        "dir1/dir2/laptop_macbook_pro.2",
-                        "dir1/dir2/dir3/laptop_macbook_pro.3",
-                        "dir1/dir2/dir3/dir4/laptop_macbook_pro.4",
-                        "dir1/dir2/dir3/dir4/dir5/laptop_macbook_pro.5",
-                        "dir1/dir2/dir3/dir4/dir5/dir6/laptop_macbook_pro.6",)
+depth_assets = ["laptop_macbook_pro.0",
+                "dir1/laptop_macbook_pro.1",
+                "dir1/dir2/laptop_macbook_pro.2",
+                "dir1/dir2/dir3/laptop_macbook_pro.3",
+                "dir1/dir2/dir3/dir4/laptop_macbook_pro.4",
+                "dir1/dir2/dir3/dir4/dir5/laptop_macbook_pro.5",
+                "dir1/dir2/dir3/dir4/dir5/dir6/laptop_macbook_pro.6"]
+depth_contents = [[x, content_str] for x in depth_assets]
+@pytest.mark.repo_contents(*depth_contents)
 def test_unset_depth_flag(repo: Repo) -> None:
     """
     Test correct behavior for `onyo set --depth N KEY=VALUE <assets>` for
@@ -492,12 +415,7 @@ def test_unset_depth_flag(repo: Repo) -> None:
     - changing all assets if --depth is deeper then deepest sub-directory
       without error (e.g. deepest folder is 6, but --depth 8 is called)
     """
-    set_values = "key=value"
-    key = "key"
-    # first, set values for the complete repository, so that there is something
-    # to `onyo unset`
-    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', set_values], capture_output=True, text=True)
-
+    key = list(content_dict.keys())[0]
     # try `onyo unset --depth` for different values. Always discards changes,
     # and just checks if the output is the correct one.
     ret = subprocess.run(['onyo', 'unset', '--depth', '-1', '--keys', key], capture_output=True, text=True)
@@ -571,8 +489,8 @@ name_fields = [["type"],
                ["make"],
                ["model"],
                ["serial"],
-               ["key", "type"]]
-@pytest.mark.repo_files(*assets)
+               ["one", "type"]]
+@pytest.mark.repo_contents(*contents)
 @pytest.mark.parametrize('asset', assets)
 @pytest.mark.parametrize('name_field', name_fields)
 def test_error_unset_name_fields(repo: Repo, asset: str, name_field: list[str]) -> None:


### PR DESCRIPTION
I added the `repo_contents` fixture, and to demonstrate the usage and functionality, I updated `test_unset.py` with it.

Also, I reduced some of the redundant/overlapping tests (i.e. the test directory names do not need multiple dirs with spaces), like I already did for many of the other tests.