### PR TITLE
`Repo` must be instantiated with root

### DIFF
--- a/onyo/commands/cat.py
+++ b/onyo/commands/cat.py
@@ -60,7 +60,7 @@ def cat(args: argparse.Namespace, opdir: str) -> None:
     """
     repo = None
     try:
-        repo = Repo(opdir)
+        repo = Repo(opdir, find_root=True)
         repo.fsck(['asset-yaml'])
     except OnyoInvalidRepoError:
         sys.exit(1)

--- a/onyo/commands/config.py
+++ b/onyo/commands/config.py
@@ -77,7 +77,7 @@ def config(args: argparse.Namespace, opdir: str) -> None:
     """
     repo = None
     try:
-        repo = Repo(opdir)
+        repo = Repo(opdir, find_root=True)
         repo.fsck(['asset-yaml'])
     except OnyoInvalidRepoError:
         sys.exit(1)

--- a/onyo/commands/edit.py
+++ b/onyo/commands/edit.py
@@ -120,7 +120,7 @@ def edit(args: argparse.Namespace, opdir: str) -> None:
         sys.exit(1)
 
     try:
-        repo = Repo(opdir)
+        repo = Repo(opdir, find_root=True)
         # "onyo fsck" is intentionally not run here.
         # This is so "onyo edit" can be used to fix an existing problem. This has
         # benefits over just simply using `vim`, etc directly, as "onyo edit" will

--- a/onyo/commands/fsck.py
+++ b/onyo/commands/fsck.py
@@ -26,7 +26,7 @@ def fsck(args: argparse.Namespace, opdir: str) -> None:
     """
     repo = None
     try:
-        repo = Repo(opdir)
+        repo = Repo(opdir, find_root=True)
         repo.fsck()
     except OnyoInvalidRepoError:
         sys.exit(1)

--- a/onyo/commands/get.py
+++ b/onyo/commands/get.py
@@ -122,7 +122,7 @@ def get(args: argparse.Namespace, opdir: str) -> None:
 
     repo = None
     try:
-        repo = Repo(opdir)
+        repo = Repo(opdir, find_root=True)
         repo.fsck(['asset-yaml'])
     except OnyoInvalidRepoError:
         sys.exit(1)

--- a/onyo/commands/history.py
+++ b/onyo/commands/history.py
@@ -78,7 +78,7 @@ def history(args: argparse.Namespace, opdir: str) -> None:
     """
     repo = None
     try:
-        repo = Repo(opdir)
+        repo = Repo(opdir, find_root=True)
         repo.fsck(['asset-yaml'])
     except OnyoInvalidRepoError:
         sys.exit(1)

--- a/onyo/commands/mkdir.py
+++ b/onyo/commands/mkdir.py
@@ -22,7 +22,7 @@ def mkdir(args: argparse.Namespace, opdir: str) -> None:
     """
     repo = None
     try:
-        repo = Repo(opdir)
+        repo = Repo(opdir, find_root=True)
         repo.fsck()
     except OnyoInvalidRepoError:
         sys.exit(1)

--- a/onyo/commands/mv.py
+++ b/onyo/commands/mv.py
@@ -24,7 +24,7 @@ def mv(args: argparse.Namespace, opdir: str) -> None:
         sys.exit(1)
 
     try:
-        repo = Repo(opdir)
+        repo = Repo(opdir, find_root=True)
         repo.fsck()
     except OnyoInvalidRepoError:
         sys.exit(1)

--- a/onyo/commands/new.py
+++ b/onyo/commands/new.py
@@ -238,7 +238,7 @@ def new(args: argparse.Namespace, opdir: str) -> None:
     """
     repo = None
     try:
-        repo = Repo(opdir)
+        repo = Repo(opdir, find_root=True)
         repo.fsck()
     except OnyoInvalidRepoError:
         sys.exit(1)

--- a/onyo/commands/rm.py
+++ b/onyo/commands/rm.py
@@ -24,7 +24,7 @@ def rm(args: argparse.Namespace, opdir: str) -> None:
         sys.exit(1)
 
     try:
-        repo = Repo(opdir)
+        repo = Repo(opdir, find_root=True)
         repo.fsck()
     except OnyoInvalidRepoError:
         sys.exit(1)

--- a/onyo/commands/set.py
+++ b/onyo/commands/set.py
@@ -69,7 +69,7 @@ def set(args: argparse.Namespace, opdir: str) -> None:
         sys.exit(1)
 
     try:
