### PR TITLE
(RFC) lib: properties/paths are absolute, git requests are made from repo.root

### DIFF
--- a/onyo/commands/edit.py
+++ b/onyo/commands/edit.py
@@ -88,7 +88,7 @@ def sanitize_assets(assets: list[str], repo: Repo) -> list[Path]:
     valid_assets = []
 
     for asset in assets:
-        asset = Path(asset).resolve().relative_to(repo.root)
+        asset = repo.sanitize_path(asset)
         if asset not in repo.assets:
             print(f"\n{asset} is not an asset.", file=sys.stderr)
         else:

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -57,8 +57,7 @@ class Repo:
     @property
     def assets(self) -> set[Path]:  # pyre-ignore[11]
         """
-        A `set` containing the `Path`s relative to `Repo.root` of all assets of
-        an Onyo repository.
+        A `set` containing the absolute `Path`s of all assets of a repository.
 
         This property is cached, and the cache is consistent with the state of
         the repository when only `Repo`s public functions are used. Use of
@@ -73,8 +72,7 @@ class Repo:
     @property
     def dirs(self) -> set[Path]:
         """
-        A `set` containing the `Path`s relative to `Repo.root` of all directories
-        of an Onyo repository.
+        A `set` containing the absolute `Path`s of all directories a repository.
 
         This property is cached, and the cache is consistent with the state of
         the repository when only `Repo`s public functions are used. Use of
@@ -89,8 +87,7 @@ class Repo:
     @property
     def files(self) -> set[Path]:
         """
-        A `set` containing the `Paths` relative to `Repo.root` of all files of an
-        Onyo repository.
+        A `set` containing the absolute `Paths` of all files of a repository.
 
         This property is cached, and the cache is consistent with the state of
         the repository when only `Repo`s public functions are used. Use of
@@ -105,24 +102,24 @@ class Repo:
     @property
     def files_changed(self) -> set[Path]:
         """
-        Returns a `set` containing the `Path`s relative to `Repo.root` of all
-        changed files (according to git) of an Onyo repository.
+        Returns a `set` containing the absolute `Path`s of all changed files
+        (according to git) of a repository.
         """
         return self._get_files_changed()
 
     @property
     def files_staged(self) -> set[Path]:
         """
-        Returns a `set` containing the `Path`s relative to `Repo.root` of all
-        staged files (according to git) of an Onyo repository.
+        Returns a `set` containing the absolute `Path`s of all staged files
+        (according to git) of a repository.
         """
         return self._get_files_staged()
 
     @property
     def files_untracked(self) -> set[Path]:
         """
-        Returns a `set` containing the `Path`s relative to `Repo.root` of all
-        untracked files (according to git) of an Onyo repository
+        Returns a `set` containing the absolute `Path`s of all untracked files
+        (according to git) of a repository.
         """
         return self._get_files_untracked()
 
@@ -149,8 +146,8 @@ class Repo:
     @property
     def templates(self) -> set[Path]:
         """
-        A `set` containing the `Path`s relative to `Repo.root` of all
-        template files of an Onyo repository.
+        A `set` containing the absolute `Path`s of all template files of an
+        Onyo repository.
 
         This property is cached, and the cache is consistent with the state of
         the repository when only `Repo`s public functions are used. Use of
@@ -319,34 +316,38 @@ class Repo:
 
     def _get_files(self) -> set[Path]:
         """
-        Return a set of all files in the repository (except under .git).
+        Return a set of all absolute `Path`s to files in the repository
+        (except under .git).
         """
         log.debug('Acquiring list of files')
-        files = {Path(x) for x in self._git(['ls-files', '-z']).split('\0') if x}
+        files = {Path(self.root, x) for x in self._git(['-C', str(self.root), 'ls-files', '-z']).split('\0') if x}
         return files
 
     def _get_files_changed(self) -> set[Path]:
         """
-        Return a set of all unstaged changes in the repository.
+        Return a set of all absolute `Path`s to unstaged changes in the
+        repository.
         """
         log.debug('Acquiring list of changed files')
-        changed = {Path(x) for x in self._git(['diff', '-z', '--name-only']).split('\0') if x}
+        changed = {Path(self.root, x) for x in self._git(['-C', str(self.root), 'diff', '-z', '--name-only']).split('\0') if x}
         return changed
 
     def _get_files_staged(self) -> set[Path]:
         """
-        Return a set of all staged changes in the repository.
+        Return a set of all absolute `Path`s to staged changes in the
+        repository.
         """
         log.debug('Acquiring list of staged files')
