### PR TITLE
TST: Modernize/streamline the tests for commands

### DIFF
--- a/tests/commands/test_config.py
+++ b/tests/commands/test_config.py
@@ -1,8 +1,9 @@
 import subprocess
 from pathlib import Path
+from onyo.lib import Repo
 
 
-def test_config_set(repo):
+def test_config_set(repo: Repo) -> None:
     ret = subprocess.run(["onyo", "config", "onyo.test.set", "set-test"],
                          capture_output=True, text=True)
     assert ret.returncode == 0
@@ -10,9 +11,10 @@ def test_config_set(repo):
     assert not ret.stderr
     assert 'set =' in Path('.onyo/config').read_text()
     assert '= set-test' in Path('.onyo/config').read_text()
+    repo.fsck()
 
 
-def test_config_get_onyo(repo):
+def test_config_get_onyo(repo: Repo) -> None:
     # set
     ret = subprocess.run(["onyo", "config", "onyo.test.get-onyo", "get-onyo-test"],
                          capture_output=True, text=True)
@@ -24,9 +26,10 @@ def test_config_get_onyo(repo):
     assert ret.returncode == 0
     assert ret.stdout == 'get-onyo-test\n'
     assert not ret.stderr
+    repo.fsck()
 
 
-def test_config_get_pristine(repo):
+def test_config_get_pristine(repo: Repo) -> None:
     """
     onyo should not alter git config's output (newline, etc)
     """
@@ -48,9 +51,10 @@ def test_config_get_pristine(repo):
     assert ret.stdout == 'get-pristine-test\n'
 
     assert ret.stdout == git_config_output
+    repo.fsck()
 
 
-def test_config_get_empty(repo):
+def test_config_get_empty(repo: Repo) -> None:
     assert 'onyo.test.not-exist' not in Path('.onyo/config').read_text()
 
     ret = subprocess.run(["onyo", "config", "--get", "onyo.test.not-exist"],
@@ -58,9 +62,10 @@ def test_config_get_empty(repo):
     assert ret.returncode == 1
     assert not ret.stdout
     assert not ret.stderr
+    repo.fsck()
 
 
-def test_config_unset(repo):
+def test_config_unset(repo: Repo) -> None:
     # set
     ret = subprocess.run(["onyo", "config", "onyo.test.unset", "unset-test"],
                          capture_output=True, text=True)
@@ -81,9 +86,10 @@ def test_config_unset(repo):
     assert ret.returncode == 1
     assert not ret.stdout
     assert not ret.stderr
+    repo.fsck()
 
 
-def test_config_help(repo):
+def test_config_help(repo: Repo) -> None:
     """
     `onyo config --help` is shown and not `git config --help`.
     """
@@ -93,9 +99,10 @@ def test_config_help(repo):
         assert ret.returncode == 0
         assert 'onyo' in ret.stdout
         assert not ret.stderr
+    repo.fsck()
 
 
-def test_config_forbidden_flags(repo):
+def test_config_forbidden_flags(repo: Repo) -> None:
     """
     Flags that change the source of values are not allowed.
     """
@@ -104,9 +111,10 @@ def test_config_forbidden_flags(repo):
                              capture_output=True, text=True)
         assert ret.returncode == 1
         assert flag in ret.stderr
+    repo.fsck()
 
 
-def test_config_bubble_retcode(repo):
+def test_config_bubble_retcode(repo: Repo) -> None:
     """
     Bubble up git-config's retcodes.
     According to the git config manpage, attempting to unset an option which
@@ -117,9 +125,10 @@ def test_config_bubble_retcode(repo):
     ret = subprocess.run(["onyo", "config", "--unset", "onyo.test.not-exist"],
                          capture_output=True, text=True)
     assert ret.returncode == 5
+    repo.fsck()
 
 
-def test_config_bubble_stderr(repo):
+def test_config_bubble_stderr(repo: Repo) -> None:
     """
     Bubble up git-config printing to stderr.
     """
@@ -128,3 +137,4 @@ def test_config_bubble_stderr(repo):
     assert ret.returncode == 129
     assert not ret.stdout
     assert ret.stderr
+    repo.fsck()

--- a/tests/commands/test_edit.py
+++ b/tests/commands/test_edit.py
@@ -159,7 +159,7 @@ def test_edit_message_flag(repo: Repo, asset: str) -> None:
 @pytest.mark.repo_files(*assets)
 def test_quiet_flag(repo: Repo) -> None:
     """