-        repo = Repo(opdir)
+        repo = Repo(opdir, find_root=True)
         repo.fsck()
     except OnyoInvalidRepoError:
         sys.exit(1)

--- a/onyo/commands/tree.py
+++ b/onyo/commands/tree.py
@@ -62,7 +62,7 @@ def tree(args: argparse.Namespace, opdir: str) -> None:
     """
     repo = None
     try:
-        repo = Repo(opdir)
+        repo = Repo(opdir, find_root=True)
         repo.fsck(['asset-yaml'])
     except OnyoInvalidRepoError:
         sys.exit(1)

--- a/onyo/commands/unset.py
+++ b/onyo/commands/unset.py
@@ -64,7 +64,7 @@ def unset(args: argparse.Namespace, opdir: str) -> None:
 
     repo = None
     try:
-        repo = Repo(opdir)
+        repo = Repo(opdir, find_root=True)
         repo.fsck()
     except OnyoInvalidRepoError:
         sys.exit(1)

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -33,13 +33,15 @@ class Repo:
         path is invalid a `OnyoInvalidRepoError` is raised.
         """
         path = Path(path)
-        path = self._find_root(path) if find_root else path.resolve()
 
         if init:
+            path = path.resolve()
             self._init(path)
-        elif not Repo._is_onyo_root(path):
-            log.error(f"'{path}' is no valid Onyo Repository.")
-            raise OnyoInvalidRepoError(f"'{path}' is no valid Onyo Repository.")
+        else:
+            path = self._find_root(path) if find_root else path.resolve()
+            if not Repo._is_onyo_root(path):
+                log.error(f"'{path}' is no valid Onyo Repository.")
+                raise OnyoInvalidRepoError(f"'{path}' is no valid Onyo Repository.")
 
         self._opdir: Path = path
         self._root: Path = path

--- a/tests/lib/test_Repo.py
+++ b/tests/lib/test_Repo.py
@@ -133,6 +133,16 @@ def test_init_not_exist_dir(tmp_path: Path, variant: str) -> None:
     assert fully_populated_dot_onyo(repo_path)
 
 
+def test_init_and_find_root_true(tmp_path: Path) -> None:
+    """
+    `Repo(<directory>, init=True, find_root=True)` must init the directory and
+    use it as a root.
+    """
+    repo = Repo(tmp_path, init=True, find_root=True)
+    assert fully_populated_dot_onyo(tmp_path)
+    assert tmp_path.samefile(repo.root)
+
+
 @pytest.mark.parametrize('variant', ['', './', 'dir', 's p a c e s'])
 def test_init_exist_dir(tmp_path: Path, variant: str) -> None:
     """

--- a/tests/lib/test_Repo.py
+++ b/tests/lib/test_Repo.py
@@ -16,7 +16,7 @@ from tests.conftest import params
     "str": {"variant": "the-repo"},
 })
 def test_Repo_instantiate_types(
-        tmp_path: str, variant: Union[str, Path]) -> None:
+        tmp_path: Path, variant: Union[str, Path]) -> None:
     """
     The Repo class must instantiate correctly for different data types for
     paths to existing repositories.