-        staged = {Path(x) for x in self._git(['diff', '--name-only', '-z', '--staged']).split('\0') if x}
+        staged = {Path(self.root, x) for x in self._git(['-C', str(self.root), 'diff', '--name-only', '-z', '--staged']).split('\0') if x}
         return staged
 
     def _get_files_untracked(self) -> set[Path]:
         """
-        Return a set of all untracked files in the repository.
+        Return a set of all absolute `Path`s to untracked files in the
+        repository.
         """
         log.debug('Acquiring list of untracked files')
-        untracked = {Path(x) for x in self._git(['ls-files', '-z', '--others', '--exclude-standard']).split('\0') if x}
+        untracked = {Path(self.root, x) for x in self._git(['-C', str(self.root), 'ls-files', '-z', '--others', '--exclude-standard']).split('\0') if x}
         return untracked
 
     @staticmethod

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -213,7 +213,7 @@ class Repo:
 
         # staged files and directories (without ".anchor") in alphabetical order
         staged_changes = [x if not x.name == ".anchor" else x.parent
-                          for x in sorted(self.files_staged)]
+                          for x in sorted(self.relative_to_root(self.files_staged))]
 
         if message:
             message_subject = message[0][0]

--- a/onyo/lib/utils.py
+++ b/onyo/lib/utils.py
@@ -29,7 +29,7 @@ def get_assets(repo: Repo) -> set[Path]:
 
 
 def get_templates(repo: Repo) -> set[Path]:
-    return {Path(file)
+    return {repo.sanitize_path(file)
             for file in Path(repo.root, ".onyo", "templates").glob('*')
             if Path(file).is_file() and not Path(file).name == ".anchor"}
 

--- a/onyo/lib/utils.py
+++ b/onyo/lib/utils.py
@@ -52,7 +52,7 @@ def get_assets_by_path(repo: Repo, paths: Iterable[Union[Path, str]],
         log.error(f"depth values must be positive, but is {depth}.")
         raise ValueError(f"depth values must be positive, but is {depth}.")
 
-    paths = {Path(p) for p in paths}
+    paths = {repo.sanitize_path(p) for p in paths}
     assets = [
         a for a in repo.assets if any([
             a.is_relative_to(p) and

--- a/tests/commands/test_get.py
+++ b/tests/commands/test_get.py
@@ -356,8 +356,7 @@ def test_get_path_error(repo: Repo, path: str) -> None:
     """
     cmd = ['onyo', 'get', '--path', path, '-H']
     ret = subprocess.run(cmd, capture_output=True, text=True)
-    eval_path = Path(path)
-    assert f"cannot access '{str(eval_path)}': No such directory" in ret.stderr
+    assert f"The following paths do not exist:\n{path}" in ret.stderr
     assert ret.returncode == 1
 
 

--- a/tests/commands/test_new.py
+++ b/tests/commands/test_new.py
@@ -102,8 +102,8 @@ def test_folder_creation_with_new(repo: Repo, directory: str) -> None:
 
     # verify that the new assets exist and the repository is in a clean state
     repo_assets = repo.assets
-    assert Path(asset).is_file()
-    assert Path(asset) in repo_assets
+    assert Path(repo.root / asset).is_file()
+    assert Path(repo.root / asset) in repo_assets
     assert len(repo_assets) == 1
     repo.fsck()
 
@@ -150,8 +150,8 @@ def test_new_assets_in_multiple_directories_at_once(repo: Repo) -> None:
     # verify that the new assets exist and the repository is in a clean state
     repo_assets = repo.assets
     for asset in assets:
-        assert Path(asset).is_file()
-        assert Path(asset) in repo_assets
+        assert Path(repo.root / asset).is_file()
+        assert Path(repo.root / asset) in repo_assets
     assert len(repo_assets) == len(directories)
     repo.fsck()
 
@@ -177,7 +177,7 @@ def test_yes_flag(repo: Repo, directory: str) -> None:
     # verify that the new asset exists and the repository is in a clean state
     assert Path(asset).is_file()
     repo_assets = repo.assets
-    assert Path(asset) in repo_assets
+    assert Path(repo.root / asset) in repo_assets
     assert len(repo_assets) == 1
     repo.fsck()
 
@@ -202,8 +202,8 @@ def test_keys_flag(repo: Repo, directory: str) -> None:
     assert ret.returncode == 0
 
     # verify that asset exists, the content is set, and the repository is clean
-    assert Path(asset) in repo.assets
-    assert 'mode: keys_flag' in Path.read_text(Path(asset))
+    assert Path(repo.root / asset) in repo.assets
+    assert 'mode: keys_flag' in Path.read_text(Path(repo.root / asset))
     repo.fsck()
 
 
@@ -247,8 +247,8 @@ def test_discard_changes(repo: Repo, directory: str) -> None:
 
     # verify that no new asset was created and the repository is still clean
     repo_assets = repo.assets
-    assert not Path(asset).is_file()
-    assert Path(asset) not in repo_assets
+    assert not Path(repo.root / asset).is_file()
+    assert Path(repo.root / asset) not in repo_assets
     assert len(repo_assets) == 0
     repo.fsck()
 
@@ -302,7 +302,7 @@ def test_new_with_flags_edit_keys_template(repo: Repo, directory: str) -> None:
     assert ret.returncode == 0
 
     # verify that new asset exists and that the content is added.
-    assert asset in repo.assets
+    assert Path(repo.root / asset) in repo.assets
     contents = Path.read_text(asset)
     # value from --template:
     assert 'RAM:' in contents
@@ -338,7 +338,7 @@ def test_new_with_keys_overwrite_template(repo: Repo, directory: str) -> None:
     assert ret.returncode == 0
 
     # verify that new asset exists and that the content is added.
-    assert asset in repo.assets
+    assert Path(repo.root / asset) in repo.assets
     contents = Path.read_text(asset)
 
     # verify values from --keys are set
@@ -492,7 +492,7 @@ def test_tsv_with_value_columns(repo: Repo) -> None:
     repo_assets = repo.assets
     assert len(repo_assets) > 0
     for asset in repo_assets:
-        contents = Path.read_text(asset)
+        contents = Path.read_text(repo.root / asset)
         assert "group: " in contents
         assert "age: " in contents
     repo.fsck()
@@ -528,7 +528,7 @@ def test_tsv_with_flags_template_keys_edit(repo: Repo) -> None:
     repo_assets = repo.assets
     assert len(repo_assets) > 0
     for asset in repo_assets:
-        contents = Path.read_text(asset)
+        contents = Path.read_text(repo.root / asset)
         # from --template:
         assert "RAM:" in contents
         # from --edit:

--- a/tests/commands/test_set.py
+++ b/tests/commands/test_set.py
@@ -370,7 +370,7 @@ def test_set_depth_flag(
     cmd = ['onyo', 'set', '--depth', depth, '--keys', *set_values]
     ret = subprocess.run(cmd, input='n', capture_output=True, text=True)
     output = [output for output in ret.stdout.split('\n')]
-    asset_paths = [str(a) for a in repo.assets]
+    asset_paths = [str(a) for a in repo.relative_to_root(repo.assets)]
     n_assets = 0
 
     assert not ret.stderr

--- a/tests/commands/test_unset.py
+++ b/tests/commands/test_unset.py
@@ -151,8 +151,8 @@ def test_unset_multiple_assets(repo: Repo) -> None:
 
     # verify output
     assert "The following assets will be changed:" in ret.stdout
-    for asset in repo.assets:
-        assert str(Path(asset)) in ret.stdout
+    for asset in repo.relative_to_root(repo.assets):
+        assert str(asset) in ret.stdout
     assert not ret.stderr
     assert ret.returncode == 0
 

--- a/tests/lib/test_Repo.py
+++ b/tests/lib/test_Repo.py
@@ -252,6 +252,7 @@ def test_Repo_assets(repo: Repo) -> None:
     for i in repo.assets:
         assert isinstance(i, Path)
         assert i.is_file()
+        assert i.is_absolute()
         # nothing from .git
         assert '.git' not in i.parts
         # nothing from .onyo
@@ -285,6 +286,7 @@ def test_Repo_dirs(repo: Repo) -> None:
     for i in repo.dirs:
         assert isinstance(i, Path)
         assert i.is_dir()
+        assert i.is_absolute()
         # nothing from .git
         assert '.git' not in i.parts
 
@@ -315,6 +317,7 @@ def test_Repo_files(repo: Repo) -> None:
     for i in repo.files:
         assert isinstance(i, Path)
         assert i.is_file()
+        assert i.is_absolute()
         # nothing from .git
         assert '.git' not in i.parts
 
@@ -351,6 +354,7 @@ def test_Repo_files_changed(repo: Repo) -> None:
     for i in repo.files_changed:
         assert isinstance(i, Path)
         assert i.is_file()
+        assert i.is_absolute()
 
     # make sure all changed files are returned
     for i in files_to_change:
@@ -383,6 +387,7 @@ def test_Repo_files_staged(repo: Repo) -> None:
     for i in repo.files_staged:
         assert isinstance(i, Path)
         assert i.is_file()
+        assert i.is_absolute()
 
     # make sure all staged files are returned
     for i in files_to_stage:
@@ -414,6 +419,7 @@ def test_Repo_files_untracked(repo: Repo) -> None:
     for i in repo.files_untracked:
         assert isinstance(i, Path)
         assert i.is_file()
+        assert i.is_absolute()
 
     # make sure all untracked files are returned
     for i in files_to_be_untracked:
@@ -437,6 +443,7 @@ def test_Repo_opdir(tmp_path: Path) -> None:
     # test
     repo = Repo('opdir-repo')
     assert isinstance(repo.opdir, Path)
+    assert repo.opdir.is_absolute()
     assert Path('opdir-repo').samefile(repo.opdir)
 
 
@@ -455,6 +462,7 @@ def test_Repo_opdir_root(tmp_path: Path) -> None:
     os.chdir('opdir-root')
     repo = Repo('.')
     assert Path('.').samefile(repo.opdir)
+    assert repo.opdir.is_absolute()
     assert repo.root.samefile(repo.opdir)
 
 
@@ -470,9 +478,9 @@ def test_Repo_opdir_child(repo: Repo, tmp_path: Path) -> None:
     with pytest.raises(OnyoInvalidRepoError):
         repo = Repo('.')
 
-    # test
     repo = Repo('.', find_root=True)
     assert tmp_path.samefile(repo.root)
+    assert repo.opdir.is_absolute()
 
 
 #
@@ -489,6 +497,7 @@ def test_Repo_root(tmp_path: Path) -> None:
     assert ret.returncode == 0
 
     repo = Repo('root-repo')
+    assert repo.root.is_absolute()
     assert isinstance(repo.root, Path)
 
 
@@ -504,6 +513,7 @@ def test_Repo_root_parent(tmp_path: Path) -> None:
 
     # test
     repo = Repo('root-parent')
+    assert repo.root.is_absolute()
     assert Path('root-parent').samefile(repo.root)
 
 
@@ -521,6 +531,7 @@ def test_Repo_root_root(tmp_path: Path) -> None:
     # test
     os.chdir('root-root')
     repo = Repo('.')
+    assert repo.root.is_absolute()
     assert Path('.').samefile(repo.root)
 
 #
@@ -586,6 +597,7 @@ def test_Repo_templates(repo: Repo) -> None:
     for i in repo.templates:
         assert isinstance(i, Path)
         assert i.is_file()
+        assert i.is_absolute()
         assert '.onyo' in i.parts and 'templates' in i.parts
         # nothing from .git
         assert '.git' not in i.parts
@@ -607,6 +619,7 @@ def test_Repo_get_template(repo: Repo) -> None:
         assert isinstance(template, Path)
 
         assert template.is_file()
+        assert template.is_absolute()
         assert '.onyo' in template.parts and 'templates' in template.parts
         # nothing from .git
         assert '.git' not in template.parts
@@ -623,6 +636,7 @@ def test_Repo_get_template_default(repo: Repo) -> None:
     assert isinstance(template, Path)
 
     assert template.is_file()
+    assert template.is_absolute()
     assert '.onyo' in template.parts and 'templates' in template.parts
     # nothing from .git
     assert '.git' not in template.parts

--- a/tests/lib/test_Repo_add.py
+++ b/tests/lib/test_Repo_add.py
@@ -24,7 +24,7 @@ def test_add_args_single_file(
 
     # test
     repo.add(variant)
-    assert Path('single-file') in repo.files_staged
+    assert Path(repo.root / 'single-file') in repo.files_staged
 
 
 @params({
@@ -47,9 +47,9 @@ def test_add_args_multi_file(
 
     # test
     repo.add(variant)
-    assert Path('one') in repo.files_staged
-    assert Path('two') in repo.files_staged
-    assert Path('three') in repo.files_staged
+    assert Path(repo.root / 'one') in repo.files_staged
+    assert Path(repo.root / 'two') in repo.files_staged
+    assert Path(repo.root / 'three') in repo.files_staged
 
 
 @pytest.mark.repo_dirs('single-dir')
@@ -72,7 +72,7 @@ def test_add_args_single_dir(
 
     # test
     repo.add(variant)
-    assert Path('single-dir/file') in repo.files_staged
+    assert Path(repo.root / 'single-dir/file') in repo.files_staged
 
 
 @pytest.mark.repo_dirs('one', 'two', 'three')
@@ -100,8 +100,8 @@ def test_add_args_multi_dir(
     # test
     repo.add(variant)
     for i in variant:
-        assert Path(f'{i}/file-{i}-A') in repo.files_staged
-        assert Path(f'{i}/file-{i}-B') in repo.files_staged
+        assert Path(repo.root / f'{i}/file-{i}-A') in repo.files_staged
+        assert Path(repo.root / f'{i}/file-{i}-B') in repo.files_staged
 
     assert len(variant) * 2 == len(repo.files_staged)
 
@@ -145,7 +145,7 @@ def test_add_spaces(repo: Repo, variant: Collection[Union[Path, str]]) -> None:
     # test
     repo.add(variant)
     for i in variant:
-        assert Path(i) in repo.files_staged
+        assert Path(repo.root / i) in repo.files_staged
     assert len(variant) == len(repo.files_staged)
 
 
@@ -159,9 +159,9 @@ def test_add_repeat(repo: Repo) -> None:
 
     # test
     repo.add(['repeat-one', 'two', 'repeat-one', 'three'])
-    assert Path('repeat-one') in repo.files_staged
-    assert Path('two') in repo.files_staged
-    assert Path('three') in repo.files_staged
+    assert Path(repo.root / 'repeat-one') in repo.files_staged
+    assert Path(repo.root / 'two') in repo.files_staged
+    assert Path(repo.root / 'three') in repo.files_staged
 
 
 @pytest.mark.repo_dirs('unchanged-dir')

--- a/tests/lib/test_generate_commit_message.py
+++ b/tests/lib/test_generate_commit_message.py
@@ -1,0 +1,57 @@
+from typing import List
+
+import pytest
+from onyo import Repo
+
+files = ['laptop_apple_macbookpro',
+         'lap top_ap ple_mac book pro']
+
+directories = ['.',
+               's p a c e s',
+               'r/e/c/u/r/s/i/v/e',
+               'overlap/one',
+               'overlap/two',
+               'very/very/very/deep'
+               ]
+
+assets: List[str] = [f"{d}/{f}.{i}" for f in files for i, d in enumerate(directories)]
+
+content_dict = {"one_key": "one_value",
+                "two_key": "two_value",
+                "three_key": "three_value"}
+
+content_str: str = "\n".join([f"{elem}: {content_dict.get(elem)}"
+                              for elem in content_dict]) + "\n"
+
+contents: List[List[str]] = [[x, content_str] for x in assets]
+
+
+@pytest.mark.repo_contents(*contents)
+def test_Repo_generate_commit_message(repo: Repo) -> None:
+    """
+    A generated commit message has to have a header with less then 80 characters
+    length, and a body with the paths to changed files and directories relative
+    to the root of the repository.
+    """
+    # modify the repository with some different commands:
+    repo.mkdir(repo.sanitize_path("a/new/folder"))
+    repo.mv(repo.sanitize_path("s p a c e s"),
+            repo.sanitize_path("a/new/folder"))
+    repo.set([repo.root], {"one_key": "new_value"},
+             dryrun=False, rename=False, depth=0)
+    repo.unset([repo.root], ["two_key", "three_key"],
+               dryrun=False, quiet=True, depth=0)
+
+    # generate a commit message:
+    message = repo.generate_commit_message(cmd="TST")
+    header = message.split("\n")[0]
+    list_files_changed = message.split("\n\n")[-1]
+    assert str(repo.root) not in message
+
+    # verify all necessary information is in the header:
+    assert f"TST [{len(repo.files_staged)}]: " in header
+
+    # verify all necessary information is in the body:
+    assert "a/new/folder" in list_files_changed
+    assert "s p a c e s" in list_files_changed
+    assert len(list_files_changed.split("\n")) == len(repo.files_staged)


### PR DESCRIPTION
Changes added:
- all properties are now absolute paths
- all `git` queries (e.g. `git ls-files`) are run from `repo.root` to contain all assets/dirs etc from the repo, not just relative to `repo.opdir`, and all are absolute
- adds functions:
  - `Repo.sanitize_path()`: checks if paths are absolute or relative to the opdir and returns them as an absolute `Path`
  - `Repo.relative_to_root()`: returns for a set of absolute paths (that must be inside of the repository) a set of Pathsrelative to `repo.root`
  - `relative_to_opdir()`: returns for a set of absolute paths as set of Paths relative to the operating directory
- updates the generating of commit messages to still display paths relative from `repo.root`
- updates the tests/commands which are effected by the changes to work with the changes

Close #297

Additionally: 
- This PR currently still does not remove `Repo.opdir`, but since the helper functions work without it, and instead enable easy usage with absolute paths, I would remove it, if this is the way we want to go.