-    Test that `onyo edit --quiet` does not print anything.
+    Test that `onyo edit --yes --quiet` does not print anything.
     """
     os.environ['EDITOR'] = "printf 'key: quiet' >"
 
@@ -174,6 +174,23 @@ def test_quiet_flag(repo: Repo) -> None:
     # verify the changes were saved for all assets and the repository is clean
     for asset in repo.assets:
         assert 'key: quiet' in Path.read_text(asset)
+    repo.fsck()
+
+
+@pytest.mark.repo_files(*assets)
+def test_quiet_errors_without_yes_flag(repo: Repo) -> None:
+    """
+    Test that `onyo edit --quiet` does error without --yes flag.
+    """
+    os.environ['EDITOR'] = "printf 'key: quiet' >"
+
+    # edit a list of assets all at once
+    ret = subprocess.run(['onyo', 'edit', '--quiet', *assets], capture_output=True, text=True)
+
+    # verify correct error.
+    assert not ret.stdout
+    assert ret.returncode == 1
+    assert 'The --quiet flag requires --yes.' in ret.stderr
     repo.fsck()
 
 

--- a/tests/commands/test_init.py
+++ b/tests/commands/test_init.py
@@ -2,8 +2,10 @@ import os
 import subprocess
 from pathlib import Path
 
+from onyo.lib import Repo
 
-def fully_populated_dot_onyo(directory=''):
+
+def fully_populated_dot_onyo(directory: str = '') -> bool:
     """
     Assert whether a .onyo dir is fully populated.
     """
@@ -17,23 +19,61 @@ def fully_populated_dot_onyo(directory=''):
        not Path(dot_onyo, "templates/.anchor").is_file() or \
        not Path(dot_onyo, "validation/.anchor").is_file():
            return False  # noqa: E111, E117
-    # TODO: assert that no unstaged or untracked under .onyo/
 
+    Repo(directory).fsck()
     return True
 
 
-def test_cwd(tmp_path):
+def test_init_cwd(tmp_path: str) -> None:
+    """
+    Test that `onyo init` without a path argument uses the cwd to initialize a
+    new onyo repository.
+    """
     os.chdir(tmp_path)
+    ret = subprocess.run(["onyo", "init"], capture_output=True, text=True)
 
-    ret = subprocess.run(["onyo", "init"])
-
+    # verify output and that initializing the new repository was successful.
+    assert "Initialized Onyo repository in" in ret.stderr
     assert ret.returncode == 0
-    assert fully_populated_dot_onyo()
+    assert fully_populated_dot_onyo(tmp_path)
+    repo = Repo(tmp_path)
+    assert repo.root == tmp_path
+    repo.fsck()
 
 
-def test_explicit(tmp_path):
+def test_init_with_path(tmp_path: str) -> None:
+    """
+    Test that `onyo init PATH` uses a provided path to initialize a new onyo
+    repository.
+    """
     repo_path = Path(tmp_path).resolve()
-    ret = subprocess.run(["onyo", "init", repo_path])
+    ret = subprocess.run(["onyo", "init", repo_path], capture_output=True, text=True)
 
+    # verify output and that initializing the new repository was successful.
     assert ret.returncode == 0
-    assert fully_populated_dot_onyo(repo_path)
+    assert fully_populated_dot_onyo(tmp_path)
+    assert "Initialized Onyo repository in" in ret.stderr
+    repo = Repo(repo_path)
+    assert repo.root == repo_path
+    repo.fsck()
+
+
+def test_init_error_on_existing_repository(tmp_path: str) -> None:
+    """
+    Test that `onyo init PATH` errors correctly, when called on an existing
+    repository.
+    """
+    repo_path = Path(tmp_path).resolve()
+    ret = subprocess.run(["onyo", "init", repo_path], capture_output=True, text=True)
+    ret = subprocess.run(["onyo", "init", repo_path], capture_output=True, text=True)
+
+    # verify output and that double-initializing errors correctly, but the
+    # repository stays in a valid state.
+    assert ret.returncode == 1
+    assert not ret.stdout
+    assert "already exists." in ret.stderr
+
+    assert fully_populated_dot_onyo(tmp_path)
+    repo = Repo(repo_path)
+    assert repo.root == repo_path
+    repo.fsck()

--- a/tests/commands/test_onyo.py
+++ b/tests/commands/test_onyo.py
@@ -1,36 +1,31 @@
 import subprocess
 from itertools import product
 
+from onyo.lib import Repo
 import pytest
 
 
-variants = [
-    '-d',
-    '--debug',
-]
 @pytest.mark.repo_dirs('just-a-dir')
-@pytest.mark.parametrize('variant', variants)
-def test_onyo_debug(repo, variant):
+@pytest.mark.parametrize('variant', ['-d', '--debug'])
+def test_onyo_debug(repo: Repo, variant: str) -> None:
     ret = subprocess.run(['onyo', variant, 'mkdir', '--yes', f'flag{variant}'],
                          capture_output=True, text=True)
     assert ret.returncode == 0
     assert 'DEBUG:onyo' in ret.stderr
+    repo.fsck()
 
 
-variants = [
-    '-h',
-    '--help',
-]
-@pytest.mark.parametrize('variant', variants)
-def test_onyo_help(repo, variant):
+@pytest.mark.parametrize('variant', ['-h', '--help'])
+def test_onyo_help(repo: Repo, variant: str) -> None:
     ret = subprocess.run(['onyo', variant], capture_output=True, text=True)
     assert ret.returncode == 0
     assert 'usage: onyo [-h]' in ret.stdout
     assert not ret.stderr
+    repo.fsck()
 
 
 # TODO: this would be better if parametrized
-def test_onyo_without_subcommand(repo, helpers):
+def test_onyo_without_subcommand(repo: Repo, helpers) -> None:
     """
     Test all possible combinations of flags for onyo, without any subcommand.
     """
@@ -43,3 +38,4 @@ def test_onyo_without_subcommand(repo, helpers):
             assert ret.returncode == 1
             assert 'usage: onyo [-h]' in ret.stdout
             assert not ret.stderr
+    repo.fsck()

--- a/tests/commands/test_rm.py
+++ b/tests/commands/test_rm.py
@@ -4,19 +4,110 @@ from pathlib import Path
 from onyo.lib import Repo
 import pytest
 
-# These tests focus on functionality specific to the CLI for `onyo rm`.
-# Tests located in this file should not duplicate those testing `Repo.rm()`
-# directly.
+files = ['laptop_apple_macbookpro',
+         'lap top_ap ple_mac book pro',
+         'spe\"c_ial\\ch_ar\'ac.teஞrs']
 
-assets = ['laptop_apple_macbookpro.0',
-          'simple/laptop_apple_macbookpro.1',
-          's p a/c e s/laptop_apple_macbookpro.2',
-          'very/very/very/deep/spe\"c_ial\\ch_ar\'ac.teஞrs'
-          ]
+directories = ['.',
+               's p a c e s',
+               'r/e/c/u/r/s/i/v/e',
+               'overlap/one',
+               'overlap/two',
+               'very/very/very/deep'
+               ]
 
-#
-# FLAGS
-#
+assets = [f"{d}/{f}.{i}" for f in files for i, d in enumerate(directories)]
+
+@pytest.mark.repo_files(*assets)
+@pytest.mark.parametrize('asset', assets)
+def test_rm(repo: Repo, asset: str) -> None:
+    """
+    Test that `onyo rm ASSET` deletes assets and leaves the repository in a
+    clean state.
+    """
+    ret = subprocess.run(['onyo', 'rm', '--yes', asset],
+                         capture_output=True, text=True)
+    assert ret.returncode == 0
+    assert "The following will be deleted:" in ret.stdout
+    assert not ret.stderr
+
+    # verify deleting was successful and the repository is in a clean state
+    assert not Path(asset).exists()
+    repo.fsck()
+
+
+@pytest.mark.repo_files(*assets)
+def test_rm_multiple_inputs(repo: Repo) -> None:
+    """
+    Test that `onyo rm ASSET` deletes a list of assets all at once and leaves
+    the repository in a clean state.
+    """
+    ret = subprocess.run(['onyo', 'rm', '--yes', *assets],
+                         capture_output=True, text=True)
+    assert ret.returncode == 0
+    assert "The following will be deleted:" in ret.stdout
+    assert not ret.stderr
+
+    # verify deleting was successful and the repository is in a clean state
+    for asset in assets:
+        assert not Path(asset).exists()
+    repo.fsck()
+
+
+@pytest.mark.repo_files(*assets)
+@pytest.mark.parametrize('directory', directories[1:])  # do not use "." as dir
+def test_rm_single_dirs_with_files(repo: Repo, directory: str) -> None:
+    """
+    Test that `onyo rm DIRECTORY` deletes directories successfully and leaves
+    the repository in a clean state.
+    """
+    ret = subprocess.run(['onyo', 'rm', '--yes', directory],
+                         capture_output=True, text=True)
+    assert ret.returncode == 0
+    assert "The following will be deleted:" in ret.stdout
+    assert not ret.stderr
+
+    # verify deleting was successful and the repository is in a clean state
+    assert not Path(directory).exists()
+    repo.fsck()
+
+
+@pytest.mark.repo_files(*assets)
+def test_rm_multiple_directories(repo: Repo) -> None:
+    """
+    Test that `onyo rm DIRECTORY` deletes a list of directories all at once and
+    leaves the repository in a clean state.
+    """
+    ret = subprocess.run(['onyo', 'rm', '--yes', *directories[1:]],
+                         capture_output=True, text=True)
+    assert ret.returncode == 0
+    assert "The following will be deleted:" in ret.stdout
+    assert not ret.stderr
+
+    # verify deleting was successful and the repository is in a clean state
+    for directory in directories[1:]:
+        assert not Path(directory).exists()
+    repo.fsck()
+
+
+@pytest.mark.repo_dirs(*directories[1:])  # skip "." for directory creation
+def test_rm_empty_directories(repo: Repo) -> None:
+    """
+    Test that `onyo rm DIRECTORY` deletes empty directories and leaves the
+    repository in a clean state.
+    """
+    ret = subprocess.run(['onyo', 'rm', '--yes', *directories[1:]],
+                         capture_output=True, text=True)
+    assert ret.returncode == 0
+    assert "The following will be deleted:" in ret.stdout
+    assert not ret.stderr
+
+    # verify deleting was successful and the repository is in a clean state
+    for directory in directories[1:]:
+        assert not Path(directory).exists()
+    repo.fsck()
+
+
 @pytest.mark.repo_files(*assets)
 def test_rm_interactive_missing_y(repo: Repo) -> None:
     """
