### PR TITLE
Change depth=0 to a no-limit depth and add it as default

### DIFF
--- a/onyo/commands/unset.py
+++ b/onyo/commands/unset.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import logging
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from onyo import Repo, OnyoInvalidRepoError
@@ -11,6 +12,28 @@ if TYPE_CHECKING:
 
 logging.basicConfig()
 log = logging.getLogger('onyo')
+
+
+def _sanitize_paths(repo: Repo, paths: list[str]) -> set[Path]:
+    """Validate paths, returning an error if paths are invalid"""
+    formatted_paths = {Path(p) for p in paths}
+    nonexistent = {p for p in formatted_paths if not p.exists()}
+    if nonexistent:
+        print(
+            ('The following paths do not exist:\n{0}\nNothing was '
+             'unset.').format('\n'.join(map(str, nonexistent))),
+            file=sys.stderr)
+        sys.exit(1)
+
+    protected = {p for p in formatted_paths if repo._is_protected_path(p)}
+    if protected:
+        print(
+            ('The following paths are protected by onyo:\n{0}\nNothing was '
+             'unset.').format('\n'.join(map(str, protected))),
+            file=sys.stderr)
+        sys.exit(1)
+
+    return formatted_paths
 
 
 def unset(args: argparse.Namespace, opdir: str) -> None:
@@ -47,8 +70,10 @@ def unset(args: argparse.Namespace, opdir: str) -> None:
         sys.exit(1)
 
     diff = ""
+    paths = _sanitize_paths(repo, args.path)
     try:
-        diff = repo.unset(args.path, args.keys, args.dry_run, args.quiet, args.depth)
+        diff = repo.unset(
+            paths, args.keys, args.dry_run, args.quiet, args.depth)
     except ValueError:
         sys.exit(1)
 

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -478,9 +478,10 @@ def setup_parser():
         metavar='N',
         type=int,
         required=False,
