### PR TITLE
(to be deleted) TST: add some type hints

### DIFF
--- a/onyo/__init__.py
+++ b/onyo/__init__.py
@@ -4,7 +4,7 @@ from onyo.lib import Repo, OnyoInvalidRepoError, OnyoProtectedPathError
 
 
 logging.basicConfig(level=logging.ERROR)  # external logging level
-log = logging.getLogger('onyo')  # internal logging level
+log: logging.Logger = logging.getLogger('onyo')  # internal logging level
 log.setLevel(level=logging.INFO)
 
 __all__ = [

--- a/onyo/commands/cat.py
+++ b/onyo/commands/cat.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     import argparse
 
 logging.basicConfig()
-log = logging.getLogger('onyo')
+log: logging.Logger = logging.getLogger('onyo')
 
 
 def sanitize_paths(paths: list[str], opdir: str) -> list[Path]:

--- a/onyo/commands/config.py
+++ b/onyo/commands/config.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     import argparse
 
 logging.basicConfig()
-log = logging.getLogger('onyo')
+log: logging.Logger = logging.getLogger('onyo')
 
 
 def sanitize_args(git_config_args: list[str]) -> list[str]:

--- a/onyo/commands/edit.py
+++ b/onyo/commands/edit.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     import argparse
 
 logging.basicConfig()
-log = logging.getLogger('onyo')
+log: logging.Logger = logging.getLogger('onyo')
 
 
 def get_editor(repo: Repo) -> str:

--- a/onyo/commands/history.py
+++ b/onyo/commands/history.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     import argparse
 
 logging.basicConfig()
-log = logging.getLogger('onyo')
+log: logging.Logger = logging.getLogger('onyo')
 
 
 def sanitize_path(path: str, opdir: str) -> Path:

--- a/onyo/commands/new.py
+++ b/onyo/commands/new.py
@@ -10,12 +10,15 @@ from onyo.commands.edit import edit_asset, get_editor, request_user_response
 
 if TYPE_CHECKING:
     import argparse
+    from typing import Dict, Union
 
 logging.basicConfig()
-log = logging.getLogger('onyo')
+log: logging.Logger = logging.getLogger('onyo')
 
 
-def create_assets_in_destination(assets: dict, repo: Repo) -> None:
+def create_assets_in_destination(
+        assets: Dict[Path, Dict[str, Union[float, int, str]]],
+        repo: Repo) -> None:
     """
     Create and populate assets. Parent directories are created if necessary.
     """
@@ -29,7 +32,9 @@ def create_assets_in_destination(assets: dict, repo: Repo) -> None:
     repo.add(list(assets.keys()))
 
 
-def read_assets_from_tsv(tsv: str, template_name: str, key_values: dict, repo: Repo) -> dict:
+def read_assets_from_tsv(
+        tsv: str, template_name: str, key_values: Dict[str, str],
+        repo: Repo) -> Dict[Path, Dict[str, Union[float, int, str]]]:
     """
     Read a tsv table with a header row and one row for each new asset to
     create. Check the information (e.g. filenames correct and unique), and add
@@ -114,7 +119,9 @@ def read_assets_from_tsv(tsv: str, template_name: str, key_values: dict, repo: R
     return new_assets
 
 
-def read_assets_from_CLI(assets: list[str], template_name: str, key_values: dict, repo: Repo) -> dict:
+def read_assets_from_CLI(
+        assets: list[str], template_name: str, key_values: Dict[str, str],
+        repo: Repo) -> Dict[Path, Dict[str, Union[float, int, str]]]:
     """
     Read information from `assets`, with a new asset file for each entry.
     Check the information (e.g. filename correct and unique), and add
@@ -163,8 +170,9 @@ def read_assets_from_CLI(assets: list[str], template_name: str, key_values: dict
     return new_assets
 
 
-def sanitize_asset_information(assets: list[str], template: str,
-                               tsv: str, key_values: dict, repo: Repo) -> dict:
+def sanitize_asset_information(
+        assets: list[str], template: str, tsv: str, key_values: Dict[str, str],
+        repo: Repo) -> Dict[Path, Dict[str, Union[float, int, str]]]:
     """
     Collect and normalize information from TSV and CLI for the creation of
     new assets.
@@ -184,7 +192,7 @@ def sanitize_asset_information(assets: list[str], template: str,
     return new_assets
 
 
-def check_against_argument_conflicts(args) -> None:
+def check_against_argument_conflicts(args: argparse.Namespace) -> None:
     """
     Some arguments conflict with each other, e.g. it has to be checked that the
     information from a tsv table does not conflict with the information from

--- a/onyo/commands/set.py
+++ b/onyo/commands/set.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     import argparse
 
 logging.basicConfig()
-log = logging.getLogger('onyo')
+log: logging.Logger = logging.getLogger('onyo')
 
 
 def set(args: argparse.Namespace, opdir: str) -> None:

--- a/onyo/commands/shell_completion.py
+++ b/onyo/commands/shell_completion.py
@@ -39,7 +39,8 @@ class TabCompletion:
     completion_script
         Returns the completion script.
     """
-    def __init__(self, parser, *, type_to_action_map={}, epilogue=''):
+    def __init__(
+            self, parser, *, type_to_action_map={}, epilogue: str = '') -> None:
         self._cmd_tree = self._argparse_to_dict(parser)
         self._type_to_action_map = type_to_action_map
         self._completion_script = None
@@ -146,7 +147,7 @@ class TabCompletion:
         }
         return arg
 
-    def _get_arg_required(self, sp):
+    def _get_arg_required(self, sp) -> bool:
         """
         Return whether an argument is required.
         """
@@ -188,10 +189,10 @@ class TabCompletion:
 
 
 class Zsh(TabCompletion):
-    def _completion(self, cmd_tree):
+    def _completion(self, cmd_tree) -> str:
         return self._zsh_completion(cmd_tree)
 
-    def _zsh_completion(self, cmd_tree):
+    def _zsh_completion(self, cmd_tree) -> str:
         """
         Return a script for ZSH tab completion, suitable for use with the
         "source" command.
@@ -269,7 +270,7 @@ compdef _onyo onyo
 """
         return content
 
-    def _zsh_build_args_and_flags(self, cmd_tree, padding=0):
+    def _zsh_build_args_and_flags(self, cmd_tree, padding: int = 0) -> str:
         """
         Return a string (for use in a ZSH list) containing rules for flags (with
         their arguments) and standalone arguments.
@@ -285,7 +286,7 @@ compdef _onyo onyo
 
         return output
 
-    def _zsh_build_arg(self, arg, arg_tree):
+    def _zsh_build_arg(self, arg, arg_tree) -> str:
         """
         Build and return a string containing the ZSH completion rule for an
         argument.
@@ -419,7 +420,7 @@ compdef _onyo onyo
 
         return output
 
-    def _zsh_build_subcommands(self, cmd_tree):
+    def _zsh_build_subcommands(self, cmd_tree) -> str:
         """
         Return a string (for use in a ZSH list) containing subcommands and their
         help text in the format of:
@@ -432,7 +433,7 @@ compdef _onyo onyo
 
         return "\n".join(subcmd_list)
 
-    def _zsh_build_subcommands_case_statement(self, cmd_tree):
+    def _zsh_build_subcommands_case_statement(self, cmd_tree) -> str:
         """
         Return a ZSH case statement for subcommands. Within each is defined the
         flags and args for the appropriate command.

--- a/onyo/commands/shell_completion.py
+++ b/onyo/commands/shell_completion.py
@@ -1,4 +1,5 @@
 import argparse
+from typing import Optional
 
 
 class TabCompletion:
@@ -174,7 +175,7 @@ class TabCompletion:
 
         return sp.nargs
 
-    def _get_type(self, sp):
+    def _get_type(self, sp) -> Optional[str]:
         """
         Return the name of an argument's type.
         """
@@ -321,7 +322,7 @@ compdef _onyo onyo
 
         return output
 
-    def _zsh_build_flag(self, flag, flag_tree):
+    def _zsh_build_flag(self, flag: str, flag_tree) -> str:
         """
         Build and return a string containing the ZSH completion rule for a flag
         and its arguments.

--- a/onyo/commands/tree.py
+++ b/onyo/commands/tree.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     import argparse
 
 logging.basicConfig()
-log = logging.getLogger('onyo')
+log: logging.Logger = logging.getLogger('onyo')
 
 
 def sanitize_directories(repo: Repo, directories: list[str]) -> list[str]:

--- a/onyo/commands/unset.py
+++ b/onyo/commands/unset.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     import argparse
 
 logging.basicConfig()
-log = logging.getLogger('onyo')
+log: logging.Logger = logging.getLogger('onyo')
 
 
 def unset(args: argparse.Namespace, opdir: str) -> None:

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -5,12 +5,12 @@ import shutil
 import string
 import subprocess
 from pathlib import Path
-from typing import Iterable, Optional, Union
+from typing import Dict, Iterable, Optional, Union
 
 from ruamel.yaml import YAML, scanner  # pyre-ignore[21]
 
 logging.basicConfig()
-log = logging.getLogger('onyo')
+log: logging.Logger = logging.getLogger('onyo')
 
 
 class OnyoInvalidRepoError(Exception):
@@ -28,13 +28,13 @@ class Repo:
         if init:
             self._init(path)
 
-        self._opdir = Path(path).resolve()
-        self._root = self._get_root()
+        self._opdir: Path = Path(path).resolve()
+        self._root: Path = self._get_root()
         # caches
-        self._assets = None
-        self._dirs = None
-        self._files = None
-        self._templates = None
+        self._assets: Union[set[Path], None] = None
+        self._dirs: Union[set[Path], None] = None
+        self._files: Union[set[Path], None] = None
+        self._templates: Union[set[Path], None] = None
 
     @property
     def assets(self) -> set[Path]:  # pyre-ignore[11]
@@ -375,7 +375,7 @@ class Repo:
         return False
 
     @staticmethod
-    def _n_join(to_join: Iterable) -> str:
+    def _n_join(to_join: Iterable[Union[Path, str]]) -> str:
         """
         Convert an Iterable's contents to strings and join with newlines.
         """
@@ -1142,7 +1142,8 @@ class Repo:
     #
     # SET
     #
-    def set(self, paths: Iterable[Union[Path, str]], values: dict, dryrun: bool,
+    def set(self, paths: Iterable[Union[Path, str]],
+            values: Dict[str, Union[str, int, float]], dryrun: bool,
             rename: bool, depth: Union[int]) -> str:
         """
         Set values for a list of assets (or directories), or rename assets
@@ -1237,7 +1238,7 @@ class Repo:
         return "\n".join(diff).strip()
 
     @staticmethod
-    def _read_asset(asset: Path) -> dict:
+    def _read_asset(asset: Path) -> Dict[str, Union[str, int, float]]:
         """
         Read and return the contents of an asset as a dictionary.
         """
@@ -1304,7 +1305,8 @@ class Repo:
 
         return paths_to_set
 
-    def _update_names(self, assets: list[Path], name_values: dict) -> None:
+    def _update_names(self, assets: list[Path],
+                      name_values: Dict[str, Union[float, int, str]]) -> None:
         """
         Set the pseudo key fields of an assets name (rename an asset file) from
         values of a dictionary and test that the new name is valid and
@@ -1353,7 +1355,8 @@ class Repo:
             self._git(["mv", str(asset), str(new_name)])
 
     @staticmethod
-    def _write_asset(asset: Path, contents: dict) -> None:
+    def _write_asset(asset: Path,
+                     contents: Dict[str, Union[float, int, str]]) -> None:
         """
         Write contents into an asset file.
         """

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -14,12 +14,14 @@ log.setLevel(logging.INFO)
 
 
 class StoreKeyValuePairs(argparse.Action):
-    def __init__(self, option_strings: Sequence[str], dest: str, nargs: Union[None, int, str]=None, **kwargs) -> None:
+    def __init__(self, option_strings: Sequence[str], dest: str,
+                 nargs: Union[None, int, str] = None, **kwargs) -> None:
         self._nargs = nargs
         super().__init__(option_strings, dest, nargs=nargs, **kwargs)
 
-    def __call__(self, parser: argparse.ArgumentParser, namespace: argparse.Namespace, key_values: list[str],
-                 option_string: Optional[str]=None) -> None:
+    def __call__(self, parser: argparse.ArgumentParser,
+                 namespace: argparse.Namespace, key_values: list[str],
+                 option_string: Optional[str] = None) -> None:
         results = {}
         for pair in key_values:
             k, v = pair.split('=', maxsplit=1)

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -6,18 +6,20 @@ import textwrap
 
 from onyo import commands
 from onyo._version import __version__
+from typing import Union
 
 logging.basicConfig()
-log = logging.getLogger('onyo')
+log: logging.Logger = logging.getLogger('onyo')
 log.setLevel(logging.INFO)
 
 
 class StoreKeyValuePairs(argparse.Action):
-    def __init__(self, option_strings, dest, nargs=None, **kwargs):
+    def __init__(self, option_strings, dest, nargs=None, **kwargs) -> None:
         self._nargs = nargs
         super().__init__(option_strings, dest, nargs=nargs, **kwargs)
 
-    def __call__(self, parser, namespace, key_values: list[str], option_string=None):
+    def __call__(self, parser, namespace, key_values: list[str],
+                 option_string=None) -> None:
         results = {}
         for pair in key_values:
             k, v = pair.split('=', maxsplit=1)
@@ -34,7 +36,7 @@ class StoreKeyValuePairs(argparse.Action):
 
 # credit: https://stackoverflow.com/a/13429281
 class SubcommandHelpFormatter(argparse.RawDescriptionHelpFormatter):
-    def _format_action(self, action):
+    def _format_action(self, action) -> str:
         parts = super()._format_action(action)
 
         # strip the first line (metavar) of the subcommands section
@@ -43,7 +45,7 @@ class SubcommandHelpFormatter(argparse.RawDescriptionHelpFormatter):
 
         return parts
 
-    def _fill_text(self, text, width, indent):
+    def _fill_text(self, text, width, indent) -> str:
         """
         This is a very, very naive approach to stripping rst syntax from
         docstrings. Sadly, docutils does not have a plain-text writer. That
@@ -83,42 +85,42 @@ def parse_key_values(string):
     return results
 
 
-def directory(string: str):
+def directory(string: str) -> str:
     """
     A no-op type-check for ArgParse. Used to hint for shell tab-completion.
     """
     return string
 
 
-def file(string: str):
+def file(string: str) -> str:
     """
     A no-op type-check for ArgParse. Used to hint for shell tab-completion.
     """
     return string
 
 
-def git_config(string: str):
+def git_config(string: str) -> str:
     """
     A no-op type-check for ArgParse. Used to hint for shell tab-completion.
     """
     return string
 
 
-def path(string: str):
+def path(string: str) -> str:
     """
     A no-op type-check for ArgParse. Used to hint for shell tab-completion.
     """
     return string
 
 
-def template(string: str):
+def template(string: str) -> str:
     """
     A no-op type-check for ArgParse. Used to hint for shell tab-completion.
     """
     return string
 
 
-def setup_parser():
+def setup_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description='A text-based inventory system backed by git.',
         formatter_class=SubcommandHelpFormatter
@@ -635,7 +637,7 @@ def setup_parser():
     return parser
 
 
-def get_subcmd_index(arglist, start=1):
+def get_subcmd_index(arglist, start: int = 1) -> Union[int, None]:
     """
     Get the index of the subcommand from a provided list of arguments (usually sys.argv).
 
@@ -659,7 +661,7 @@ def get_subcmd_index(arglist, start=1):
     return index
 
 
-def main():
+def main() -> None:
     # NOTE: this unfortunately-located-hack is to pass uninterpreted args to
     # "onyo config".
     # nargs=argparse.REMAINDER is supposed to do this, but did not work for our

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -6,7 +6,7 @@ import textwrap
 
 from onyo import commands
 from onyo._version import __version__
-from typing import Union
+from typing import Optional, Sequence, Union
 
 logging.basicConfig()
 log: logging.Logger = logging.getLogger('onyo')
@@ -14,12 +14,12 @@ log.setLevel(logging.INFO)
 
 
 class StoreKeyValuePairs(argparse.Action):
-    def __init__(self, option_strings, dest, nargs=None, **kwargs) -> None:
+    def __init__(self, option_strings: Sequence[str], dest: str, nargs: Union[None, int, str]=None, **kwargs) -> None:
         self._nargs = nargs
         super().__init__(option_strings, dest, nargs=nargs, **kwargs)
 
-    def __call__(self, parser, namespace, key_values: list[str],
-                 option_string=None) -> None:
+    def __call__(self, parser: argparse.ArgumentParser, namespace: argparse.Namespace, key_values: list[str],
+                 option_string: Optional[str]=None) -> None:
         results = {}
         for pair in key_values:
             k, v = pair.split('=', maxsplit=1)
@@ -36,7 +36,7 @@ class StoreKeyValuePairs(argparse.Action):
 
 # credit: https://stackoverflow.com/a/13429281
 class SubcommandHelpFormatter(argparse.RawDescriptionHelpFormatter):
-    def _format_action(self, action) -> str:
+    def _format_action(self, action: argparse.Action) -> str:
         parts = super()._format_action(action)
 
         # strip the first line (metavar) of the subcommands section
@@ -45,7 +45,7 @@ class SubcommandHelpFormatter(argparse.RawDescriptionHelpFormatter):
 
         return parts
 
-    def _fill_text(self, text, width, indent) -> str:
+    def _fill_text(self, text: str, width: int, indent: str) -> str:
         """
         This is a very, very naive approach to stripping rst syntax from
         docstrings. Sadly, docutils does not have a plain-text writer. That

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,11 +4,12 @@ from itertools import chain, combinations
 from pathlib import Path
 
 from onyo import Repo
+from typing import Generator, List, Union
 import pytest
 
 
 @pytest.fixture(scope='function')
-def repo(tmp_path, monkeypatch, request):
+def repo(tmp_path: str, monkeypatch, request) -> Generator[Repo, None, None]:
     """
     This fixture:
     - creates a new repository in a temporary directory
@@ -72,7 +73,7 @@ def repo(tmp_path, monkeypatch, request):
 
 
 @pytest.fixture(scope="function", autouse=True)
-def clean_env(request):
+def clean_env(request) -> None:
     """
     Ensure that $EDITOR is not inherited from the environment or other tests.
     """
@@ -97,13 +98,13 @@ class Helpers:
                 yield x
 
     @staticmethod
-    def onyo_flags():
+    def onyo_flags() -> List[Union[List[List[str]], List[str]]]:
         return [['-d', '--debug'],
                 [['-C', '/tmp'], ['--onyopath', '/tmp']],
                 ]
 
     @staticmethod
-    def powerset(iterable):
+    def powerset(iterable: Iterable):
         "powerset([1,2,3]) --> () (1,) (2,) (3,) (1,2) (1,3) (2,3) (1,2,3)"
         s = list(iterable)
         return chain.from_iterable(combinations(s, r) for r in range(len(s) + 1))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,9 +1,9 @@
 from itertools import product
 
 from onyo import main
+from tests.conftest import Helpers
 
-
-def test_get_subcmd_index_missing(helpers):
+def test_get_subcmd_index_missing(helpers: Helpers) -> None:
     """
     All combinations of flags for onyo, without any subcommand.
     """
@@ -15,7 +15,7 @@ def test_get_subcmd_index_missing(helpers):
             assert idx is None
 
 
-def test_get_subcmd_index_valid(helpers):
+def test_get_subcmd_index_valid(helpers: Helpers) -> None:
     """
     All combinations of flags for onyo, with a subcommand.
     """
@@ -27,7 +27,7 @@ def test_get_subcmd_index_valid(helpers):
             assert idx == full_cmd.index('config')
 
 
-def test_get_subcmd_index_overlap(helpers):
+def test_get_subcmd_index_overlap(helpers: Helpers) -> None:
     """
     Arg values overlap with onyo or its subcommands. Borderline pathological.
     """


### PR DESCRIPTION
This still adds not all type hints, mainly a bunch of the easier ones, but it shows (and goes in the direction of) what `pyre --strict` expects.