### PR TITLE
BF/TST: check PATH is in repo for `onyo tree PATH`; add `test_tree.py`

### DIFF
--- a/onyo/commands/tree.py
+++ b/onyo/commands/tree.py
@@ -9,7 +9,7 @@ logging.basicConfig()
 log = logging.getLogger('onyo')
 
 
-def sanitize_directories(directories: list, opdir: str) -> list[str]:
+def sanitize_directories(repo: Repo, directories: list[str]) -> list[str]:
     """
     Check a list of directories. If any do not exist or are a file, and error
     will be printed.
@@ -17,19 +17,29 @@ def sanitize_directories(directories: list, opdir: str) -> list[str]:
     Returns a string of the valid directories relative to opdir.
     """
     dirs = []
-    error_path = []
+    error_path_not_in_repo = []
+    error_path_not_dir = []
 
     for d in directories:
-        full_path = Path(opdir, d)
+        full_path = Path(repo.opdir, d).resolve()
+        if not full_path.is_relative_to(repo.root):
+            error_path_not_in_repo.append(d)
+            continue
 
         if full_path.is_dir():
-            dirs.append(full_path.relative_to(opdir))
+            dirs.append(full_path.relative_to(repo.opdir))
         else:
-            error_path.append(d)
+            error_path_not_dir.append(d)
 
-    if error_path:
-        print('The following paths are not directories:\n' + '\n'.join(error_path),
+    if error_path_not_in_repo or error_path_not_dir:
+        print("All paths must be directories inside the repository.",
               file=sys.stderr)
+        if error_path_not_in_repo:
+            print('The following paths are not inside the repository:\n' +
+                  repo._n_join(error_path_not_in_repo), file=sys.stderr)
+        if error_path_not_dir:
+            print('The following paths are not directories:\n' +
+                  repo._n_join(error_path_not_dir), file=sys.stderr)
         sys.exit(1)
 
     return dirs
@@ -39,6 +49,7 @@ def tree(args, opdir: str) -> None:
     """
     List the assets and directories in ``directory`` using ``tree``.
     """
+    repo = None
     try:
         repo = Repo(opdir)
         repo.fsck(['asset-yaml'])
@@ -46,7 +57,7 @@ def tree(args, opdir: str) -> None:
         sys.exit(1)
 
     # sanitize the paths
-    dirs = sanitize_directories(args.directory, opdir)
+    dirs = sanitize_directories(repo, args.directory)
 
     # run it
     ret = subprocess.run(['tree'] + dirs, capture_output=True, text=True)

--- a/tests/commands/test_tree.py
+++ b/tests/commands/test_tree.py
@@ -1,0 +1,134 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+from onyo.lib import Repo
+
+files = ['laptop_apple_macbookpro',
+         'lap top_ap ple_mac book pro']
+
+directories = ['.',
+               's p a c e s',
+               'r/e/c/u/r/s/i/v/e',
+               'overlap/one',
+               'overlap/two',
+               'very/very/very/deep'
+               ]
+
+assets = [f"{d}/{f}.{i}" for f in files for i, d in enumerate(directories)]
+
+
+@pytest.mark.repo_files(*assets)
+def test_tree(repo: Repo) -> None:
+    """
+    Test that `onyo tree` works without input paths.
+    """
+    ret = subprocess.run(['onyo', 'tree'], capture_output=True, text=True)
+
+    # verify output
+    assert not ret.stderr
+    assert ret.returncode == 0
+
+    for d in [d for directory in directories for d in Path(directory).parts]:
+        assert d in ret.stdout
+    for a in assets:
+        assert Path(a).name in ret.stdout
+
+
+@pytest.mark.repo_files(*assets)
+@pytest.mark.parametrize('directory', directories)
+def test_tree_with_directory(repo: Repo, directory: str) -> None:
+    """
+    Test that `onyo tree DIRECTORY` displays directories correctly.
+    """
+    ret = subprocess.run(['onyo', 'tree', directory], capture_output=True, text=True)
+
+    # verify output
+    assert not ret.stderr
+    assert ret.returncode == 0
+
+    for d in Path(directory).parts:
+        assert d in ret.stdout
+    # check that the other paths are not in output
+    for d in [d for dirs in directories for d in Path(dirs).parts
+              if d not in Path(dirs).parts and dirs != directory]:
+        assert d not in ret.stdout
+    for a in [a.name for a in Path(directory).iterdir() if a.name[0] != "."]:
+        assert a in ret.stdout
+
+
+@pytest.mark.repo_files(*assets)
+def test_tree_multiple_inputs(repo: Repo) -> None:
+    """
+    Test that `onyo tree <dirs>` displays all directories when given a list of
+    paths in one call.
+    """
+    ret = subprocess.run(['onyo', 'tree', *directories], capture_output=True, text=True)
+
+    # verify output
+    assert not ret.stderr
+    assert ret.returncode == 0
+    for d in [d for directory in directories for d in Path(directory).parts]:
+        assert d in ret.stdout
+    for a in assets:
+        assert Path(a).name in ret.stdout
+
+
+no_directories = ["does_not_exist",
+                  ] + [d + "/subdir" for d in directories]
+@pytest.mark.repo_files(*assets)
+@pytest.mark.parametrize('directory', no_directories)
+def test_tree_error_dir_does_not_exist(repo: Repo, directory: str) -> None:
+    """
+    Test the correct error behavior when `onyo tree <path>` is called on
+    non-existing directories and sub-directories.
+    """
+    ret = subprocess.run(['onyo', 'tree', directory], capture_output=True, text=True)
+
+    # verify output
+    assert not ret.stdout
+    assert "The following paths are not directories:" in ret.stderr
+    assert directory in ret.stderr
+    assert ret.returncode == 1
+
+
+@pytest.mark.repo_files(*assets)
+@pytest.mark.parametrize('asset', assets)
+def test_tree_error_is_file(repo: Repo, asset: str) -> None:
+    """
+    Test the correct error behavior when `onyo tree ASSET` is called on assets.
+    """
+    ret = subprocess.run(['onyo', 'tree', asset], capture_output=True, text=True)
+
+    # verify output
+    assert not ret.stdout
+    assert "The following paths are not directories:" in ret.stderr
+    assert asset in ret.stderr
+    assert ret.returncode == 1
+
+
+@pytest.mark.repo_files(*assets)
+def test_tree_relative_path(repo: Repo) -> None:
+    """
+    Test `onyo tree <path>` with a relative path given as input.
+    """
+    ret = subprocess.run(["onyo", "tree", "simple/../s p a c e s"], capture_output=True, text=True)
+
+    # verify output
+    assert not ret.stderr
+    assert ret.returncode == 0
+    assert "s p a c e s" in ret.stdout
+
+
+@pytest.mark.repo_files(*assets)
+def test_tree_error_relative_path_outside_repo(repo: Repo) -> None:
+    """
+    Test `onyo tree <path>` gives error with a relative path that leads outside
+    of the repository.
+    """
+    ret = subprocess.run(["onyo", "tree", ".."], capture_output=True, text=True)
+
+    # verify output
+    assert not ret.stdout
+    assert "The following paths are not inside the repository:" in ret.stderr
+    assert ret.returncode == 1


### PR DESCRIPTION
`onyo tree PATH` did test that the opdir is in the repository, but did not test if the PATH given as input is in the repository, which I fixed.

To verify that the fix does not introduce new bugs, I added `test_tree.py`, because it seems we never had any tests at all for this command.

Close #121