### PR TITLE
Consistency: add typing to commands; update default values and add some typing in main.py

### DIFF
--- a/onyo/commands/cat.py
+++ b/onyo/commands/cat.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
 import logging
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from onyo import Repo, OnyoInvalidRepoError
+
+if TYPE_CHECKING:
+    import argparse
 
 logging.basicConfig()
 log = logging.getLogger('onyo')
@@ -48,7 +53,7 @@ def sanitize_paths(paths: list[str], opdir: str) -> list[Path]:
     return paths_to_cat
 
 
-def cat(args, opdir: str) -> None:
+def cat(args: argparse.Namespace, opdir: str) -> None:
     """
     Print the contents of ``asset``\(s) to the terminal without parsing or
     validating the contents.

--- a/onyo/commands/config.py
+++ b/onyo/commands/config.py
@@ -1,9 +1,14 @@
+from __future__ import annotations
 import logging
 import subprocess
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from onyo import Repo, OnyoInvalidRepoError
+
+if TYPE_CHECKING:
+    import argparse
 
 logging.basicConfig()
 log = logging.getLogger('onyo')
@@ -39,7 +44,7 @@ def sanitize_args(git_config_args: list[str]) -> list[str]:
     return git_config_args
 
 
-def config(args, opdir: str) -> None:
+def config(args: argparse.Namespace, opdir: str) -> None:
     """
     Set, query, and unset Onyo repository configuration options. These options
     are stored in ``.onyo/config`` (which is tracked by git) and are shared with

--- a/onyo/commands/edit.py
+++ b/onyo/commands/edit.py
@@ -1,11 +1,16 @@
+from __future__ import annotations
 import logging
 import os
 import sys
 from pathlib import Path
 from shlex import quote
+from typing import TYPE_CHECKING
 
 from ruamel.yaml import YAML, scanner  # pyre-ignore[21]
 from onyo import Repo, OnyoInvalidRepoError
+
+if TYPE_CHECKING:
+    import argparse
 
 logging.basicConfig()
 log = logging.getLogger('onyo')
@@ -95,7 +100,7 @@ def sanitize_assets(assets: list[str], repo: Repo) -> list[Path]:
     return valid_assets
 
 
-def edit(args, opdir: str) -> None:
+def edit(args: argparse.Namespace, opdir: str) -> None:
     """
     Open the ``asset`` file(s) using the editor specified by "onyo.core.editor",
     the environment variable ``EDITOR``, or ``nano`` (as a final fallback).

--- a/onyo/commands/fsck.py
+++ b/onyo/commands/fsck.py
@@ -1,9 +1,14 @@
+from __future__ import annotations
 import sys
+from typing import TYPE_CHECKING
 
 from onyo import Repo, OnyoInvalidRepoError
 
+if TYPE_CHECKING:
+    import argparse
 
-def fsck(args, opdir: str) -> None:
+
+def fsck(args: argparse.Namespace, opdir: str) -> None:
     """
     Run a suite of checks to verify the integrity and validity of an Onyo
     repository and its contents.

--- a/onyo/commands/history.py
+++ b/onyo/commands/history.py
@@ -1,11 +1,16 @@
+from __future__ import annotations
 import logging
 import os
 import shutil
 import sys
 from pathlib import Path
 from shlex import quote
+from typing import TYPE_CHECKING
 
 from onyo import Repo, OnyoInvalidRepoError
+
+if TYPE_CHECKING:
+    import argparse
 
 logging.basicConfig()
 log = logging.getLogger('onyo')
@@ -61,7 +66,7 @@ def get_history_cmd(interactive: bool, repo: Repo) -> str:
     return history_cmd
 
 
-def history(args, opdir: str) -> None:
+def history(args: argparse.Namespace, opdir: str) -> None:
     """
     Display the history of an ``asset`` or ``directory``.
 

--- a/onyo/commands/init.py
+++ b/onyo/commands/init.py
@@ -1,9 +1,15 @@
+from __future__ import annotations
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
+
 from onyo import Repo
 
+if TYPE_CHECKING:
+    import argparse
 
-def init(args, opdir: str) -> None:
+
+def init(args: argparse.Namespace, opdir: str) -> None:
     """
     Initialize an Onyo repository. The directory will be initialized as a git
     repository (if it is not one already), the ``.onyo/`` directory created and

--- a/onyo/commands/mkdir.py
+++ b/onyo/commands/mkdir.py
@@ -1,10 +1,15 @@
+from __future__ import annotations
 import sys
+from typing import TYPE_CHECKING
 
 from onyo import Repo, OnyoInvalidRepoError, OnyoProtectedPathError
 from onyo.commands.edit import request_user_response
 
+if TYPE_CHECKING:
+    import argparse
 
-def mkdir(args, opdir: str) -> None:
+
+def mkdir(args: argparse.Namespace, opdir: str) -> None:
     """
     Create ``directory``\(s). Intermediate directories will be created as needed
     (i.e. parent and child directories can be created in one call).

--- a/onyo/commands/mv.py
+++ b/onyo/commands/mv.py
@@ -1,10 +1,15 @@
+from __future__ import annotations
 import sys
+from typing import TYPE_CHECKING
 
 from onyo import Repo, OnyoInvalidRepoError, OnyoProtectedPathError
 from onyo.commands.edit import request_user_response
 
+if TYPE_CHECKING:
+    import argparse
 
-def mv(args, opdir: str) -> None:
+
+def mv(args: argparse.Namespace, opdir: str) -> None:
     """
     Move ``source``\(s) (assets or directories) to the ``destination``
     directory, or rename a ``source`` directory to ``destination``.