@@ -29,7 +29,7 @@ def test_Repo_instantiate_types(
     Repo(variant)
 
 
-def test_Repo_instantiate_invalid_path(tmp_path: str) -> None:
+def test_Repo_instantiate_invalid_path(tmp_path: Path) -> None:
     """
     The Repo class must raise a `OnyoInvalidRepoError` if instantiated with a
     non-existing path.
@@ -40,40 +40,37 @@ def test_Repo_instantiate_invalid_path(tmp_path: str) -> None:
         Repo(repo_path)
 
 
-def test_Repo_instantiate_empty_dir(tmp_path: str) -> None:
+def test_Repo_instantiate_empty_dir(tmp_path: Path) -> None:
     """
     The Repo class must raise a `OnyoInvalidRepoError` if instantiated with a
     path that is not an Onyo repository.
     """
-    repo_path = Path(tmp_path)
     with pytest.raises(OnyoInvalidRepoError):
-        Repo(repo_path)
+        Repo(tmp_path)
 
 
-def test_Repo_instantiate_git_no_onyo(tmp_path: str) -> None:
+def test_Repo_instantiate_git_no_onyo(tmp_path: Path) -> None:
     """
     The Repo class must raise a `OnyoInvalidRepoError` if instantiated on a
     git repository that is not an Onyo repository.
     """
-    repo_path = Path(tmp_path)
-    ret = subprocess.run(['git', 'init', str(repo_path)])
+    ret = subprocess.run(['git', 'init', str(tmp_path)])
     assert ret.returncode == 0
 
     # test
     with pytest.raises(OnyoInvalidRepoError):
-        Repo(repo_path)
+        Repo(tmp_path)
 
 
-def test_Repo_instantiate_onyo_no_git(tmp_path: str) -> None:
+def test_Repo_instantiate_onyo_no_git(tmp_path: Path) -> None:
     """
     The Repo class must raise a `OnyoInvalidRepoError` if instantiated with a
     path that contains a `.onyo/` that is not a git repository.
     """
-    repo_path = Path(tmp_path)
-    Path(repo_path, '.onyo').mkdir()
+    Path(tmp_path, '.onyo').mkdir()
 
     with pytest.raises(OnyoInvalidRepoError):
-        Repo(repo_path)
+        Repo(tmp_path)
 
 
 #
@@ -102,7 +99,7 @@ def fully_populated_dot_onyo(directory: Union[Path, str]) -> bool:
     "Path": {"variant": Path("dir")},
     "str": {"variant": "dir"},
 })
-def test_init_types(tmp_path: str, variant: Union[str, Path]) -> None:
+def test_init_types(tmp_path: Path, variant: Union[str, Path]) -> None:
     """
     Test that `Repo(<directory>, init=True)` initializes an Onyo Repository for
     an existing, empty directory.
@@ -114,7 +111,7 @@ def test_init_types(tmp_path: str, variant: Union[str, Path]) -> None:
     assert fully_populated_dot_onyo(variant)
 
 
-def test_init_False(tmp_path: str) -> None:
+def test_init_False(tmp_path: Path) -> None:
     """
     `Repo(<directory>, init=False)` must not create onyo-files when it is
     initialized a path that is not already an Onyo Repository.
@@ -125,7 +122,7 @@ def test_init_False(tmp_path: str) -> None:
 
 
 @pytest.mark.parametrize('variant', ['dir', 's p a c e s'])
-def test_init_not_exist_dir(tmp_path: str, variant: str) -> None:
+def test_init_not_exist_dir(tmp_path: Path, variant: str) -> None:
     """
     Init a non-existent directory.
     """
@@ -137,7 +134,7 @@ def test_init_not_exist_dir(tmp_path: str, variant: str) -> None:
 
 
 @pytest.mark.parametrize('variant', ['', './', 'dir', 's p a c e s'])
-def test_init_exist_dir(tmp_path: str, variant: str) -> None:
+def test_init_exist_dir(tmp_path: Path, variant: str) -> None:
     """
     Test init for an existing, empty directory.
     """
@@ -151,7 +148,7 @@ def test_init_exist_dir(tmp_path: str, variant: str) -> None:
 
 
 @pytest.mark.parametrize('variant', ['./', 'dir', 's p a c e s'])
-def test_init_reinit(tmp_path: str, variant: str) -> None:
+def test_init_reinit(tmp_path: Path, variant: str) -> None:
     """
     `Repo(<directory>, init=True)` must raise a `FileExistsError` on a path that
     is already an Onyo repository.
@@ -170,7 +167,7 @@ def test_init_reinit(tmp_path: str, variant: str) -> None:
     assert not Path(repo_path, '.onyo/', '.onyo/').exists()
 
 
-def test_init_file(tmp_path: str) -> None:
+def test_init_file(tmp_path: Path) -> None:
     """
     Instantiation of Repo() on a file must raise a `FileExistsError`.
     """
@@ -182,7 +179,7 @@ def test_init_file(tmp_path: str) -> None:
         Repo(repo_path, init=True)
 
 
-def test_init_missing_parent_dir(tmp_path: str) -> None:
+def test_init_missing_parent_dir(tmp_path: Path) -> None:
     """
     Parent directories must exist.
     """
@@ -197,11 +194,11 @@ def test_init_missing_parent_dir(tmp_path: str) -> None:
         assert not fully_populated_dot_onyo(i)
 
 
-def test_init_already_git(tmp_path: str) -> None:
+def test_init_already_git(tmp_path: Path) -> None:
     """
     Init-ing a git repo is allowed.
     """
-    repo_path = Path(tmp_path).resolve()
+    repo_path = tmp_path.resolve()
     ret = subprocess.run(['git', 'init', repo_path])
     assert ret.returncode == 0
 
@@ -210,12 +207,12 @@ def test_init_already_git(tmp_path: str) -> None:
     assert fully_populated_dot_onyo(repo_path)
 
 
-def test_init_with_cruft(tmp_path: str) -> None:
+def test_init_with_cruft(tmp_path: Path) -> None:
     """
     Init-ing a directory with content is allowed, and should not commit anything
     other than the newly created .onyo dir.
     """
-    repo_path = Path(tmp_path).resolve()
+    repo_path = tmp_path.resolve()
     Path(repo_path, 'dir').mkdir()
     Path(repo_path, 'dir', 'such_cruft.txt').touch()
 
@@ -418,7 +415,7 @@ def test_Repo_files_untracked(repo: Repo) -> None:
 #
 # Repo.opdir
 #
-def test_Repo_opdir(tmp_path: str) -> None:
+def test_Repo_opdir(tmp_path: Path) -> None:
     """
     On instantiation the property Repo.opdir must contain the
     operating directory of an existing repository.
@@ -435,7 +432,7 @@ def test_Repo_opdir(tmp_path: str) -> None:
     assert Path('opdir-repo').samefile(repo.opdir)
 
 
-def test_Repo_opdir_root(tmp_path: str) -> None:
+def test_Repo_opdir_root(tmp_path: Path) -> None:
     """
     When instantiated with '.' as the path, the property Repo.opdir must contain
     the operating directory as a Path.
@@ -454,7 +451,7 @@ def test_Repo_opdir_root(tmp_path: str) -> None:
 
 
 @pytest.mark.repo_dirs('1/2/3/4/5/6')
-def test_Repo_opdir_child(repo: Repo, tmp_path: str) -> None:
+def test_Repo_opdir_child(repo: Repo, tmp_path: Path) -> None:
     """
     An existing Repo must be instantiated with the root of a repository,
     otherwise an error is raised.
@@ -467,13 +464,13 @@ def test_Repo_opdir_child(repo: Repo, tmp_path: str) -> None:
 
     # test
     repo = Repo('.', find_root=True)
-    assert Path(tmp_path).samefile(repo.root)
+    assert tmp_path.samefile(repo.root)
 
 
 #
 # Repo.root
 #
-def test_Repo_root(tmp_path: str) -> None:
+def test_Repo_root(tmp_path: Path) -> None:
     """
     The property `repo.root` must be set correctly.
     """
@@ -487,7 +484,7 @@ def test_Repo_root(tmp_path: str) -> None:
     assert isinstance(repo.root, Path)
 
 
-def test_Repo_root_parent(tmp_path: str) -> None:
+def test_Repo_root_parent(tmp_path: Path) -> None:
     """
     The property `repo.root` must be set correctly.
     """
@@ -502,7 +499,7 @@ def test_Repo_root_parent(tmp_path: str) -> None:
     assert Path('root-parent').samefile(repo.root)
 
 
-def test_Repo_root_root(tmp_path: str) -> None:
+def test_Repo_root_root(tmp_path: Path) -> None:
     """
     The property `repo.root` must be set correctly when Repo(".") is
     instantiated with a "." as path.
@@ -544,16 +541,16 @@ def test_Repo_find_root_opdir_child(repo: Repo) -> None:
     assert new_repo.root.samefile(repo.root)
 
 
-def test_Repo_find_root_with_no_repository_path(tmp_path: str) -> None:
+def test_Repo_find_root_with_no_repository_path(tmp_path: Path) -> None:
     """
     If `Repo._find_root()` is called on an existing path that is not a
     repository, it has to raise a `OnyoInvalidRepoError`
     """
     with pytest.raises(OnyoInvalidRepoError):
-        Repo._find_root(Path(tmp_path))
+        Repo._find_root(tmp_path)
 
 
-def test_Repo_find_root_with_non_existing_path(tmp_path: str) -> None:
+def test_Repo_find_root_with_non_existing_path(tmp_path: Path) -> None:
     """
     If `Repo._find_root()` is called on a path that does not exist, it has to
     raise a `OnyoInvalidRepoError`

--- a/tests/lib/test_Repo.py
+++ b/tests/lib/test_Repo.py
@@ -31,12 +31,12 @@ def test_Repo_instantiate_types(
 
 def test_Repo_instantiate_invalid_path(tmp_path: str) -> None:
     """
-    The Repo class must raise a `FileNotFoundError` if instantiated with a
+    The Repo class must raise a `OnyoInvalidRepoError` if instantiated with a
     non-existing path.
     """
     repo_path = Path(tmp_path, 'does-not-exist')
 
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(OnyoInvalidRepoError):
         Repo(repo_path)
 
 
@@ -453,24 +453,17 @@ def test_Repo_opdir_root(tmp_path: str) -> None:
     assert repo.root.samefile(repo.opdir)
 
 
-def test_Repo_opdir_child(tmp_path: str) -> None:
+@pytest.mark.repo_dirs('1/2/3/4/5/6')
+def test_Repo_opdir_child(repo: Repo, tmp_path: str) -> None:
     """
-    When instantiating the Repo with the cwd being inside a folder, the property
-    repo.opdir must be the cwd.
+    An existing Repo must be instantiated with the root of a repository,
+    otherwise an error is raised.
     """
-    os.chdir(tmp_path)
+    os.chdir(Path(repo.root, '1/2/3/4/5/6'))
 
-    # setup repo
-    ret = subprocess.run(['onyo', 'init', 'opdir-child'])
-    assert ret.returncode == 0
-    os.chdir('opdir-child')
-    ret = subprocess.run(['onyo', 'mkdir', '--yes', '1/2/3/4/5/6'])
-    assert ret.returncode == 0
-
-    # test
-    os.chdir('1/2/3/4/5/6')
-    repo = Repo('.')
-    assert Path('.').samefile(repo.opdir)
+    # test error response
+    with pytest.raises(OnyoInvalidRepoError):
+        repo = Repo('.')
 
 
 #

--- a/tests/lib/test_Repo.py
+++ b/tests/lib/test_Repo.py
@@ -135,12 +135,10 @@ def test_init_not_exist_dir(tmp_path: Path, variant: str) -> None:
 
 def test_init_and_find_root_true(tmp_path: Path) -> None:
     """
-    `Repo(<directory>, init=True, find_root=True)` must init the directory and
-    use it as a root.
+    `Repo(<directory>, init=True, find_root=True)` is ambiguous and disallowed.
     """
-    repo = Repo(tmp_path, init=True, find_root=True)
-    assert fully_populated_dot_onyo(tmp_path)
-    assert tmp_path.samefile(repo.root)
+    with pytest.raises(ValueError):
+        Repo(tmp_path, init=True, find_root=True)
 
 
 @pytest.mark.parametrize('variant', ['', './', 'dir', 's p a c e s'])
@@ -466,7 +464,7 @@ def test_Repo_opdir_child(repo: Repo, tmp_path: Path) -> None:
     An existing Repo must be instantiated with the root of a repository,
     otherwise an error is raised.
     """
-    os.chdir(Path(repo.root, '1/2/3/4/5/6'))
+    os.chdir(repo.root / '1' / '2' / '3' / '4' / '5' / '6')
 
     # test error response
     with pytest.raises(OnyoInvalidRepoError):
@@ -546,8 +544,9 @@ def test_Repo_find_root_opdir_child(repo: Repo) -> None:
     When the cwd is inside an existing repo, a `Repo` can be instantiated with
     `Repo(<opdir>, find_root=True)`.
     """
-    os.chdir(Path(repo.root, '1/2/3/4/5/6'))
-    new_repo = Repo(Path(repo.root, '1/2/3/4/5/6'), find_root=True)
+    path_deep_within = repo.root / '1' / '2' / '3' / '4' / '5' / '6'
+    os.chdir(path_deep_within)
+    new_repo = Repo(path_deep_within, find_root=True)
     assert new_repo.root.samefile(repo.root)
 
 


### PR DESCRIPTION
To remove ambiguity in situations were a `Repo` object is instantiated with a path that is a subdirectory inside a repository, and a function of `Repo` is called with a relative path, this PR updates the `Repo` class so as to only accept the root of an onyo repository.

- Updates `Repo` to either just allow root as path to instantiate, or to use `Repo(find_root=True)` to search the root from a subdirectory inside a repo
- Adds `Repo._find_root()` to allow the easy identification of the root of an existing repository when called from a subdirectory of it
- Applies changes to commands
- Updates existing `tests/lib/test_Repo.py` to be conform with new behavior
- Adds tests for `Repo._find_root()`

This is the first step in the direction of working only with absolute paths in Repo, and to retire `Repo.opdir`.