### PR TITLE
Cleanup

### DIFF
--- a/onyo/commands/cat.py
+++ b/onyo/commands/cat.py
@@ -50,7 +50,7 @@ def sanitize_paths(paths: list[str], opdir: str) -> list[Path]:
 
 def cat(args, opdir: str) -> None:
     """
-    Print the contents of ``asset``\(s) to the terminal without parsing or
+    Print the contents of ``asset``\\(s) to the terminal without parsing or
     validating the contents.
     """
     repo = None

--- a/onyo/commands/mkdir.py
+++ b/onyo/commands/mkdir.py
@@ -6,8 +6,8 @@ from onyo.commands.edit import request_user_response
 
 def mkdir(args, opdir: str) -> None:
     """
-    Create ``directory``\(s). Intermediate directories will be created as needed
-    (i.e. parent and child directories can be created in one call).
+    Create ``directory``\\(s). Intermediate directories will be created as
+    needed (i.e. parent and child directories can be created in one call).
 
     An empty ``.anchor`` file is added to each directory, to ensure that git
     tracks it even when empty.

--- a/onyo/commands/mv.py
+++ b/onyo/commands/mv.py
@@ -6,7 +6,7 @@ from onyo.commands.edit import request_user_response
 
 def mv(args, opdir: str) -> None:
     """
-    Move ``source``\(s) (assets or directories) to the ``destination``
+    Move ``source``\\(s) (assets or directories) to the ``destination``
     directory, or rename a ``source`` directory to ``destination``.
 
     Files cannot be renamed using ``onyo mv``. To do so, use ``onyo set``.

--- a/onyo/commands/new.py
+++ b/onyo/commands/new.py
@@ -215,12 +215,13 @@ def check_against_argument_conflicts(args) -> None:
 
 def new(args, opdir: str) -> None:
     """
-    Create new ``<path>/asset``\(s) and add contents with ``--template``,
+    Create new ``<path>/asset``\\(s) and add contents with ``--template``,
     ``--keys`` and ``--edit``. If the directories do not exist, they will be
     created.
 
-    After the contents are added, the new ``assets``\(s) will be checked for the
-    validity of its YAML syntax and based on the rules in ``.onyo/validation/``.
+    After the contents are added, the new ``assets``\\(s) will be checked for
+    the validity of its YAML syntax and based on the rules in
+    ``.onyo/validation/``.
     """
     repo = None
     try:

--- a/onyo/commands/rm.py
+++ b/onyo/commands/rm.py
@@ -6,7 +6,7 @@ from onyo.commands.edit import request_user_response
 
 def rm(args, opdir: str) -> None:
     """
-    Delete ``asset``\(s) and ``directory``\(s).
+    Delete ``asset``\\(s) and ``directory``\\(s).
 
     A list of all files and directories to delete will be presented, and the
     user prompted for confirmation.

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -90,9 +90,10 @@ class Repo:
         self._files = None
         self._templates = None
 
-    def generate_commit_message(self, message: list[str] = [], cmd: str = "",
-                                keys: list[str] = [], destination: str = "",
-                                MAX_LEN: int = 80) -> str:
+    def generate_commit_message(
+            self, message: Union[list[str], None] = None, cmd: str = "",
+            keys: Union[list[str], None] = None, destination: str = "",
+            max_length: int = 80) -> str:
         """
         Generate a commit subject and body suitable for use with git commit.
 
@@ -108,6 +109,9 @@ class Repo:
         Adds a list of `changed files` with their path relative to the root of
         the repository to the body of all commit messages.
         """
+        message = [] if message is None else message
+        keys = [] if keys is None else keys
+
         message_subject = ""
         message_body = ""
         message_appendix = ""
@@ -134,17 +138,16 @@ class Repo:
             # message headers (independently of later adding/shortening of
             # information) begin, for all commands.
             msg_dummy = f"{cmd} [{len(staged_changes)}]{keys_str}"
-            message_subject = self._generate_commit_message_subject(msg_dummy,
-                                                                    staged_changes,
-                                                                    dest, MAX_LEN)
+            message_subject = self._generate_commit_message_subject(
+                msg_dummy, staged_changes, dest, max_length)
 
         message_appendix = self._n_join([str(x) for x in staged_changes])
         return f"{message_subject}\n\n{message_body}\n\n{message_appendix}"
 
-    def _generate_commit_message_subject(self, msg_dummy: str,
-                                         staged_changes: list[Path],
-                                         destination: Optional[Path],
-                                         MAX_LEN: int = 80) -> str:
+    @staticmethod
+    def _generate_commit_message_subject(
+            msg_dummy: str, staged_changes: list[Path],
+            destination: Optional[Path], max_length: int = 80) -> str:
         """
         Generates "commit message subject" with the `msg_dummy` and the paths
         from `staged_changes` and `destination`, and shortens the paths if the
@@ -157,7 +160,7 @@ class Repo:
         if destination:
             msg = f"{msg} -> '{destination}'"
 
-        if len(msg) < MAX_LEN:
+        if len(msg) < max_length:
             return msg
 
         # medium message: highest level (e.g. dir or asset name)
@@ -167,7 +170,7 @@ class Repo:
         if destination:
             msg = f"{msg} -> '{destination.relative_to(destination.parent)}'"
 