@@ -36,7 +127,8 @@ def test_rm_interactive_missing_y(repo: Repo) -> None:
 @pytest.mark.repo_files(*assets)
 def test_rm_interactive_abort(repo: Repo) -> None:
     """
-    Default mode is interactive. Provide the "n" to abort.
+    Test that `onyo rm ASSET` does not delete any asset, when the user provides
+    "n" as response in interactive mode.
     """
     ret = subprocess.run(['onyo', 'rm', *assets], input='n', capture_output=True, text=True)
     assert ret.returncode == 0
@@ -53,7 +145,8 @@ def test_rm_interactive_abort(repo: Repo) -> None:
 @pytest.mark.parametrize('asset', assets)
 def test_rm_interactive(repo: Repo, asset: str) -> None:
     """
-    Default mode is interactive. Provide the "y" to approve.
+    Test that `onyo rm ASSET` deletes ASSET successfully, when the user provides
+    "y" as the response in interactive mode.
     """
     ret = subprocess.run(['onyo', 'rm', asset], input='y', capture_output=True, text=True)
     assert ret.returncode == 0
@@ -68,7 +161,8 @@ def test_rm_interactive(repo: Repo, asset: str) -> None:
 @pytest.mark.repo_files(*assets)
 def test_rm_quiet_missing_yes(repo: Repo) -> None:
     """
-    ``--quiet`` requires ``--yes``
+    Test that `onyo rm --quiet` errors correctly, when the required flag
+    `--yes` is missing.
     """
     ret = subprocess.run(['onyo', 'rm', '--quiet', *assets], capture_output=True, text=True)
     assert ret.returncode == 1