-        default=None,
-        help='descend at most "N" levels of directories below the starting-point'
-    )
+        default=0,
+        help=(
+            'descend at most N levels of directories below the '
+            'starting-point, with an N value of 0 for infinite'))
     cmd_set.add_argument(
         '-m', '--message',
         metavar='MESSAGE',
@@ -584,9 +585,10 @@ def setup_parser():
         metavar='N',
         type=int,
         required=False,
-        default=None,
-        help='descend at most "N" levels of directories below the starting-point'
-    )
+        default=0,
+        help=(
+            'descend at most N levels of directories below the '
+            'starting-point, with an N value of 0 for infinite'))
     cmd_unset.add_argument(
         '-m', '--message',
         metavar='MESSAGE',

--- a/tests/commands/test_set.py
+++ b/tests/commands/test_set.py
@@ -339,81 +339,72 @@ def test_set_dryrun_flag(repo: Repo, set_values: list[str]) -> None:
     repo.fsck()
 
 
-@pytest.mark.repo_files("laptop_macbook_pro.0",
-                        "dir1/laptop_macbook_pro.1",
-                        "dir1/dir2/laptop_macbook_pro.2",
-                        "dir1/dir2/dir3/laptop_macbook_pro.3",
-                        "dir1/dir2/dir3/dir4/laptop_macbook_pro.4",
-                        "dir1/dir2/dir3/dir4/dir5/laptop_macbook_pro.5",
-                        "dir1/dir2/dir3/dir4/dir5/dir6/laptop_macbook_pro.6",)
+@pytest.mark.repo_files(
+    "laptop_macbook_pro.0",
+    "dir1/laptop_macbook_pro.1",
+    "dir1/dir2/laptop_macbook_pro.2",
+    "dir1/dir2/dir3/laptop_macbook_pro.3",
+    "dir1/dir2/dir3/dir4/laptop_macbook_pro.4",
+    "dir1/dir2/dir3/dir4/dir5/laptop_macbook_pro.5",
+    "dir1/dir2/dir3/dir4/dir5/dir6/laptop_macbook_pro.6",)
 @pytest.mark.parametrize('set_values', values)
-def test_set_depth_flag(repo: Repo, set_values: list[str]) -> None:
+@pytest.mark.parametrize('depth,expected', [
+    ('0', 7), ('1', 1), ('3', 3), ('6', 6), ('10', 7)
+])
+def test_set_depth_flag(
+        repo: Repo, set_values: list[str], depth: str, expected: int) -> None:
     """
     Test correct behavior for `onyo set --depth N KEY=VALUE <assets>` for
-    different values for `--depth N`:
-    - correct error for values smaller then 0
-    - changing correct just assets in same dir for --depth 0
-    - changing assets until sub-dir is --depth N deep
-    - changing all assets if --depth is deeper then deepest sub-directory
-      without error (e.g. deepest folder is 6, but --depth 8 is called)
+    different values for `--depth N`.
+
+    The test searches through the output to find returned assets and ensures
+    the number of returned assets matches the expected number, and the
+    returned assets do not have more parents than the specified depth.
     """
-    ret = subprocess.run(['onyo', 'set', '--depth', '-1', '--keys', *set_values], capture_output=True, text=True)
-    # verify output for invalid --depth
+    cmd = ['onyo', 'set', '--depth', depth, '--keys', *set_values]
+    ret = subprocess.run(cmd, input='n', capture_output=True, text=True)
+    output = [output for output in ret.stdout.split('\n')]
+    asset_paths = [str(a) for a in repo.assets]
+    n_assets = 0
+
+    assert not ret.stderr
+    assert ret.returncode == 0
+
+    for line in output:
+        if line not in asset_paths:
+            continue
+
+        n_assets += 1
+
+        if depth != '0':
+            assert len(Path(line).parents) <= int(depth)
+
+    assert n_assets == expected
+
+
+@pytest.mark.repo_files(
+    "laptop_macbook_pro.0",
+    "dir1/laptop_macbook_pro.1",
+    "dir1/dir2/laptop_macbook_pro.2",
+    "dir1/dir2/dir3/laptop_macbook_pro.3",
+    "dir1/dir2/dir3/dir4/laptop_macbook_pro.4",
+    "dir1/dir2/dir3/dir4/dir5/laptop_macbook_pro.5",
+    "dir1/dir2/dir3/dir4/dir5/dir6/laptop_macbook_pro.6",)
+@pytest.mark.parametrize('set_values', values)
+@pytest.mark.parametrize('depth,expected', [
+    ('-1', 'depth values must be positive, but is -1'),
+])
+def test_set_depth_flag_error(
+        repo: Repo, set_values: list[str], depth: str, expected: str) -> None:
+    """
+    Test correct behavior for `onyo set --depth N KEY=VALUE <assets>` when an
+    invalid depth value is given.
+    """
+    cmd = ['onyo', 'set', '--depth', depth, '--keys', *set_values]
+    ret = subprocess.run(cmd, capture_output=True, text=True)
     assert not ret.stdout
-    assert "depth values must be positive, but is -1" in ret.stderr
+    assert expected in ret.stderr
     assert ret.returncode == 1
-    repo.fsck()
-
-    ret = subprocess.run(['onyo', 'set', '--depth', '0', '--keys', *set_values], input='n', capture_output=True, text=True)
-    # verify output for --depth 0
-    assert "laptop_macbook_pro.0" in ret.stdout
-    assert "dir1/laptop_macbook_pro.1" not in ret.stdout
-    assert "depth values must be positive" not in ret.stderr
-    assert ret.returncode == 0
-    repo.fsck()
-
-    ret = subprocess.run(['onyo', 'set', '--depth', '1', '--keys', *set_values], input='n', capture_output=True, text=True)
-    # verify output for --depth 1
-    assert "laptop_macbook_pro.0" in ret.stdout
-    assert "dir1/laptop_macbook_pro.1" in ret.stdout
-    assert "dir1/dir2/laptop_macbook_pro.2" not in ret.stdout
-    assert "depth values must be positive" not in ret.stderr
-    assert ret.returncode == 0
-    repo.fsck()
-
-    ret = subprocess.run(['onyo', 'set', '--depth', '3', '--keys', *set_values], input='n', capture_output=True, text=True)
-    # verify output for --depth 3
-    assert "laptop_macbook_pro.0" in ret.stdout
-    assert "dir1/laptop_macbook_pro.1" in ret.stdout
-    assert "dir1/dir2/laptop_macbook_pro.2" in ret.stdout
-    assert "dir1/dir2/dir3/laptop_macbook_pro.3" in ret.stdout
-    assert "dir1/dir2/dir3/dir4/laptop_macbook_pro.4" not in ret.stdout
-    assert ret.returncode == 0
-    repo.fsck()
-
-    ret = subprocess.run(['onyo', 'set', '--depth', '6', '--keys', *set_values], input='n', capture_output=True, text=True)
-    # verify output for --depth 6 (maximum depth) contains all files
-    assert "laptop_macbook_pro.0" in ret.stdout
-    assert "dir1/laptop_macbook_pro.1" in ret.stdout
-    assert "dir1/dir2/laptop_macbook_pro.2" in ret.stdout
-    assert "dir1/dir2/dir3/laptop_macbook_pro.3" in ret.stdout
-    assert "dir1/dir2/dir3/dir4/laptop_macbook_pro.4" in ret.stdout
-    assert "dir1/dir2/dir3/dir4/dir5/laptop_macbook_pro.5" in ret.stdout
-    assert "dir1/dir2/dir3/dir4/dir5/dir6/laptop_macbook_pro.6" in ret.stdout
-    assert ret.returncode == 0
-    repo.fsck()
-
-    ret = subprocess.run(['onyo', 'set', '--depth', '10', '--keys', *set_values], input='n', capture_output=True, text=True)
-    # verify output for --depth bigger then folder depth without error
-    assert "laptop_macbook_pro.0" in ret.stdout
-    assert "dir1/laptop_macbook_pro.1" in ret.stdout
-    assert "dir1/dir2/laptop_macbook_pro.2" in ret.stdout
-    assert "dir1/dir2/dir3/laptop_macbook_pro.3" in ret.stdout
-    assert "dir1/dir2/dir3/dir4/laptop_macbook_pro.4" in ret.stdout
-    assert "dir1/dir2/dir3/dir4/dir5/laptop_macbook_pro.5" in ret.stdout
-    assert "dir1/dir2/dir3/dir4/dir5/dir6/laptop_macbook_pro.6" in ret.stdout
-    assert ret.returncode == 0
-    repo.fsck()
 
 
 @pytest.mark.repo_files(*assets)

--- a/tests/commands/test_unset.py
+++ b/tests/commands/test_unset.py
@@ -26,6 +26,7 @@ content_str = "\n".join([f"{elem}: {content_dict.get(elem)}"
 
 contents = [[x, content_str] for x in assets]
 
+
 @pytest.mark.repo_contents(*contents)
 @pytest.mark.parametrize('asset', assets)
 def test_unset(repo: Repo, asset: str) -> None:
@@ -429,7 +430,7 @@ def test_unset_depth_flag(repo: Repo) -> None:
     # verify output for --depth 0
     assert "laptop_macbook_pro.0" in ret.stdout
     assert f"-{key}" in ret.stdout
-    assert "dir1/laptop_macbook_pro.1" not in ret.stdout
+    assert "dir1/dir2/dir3/dir4/dir5/dir6/laptop_macbook_pro.6" in ret.stdout
     # I think a value of zero should be allowed without error. It has no
     # additional functionality, but is logically consistent, and might help
     # while scripting with onyo.
@@ -440,9 +441,9 @@ def test_unset_depth_flag(repo: Repo) -> None:
     ret = subprocess.run(['onyo', 'unset', '--depth', '1', '--keys', key], input='n', capture_output=True, text=True)
     # verify output for --depth 1
     assert "laptop_macbook_pro.0" in ret.stdout
-    assert ret.stdout.count(f"-{key}") == 2
-    assert "dir1/laptop_macbook_pro.1" in ret.stdout
-    assert "dir1/dir2/laptop_macbook_pro.2" not in ret.stdout
+    assert ret.stdout.count(f"-{key}") == 1
+    assert "laptop_macbook_pro.0" in ret.stdout
+    assert "dir1/laptop_macbook_pro.1" not in ret.stdout
     assert "--depth must be bigger than 0" not in ret.stderr
     assert ret.returncode == 0
     repo.fsck()
@@ -452,9 +453,8 @@ def test_unset_depth_flag(repo: Repo) -> None:
     assert "laptop_macbook_pro.0" in ret.stdout
     assert "dir1/laptop_macbook_pro.1" in ret.stdout
     assert "dir1/dir2/laptop_macbook_pro.2" in ret.stdout
-    assert "dir1/dir2/dir3/laptop_macbook_pro.3" in ret.stdout
-    assert "dir1/dir2/dir3/dir4/laptop_macbook_pro.4" not in ret.stdout
-    assert ret.stdout.count(f"-{key}") == 4
+    assert "dir1/dir2/dir3/laptop_macbook_pro.3" not in ret.stdout
+    assert ret.stdout.count(f"-{key}") == 3
     assert ret.returncode == 0
     repo.fsck()
 
@@ -466,8 +466,8 @@ def test_unset_depth_flag(repo: Repo) -> None:
     assert "dir1/dir2/dir3/laptop_macbook_pro.3" in ret.stdout
     assert "dir1/dir2/dir3/dir4/laptop_macbook_pro.4" in ret.stdout
     assert "dir1/dir2/dir3/dir4/dir5/laptop_macbook_pro.5" in ret.stdout
-    assert "dir1/dir2/dir3/dir4/dir5/dir6/laptop_macbook_pro.6" in ret.stdout
-    assert ret.stdout.count(f"-{key}") == len(repo.assets)
+    assert "dir1/dir2/dir3/dir4/dir5/dir6/laptop_macbook_pro.6" not in ret.stdout
+    assert ret.stdout.count(f"-{key}") == 6
     assert ret.returncode == 0
     repo.fsck()
 


### PR DESCRIPTION
Change the argparse defaults for the `--depth` flag in `onyo set` and `onyo unset` to 0, and have 0 mean "no depth limit". Rather than have onyo crawl through the directory structure of the repository, it will instead filter `self.assets` based on path and depth requirements. Tests have been modified to work with the new "0 is no depth limit" setting.

There are a few things that still require discussion:
  1. `depth` as a positive integer should be a type annotation, rather than an error in `_set_sanitize`
  2. In argparse, one could use `cmd_set.add_argument('--depth', type=positive_int)`, writing a `def positive_int(value)` that returns `int(value)` if the value is positive, otherwise returning an `argparse.ArgumentTypeError`, therefore disallowing negative values. At the least the type check should then be in `commands.set` and `commands.unset`.
  3. Due to the use of `self.assets` instead of crawling through repo directories, checking for invalid and protected paths is superfluous. There should be no assets in protected or invalid paths and if they are used as given paths, the command should always return "No assets selected". I've left them in for now to warn users when protected or invalid paths are given, but if this is handled at all, it should be handled in `commands`, not the API.
  4. Due to the aforementioned use of `self.assets` in `_set_sanitize`, the `_select_assets_from_directory` function in `onyo.py` is no longer used. I have not removed it yet because it may be used elsewhere outside of `lib/onyo.py`, but it is generally not an optimal approach to asset selection as it requires a type of validation that `self.assets` has already gone through.
  5. I have adapted the `test_set_depth_flag` test and split it into "expected to work" and "expected to error" tests. I did not give `test_unset_depth_flag` the same courtesy because it was easier to fix and these tests should be optimized in a different PR.


