### PR TITLE
(to be deleted) TST: modernize `tests/lib/`

### DIFF
--- a/tests/commands/test_cat.py
+++ b/tests/commands/test_cat.py
@@ -2,6 +2,7 @@ import subprocess
 
 from onyo.lib import Repo, OnyoInvalidRepoError
 import pytest
+from typing import List
 
 files = ['laptop_apple_macbookpro',
          'lap top_ap ple_mac book pro']
@@ -14,16 +15,16 @@ directories = ['.',
                'very/very/very/deep'
                ]
 
-assets = [f"{d}/{f}.{i}" for f in files for i, d in enumerate(directories)]
+assets: List[str] = [f"{d}/{f}.{i}" for f in files for i, d in enumerate(directories)]
 
 content_dict = {"one_key": "one_value",
                 "two_key": "two_value",
                 "three_key": "three_value"}
 
-content_str = "\n".join([f"{elem}: {content_dict.get(elem)}"
+content_str: str = "\n".join([f"{elem}: {content_dict.get(elem)}"
                          for elem in content_dict]) + "\n"
 
-contents = [[x, content_str] for x in assets]
+contents: List[List[str]] = [[x, content_str] for x in assets]
 
 
 @pytest.mark.repo_contents(*contents)

--- a/tests/commands/test_cat.py
+++ b/tests/commands/test_cat.py
@@ -22,7 +22,7 @@ content_dict = {"one_key": "one_value",
                 "three_key": "three_value"}
 
 content_str: str = "\n".join([f"{elem}: {content_dict.get(elem)}"
-                         for elem in content_dict]) + "\n"
+                              for elem in content_dict]) + "\n"
 
 contents: List[List[str]] = [[x, content_str] for x in assets]
 

--- a/tests/commands/test_history.py
+++ b/tests/commands/test_history.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from onyo.lib import Repo
 import pytest
+from typing import List
 
 
 # NOTE: the output of `onyo history` is not tested for formatting or content, as
@@ -19,7 +20,7 @@ directories = ['.',
                'very/very/very/deep',
                ]
 
-assets = [f"{d}/{f}.{i}" for f in files for i, d in enumerate(directories)]
+assets: List[str] = [f"{d}/{f}.{i}" for f in files for i, d in enumerate(directories)]
 
 
 @pytest.mark.repo_files(*assets)

--- a/tests/commands/test_rm.py
+++ b/tests/commands/test_rm.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from onyo.lib import Repo
 import pytest
+from typing import List
 
 files = ['laptop_apple_macbookpro',
          'lap top_ap ple_mac book pro',
@@ -16,7 +17,7 @@ directories = ['.',
                'very/very/very/deep'
                ]
 
-assets = [f"{d}/{f}.{i}" for f in files for i, d in enumerate(directories)]
+assets: List[str] = [f"{d}/{f}.{i}" for f in files for i, d in enumerate(directories)]
 
 @pytest.mark.repo_files(*assets)
 @pytest.mark.parametrize('asset', assets)

--- a/tests/commands/test_set.py
+++ b/tests/commands/test_set.py
@@ -16,7 +16,8 @@ directories = ['.',
                'very/very/very/deep'
                ]
 
-assets: List[str] = [f"{d}/{f}.{i}" for f in files for i, d in enumerate(directories)]
+assets: List[str] = [f"{d}/{f}.{i}" for f in files
+                     for i, d in enumerate(directories)]
 
 values = [["mode=single"],
           ["mode=double"], ["key=space bar"]]
@@ -87,19 +88,22 @@ def test_set_multiple_assets(repo: Repo, set_values: list[str]) -> None:
     repo.fsck()
 
 
-non_existing_assets: List[List[str]] = [["single_non_existing.asset"],
-                       ["simple/single_non_existing.asset"],
-                       [assets[0], "single_non_existing.asset"]]
+non_existing_assets: List[List[str]] = [
+    ["single_non_existing.asset"],
+    ["simple/single_non_existing.asset"],
+    [assets[0], "single_non_existing.asset"]]
 @pytest.mark.repo_files(*assets)
 @pytest.mark.parametrize('no_assets', non_existing_assets)
-def test_set_error_non_existing_assets(repo: Repo, no_assets: list[str]) -> None:
+def test_set_error_non_existing_assets(repo: Repo,
+                                       no_assets: list[str]) -> None:
     """
     Test that `onyo set KEY=VALUE <asset>` errors correctly for:
     - non-existing assets on root
     - non-existing assets in directories
     - one non-existing asset in a list of existing ones
     """
-    ret = subprocess.run(['onyo', 'set', '--keys', 'key=value', '--path', *no_assets], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', 'set', '--keys', 'key=value',
+                          '--path', *no_assets], capture_output=True, text=True)
 
     # verify output and the state of the repository
     assert not ret.stdout
@@ -115,7 +119,8 @@ def test_set_with_dot_recursive(repo: Repo, set_values: list[str]) -> None:
     Test that when `onyo set KEY=VALUE .` is called from the repository root,
     onyo selects all assets in the complete repo recursively.
     """
-    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', *set_values, '--path', "."], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', *set_values,
+                          '--path', "."], capture_output=True, text=True)
 
     # verify that output mentions every asset
     assert "The following assets will be changed:" in ret.stdout

--- a/tests/commands/test_set.py
+++ b/tests/commands/test_set.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from onyo.lib import Repo
 import pytest
+from typing import List
 
 files = ['laptop_apple_macbookpro',
          'lap top_ap ple_mac book pro']
@@ -15,7 +16,7 @@ directories = ['.',
                'very/very/very/deep'
                ]
 
-assets = [f"{d}/{f}.{i}" for f in files for i, d in enumerate(directories)]
+assets: List[str] = [f"{d}/{f}.{i}" for f in files for i, d in enumerate(directories)]
 
 values = [["mode=single"],
           ["mode=double"], ["key=space bar"]]
@@ -86,7 +87,7 @@ def test_set_multiple_assets(repo: Repo, set_values: list[str]) -> None:
     repo.fsck()
 
 
-non_existing_assets = [["single_non_existing.asset"],
+non_existing_assets: List[List[str]] = [["single_non_existing.asset"],
                        ["simple/single_non_existing.asset"],
                        [assets[0], "single_non_existing.asset"]]
 @pytest.mark.repo_files(*assets)

--- a/tests/commands/test_shell-completion.py
+++ b/tests/commands/test_shell-completion.py
@@ -2,14 +2,14 @@ import subprocess
 
 
 # command does not explode
-def test_good_returncode():
+def test_good_returncode() -> None:
     ret = subprocess.run(["onyo", "shell-completion"])
     assert ret.returncode == 0
 
 
 # There should be no "None"s in the output. If so, it is usually due to an unset
 # metavar variable in the argparse arguments.
-def test_no_empty_metavars():
+def test_no_empty_metavars() -> None:
     ret = subprocess.run(["onyo", "shell-completion"], capture_output=True, text=True)
     assert 'None' not in ret.stdout
 
@@ -17,14 +17,14 @@ def test_no_empty_metavars():
 # A naive test to see if there are "enough" lines. Boilerplate alone was 54
 # lines at the time of this writing and the full script at 168. If there's
 # fewer than 100 lines, then something significant is missing (or has changed).
-def test_script_length():
+def test_script_length() -> None:
     ret = subprocess.run(["onyo", "shell-completion"], capture_output=True, text=True)
     lines = ret.stdout.count('\n')
     assert lines >= 100
 
 
 # zsh parses the script successfully
-def test_zsh_parseable():
+def test_zsh_parseable() -> None:
     # "compinit -C" disables security-related checks. This is necessary for
     # non-interactive environments. See the compinit source for more info.
     ret = subprocess.run(["zsh", "-c", "autoload -Uz compinit && compinit -C && source <(onyo shell-completion)"])

--- a/tests/commands/test_tree.py
+++ b/tests/commands/test_tree.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pytest
 from onyo.lib import Repo
+from typing import List
 
 files = ['laptop_apple_macbookpro',
          'lap top_ap ple_mac book pro']
@@ -15,7 +16,7 @@ directories = ['.',
                'very/very/very/deep'
                ]
 
-assets = [f"{d}/{f}.{i}" for f in files for i, d in enumerate(directories)]
+assets: List[str] = [f"{d}/{f}.{i}" for f in files for i, d in enumerate(directories)]
 
 
 @pytest.mark.repo_files(*assets)
@@ -74,7 +75,7 @@ def test_tree_multiple_inputs(repo: Repo) -> None:
         assert Path(a).name in ret.stdout
 
 
-no_directories = ["does_not_exist",
+no_directories: List[str] = ["does_not_exist",
                   ] + [d + "/subdir" for d in directories]
 @pytest.mark.repo_files(*assets)
 @pytest.mark.parametrize('directory', no_directories)

--- a/tests/commands/test_tree.py
+++ b/tests/commands/test_tree.py
@@ -16,7 +16,8 @@ directories = ['.',
                'very/very/very/deep'
                ]
 
-assets: List[str] = [f"{d}/{f}.{i}" for f in files for i, d in enumerate(directories)]
+assets: List[str] = [f"{d}/{f}.{i}" for f in files
+                     for i, d in enumerate(directories)]
 
 
 @pytest.mark.repo_files(*assets)
@@ -75,8 +76,8 @@ def test_tree_multiple_inputs(repo: Repo) -> None:
         assert Path(a).name in ret.stdout
 
 
-no_directories: List[str] = ["does_not_exist",
-                  ] + [d + "/subdir" for d in directories]
+no_directories: List[str] = ["does_not_exist"] + [d + "/subdir"
+                                                  for d in directories]
 @pytest.mark.repo_files(*assets)
 @pytest.mark.parametrize('directory', no_directories)
 def test_tree_error_dir_does_not_exist(repo: Repo, directory: str) -> None:

--- a/tests/commands/test_unset.py
+++ b/tests/commands/test_unset.py
@@ -16,14 +16,15 @@ directories = ['.',
                'very/very/very/deep',
                ]
 
-assets: List[str] = [f"{d}/{f}.{i}" for f in files for i, d in enumerate(directories)]
+assets: List[str] = [f"{d}/{f}.{i}" for f in files
+                     for i, d in enumerate(directories)]
 
 content_dict = {"one_key": "one_value",
                 "two_key": "two_value",
                 "three_key": "three_value"}
 
 content_str: str = "\n".join([f"{elem}: {content_dict.get(elem)}"
-                         for elem in content_dict]) + "\n"
+                              for elem in content_dict]) + "\n"
 
 contents: List[List[str]] = [[x, content_str] for x in assets]
 
@@ -160,12 +161,14 @@ def test_unset_multiple_assets(repo: Repo) -> None:
     repo.fsck()
 
 
-non_existing_assets: List[List[str]] = [["single_non_existing.asset"],
-                       ["simple/single_non_existing.asset"],
-                       [assets[0], "single_non_existing.asset"]]
+non_existing_assets: List[List[str]] = [
+    ["single_non_existing.asset"],
+    ["simple/single_non_existing.asset"],
+    [assets[0], "single_non_existing.asset"]]
 @pytest.mark.repo_files(*assets)
 @pytest.mark.parametrize('no_assets', non_existing_assets)
-def test_unset_error_non_existing_assets(repo: Repo, no_assets: list[str]) -> None:
+def test_unset_error_non_existing_assets(repo: Repo,
+                                         no_assets: list[str]) -> None:
     """
     Test that `onyo unset --keys KEY --path ASSET` errors correctly for
     non-existing assets on root, in directories, or if an invalid asset name is