-        if len(msg) < MAX_LEN:
+        if len(msg) < max_length:
             return msg
 
         # short message: "type" of devices in summary (e.g.  "laptop (2)")

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -663,11 +663,11 @@ class Repo:
     #
     def mkdir(self, directories: Union[Iterable[Union[Path, str]], Path, str]) -> None:
         """
-        Create ``directory``\(s). Intermediate directories will be created as
+        Create ``directory``\\(s). Intermediate directories will be created as
         needed (i.e. parent and child directories can be created in one call).
 
-        An empty ``.anchor`` file is added to each directory, to ensure that git
-        tracks it even when empty.
+        An empty ``.anchor`` file is added to each directory, to ensure that
+        git tracks it even when empty.
 
         If a directory already exists, or the path is protected, an exception
         will be raised. All checks are performed before creating directories.
@@ -738,7 +738,7 @@ class Repo:
     #
     def mv(self, sources: Union[Iterable[Union[Path, str]], Path, str], destination: Union[Path, str], dryrun: bool = False) -> list[tuple[str, str]]:
         """
-        Move ``source``\(s) (assets or directories) to the ``destination``
+        Move ``source``\\(s) (assets or directories) to the ``destination``
         directory, or rename a ``source`` directory to ``destination``.
 
         Files cannot be renamed using ``mv()``. To do so, use ``set()``.
@@ -1032,7 +1032,7 @@ class Repo:
         asset = Path(asset)
 
         try:
-            re.findall('(^[^._]+?)_([^._]+?)_([^._]+?)\.(.+)', asset.name)[0]
+            re.findall(r'(^[^._]+?)_([^._]+?)_([^._]+?)\.(.+)', asset.name)[0]
         except (ValueError, IndexError):
             log.info(f"'{asset.name}' must be in the format '<type>_<make>_<model>.<serial>'")
             return False
@@ -1218,7 +1218,7 @@ class Repo:
 
         for asset in assets:
             # split old name into parts
-            [serial, model, make, type] = [field[::-1] for field in re.findall('(.*)\.(.*)_(.*)_(.*)', asset.name[::-1])[0]]
+            [serial, model, make, type] = [field[::-1] for field in re.findall(r'(.*)\.(.*)_(.*)_(.*)', asset.name[::-1])[0]]
             fields = name_values.keys()
 
             # update name fields and build new asset name
@@ -1265,7 +1265,7 @@ class Repo:
     #
     def rm(self, paths: Union[Iterable[Union[Path, str]], Path, str], dryrun: bool = False) -> list[str]:
         """
-        Delete ``asset``\(s) and ``directory``\(s).
+        Delete ``asset``\\(s) and ``directory``\\(s).
         """
         if not isinstance(paths, (list, set)):
             paths = [paths]

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -273,7 +273,8 @@ class Repo:
     #
     # HELPERS
     #
-    def _is_protected_path(self, path: Union[Path, str]) -> bool:
+    @staticmethod
+    def _is_protected_path(path: Union[Path, str]) -> bool:
         """
         Checks whether a path contains protected elements (.anchor, .git, .onyo).
         Returns True if it contains protected elements. Otherwise False.
@@ -287,7 +288,8 @@ class Repo:
 
         return False
 
-    def _n_join(self, to_join: Iterable) -> str:
+    @staticmethod
+    def _n_join(to_join: Iterable) -> str:
         """
         Convert an Iterable's contents to strings and join with newlines.
         """
@@ -629,7 +631,8 @@ class Repo:
 
         log.info(f'Initialized Onyo repository in {dot_onyo}/')
 
-    def _init_sanitize(self, directory: Union[Path, str]) -> Path:
+    @staticmethod
+    def _init_sanitize(directory: Union[Path, str]) -> Path:
         """
         Check the target path for viability as an init target.
 
@@ -1130,7 +1133,8 @@ class Repo:
 
         return "\n".join(diff).strip()
 
-    def _read_asset(self, asset: Path) -> dict:
+    @staticmethod
+    def _read_asset(asset: Path) -> dict:
         """
         Read and return the contents of an asset as a dictionary.
         """
@@ -1245,7 +1249,8 @@ class Repo:
 
             self._git(["mv", str(asset), str(new_name)])
 
-    def _write_asset(self, asset: Path, contents: dict) -> None:
+    @staticmethod
+    def _write_asset(asset: Path, contents: dict) -> None:
         """
         Write contents into an asset file.
         """


### PR DESCRIPTION
This PR addresses a few issues `onyo.py`.

[Mutable defaults](https://florimond.dev/en/posts/2018/08/python-mutable-defaults-are-the-source-of-all-evil/) should be avoided, because by calling a function overwriting it's default value, you're also defining that as a new default value. Therefore, any subsequent calls to that function will use the new value. This can lead to very difficult to diagnose problems.

Some functions in `Repo` are staticmethods but are not defined as such. I've added the decorators. This can also give us a clear overview of which functions can easily (but not necessarily) be placed outside of the class to be used more broadly.

Lastly, various warnings were given regarding the use of deprecated escape characters. This was caused by the use of `\` in docstrings, as well as in regular expressions that were not defined as raw strings, e.g., `r'raw string'` vs `'literal string'`. The latter applies Python string formatting (like transforming `\n` to a newline, which then counts as one character; you can try this with `len('\n')`), whereas the former does not. We want the former, because in the affected regular expressions we're not using `\` as a Python escape character.