@@ -82,9 +176,10 @@ def test_rm_quiet_missing_yes(repo: Repo) -> None:
 
 
 @pytest.mark.repo_files(*assets)
-def test_rm_quiet(repo: Repo) -> None:
+def test_rm_quiet_flag(repo: Repo) -> None:
     """
-    ``--quiet`` requires ``--yes``
+    Test that `onyo rm --quiet --yes` deletes a list of assets successfully
+    without printing any output or error.
     """
     ret = subprocess.run(['onyo', 'rm', '--yes', '--quiet', *assets], capture_output=True, text=True)
     assert ret.returncode == 0
@@ -99,26 +194,9 @@ def test_rm_quiet(repo: Repo) -> None:
 
 @pytest.mark.repo_files(*assets)
 @pytest.mark.parametrize('asset', assets)
-def test_rm_yes(repo: Repo, asset: str) -> None:
-    """
-    --yes removes any prompts and auto-approves the deletion.
-    """
-    ret = subprocess.run(['onyo', 'rm', '--yes', asset], capture_output=True, text=True)
-    assert ret.returncode == 0
-    assert "The following will be deleted:" in ret.stdout
-    assert "Remove assets? (y/N) " not in ret.stdout
-    assert not ret.stderr
-
-    # verify deleting was successful and the repository is in a clean state
-    assert not Path(asset).exists()
-    repo.fsck()
-
-
-@pytest.mark.repo_files(*assets)
-@pytest.mark.parametrize('asset', assets)
 def test_rm_message_flag(repo: Repo, asset: str) -> None:
     """
-    Test that `onyo edit --message msg` overwrites the default commit message
+    Test that `onyo rm --message MESSAGE` overwrites the default commit message
     with one specified by the user containing different special characters.
     """
     msg = "I am here to test the --message flag with spe\"cial\\char\'acteஞrs!"


### PR DESCRIPTION
This PR contains a lot of small modernizations, that basically try to make all tests look/work similar, which mainly add or effect Pyre, doc-strings, parameterization, usage of the new fixture, and such things, that I found while looking through the tests for the commands. These do not add any functionality as such, but rather are meant to make the tests easier to update in the future. Also, I used valid asset names in tests (except for cases that do not test the behavior for invalid names, obviously).

Also, in some cases I noticed some of our more classic test cases missing, e.g. deletion of directories with `onyo rm`, or having at least one or two test cases for each flag of the commands. This is not meant to cover all scenarios in this PR, but I think it will help in case we want to split the code base in the future into independent packages.

When tests contained calls to subcommands, which are not tested, these were replaced by API calls, like already done for the tests of `onyo unset`. I updated the order of tests for `onyo rm`, so that now all our tests on assets start on single files, then a list of files.