### PR TITLE
BF: add `tests/__init__.py` to enable importing from conftest

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,7 @@
+from tests.conftest import params, Helpers
+
+
+__all__ = [
+    params,
+    Helpers,
+]


### PR DESCRIPTION
The `__init__.py` is needed to make functions and variables inside of the project explicitely import-able, otherwise the CI errors with a `ModuleNotFoundError`.