--- a/tests/commands/test_unset.py
+++ b/tests/commands/test_unset.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from onyo.lib import Repo
 import pytest
+from typing import List
 
 files = ['laptop_apple_macbookpro',
          'lap top_ap ple_mac book pro']
@@ -15,16 +16,16 @@ directories = ['.',
                'very/very/very/deep',
                ]
 
-assets = [f"{d}/{f}.{i}" for f in files for i, d in enumerate(directories)]
+assets: List[str] = [f"{d}/{f}.{i}" for f in files for i, d in enumerate(directories)]
 
 content_dict = {"one_key": "one_value",
                 "two_key": "two_value",
                 "three_key": "three_value"}
 
-content_str = "\n".join([f"{elem}: {content_dict.get(elem)}"
+content_str: str = "\n".join([f"{elem}: {content_dict.get(elem)}"
                          for elem in content_dict]) + "\n"
 
-contents = [[x, content_str] for x in assets]
+contents: List[List[str]] = [[x, content_str] for x in assets]
 
 @pytest.mark.repo_contents(*contents)
 @pytest.mark.parametrize('asset', assets)
@@ -159,7 +160,7 @@ def test_unset_multiple_assets(repo: Repo) -> None:
     repo.fsck()
 
 
-non_existing_assets = [["single_non_existing.asset"],
+non_existing_assets: List[List[str]] = [["single_non_existing.asset"],
                        ["simple/single_non_existing.asset"],
                        [assets[0], "single_non_existing.asset"]]
 @pytest.mark.repo_files(*assets)
@@ -403,7 +404,7 @@ depth_assets = ["laptop_macbook_pro.0",
                 "dir1/dir2/dir3/dir4/laptop_macbook_pro.4",
                 "dir1/dir2/dir3/dir4/dir5/laptop_macbook_pro.5",
                 "dir1/dir2/dir3/dir4/dir5/dir6/laptop_macbook_pro.6"]
-depth_contents = [[x, content_str] for x in depth_assets]
+depth_contents: List[List[str]] = [[x, content_str] for x in depth_assets]
 @pytest.mark.repo_contents(*depth_contents)
 def test_unset_depth_flag(repo: Repo) -> None:
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from onyo import Repo
 import pytest
+from typing import List, Type, Union
 
 
 @pytest.fixture(scope='function')
@@ -72,7 +73,7 @@ def repo(tmp_path, monkeypatch, request):
 
 
 @pytest.fixture(scope="function", autouse=True)
-def clean_env(request):
+def clean_env(request) -> None:
     """
     Ensure that $EDITOR is not inherited from the environment or other tests.
     """
@@ -83,7 +84,7 @@ def clean_env(request):
 
 
 @pytest.fixture
-def helpers():
+def helpers() -> Type[Helpers]:
     return Helpers
 
 
@@ -97,7 +98,7 @@ class Helpers:
                 yield x
 
     @staticmethod
-    def onyo_flags():
+    def onyo_flags() -> List[Union[List[List[str]], List[str]]]:
         return [['-d', '--debug'],
                 [['-C', '/tmp'], ['--onyopath', '/tmp']],
                 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,11 +83,6 @@ def clean_env(request) -> None:
         pass
 
 
-@pytest.fixture
-def helpers() -> Type[Helpers]:
-    return Helpers
-
-
 class Helpers:
     @staticmethod
     def flatten(xs):
@@ -108,3 +103,8 @@ class Helpers:
         "powerset([1,2,3]) --> () (1,) (2,) (3,) (1,2) (1,3) (2,3) (1,2,3)"
         s = list(iterable)
         return chain.from_iterable(combinations(s, r) for r in range(len(s) + 1))
+
+
+@pytest.fixture
+def helpers() -> Type[Helpers]:
+    return Helpers

--- a/tests/demo/test_generate_demo_repo.py
+++ b/tests/demo/test_generate_demo_repo.py
@@ -2,7 +2,7 @@ import subprocess
 from pathlib import Path
 
 
-def test_generate_demo_repo(tmp_path, request):
+def test_generate_demo_repo(tmp_path, request) -> None:
     """
     Generate an Onyo demo repository, and compare it against the git log of
     another known-good-demo-repo.

--- a/tests/lib/test_Repo.py
+++ b/tests/lib/test_Repo.py
@@ -10,12 +10,12 @@ from onyo import Repo, OnyoInvalidRepoError
 #
 # instantiation
 #
-variants = {
-    'str': 'the-repo',
-    'Path': Path('the-repo'),
-}
-@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
-def test_Repo_instantiate_types(tmp_path, variant):
+@pytest.mark.parametrize('variant', ['the-repo', Path('the-repo')])
+def test_Repo_instantiate_types(tmp_path: str, variant: Union[Path, str]) -> None:
+    """
+    Test that the Repo class instantiates correctly for different data types
+    describing paths to existing repositories.
+    """
     os.chdir(tmp_path)
     ret = subprocess.run(['onyo', 'init', 'the-repo'])
     assert ret.returncode == 0
@@ -24,20 +24,32 @@ def test_Repo_instantiate_types(tmp_path, variant):
     Repo(variant)
 
 
-def test_Repo_instantiate_invalid_path(tmp_path):
+def test_Repo_instantiate_invalid_path(tmp_path: str) -> None:
+    """
+    Test that the Repo class raises the correct error if instantiated with a
+    path that does not exist.
+    """
     repo_path = Path(tmp_path, 'does-not-exist')
 
     with pytest.raises(FileNotFoundError):
         Repo(repo_path)
 
 
-def test_Repo_instantiate_empty_dir(tmp_path):
+def test_Repo_instantiate_empty_dir(tmp_path: str) -> None:
+    """
+    Test that the Repo class raises the correct error if instantiated with a
+    path that is not an Onyo repository.
+    """
     repo_path = Path(tmp_path)
     with pytest.raises(OnyoInvalidRepoError):
         Repo(repo_path)
 
 
-def test_Repo_instantiate_git_no_onyo(tmp_path):
+def test_Repo_instantiate_git_no_onyo(tmp_path: str) -> None:
+    """
+    Test that the Repo class raises the correct error if used on a git
+    repository that is not an Onyo repository.
+    """
     repo_path = Path(tmp_path)
     ret = subprocess.run(['git', 'init', str(repo_path)])
     assert ret.returncode == 0
@@ -47,7 +59,11 @@ def test_Repo_instantiate_git_no_onyo(tmp_path):
         Repo(repo_path)
 
 
-def test_Repo_instantiate_onyo_no_git(tmp_path):
+def test_Repo_instantiate_onyo_no_git(tmp_path: str) -> None:
+    """
+    Test that the Repo class raises the correct error if instantiated with a
+    path that contains a `.onyo/` that is not a git repository.
+    """
     repo_path = Path(tmp_path)
     Path(repo_path, '.onyo').mkdir()
 
@@ -77,14 +93,11 @@ def fully_populated_dot_onyo(directory: Union[Path, str]) -> bool:
     return True
 
 
-variants = {
-    'string': 'dir',
-    'Path': Path('dir'),
-}
-@pytest.mark.parametrize('variant', variants)
-def test_init_types(tmp_path, variant):
+@pytest.mark.parametrize('variant', ['dir', Path('dir')])
+def test_init_types(tmp_path: str, variant: Union[str, Path]) -> None:
     """
-    Init an existing, empty directory.
+    Test that `Repo(<directory>, init=True)` initializes an Onyo Repository for
+    an existing, empty directory.
     """
     os.chdir(tmp_path)
 
@@ -93,22 +106,18 @@ def test_init_types(tmp_path, variant):
     assert fully_populated_dot_onyo(variant)
 
 
-def test_init_False(tmp_path):
+def test_init_False(tmp_path: str) -> None:
     """
-    False does not init.
+    Test that `Repo(<directory>, init=False)` does not initializes an Onyo
+    Repository.
     """
-    # test
     with pytest.raises(OnyoInvalidRepoError):
         Repo(tmp_path, init=False)
     assert not fully_populated_dot_onyo(tmp_path)
 
 
-variants = [  # pyre-ignore[9]
-    'dir',
-    's p a c e s',
-]
-@pytest.mark.parametrize('variant', variants)
-def test_init_not_exist_dir(tmp_path, variant):
+@pytest.mark.parametrize('variant', ['dir', 's p a c e s'])
+def test_init_not_exist_dir(tmp_path: str, variant: str) -> None:
     """
     Init a non-existent directory.
     """
@@ -119,16 +128,10 @@ def test_init_not_exist_dir(tmp_path, variant):
     assert fully_populated_dot_onyo(repo_path)
 
 
-variants = [  # pyre-ignore[9]
-    '',
-    './',
-    'dir',
-    's p a c e s',
-]
-@pytest.mark.parametrize('variant', variants)
-def test_init_exist_dir(tmp_path, variant):
+@pytest.mark.parametrize('variant', ['', './', 'dir', 's p a c e s'])
+def test_init_exist_dir(tmp_path: str, variant: str) -> None:
     """
-    Init an existing, empty directory.
+    Test init for an existing, empty directory.
     """
     os.chdir(tmp_path)
     repo_path = Path(tmp_path, variant)
@@ -139,15 +142,11 @@ def test_init_exist_dir(tmp_path, variant):
     assert fully_populated_dot_onyo(repo_path)
 
 
-variants = [  # pyre-ignore[9]
-    './',
-    'dir',
-    's p a c e s',
-]
-@pytest.mark.parametrize('variant', variants)
-def test_init_reinit(tmp_path, variant):
+@pytest.mark.parametrize('variant', ['./', 'dir', 's p a c e s'])
+def test_init_reinit(tmp_path: str, variant: str) -> None:
     """
-    Cannot re-init an Onyo repo.
+    Test that `Repo(<directory>, init=True)` raises the correct error on a path
+    that is already an Onyo repository.
     """
     os.chdir(tmp_path)
     repo_path = Path(tmp_path, variant)
@@ -163,9 +162,9 @@ def test_init_reinit(tmp_path, variant):
     assert not Path(repo_path, '.onyo/', '.onyo/').exists()
 
 
-def test_init_file(tmp_path):
+def test_init_file(tmp_path: str) -> None:
     """
-    Target must be a directory.
+    Test that instantiation of Repo() on a file raises the correct error.
     """
     repo_path = Path(tmp_path, 'file').resolve()
     repo_path.touch()
@@ -175,7 +174,7 @@ def test_init_file(tmp_path):
         Repo(repo_path, init=True)
 
 
-def test_init_missing_parent_dir(tmp_path):
+def test_init_missing_parent_dir(tmp_path: str) -> None:
     """
     Parent directories must exist.
     """
@@ -190,7 +189,7 @@ def test_init_missing_parent_dir(tmp_path):
         assert not fully_populated_dot_onyo(i)
 
 
-def test_init_already_git(tmp_path):
+def test_init_already_git(tmp_path: str) -> None:
     """
     Init-ing a git repo is allowed.
     """
@@ -203,7 +202,7 @@ def test_init_already_git(tmp_path):
     assert fully_populated_dot_onyo(repo_path)
 
 
-def test_init_with_cruft(tmp_path):
+def test_init_with_cruft(tmp_path: str) -> None:
     """
     Init-ing a directory with content is allowed, and should not commit anything
     other than the newly created .onyo dir.
@@ -222,7 +221,11 @@ def test_init_with_cruft(tmp_path):
 # Repo.assets
 #
 @pytest.mark.repo_files('README', 'a/1', 'a/2', 'b/3', 'b/4', 'c/5', 'c/6', 'd/7', 'd/8')
-def test_Repo_assets(repo):
+def test_Repo_assets(repo: Repo) -> None:
+    """
+    Test that when instantiating a Repo object, the property Repo.assets does
+    contain the assets of an existing repository.
+    """
     assets = ['README', 'a/1', 'a/2', 'b/3', 'b/4', 'c/5', 'c/6', 'd/7', 'd/8']
 
     # test
@@ -253,7 +256,11 @@ def test_Repo_assets(repo):
 # Repo.dirs
 #
 @pytest.mark.repo_files('README', 'a/1', 'a/2', 'b/3', 'b/4', 'c/5', 'c/6', 'd/7', 'd/8')
-def test_Repo_dirs(repo):
+def test_Repo_dirs(repo: Repo) -> None:
+    """
+    Test that when instantiating a Repo object, the property Repo.dirs does
+    contain the directories of an existing repository.
+    """
     dirs = ['a', 'b', 'c', 'd']
 
     # test
@@ -278,7 +285,11 @@ def test_Repo_dirs(repo):
 # Repo.files
 #
 @pytest.mark.repo_files('README', 'a/1', 'a/2', 'b/3', 'b/4', 'c/5', 'c/6', 'd/7', 'd/8')
-def test_Repo_files(repo):
+def test_Repo_files(repo: Repo) -> None:
+    """
+    Test that when instantiating a Repo object, the property Repo.files does
+    contain the files of an existing repository.
+    """
     files = ['README', 'a/1', 'a/2', 'b/3', 'b/4', 'c/5', 'c/6', 'd/7', 'd/8']
 
     # test
@@ -305,7 +316,11 @@ def test_Repo_files(repo):
 # Repo.files_changed
 #
 @pytest.mark.repo_files('README', 'a/1', 'a/2', 'b/3', 'b/4', 'c/5', 'c/6', 'd/7', 'd/8')
-def test_Repo_files_changed(repo):
+def test_Repo_files_changed(repo: Repo) -> None:
+    """
+    Test that when instantiating a Repo object, the property Repo.files_changed
+    does contain changed files of an existing repository.
+    """
     files_to_change = ['a/1', 'b/3']
     # change files
     for i in files_to_change:
@@ -329,7 +344,11 @@ def test_Repo_files_changed(repo):
 # Repo.files_staged
 #
 @pytest.mark.repo_files('README', 'a/1', 'a/2', 'b/3', 'b/4', 'c/5', 'c/6', 'd/7', 'd/8')
-def test_Repo_files_staged(repo):
+def test_Repo_files_staged(repo: Repo) -> None:
+    """
+    Test that when instantiating a Repo object, the property Repo.files_staged
+    does contain staged files for an existing repository.
+    """
     files_to_stage = ['a/1', 'b/3']
 
     # change and stage files
@@ -356,7 +375,12 @@ def test_Repo_files_staged(repo):
 # Repo.files_untracked
 #
 @pytest.mark.repo_files('README', 'a/1', 'a/2', 'b/3', 'b/4', 'c/5', 'c/6', 'd/7', 'd/8')
-def test_Repo_files_untracked(repo):
+def test_Repo_files_untracked(repo: Repo) -> None:
+    """
+    Test that when instantiating a Repo object, the property
+    Repo.files_untracked does contain untracked files of an existing repository.
+    """
+
     files_to_be_untracked = ['LICENSE', 'd/9']
 
     # create untracked files
@@ -380,7 +404,11 @@ def test_Repo_files_untracked(repo):
 #
 # Repo.opdir
 #
-def test_Repo_opdir(tmp_path):
+def test_Repo_opdir(tmp_path: str) -> None:
+    """
+    Test that the property Repo.opdir contains the operating directory as a Path
+    when instantiated with it.
+    """
     os.chdir(tmp_path)
 
     # setup repo
@@ -390,21 +418,14 @@ def test_Repo_opdir(tmp_path):
     # test
     repo = Repo('opdir-repo')
     assert isinstance(repo.opdir, Path)
+    assert Path('opdir-repo').samefile(repo.opdir)
 
 
-def test_Repo_opdir_parent(tmp_path):
-    os.chdir(tmp_path)
-
-    # setup repo
-    ret = subprocess.run(['onyo', 'init', 'opdir-parent'])
-    assert ret.returncode == 0
-
-    # test
-    repo = Repo('opdir-parent')
-    assert Path('opdir-parent').samefile(repo.opdir)
-
-
-def test_Repo_opdir_root(tmp_path):
+def test_Repo_opdir_root(tmp_path: str) -> None:
+    """
+    Test that the property Repo.opdir contains the operating directory as a Path
+    when instantiated with '.' as the path.
+    """
     os.chdir(tmp_path)
 
     # setup repo
@@ -418,7 +439,11 @@ def test_Repo_opdir_root(tmp_path):
     assert repo.root.samefile(repo.opdir)
 
 
-def test_Repo_opdir_child(tmp_path):
+def test_Repo_opdir_child(tmp_path: str) -> None:
+    """
+    Test that instantiating of the Repo with the cwd when in a folder inside the
+    repository, the property repo.opdir is actually the opdir.
+    """
     os.chdir(tmp_path)
 
     # setup repo
@@ -437,7 +462,10 @@ def test_Repo_opdir_child(tmp_path):
 #
 # Repo.root
 #
-def test_Repo_root(tmp_path):
+def test_Repo_root(tmp_path: str) -> None:
+    """
+    Test that the property repo.root is set correctly.
+    """
     os.chdir(tmp_path)
 
     # setup repo
@@ -448,7 +476,10 @@ def test_Repo_root(tmp_path):
     assert isinstance(repo.root, Path)
 
 
-def test_Repo_root_parent(tmp_path):
+def test_Repo_root_parent(tmp_path: str) -> None:
+    """
+    Test that the property repo.root is set correctly.
+    """
     os.chdir(tmp_path)
 
     # setup repo
@@ -460,7 +491,11 @@ def test_Repo_root_parent(tmp_path):
     assert Path('root-parent').samefile(repo.root)
 
 
-def test_Repo_root_root(tmp_path):
+def test_Repo_root_root(tmp_path: str) -> None:
+    """
+    Test that the property repo.root is set correctly when Repo(".") is
+    instantiated with a "." as path.
+    """
     os.chdir(tmp_path)
 
     # setup repo
@@ -473,7 +508,11 @@ def test_Repo_root_root(tmp_path):
     assert Path('.').samefile(repo.root)
 
 
-def test_Repo_root_child(tmp_path):
+def test_Repo_root_child(tmp_path: str) -> None:
+    """
+    Test that the property repo.root is set to the correct root of the
+    repository, when Repo() is instantiated in a sub-directory of a repository.
+    """
     os.chdir(tmp_path)
 
     # setup repo

--- a/tests/lib/test_Repo_add.py
+++ b/tests/lib/test_Repo_add.py
@@ -1,19 +1,18 @@
 from pathlib import Path
+from typing import Collection, Dict, Iterable, List, Union
+
 import pytest
+from onyo import Repo
 
 
-variants = {
-    'str': 'single-file',
-    'Path': Path('single-file'),
-    'list-str': ['single-file'],
-    'list-Path': [Path('single-file')],
-    'set-str': {'single-file'},
-    'set-Path': {Path('single-file')},
-}
-@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
-def test_add_args_single_file(repo, variant):
+@pytest.mark.parametrize('variant', [
+    'single-file', Path('single-file'), ['single-file'], [Path('single-file')],
+    {'single-file'}, {Path('single-file')}])
+def test_add_args_single_file(
+        repo: Repo,
+        variant: Union[Iterable[Union[Path, str]], Path, str]) -> None:
     """
-    Single file across types.
+    Test `Repo.add()` for a single file with different types.
     """
     Path('single-file').touch()
 
@@ -22,18 +21,16 @@ def test_add_args_single_file(repo, variant):
     assert Path('single-file') in repo.files_staged
 
 
-variants = {  # pyre-ignore[9]
-    'list-str': ['one', 'two', 'three'],
-    'list-Path': [Path('one'), Path('two'), Path('three')],
-    'list-mixed': ['one', Path('two'), 'three'],
-    'set-str': {'one', 'two', 'three'},
-    'set-Path': {Path('one'), Path('two'), Path('three')},
-    'set-mixed': {Path('one'), 'two', Path('three')},
-}
-@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
-def test_add_args_multi_file(repo, variant):
+@pytest.mark.parametrize('variant', [
+    ['one', 'two', 'three'], [Path('one'), Path('two'), Path('three')],
+    ['one', Path('two'), 'three'], {'one', 'two', 'three'},
+    {Path('one'), Path('two'), Path('three')},
+    {Path('one'), 'two', Path('three')}])
+def test_add_args_multi_file(
+        repo: Repo,
+        variant: Union[Iterable[Union[Path, str]], Path, str]) -> None:
     """
-    Multiple files across types.
+    Test `Repo.add()` for multiple files with different types.
     """
     Path('one').touch()
     Path('two').touch()
@@ -46,19 +43,16 @@ def test_add_args_multi_file(repo, variant):
     assert Path('three') in repo.files_staged
 
 
-variants = {
-    'str': 'single-dir',
-    'Path': Path('single-dir'),
-    'list-str': ['single-dir'],
-    'list-Path': [Path('single-dir')],
-    'set-str': {'single-dir'},
-    'set-Path': {Path('single-dir')},
-}
 @pytest.mark.repo_dirs('single-dir')
-@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
-def test_add_args_single_dir(repo, variant):
+@pytest.mark.parametrize('variant', [
+    'single-dir', Path('single-dir'), ['single-dir'], [Path('single-dir')],
+    {'single-dir'}, {Path('single-dir')}])
+def test_add_args_single_dir(
+        repo: Repo,
+        variant: Union[Iterable[Union[Path, str]], Path, str]) -> None:
     """
-    Single directory across types.
+    Test `Repo.add()` for a single directory containing files with different
+    types.
     """
     Path('single-dir/file').touch()
 
@@ -67,19 +61,17 @@ def test_add_args_single_dir(repo, variant):
     assert Path('single-dir/file') in repo.files_staged
 
 
-variants = {  # pyre-ignore[9]
-    'list-str': ['one', 'two', 'three'],
-    'list-Path': [Path('one'), Path('two'), Path('three')],
-    'list-mixed': ['one', Path('two'), 'three'],
-    'set-str': {'one', 'two', 'three'},
-    'set-Path': {Path('one'), Path('two'), Path('three')},
-    'set-mixed': {Path('one'), 'two', Path('three')},
-}
 @pytest.mark.repo_dirs('one', 'two', 'three')
-@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
-def test_add_args_multi_dir(repo, variant):
+@pytest.mark.parametrize('variant', [
+    ['one', 'two', 'three'], [Path('one'), Path('two'), Path('three')],
+    ['one', Path('two'), 'three'], {'one', 'two', 'three'},
+    {Path('one'), Path('two'), Path('three')},
+    {Path('one'), 'two', Path('three')}])
+def test_add_args_multi_dir(
+        repo: Repo, variant: Collection[Union[Path, str]]) -> None:
     """
-    Multiple directories across types.
+    Test `Repo.add()` for multiple directories containing multiple files with
+    different types.
     """
     Path('one/file-one-A').touch()
     Path('one/file-one-B').touch()
@@ -97,17 +89,14 @@ def test_add_args_multi_dir(repo, variant):
     assert len(variant) * 2 == len(repo.files_staged)
 
 
-variants = {  # pyre-ignore[9]
-    'top': {'dirs': 'r', 'num': 4},
-    'deep': {'dirs': 'r/e/c/u/r/s/i/v/e', 'num': 2},
-    'overlap-same': {'dirs': ['r/e/c/u/r', 'r/e/c/u/r/s/i/v/e'], 'num': 2},
-    'overlap-more': {'dirs': ['r/e', 'r/e/c/u/r/s/i/v/e'], 'num': 4},
-}
 @pytest.mark.repo_dirs('r/e/c/u/r/s/i/v/e')
-@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
-def test_add_dir_recursive(repo, variant):
+@pytest.mark.parametrize('variant', [
+    {'dirs': 'r', 'num': 4}, {'dirs': 'r/e/c/u/r/s/i/v/e', 'num': 2},
+    {'dirs': ['r/e/c/u/r', 'r/e/c/u/r/s/i/v/e'], 'num': 2},
+    {'dirs': ['r/e', 'r/e/c/u/r/s/i/v/e'], 'num': 4}])
+def test_add_dir_recursive(repo: Repo, variant: Dict) -> None:
     """
-    Recursive directories
+    Test `Repo.add()` for recursive directories.
     """
     Path('r/e/c/child-r-A').touch()
     Path('r/e/c/child-r-B').touch()
@@ -119,15 +108,12 @@ def test_add_dir_recursive(repo, variant):
     assert variant['num'] == len(repo.files_staged)
 
 
-variants = {
-    'single': ['o n e'],
-    'multi': ['o n e', 't w o', 'd i r/t h r e e'],
-}
 @pytest.mark.repo_dirs('d i r')
-@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
-def test_add_spaces(repo, variant):
+@pytest.mark.parametrize('variant', [
+    ['o n e'], ['o n e', 't w o', 'd i r/t h r e e']])
+def test_add_spaces(repo: Repo, variant: Collection[Union[Path, str]]) -> None:
     """
-    Spaces.
+    Test `Repo.add()` for directories with spaces in their name.
     """
     Path('o n e').touch()
     Path('t w o').touch()
@@ -140,9 +126,9 @@ def test_add_spaces(repo, variant):
     assert len(variant) == len(repo.files_staged)
 
 
-def test_add_repeat(repo):
+def test_add_repeat(repo: Repo) -> None:
     """
-    Repeated target paths are OK.
+    Test that `Repo.add()` allows repeated adding of paths without failing.
     """
     Path('repeat-one').touch()
     Path('two').touch()
@@ -155,31 +141,26 @@ def test_add_repeat(repo):
     assert Path('three') in repo.files_staged
 
 
-variants = {
-    'file': 'unchanged-file',
-    'dir': 'unchanged-dir',
-    'mixed': ['unchanged-file', 'unchanged-dir'],
-}
 @pytest.mark.repo_dirs('unchanged-dir')
 @pytest.mark.repo_files('unchanged-file')
-@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
-def test_add_unchanged(repo, variant):
+@pytest.mark.parametrize('variant', ['unchanged-file', 'unchanged-dir',
+                                     ['unchanged-file', 'unchanged-dir']])
+def test_add_unchanged(repo: Repo, variant: Union[str, List[str]]) -> None:
     """
-    Unchanged targets.
+    Test that `Repo.add()` does not fail on unchanged targets and
+    repo.files_staged does not wrongly contain those targets.
     """
     repo.add(variant)
     assert not repo.files_staged
 
 
-variants = {
-    'root': ['one', 'not-exist', 'dir/three'],
-    'subdir': ['one', 'two', 'dir/not-exist'],
-}
 @pytest.mark.repo_dirs('dir')
-@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
-def test_add_not_exist(repo, variant):
+@pytest.mark.parametrize('variant', [
+    ['one', 'not-exist', 'dir/three'], ['one', 'two', 'dir/not-exist']])
+def test_add_not_exist(repo: Repo, variant: List[str]) -> None:
     """
-    Targets that don't exist.
+    Test that `Repo.add()` raises the correct exception on targets that don't
+    exist.
     """
     Path('one').touch()
     Path('two').touch()

--- a/tests/lib/test_Repo_config.py
+++ b/tests/lib/test_Repo_config.py
@@ -1,6 +1,8 @@
 from pathlib import Path
+from typing import Dict
 
 import pytest
+from onyo import Repo
 
 
 # NOTE: configuration options can be set in multiple locations:
@@ -12,7 +14,7 @@ import pytest
 #
 # 'system` and 'global' are left untested, to not tamper with developer machines.
 
-variants = {
+@pytest.mark.parametrize('variant', {
     'default': {
         'args': ('onyo.test.set-config', 'default'),
         'file': '.onyo/config',
@@ -28,14 +30,13 @@ variants = {
     'onyo': {
         'args': ('onyo.test.set-config', 'onyo', 'onyo'),
         'file': '.onyo/config',
-    },
-}
-@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
-def test_set_config(repo, variant):
+    }}.values())
+def test_set_config(repo: Repo, variant: Dict) -> None:
     """
     Set config in different locations.
 
-    NOTE: 'global' and 'system' are untested to not touch the user or system config.
+    NOTE: 'global' and 'system' are untested to not touch the user or
+    system config.
     """
     # set extensions.worktreeConfig (for the 'worktree' test)
     repo._git(['config', 'extensions.worktreeConfig', 'true'])
@@ -43,18 +44,20 @@ def test_set_config(repo, variant):
     # test
     repo.set_config(*variant['args'])
     value = variant['args'][1]
-    assert f'set-config = {value}' in Path(repo.root, variant['file']).read_text()
+    assert f'set-config = {value}' in Path(repo.root,
+                                           variant['file']).read_text()
 
 
-def test_set_config_invalid_location(repo):
+def test_set_config_invalid_location(repo: Repo) -> None:
     """
     Invalid location should throw an exception.
     """
     with pytest.raises(ValueError):
-        repo.set_config('onyo.test.set-config-invalid-location', 'valid-value', location='completely-invalid')
+        repo.set_config('onyo.test.set-config-invalid-location', 'valid-value',
+                        location='completely-invalid')
 
 
-variants = {  # pyre-ignore[9]
+@pytest.mark.parametrize('variant', {
     'wlo-worktree': {
         'set': ['worktree', 'local', 'onyo'],
         'answer': 'worktree',
@@ -83,13 +86,13 @@ variants = {  # pyre-ignore[9]
         'set': ['onyo'],
         'answer': 'onyo',
     },
-}
-@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
-def test_get_config_precedence(repo, variant):
+}.values())
+def test_get_config_precedence(repo: Repo, variant: Dict) -> None:
     """
     The order of precedence is worktree > local > global > system > onyo.
 
-    NOTE: 'global' and 'system' are untested to not touch the user or system config.
+    NOTE: 'global' and 'system' are untested to not touch the user or
+    system config.
     """
     # enable worktreeConfig, so it doesn't save over "local"
     repo._git(['config', 'extensions.worktreeConfig', 'true'])
@@ -103,17 +106,17 @@ def test_get_config_precedence(repo, variant):
     assert ret == variant['answer']
 
 
-def test_get_config_name_not_exist(repo):
+def test_get_config_name_not_exist(repo: Repo) -> None:
     """
-    Missing values should return None
+    Missing values should return `None`.
     """
     ret = repo.get_config('onyo.test.get-config-name-does-not-exist')
     assert ret is None
 
 
-def test_get_config_empty_value(repo):
+def test_get_config_empty_value(repo: Repo) -> None:
     """
-
+    When a value exists, but is empty, it should return an empty string ''.
     """
     repo.set_config('onyo.test.get-config-empty-value', '')
 

--- a/tests/lib/test_Repo_fsck.py
+++ b/tests/lib/test_Repo_fsck.py
@@ -2,19 +2,19 @@ import logging
 from pathlib import Path
 
 import pytest
+from _pytest.logging import LogCaptureFixture
 from onyo.lib import Repo, OnyoInvalidRepoError
 
 #
 # Generic
 #
-variants = [
-    'anchors',
-    'asset-unique',
-    'asset-yaml',
-    'clean-tree',
-]
-@pytest.mark.parametrize('variant', variants)
-def test_fsck_empty(caplog, repo, variant):
+@pytest.mark.parametrize('variant', ['anchors', 'asset-unique',
+                                     'asset-yaml', 'clean-tree'])
+def test_fsck_empty(
+        caplog: LogCaptureFixture, repo: Repo, variant: str) -> None:
+    """
+    Run different types of fsck on a clean and empty repository without error.
+    """
     caplog.set_level(logging.INFO, logger='onyo')
 
     # test
@@ -24,15 +24,16 @@ def test_fsck_empty(caplog, repo, variant):
     # TODO: assert variant in caplog.text
 
 
-variants = [
-    'anchors',
-    'asset-unique',
-    'asset-yaml',
-    'clean-tree',
-]
-@pytest.mark.repo_files('README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'c/f_5', 'c/f_6', 'd/f_7', 'd/f_8')
-@pytest.mark.parametrize('variant', variants)
-def test_fsck_populated(caplog, repo, variant):
+@pytest.mark.repo_files('README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'c/f_5',
+                        'c/f_6', 'd/f_7', 'd/f_8')
+@pytest.mark.parametrize('variant', ['anchors', 'asset-unique',
+                                     'asset-yaml', 'clean-tree'])
+def test_fsck_populated(caplog: LogCaptureFixture,
+                        repo: Repo, variant: str) -> None:
+    """
+    Run different types of fsck on an non-empty but clean repository without
+    error.
+    """
     caplog.set_level(logging.INFO, logger='onyo')
 
     # test
@@ -42,12 +43,13 @@ def test_fsck_populated(caplog, repo, variant):
     # TODO: assert variant in caplog.text
 
 
-variants = [
-    '',
-    'does-not-exist'
-]
-@pytest.mark.parametrize('variant', variants)
-def test_fsck_invalid_test(caplog, repo, variant):
+@pytest.mark.parametrize('variant', ['', 'does-not-exist'])
+def test_fsck_invalid_test(caplog: LogCaptureFixture,
+                           repo: Repo, variant: str) -> None:
+    """
+    Test that when `Repo.fsck()` is called with an non-existing fsck the correct
+    error gets raised.
+    """
     caplog.set_level(logging.INFO, logger='onyo')
 
     # test
@@ -58,9 +60,9 @@ def test_fsck_invalid_test(caplog, repo, variant):
     # TODO: assert variant in caplog.text
 
 
-def test_fsck_all(caplog, repo):
+def test_fsck_all(caplog: LogCaptureFixture, repo: Repo) -> None:
     """
-    Default is to run all tests.
+    Test that `repo.fsck()` runs per default all tests.
     """
     caplog.set_level(logging.INFO, logger='onyo')
 
@@ -79,8 +81,12 @@ def test_fsck_all(caplog, repo):
 # Anchors
 #
 @pytest.mark.repo_dirs('r/e/c/u/r/s/i/v/e')
-@pytest.mark.repo_files('README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'c/f_5', 'c/f_6', 'd/f_7', 'd/f_8')
-def test_fsck_anchors_missing(caplog, repo):
+@pytest.mark.repo_files('README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'c/f_5',
+                        'c/f_6', 'd/f_7', 'd/f_8')
+def test_fsck_anchors_missing(caplog: LogCaptureFixture, repo: Repo) -> None:
+    """
+    Test that `Repo.fsck()` fails when `.anchor` files are missing.
+    """
     caplog.set_level(logging.INFO, logger='onyo')
     anchors_to_remove = ['a/.anchor', 'r/e/c/.anchor', 'r/e/c/u/r/s/i/v/.anchor']
 
@@ -102,8 +108,13 @@ def test_fsck_anchors_missing(caplog, repo):
 #
 # Asset-Unique
 #
-@pytest.mark.repo_files('README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'r/e/c/f_5', 'r/e/c/u/r/f_6', 'r/e/c/u/r/s/i/v/e/f_7')
-def test_fsck_unique_assets_conflict(caplog, repo):
+@pytest.mark.repo_files('README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4',
+                        'r/e/c/f_5', 'r/e/c/u/r/f_6', 'r/e/c/u/r/s/i/v/e/f_7')
+def test_fsck_unique_assets_conflict(caplog: LogCaptureFixture,
+                                     repo: Repo) -> None:
+    """
+    Test that `Repo.fsck()` fails if multiple assets with the same name exist.
+    """
     caplog.set_level(logging.INFO, logger='onyo')
     assets_to_conflict = ['b/f_1', 'r/e/c/f_3', 'r/e/c/u/r/s/i/v/e/f_5']
 
@@ -128,17 +139,19 @@ def test_fsck_unique_assets_conflict(caplog, repo):
 #
 # Asset-YAML
 #
-@pytest.mark.repo_files('README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'r/e/c/f_5', 'r/e/c/u/r/f_6', 'r/e/c/u/r/s/i/v/e/f_7')
-def test_fsck_yaml_invalid(caplog, repo):
+@pytest.mark.repo_files('README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4',
+                        'r/e/c/f_5', 'r/e/c/u/r/f_6', 'r/e/c/u/r/s/i/v/e/f_7')
+@pytest.mark.repo_contents(['a/f_1', 'dsfs: sdf: sdf:dd ad123e'],
+                           ['r/e/c/f_5', 'dsfs: sdf: sdf:dd ad123e'],
+                           ['r/e/c/u/r/s/i/v/e/f_7',
+                            'dsfs: sdf: sdf:dd ad123e'])
+def test_fsck_yaml_invalid(caplog: LogCaptureFixture, repo: Repo) -> None:
+    """
+    Test that `Repo.fsck()` identifies files with invalid YAML syntax inside of
+    a populated repository.
+    """
     caplog.set_level(logging.INFO, logger='onyo')
     files_to_mangle = ['a/f_1', 'r/e/c/f_5', 'r/e/c/u/r/s/i/v/e/f_7']
-
-    # mangle files
-    for i in files_to_mangle:
-        Path(i).write_text('dsfs: sdf: sdf:dd ad123e')
-
-    repo.add(files_to_mangle)
-    repo.commit('mangle files')
 
     # test
     with pytest.raises(OnyoInvalidRepoError):
@@ -150,13 +163,11 @@ def test_fsck_yaml_invalid(caplog, repo):
         assert i in caplog.text
 
 
-contents = ["type: value",
-            "make: value",
-            "model: value",
-            "serial: value",
-            "key: value\ntype: value\nfield: value"]
-@pytest.mark.parametrize('content', contents)
-def test_fsck_yaml_contains_pseudo_key(repo: Repo, caplog, content) -> None:
+@pytest.mark.parametrize('content', [
+    "type: value", "make: value", "model: value", "serial: value",
+    "key: value\ntype: value\nfield: value"])
+def test_fsck_yaml_contains_pseudo_key(caplog: LogCaptureFixture,
+                                       repo: Repo, content: str) -> None:
     """
     Test that the fsck fails when an asset contains a pseudo-key.
     """
@@ -177,15 +188,11 @@ def test_fsck_yaml_contains_pseudo_key(repo: Repo, caplog, content) -> None:
     assert "contain pseudo keys" in caplog.text
 
 
-contents = ["key_one: type",
-            "key_two: make",
-            "key_three: model",
-            "key_four: serial",
-            "key_five: 'model: value'",
-            "key_type: key_six",
-            "key_serial: key_seven"]
-@pytest.mark.parametrize('content', contents)
-def test_fsck_yaml_allows_valid_keys(repo: Repo, caplog, content) -> None:
+@pytest.mark.parametrize('content', [
+    "key_one: type", "key_two: make", "key_three: model", "key_four: serial",
+    "key_five: 'model: value'", "key_type: key_six", "key_serial: key_seven"])
+def test_fsck_yaml_allows_valid_keys(caplog: LogCaptureFixture, repo: Repo,
+                                     content: str) -> None:
     """
     Test that the fsck does not fail when an asset contains a key, where a valid
     key where just a part of it is a pseudo-key, and that pseudo-keys as values
@@ -209,8 +216,12 @@ def test_fsck_yaml_allows_valid_keys(repo: Repo, caplog, content) -> None:
 #
 # Clean-Tree
 #
-@pytest.mark.repo_files('README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'c/f_5', 'c/f_6', 'd/f_7', 'd/f_8')
-def test_fsck_clean_tree_changed(caplog, repo):
+@pytest.mark.repo_files('README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'c/f_5',
+                        'c/f_6', 'd/f_7', 'd/f_8')
+def test_fsck_clean_tree_changed(caplog: LogCaptureFixture, repo: Repo) -> None:
+    """
+    Test that `Repo.fsck()` fails if the git tree contains changed files.
+    """
     caplog.set_level(logging.INFO, logger='onyo')
     files_to_change = ['a/f_1', 'b/f_3']
 
@@ -228,8 +239,12 @@ def test_fsck_clean_tree_changed(caplog, repo):
         assert i in caplog.text
 
 
-@pytest.mark.repo_files('README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'c/f_5', 'c/f_6', 'd/f_7', 'd/f_8')
-def test_fsck_clean_tree_staged(caplog, repo):
+@pytest.mark.repo_files('README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'c/f_5',
+                        'c/f_6', 'd/f_7', 'd/f_8')
+def test_fsck_clean_tree_staged(caplog: LogCaptureFixture, repo: Repo) -> None:
+    """
+    Test that `Repo.fsck()` fails if the git tree contains staged files.
+    """
     caplog.set_level(logging.INFO, logger='onyo')
     files_to_stage = ['a/f_1', 'b/f_3']
 
@@ -249,8 +264,13 @@ def test_fsck_clean_tree_staged(caplog, repo):
         assert i in caplog.text
 
 
-@pytest.mark.repo_files('README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'c/f_5', 'c/f_6', 'd/f_7', 'd/f_8')
-def test_fsck_clean_tree_untracked(caplog, repo):
+@pytest.mark.repo_files('README', 'a/f_1', 'a/f_2', 'b/f_3', 'b/f_4', 'c/f_5',
+                        'c/f_6', 'd/f_7', 'd/f_8')
+def test_fsck_clean_tree_untracked(caplog: LogCaptureFixture,
+                                   repo: Repo) -> None:
+    """
+    Test that `Repo.fsck()` fails if the git tree contains untracked files.
+    """
     caplog.set_level(logging.INFO, logger='onyo')
     files_to_be_untracked = ['LICENSE', 'd/f_9']
 

--- a/tests/lib/test_Repo_new.py
+++ b/tests/lib/test_Repo_new.py
@@ -3,11 +3,12 @@ import pytest
 from pathlib import Path
 
 from onyo.lib import Repo
+from typing import List
 
 # generate 50 random pairings of length and num.
 variants = {f'{length} x {num}': (length, num) for length in random.sample(range(4, 20), 10) for num in random.sample(range(1, 10000), 5)}
 @pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
-def test_generate_faux_serials(repo, variant):
+def test_generate_faux_serials(repo: Repo, variant: List[int]) -> None:
     """
     Generate a faux serial numbers of variable length and quantity.
     """
@@ -27,7 +28,8 @@ def test_generate_faux_serials(repo, variant):
 # generate 30 invalid random pairings of length and num.
 variants = {f'{length} x {num}': (length, num) for length in range(-2, 4) for num in random.sample(range(1, 10000), 5)}
 @pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
-def test_generate_faux_serials_invalid_length(repo, variant):
+def test_generate_faux_serials_invalid_length(repo: Repo,
+                                              variant: List[int]) -> None:
     """
     Fewer than 4 character in the serial is invalid.
     """
@@ -38,7 +40,8 @@ def test_generate_faux_serials_invalid_length(repo, variant):
 # generate 15 invalid random pairings of length and num.
 variants = {f'{length} x {num}': (length, num) for length in random.sample(range(4, 20), 5) for num in range(-2, 1)}
 @pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
-def test_generate_faux_serials_invalid_number(repo, variant):
+def test_generate_faux_serials_invalid_number(repo: Repo,
+                                              variant: List[int]) -> None:
     """
     Number of serials must be greater than 0.
     """
@@ -49,7 +52,8 @@ def test_generate_faux_serials_invalid_number(repo, variant):
 # generate mutually invalid pairings of length and num.
 variants = {f'{length} x {num}': (length, num) for length in range(0, 4) for num in range(-2, 1)}
 @pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
-def test_generate_faux_serials_invalid_length_and_number(repo, variant):
+def test_generate_faux_serials_invalid_length_and_number(
+        repo: Repo, variant: List[int]) -> None:
     """
     Both length and number are invalid.
     """
@@ -57,18 +61,18 @@ def test_generate_faux_serials_invalid_length_and_number(repo, variant):
         repo.generate_faux_serials(*variant)
 
 
-variants = ['laptop_apple_macbookpro_0',  # no .
-            'laptop-apple-macbookpro.0',  # no _
-            'laptop-apple-macbookpro-0',  # no _ or -
-            'laptop_ap.ple_macbookpro.0',  # . can only be in serial field
-            'lap_top_apple_macbookpro.0',  # too many fields (_)
-            '__.',  # all fields are empty
-            '_apple_macbookpro.0',  # empty type
-            'laptop__macbookpro.0',  # empty make
-            'laptop_apple_.0',  # empty model
-            'laptop_apple_macbookpro.'  # empty serial
-            ]
-@pytest.mark.parametrize('variant', variants)
+@pytest.mark.parametrize('variant', [
+    'laptop_apple_macbookpro_0',  # no .
+    'laptop-apple-macbookpro.0',  # no _
+    'laptop-apple-macbookpro-0',  # no _ or -
+    'laptop_ap.ple_macbookpro.0',  # . can only be in serial field
+    'lap_top_apple_macbookpro.0',  # too many fields (_)
+    '__.',  # all fields are empty
+    '_apple_macbookpro.0',  # empty type
+    'laptop__macbookpro.0',  # empty make
+    'laptop_apple_.0',  # empty model
+    'laptop_apple_macbookpro.'  # empty serial
+])
 def test_valid_name_error(repo: Repo, variant: str) -> None:
     """
     Test `Repo.valid_name()` against invalid asset names.
@@ -79,11 +83,11 @@ def test_valid_name_error(repo: Repo, variant: str) -> None:
         assert not valid
 
 
-variants = ['laptop_apple_macbookpro.serial123',  # normal
-            'lap top_app le_mac book.ser ial',  # spaces are allowed
-            'laptop_apple_macbookpro.serial_a.b_c.d'  # serial allows any characters
-            ]
-@pytest.mark.parametrize('variant', variants)
+@pytest.mark.parametrize('variant', [
+    'laptop_apple_macbookpro.serial123',  # normal
+    'lap top_app le_mac book.ser ial',  # spaces are allowed
+    'laptop_apple_macbookpro.serial_a.b_c.d'  # serial allows any characters
+])
 def test_valid_name(repo: Repo, variant: str) -> None:
     """
     Test `Repo.valid_name()` against valid asset names --- including weird ones.

--- a/tests/lib/test_Repo_new.py
+++ b/tests/lib/test_Repo_new.py
@@ -3,10 +3,10 @@ import pytest
 from pathlib import Path
 
 from onyo.lib import Repo
-from typing import List
+from typing import Dict, Tuple, List
 
 # generate 50 random pairings of length and num.
-variants = {f'{length} x {num}': (length, num) for length in random.sample(range(4, 20), 10) for num in random.sample(range(1, 10000), 5)}
+variants: Dict[str, Tuple[int, int]] = {f'{length} x {num}': (length, num) for length in random.sample(range(4, 20), 10) for num in random.sample(range(1, 10000), 5)}
 @pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
 def test_generate_faux_serials(repo: Repo, variant: List[int]) -> None:
     """
@@ -26,7 +26,7 @@ def test_generate_faux_serials(repo: Repo, variant: List[int]) -> None:
 
 
 # generate 30 invalid random pairings of length and num.
-variants = {f'{length} x {num}': (length, num) for length in range(-2, 4) for num in random.sample(range(1, 10000), 5)}
+variants: Dict[str, Tuple[int, int]] = {f'{length} x {num}': (length, num) for length in range(-2, 4) for num in random.sample(range(1, 10000), 5)}
 @pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
 def test_generate_faux_serials_invalid_length(repo: Repo,
                                               variant: List[int]) -> None:
@@ -38,7 +38,7 @@ def test_generate_faux_serials_invalid_length(repo: Repo,
 
 
 # generate 15 invalid random pairings of length and num.
-variants = {f'{length} x {num}': (length, num) for length in random.sample(range(4, 20), 5) for num in range(-2, 1)}
+variants: Dict[str, Tuple[int, int]] = {f'{length} x {num}': (length, num) for length in random.sample(range(4, 20), 5) for num in range(-2, 1)}
 @pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
 def test_generate_faux_serials_invalid_number(repo: Repo,
                                               variant: List[int]) -> None:
@@ -50,7 +50,7 @@ def test_generate_faux_serials_invalid_number(repo: Repo,
 
 
 # generate mutually invalid pairings of length and num.
-variants = {f'{length} x {num}': (length, num) for length in range(0, 4) for num in range(-2, 1)}
+variants: Dict[str, Tuple[int, int]] = {f'{length} x {num}': (length, num) for length in range(0, 4) for num in range(-2, 1)}
 @pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
 def test_generate_faux_serials_invalid_length_and_number(
         repo: Repo, variant: List[int]) -> None:

--- a/tests/lib/test_Repo_rm.py
+++ b/tests/lib/test_Repo_rm.py
@@ -2,19 +2,19 @@ from pathlib import Path
 
 import pytest
 from onyo import OnyoProtectedPathError
+from onyo.lib import Repo
+from typing import Union
 
-
-variants = {
+@pytest.mark.repo_files('single-file', 'untouched')
+@pytest.mark.parametrize('variant', {
     'str': 'single-file',
     'Path': Path('single-file'),
     'list-str': ['single-file'],
     'list-Path': [Path('single-file')],
     'set-str': {'single-file'},
     'set-Path': {Path('single-file')},
-}
-@pytest.mark.repo_files('single-file', 'untouched')
-@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
-def test_rm_args_single_file(repo, variant):
+}.values())
+def test_rm_args_single_file(repo: Repo, variant: Union[str, Path]) -> None:
     """
     Single file across types.
     """
@@ -31,17 +31,16 @@ def test_rm_args_single_file(repo, variant):
     repo.fsck(['anchors'])
 
 
-variants = {
+@pytest.mark.repo_dirs('single-dir', 'untouched')
+@pytest.mark.parametrize('variant', {
     'str': 'single-dir',
     'Path': Path('single-dir'),
     'list-str': ['single-dir'],
     'list-Path': [Path('single-dir')],
     'set-str': {'single-dir'},
     'set-Path': {Path('single-dir')},
-}
-@pytest.mark.repo_dirs('single-dir', 'untouched')
-@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
-def test_rm_args_single_dir(repo, variant):
+}.values())
+def test_rm_args_single_dir(repo: Repo, variant: Union[str, Path]) -> None:
     """
     Single directory across types.
     """
@@ -58,17 +57,16 @@ def test_rm_args_single_dir(repo, variant):
     repo.fsck(['anchors'])
 
 
-variants = {  # pyre-ignore[9]
+@pytest.mark.repo_files('one', 'two', 'three', 'untouched')
+@pytest.mark.parametrize('variant', {
     'list-str': ['one', 'two', 'three'],
     'list-Path': [Path('one'), Path('two'), Path('three')],
     'list-mixed': ['one', Path('two'), 'three'],
     'set-str': {'one', 'two', 'three'},
     'set-Path': {Path('one'), Path('two'), Path('three')},
     'set-mixed': {Path('one'), 'two', Path('three')},
-}
-@pytest.mark.repo_files('one', 'two', 'three', 'untouched')
-@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
-def test_rm_args_multi_file(repo, variant):
+}.values())
+def test_rm_args_multi_file(repo: Repo, variant: Union[str, Path]) -> None:
     """
     Multiple files across types.
     """
@@ -87,17 +85,16 @@ def test_rm_args_multi_file(repo, variant):
     repo.fsck(['anchors'])
 
 
-variants = {  # pyre-ignore[9]
+@pytest.mark.repo_dirs('one', 'two', 'three', 'untouched')
+@pytest.mark.parametrize('variant', {
     'list-str': ['one', 'two', 'three'],
     'list-Path': [Path('one'), Path('two'), Path('three')],
     'list-mixed': ['one', Path('two'), 'three'],
     'set-str': {'one', 'two', 'three'},
     'set-Path': {Path('one'), Path('two'), Path('three')},
     'set-mixed': {Path('one'), 'two', Path('three')},
-}
-@pytest.mark.repo_dirs('one', 'two', 'three', 'untouched')
-@pytest.mark.parametrize('variant', variants.values(), ids=variants.keys())
-def test_rm_args_multi_dir(repo, variant):
+}.values())
+def test_rm_args_multi_dir(repo: Repo, variant: Union[str, Path]) -> None:
     """
     Multiple directories across types.
     """
@@ -116,13 +113,9 @@ def test_rm_args_multi_dir(repo, variant):
     repo.fsck(['anchors'])
 
 
-variants = [  # pyre-ignore[9]
-    'not-exist',
-    'subdir/not-exist'
-]
 @pytest.mark.repo_dirs('subdir')
-@pytest.mark.parametrize('variant', variants)
-def test_rm_not_exist(repo, variant):
+@pytest.mark.parametrize('variant', ['not-exist', 'subdir/not-exist'])
+def test_rm_not_exist(repo: Repo, variant: str) -> None:
     """
     Targets must exist.
     """
@@ -140,13 +133,9 @@ def test_rm_not_exist(repo, variant):
     repo.fsck(['anchors'])
 
 
-variants = [  # pyre-ignore[9]
-    'not-exist',
-    'subdir/not-exist'
-]
 @pytest.mark.repo_dirs('one', 'two', 'subdir')
-@pytest.mark.parametrize('variant', variants)
-def test_rm_not_exist_mixed(repo, variant):
+@pytest.mark.parametrize('variant', ['not-exist', 'subdir/not-exist'])
+def test_rm_not_exist_mixed(repo: Repo, variant: str) -> None:
     """
     All targets must exist.
     """
@@ -166,16 +155,15 @@ def test_rm_not_exist_mixed(repo, variant):
     repo.fsck(['anchors'])
 
 
-variants = [  # pyre-ignore[9]
+@pytest.mark.repo_dirs('one', 'untouched')
+@pytest.mark.parametrize('variant', [
     '.onyo',
     '.git',
     '.onyo/templates',
     '.git/config',
     'one/.anchor',
-]
-@pytest.mark.repo_dirs('one', 'untouched')
-@pytest.mark.parametrize('variant', variants)
-def test_rm_protected(repo, variant):
+])
+def test_rm_protected(repo: Repo, variant: str) -> None:
     """
     Protected paths.
     """
@@ -193,16 +181,15 @@ def test_rm_protected(repo, variant):
     repo.fsck(['anchors'])
 
 
-variants = [  # pyre-ignore[9]
+@pytest.mark.repo_dirs('valid-one', 'valid-two', 'dir')
+@pytest.mark.parametrize('variant', [
     '.onyo',
     '.git',
     '.onyo/templates',
     '.git/config',
     'dir/.anchor',
-]
-@pytest.mark.repo_dirs('valid-one', 'valid-two', 'dir')
-@pytest.mark.parametrize('variant', variants)
-def test_rm_protected_mixed(repo, variant):
+])
+def test_rm_protected_mixed(repo: Repo, variant: str) -> None:
     """
     Protected paths.
     """
@@ -224,7 +211,7 @@ def test_rm_protected_mixed(repo, variant):
 
 @pytest.mark.repo_dirs('repeat-dir', 'dir-two', 'dir-three')
 @pytest.mark.repo_files('repeat-file', 'file-two', 'file-three')
-def test_rm_repeat(repo):
+def test_rm_repeat(repo: Repo) -> None:
     """
     Repeated target paths are OK.
     """
@@ -250,7 +237,7 @@ def test_rm_repeat(repo):
 
 
 @pytest.mark.repo_files('overlap/one', 'overlap/two', 'overlap/three')
-def test_rm_overlap(repo):
+def test_rm_overlap(repo: Repo) -> None:
     """
     Overlapping targets.
     """
@@ -267,7 +254,7 @@ def test_rm_overlap(repo):
 
 
 @pytest.mark.repo_files('s p a/c e s/1 2', 's p a/c e s/3 4')
-def test_rm_spaces(repo):
+def test_rm_spaces(repo: Repo) -> None:
     """
     Spaces.
     """
@@ -291,7 +278,7 @@ def test_rm_spaces(repo):
 
 @pytest.mark.repo_dirs('r/e/c/u/r/s/i/v/e')
 @pytest.mark.repo_files('one/a', 'two/b')
-def test_rm_subdirs(repo):
+def test_rm_subdirs(repo: Repo) -> None:
     """
     Deleting directory contents should leave parent dir intact.
     """
@@ -318,7 +305,7 @@ def test_rm_subdirs(repo):
 
 @pytest.mark.repo_dirs('r/e/c/u/r/s/i/v/e')
 @pytest.mark.repo_files('one/a', 'two/b')
-def test_rm_dryrun(repo):
+def test_rm_dryrun(repo: Repo) -> None:
     """
     Dry run should not delete anything.
     """
@@ -338,7 +325,7 @@ def test_rm_dryrun(repo):
 
 @pytest.mark.repo_dirs('dir/subdir')
 @pytest.mark.repo_files('one', 'two')
-def test_rm_return_value(repo):
+def test_rm_return_value(repo: Repo) -> None:
     """
     Return list should contain all items/
     """

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,7 +3,7 @@ from itertools import product
 from onyo import main
 
 
-def test_get_subcmd_index_missing(helpers):
+def test_get_subcmd_index_missing(helpers) -> None:
     """
     All combinations of flags for onyo, without any subcommand.
     """
@@ -15,7 +15,7 @@ def test_get_subcmd_index_missing(helpers):
             assert idx is None
 
 
-def test_get_subcmd_index_valid(helpers):
+def test_get_subcmd_index_valid(helpers) -> None:
     """
     All combinations of flags for onyo, with a subcommand.
     """
@@ -27,7 +27,7 @@ def test_get_subcmd_index_valid(helpers):
             assert idx == full_cmd.index('config')
 
 
-def test_get_subcmd_index_overlap(helpers):
+def test_get_subcmd_index_overlap(helpers) -> None:
     """
     Arg values overlap with onyo or its subcommands. Borderline pathological.
     """


### PR DESCRIPTION
I just wanted to add type hints to the functions missing it, but obviously I could not hold back, so I also added doc-strings when they were missing, and moved definition of `variants` variables into the parameterization so as to make the tests more stable when run in random order.