### PR TITLE
Add: Pyre in all commands!

### DIFF
--- a/onyo/commands/cat.py
+++ b/onyo/commands/cat.py
@@ -8,7 +8,7 @@ logging.basicConfig()
 log = logging.getLogger('onyo')
 
 
-def sanitize_paths(paths, opdir):
+def sanitize_paths(paths: list[str], opdir: str) -> list[Path]:
     """
     Check and normalize a list of paths. If paths do not exist or are not files,
     print paths and exit with error.
@@ -48,11 +48,12 @@ def sanitize_paths(paths, opdir):
     return paths_to_cat
 
 
-def cat(args, opdir):
+def cat(args, opdir: str) -> None:
     """
     Print the contents of ``asset``\(s) to the terminal without parsing or
     validating the contents.
     """
+    repo = None
     try:
         repo = Repo(opdir)
         repo.fsck(['asset-yaml'])

--- a/onyo/commands/config.py
+++ b/onyo/commands/config.py
@@ -9,7 +9,7 @@ logging.basicConfig()
 log = logging.getLogger('onyo')
 
 
-def sanitize_args(git_config_args):
+def sanitize_args(git_config_args: list[str]) -> list[str]:
     """
     Check the git config arguments against a list of conflicting options. If
     conflicts are present, the conflict list will be printed and will exit with
@@ -39,7 +39,7 @@ def sanitize_args(git_config_args):
     return git_config_args
 
 
-def config(args, opdir):
+def config(args, opdir: str) -> None:
     """
     Set, query, and unset Onyo repository configuration options. These options
     are stored in ``.onyo/config`` (which is tracked by git) and are shared with
@@ -70,6 +70,7 @@ def config(args, opdir):
 
         $ onyo config onyo.core.editor "vim"
     """
+    repo = None
     try:
         repo = Repo(opdir)
         repo.fsck(['asset-yaml'])

--- a/onyo/commands/fsck.py
+++ b/onyo/commands/fsck.py
@@ -3,7 +3,7 @@ import sys
 from onyo import Repo, OnyoInvalidRepoError
 
 
-def fsck(args, opdir):
+def fsck(args, opdir: str) -> None:
     """
     Run a suite of checks to verify the integrity and validity of an Onyo
     repository and its contents.
@@ -19,6 +19,7 @@ def fsck(args, opdir):
     - "asset-validity": loads each asset and validates the contents against
       the validation rulesets defined in ``.onyo/validation/``.
     """
+    repo = None
     try:
         repo = Repo(opdir)
         repo.fsck()

--- a/onyo/commands/history.py
+++ b/onyo/commands/history.py
@@ -11,7 +11,7 @@ logging.basicConfig()
 log = logging.getLogger('onyo')
 
 
-def sanitize_path(path, opdir):
+def sanitize_path(path: str, opdir: str) -> Path:
     """
     Checks a path relative to opdir. If it does not exist, it will print an
     error and exit.
@@ -32,7 +32,7 @@ def sanitize_path(path, opdir):
     return full_path
 
 
-def get_history_cmd(interactive, repo: Repo):
+def get_history_cmd(interactive: bool, repo: Repo) -> str:
     """
     Get the command used to display history. The appropriate one is selected
     according to the interactive mode, and basic checks are performed for
@@ -61,7 +61,7 @@ def get_history_cmd(interactive, repo: Repo):
     return history_cmd
 
 
-def history(args, opdir):
+def history(args, opdir: str) -> None:
     """
     Display the history of an ``asset`` or ``directory``.
 
@@ -71,6 +71,7 @@ def history(args, opdir):
 
     The commands to display history are configurable using ``onyo config``.
     """
+    repo = None
     try:
         repo = Repo(opdir)
         repo.fsck(['asset-yaml'])
@@ -83,6 +84,7 @@ def history(args, opdir):
 
     # run it
     orig_cwd = os.getcwd()
+    status = 0
     try:
         os.chdir(opdir)
         status = os.system(f"{history_cmd} {quote(str(path))}")

--- a/onyo/commands/mkdir.py
+++ b/onyo/commands/mkdir.py
@@ -4,7 +4,7 @@ from onyo import Repo, OnyoInvalidRepoError, OnyoProtectedPathError
 from onyo.commands.edit import request_user_response
 
 
-def mkdir(args, opdir):
+def mkdir(args, opdir: str) -> None:
     """
     Create ``directory``\(s). Intermediate directories will be created as needed
     (i.e. parent and child directories can be created in one call).
@@ -15,6 +15,7 @@ def mkdir(args, opdir):
     If the directory already exists, or the path is protected, Onyo will throw
     an error. All checks are performed before creating directories.
     """
+    repo = None
     try:
         repo = Repo(opdir)
         repo.fsck()

--- a/onyo/commands/shell_completion.py
+++ b/onyo/commands/shell_completion.py
@@ -454,7 +454,7 @@ compdef _onyo onyo
         return case
 
 
-def shell_completion(args, opdir):
+def shell_completion(args, opdir: str) -> None:
     """
     Display a shell script for tab completion for Onyo.
 


### PR DESCRIPTION
I hate this everytime I see it. I added just pyre and lines to fix pyre when it errored then, e.g. `repo = None`.