--- a/onyo/commands/new.py
+++ b/onyo/commands/new.py
@@ -1,10 +1,15 @@
+from __future__ import annotations
 import csv
 import logging
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from onyo import Repo, OnyoInvalidRepoError
 from onyo.commands.edit import edit_asset, get_editor, request_user_response
+
+if TYPE_CHECKING:
+    import argparse
 
 logging.basicConfig()
 log = logging.getLogger('onyo')
@@ -213,7 +218,7 @@ def check_against_argument_conflicts(args) -> None:
                 sys.exit(1)
 
 
-def new(args, opdir: str) -> None:
+def new(args: argparse.Namespace, opdir: str) -> None:
     """
     Create new ``<path>/asset``\(s) and add contents with ``--template``,
     ``--keys`` and ``--edit``. If the directories do not exist, they will be

--- a/onyo/commands/rm.py
+++ b/onyo/commands/rm.py
@@ -1,10 +1,15 @@
+from __future__ import annotations
 import sys
+from typing import TYPE_CHECKING
 
 from onyo import Repo, OnyoInvalidRepoError, OnyoProtectedPathError
 from onyo.commands.edit import request_user_response
 
+if TYPE_CHECKING:
+    import argparse
 
-def rm(args, opdir: str) -> None:
+
+def rm(args: argparse.Namespace, opdir: str) -> None:
     """
     Delete ``asset``\(s) and ``directory``\(s).
 

--- a/onyo/commands/set.py
+++ b/onyo/commands/set.py
@@ -1,14 +1,19 @@
+from __future__ import annotations
 import logging
 import sys
+from typing import TYPE_CHECKING
 
 from onyo import Repo, OnyoInvalidRepoError
 from onyo.commands.edit import request_user_response
+
+if TYPE_CHECKING:
+    import argparse
 
 logging.basicConfig()
 log = logging.getLogger('onyo')
 
 
-def set(args, opdir: str) -> None:
+def set(args: argparse.Namespace, opdir: str) -> None:
     """
     Set the ``value`` of ``key`` for matching assets. If the key does not exist,
     it is added and set appropriately.

--- a/onyo/commands/shell_completion.py
+++ b/onyo/commands/shell_completion.py
@@ -454,7 +454,7 @@ compdef _onyo onyo
         return case
 
 
-def shell_completion(args, opdir: str) -> None:
+def shell_completion(args: argparse.Namespace, opdir: str) -> None:
     """
     Display a shell script for tab completion for Onyo.
 

--- a/onyo/commands/tree.py
+++ b/onyo/commands/tree.py
@@ -1,9 +1,14 @@
+from __future__ import annotations
 import logging
 import subprocess
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from onyo import Repo, OnyoInvalidRepoError
+
+if TYPE_CHECKING:
+    import argparse
 
 logging.basicConfig()
 log = logging.getLogger('onyo')
@@ -45,7 +50,7 @@ def sanitize_directories(repo: Repo, directories: list[str]) -> list[str]:
     return dirs
 
 
-def tree(args, opdir: str) -> None:
+def tree(args: argparse.Namespace, opdir: str) -> None:
     """
     List the assets and directories in ``directory`` using ``tree``.
     """

--- a/onyo/commands/unset.py
+++ b/onyo/commands/unset.py
@@ -1,14 +1,19 @@
+from __future__ import annotations
 import logging
 import sys
+from typing import TYPE_CHECKING
 
 from onyo import Repo, OnyoInvalidRepoError
 from onyo.commands.edit import request_user_response
+
+if TYPE_CHECKING:
+    import argparse
 
 logging.basicConfig()
 log = logging.getLogger('onyo')
 
 
-def unset(args, opdir: str) -> None:
+def unset(args: argparse.Namespace, opdir: str) -> None:
     """
     Remove the ``value`` of ``key`` for matching assets.
 

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -83,35 +83,35 @@ def parse_key_values(string):
     return results
 
 
-def directory(string):
+def directory(string: str):
     """
     A no-op type-check for ArgParse. Used to hint for shell tab-completion.
     """
     return string
 
 
-def file(string):
+def file(string: str):
     """
     A no-op type-check for ArgParse. Used to hint for shell tab-completion.
     """
     return string
 
 
-def git_config(string):
+def git_config(string: str):
     """
     A no-op type-check for ArgParse. Used to hint for shell tab-completion.
     """
     return string
 
 
-def path(string):
+def path(string: str):
     """
     A no-op type-check for ArgParse. Used to hint for shell tab-completion.
     """
     return string
 
 
-def template(string):
+def template(string: str):
     """
     A no-op type-check for ArgParse. Used to hint for shell tab-completion.
     """

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -383,7 +383,7 @@ def setup_parser():
         '-t', '--template',
         metavar='TEMPLATE',
         required=False,
-        default=None,
+        default=[],
         type=template,
         help='the template to seed the new asset'
     )
@@ -527,7 +527,7 @@ def setup_parser():
     )
     cmd_set.add_argument(
         '-p', '--path',
-        default=".",
+        default=["."],
         metavar='PATH',
         nargs='*',
         type=path,
@@ -626,7 +626,7 @@ def setup_parser():
     )
     cmd_unset.add_argument(
         '-p', '--path',
-        default=".",
+        default=["."],
         metavar="PATH",
         nargs='*',
         type=path,


### PR DESCRIPTION
Adds typing `argparse.Namespace` to all commands.
Adds typing to some functions in `main.py`.
Changes default values in argparsing in `main.py` to have consistent types (i.e. lists of `Path`).

Close #319 