### PR TITLE
Pathing: retire `repo.opdir` and `repo.sanitize_path()`

### DIFF
--- a/onyo/commands/cat.py
+++ b/onyo/commands/cat.py
@@ -13,7 +13,7 @@ logging.basicConfig()
 log: logging.Logger = logging.getLogger('onyo')
 
 
-def sanitize_paths(paths: list[str], opdir: str) -> list[Path]:
+def sanitize_paths(paths: list[str]) -> list[Path]:
     """
     Check and normalize a list of paths. If paths do not exist or are not files,
     print paths and exit with error.
@@ -23,8 +23,7 @@ def sanitize_paths(paths: list[str], opdir: str) -> list[Path]:
     error_path_not_file = []
 
     for p in paths:
-        # TODO: This is wrong when an absolute path is provided
-        full_path = Path(opdir, p).resolve()
+        full_path = Path(p).resolve()
 
         # path must exist
         if not full_path.exists():
@@ -53,19 +52,19 @@ def sanitize_paths(paths: list[str], opdir: str) -> list[Path]:
     return paths_to_cat
 
 
-def cat(args: argparse.Namespace, opdir: str) -> None:
+def cat(args: argparse.Namespace) -> None:
     """
     Print the contents of ``asset``\\(s) to the terminal without parsing or
     validating the contents.
     """
     repo = None
     try:
-        repo = Repo(opdir, find_root=True)
+        repo = Repo(Path.cwd(), find_root=True)
         repo.fsck(['asset-yaml'])
     except OnyoInvalidRepoError:
         sys.exit(1)
 
-    paths_to_cat = sanitize_paths(args.asset, opdir)
+    paths_to_cat = sanitize_paths(args.asset)
 
     # open file and print to stdout
     for path in paths_to_cat:

--- a/onyo/commands/config.py
+++ b/onyo/commands/config.py
@@ -44,7 +44,7 @@ def sanitize_args(git_config_args: list[str]) -> list[str]:
     return git_config_args
 
 
-def config(args: argparse.Namespace, opdir: str) -> None:
+def config(args: argparse.Namespace) -> None:
     """
     Set, query, and unset Onyo repository configuration options. These options
     are stored in ``.onyo/config`` (which is tracked by git) and are shared with
@@ -77,7 +77,7 @@ def config(args: argparse.Namespace, opdir: str) -> None:
     """
     repo = None
     try:
-        repo = Repo(opdir, find_root=True)
+        repo = Repo(Path.cwd(), find_root=True)
         repo.fsck(['asset-yaml'])
     except OnyoInvalidRepoError:
         sys.exit(1)

--- a/onyo/commands/edit.py
+++ b/onyo/commands/edit.py
@@ -88,7 +88,7 @@ def sanitize_assets(assets: list[str], repo: Repo) -> list[Path]:
     valid_assets = []
 
     for asset in assets:
-        asset = repo.sanitize_path(asset)
+        asset = Path(asset).resolve()
         if asset not in repo.assets:
             print(f"\n{asset} is not an asset.", file=sys.stderr)
         else:
@@ -100,7 +100,7 @@ def sanitize_assets(assets: list[str], repo: Repo) -> list[Path]:
     return valid_assets
 
 
-def edit(args: argparse.Namespace, opdir: str) -> None:
+def edit(args: argparse.Namespace) -> None:
     """
     Open the ``asset`` file(s) using the editor specified by "onyo.core.editor",
     the environment variable ``EDITOR``, or ``nano`` (as a final fallback).
@@ -120,7 +120,7 @@ def edit(args: argparse.Namespace, opdir: str) -> None:
         sys.exit(1)
 
     try:
-        repo = Repo(opdir, find_root=True)
+        repo = Repo(Path.cwd(), find_root=True)
         # "onyo fsck" is intentionally not run here.
         # This is so "onyo edit" can be used to fix an existing problem. This has
         # benefits over just simply using `vim`, etc directly, as "onyo edit" will

--- a/onyo/commands/fsck.py
+++ b/onyo/commands/fsck.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from onyo import Repo, OnyoInvalidRepoError
@@ -8,7 +9,7 @@ if TYPE_CHECKING:
     import argparse
 
 
-def fsck(args: argparse.Namespace, opdir: str) -> None:
+def fsck(args: argparse.Namespace) -> None:
     """
     Run a suite of checks to verify the integrity and validity of an Onyo
     repository and its contents.
@@ -26,7 +27,7 @@ def fsck(args: argparse.Namespace, opdir: str) -> None:
     """
     repo = None
     try:
-        repo = Repo(opdir, find_root=True)
+        repo = Repo(Path.cwd(), find_root=True)
         repo.fsck()
     except OnyoInvalidRepoError:
         sys.exit(1)

--- a/onyo/commands/get.py
+++ b/onyo/commands/get.py
@@ -96,7 +96,7 @@ def sanitize_keys(k: list[str], defaults: list) -> list[str]:
     return k if k else defaults
 
 
-def get(args: argparse.Namespace, opdir: str) -> None:
+def get(args: argparse.Namespace) -> None:
     """
     Return matching asset(s) and values corresponding to the requested key(s).
     If no key(s) are given, the pseudo-keys are returned instead.
@@ -122,7 +122,7 @@ def get(args: argparse.Namespace, opdir: str) -> None:
 
     repo = None
     try:
-        repo = Repo(opdir, find_root=True)
+        repo = Repo(Path.cwd(), find_root=True)
         repo.fsck(['asset-yaml'])
     except OnyoInvalidRepoError:
         sys.exit(1)
@@ -132,7 +132,7 @@ def get(args: argparse.Namespace, opdir: str) -> None:
     invalid_paths = set()
     for path in args.path:
         try:
-            onyo_path = repo.sanitize_path(path)
+            onyo_path = Path(path).resolve()
             if onyo_path.exists():
                 paths.add(onyo_path)
             else:
@@ -170,7 +170,7 @@ def get(args: argparse.Namespace, opdir: str) -> None:
         sep = '\t'  # column separator
         for asset, data in results:
             values = sep.join([str(value) for value in data.values()])
-            print(f'{values}{sep}{asset.relative_to(opdir)}')
+            print(f'{values}{sep}{asset.relative_to(Path.cwd())}')
     else:
         console = Console()
         table = Table(
@@ -185,7 +185,7 @@ def get(args: argparse.Namespace, opdir: str) -> None:
         if results:
             for asset, data in results:
                 values = [str(value) for value in data.values()]
-                table.add_row(*values, str(asset.relative_to(opdir)))
+                table.add_row(*values, str(asset.relative_to(Path.cwd())))
 
             console.print(table)
         else:

--- a/onyo/commands/history.py
+++ b/onyo/commands/history.py
@@ -16,17 +16,17 @@ logging.basicConfig()
 log: logging.Logger = logging.getLogger('onyo')
 
 
-def sanitize_path(path: str, opdir: str) -> Path:
+def sanitize_path(path: str) -> Path:
     """
-    Checks a path relative to opdir. If it does not exist, it will print an
-    error and exit.
+    Checks and resolves a path. If it does not exist, it will print an error and
+    exit.
 
     Returns an absolute path on success.
     """
     if not path:
         path = './'
 
-    full_path = Path(opdir, path).resolve()
+    full_path = Path(path).resolve()
 
     # check if path exists
     if not full_path.exists():
@@ -66,7 +66,7 @@ def get_history_cmd(interactive: bool, repo: Repo) -> str:
     return history_cmd
 
 
-def history(args: argparse.Namespace, opdir: str) -> None:
+def history(args: argparse.Namespace) -> None:
     """
     Display the history of an ``asset`` or ``directory``.
 
@@ -78,25 +78,21 @@ def history(args: argparse.Namespace, opdir: str) -> None:
     """
     repo = None
     try:
-        repo = Repo(opdir, find_root=True)
+        repo = Repo(Path.cwd(), find_root=True)
         repo.fsck(['asset-yaml'])
     except OnyoInvalidRepoError:
         sys.exit(1)
 
     # get the command and path
-    path = sanitize_path(args.path, opdir)
+    path = sanitize_path(args.path)
     history_cmd = get_history_cmd(args.interactive, repo)
 
     # run it
-    orig_cwd = os.getcwd()
     status = 0
     try:
-        os.chdir(opdir)
         status = os.system(f"{history_cmd} {quote(str(path))}")
     except:  # noqa: E722
         pass
-    finally:
-        os.chdir(orig_cwd)
 
     # covert the return status into a return code
     returncode = os.waitstatus_to_exitcode(status)

--- a/onyo/commands/init.py
+++ b/onyo/commands/init.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     import argparse
 
 
-def init(args: argparse.Namespace, opdir: str) -> None:
+def init(args: argparse.Namespace) -> None:
     """
     Initialize an Onyo repository. The directory will be initialized as a git
     repository (if it is not one already), the ``.onyo/`` directory created and
@@ -21,12 +21,7 @@ def init(args: argparse.Namespace, opdir: str) -> None:
     Running ``onyo init`` on an existing repository is safe. It will not
     overwrite anything; it will exit with an error.
     """
-    target_dir = Path(opdir)
-    if args.directory:
-        if Path(args.directory).is_absolute():
-            target_dir = Path(args.directory)
-        else:
-            target_dir = Path(opdir, args.directory)
+    target_dir = Path(args.directory).resolve() if args.directory else Path.cwd()
 
     try:
         Repo(target_dir, init=True)

--- a/onyo/commands/mkdir.py
+++ b/onyo/commands/mkdir.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from onyo import Repo, OnyoInvalidRepoError, OnyoProtectedPathError
@@ -9,7 +10,7 @@ if TYPE_CHECKING:
     import argparse
 
 
-def mkdir(args: argparse.Namespace, opdir: str) -> None:
+def mkdir(args: argparse.Namespace) -> None:
     """
     Create ``directory``\\(s). Intermediate directories will be created as
     needed (i.e. parent and child directories can be created in one call).
@@ -22,7 +23,7 @@ def mkdir(args: argparse.Namespace, opdir: str) -> None:
     """
     repo = None
     try:
-        repo = Repo(opdir, find_root=True)
+        repo = Repo(Path.cwd(), find_root=True)
         repo.fsck()
     except OnyoInvalidRepoError:
         sys.exit(1)

--- a/onyo/commands/mv.py
+++ b/onyo/commands/mv.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from onyo import Repo, OnyoInvalidRepoError, OnyoProtectedPathError
@@ -9,7 +10,7 @@ if TYPE_CHECKING:
     import argparse
 
 
-def mv(args: argparse.Namespace, opdir: str) -> None:
+def mv(args: argparse.Namespace) -> None:
     """
     Move ``source``\\(s) (assets or directories) to the ``destination``
     directory, or rename a ``source`` directory to ``destination``.
@@ -24,7 +25,7 @@ def mv(args: argparse.Namespace, opdir: str) -> None:
         sys.exit(1)
 
     try:
-        repo = Repo(opdir, find_root=True)
+        repo = Repo(Path.cwd(), find_root=True)
         repo.fsck()
     except OnyoInvalidRepoError:
         sys.exit(1)

--- a/onyo/commands/new.py
+++ b/onyo/commands/new.py
@@ -72,7 +72,7 @@ def read_assets_from_tsv(
                 row['serial'] = faux_serial_list.pop()
             filename = f"{row['type']}_{row['make']}_{row['model']}.{row['serial']}"
             directory = row['directory']
-            new_path = Path(repo.root, directory, filename).resolve()
+            new_path = Path(directory, filename).resolve()
 
             # verify that the asset name is valid and unique in repo and table
             try:
@@ -144,7 +144,7 @@ def read_assets_from_CLI(
         # set paths
         if asset[-5:] == ".faux":
             asset = asset[:-5] + asset[-5:].replace("faux", faux_serial_list.pop())
-        new_path = Path(repo.opdir, asset).resolve()
+        new_path = Path(asset).resolve()
 
         # verify that the asset name is valid and unique in repo and table
         try:
@@ -226,7 +226,7 @@ def check_against_argument_conflicts(args: argparse.Namespace) -> None:
                 sys.exit(1)
 
 
-def new(args: argparse.Namespace, opdir: str) -> None:
+def new(args: argparse.Namespace) -> None:
     """
     Create new ``<path>/asset``\\(s) and add contents with ``--template``,
     ``--keys`` and ``--edit``. If the directories do not exist, they will be
@@ -238,7 +238,7 @@ def new(args: argparse.Namespace, opdir: str) -> None:
     """
     repo = None
     try:
-        repo = Repo(opdir, find_root=True)
+        repo = Repo(Path.cwd(), find_root=True)
         repo.fsck()
     except OnyoInvalidRepoError:
         sys.exit(1)

--- a/onyo/commands/rm.py
+++ b/onyo/commands/rm.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from onyo import Repo, OnyoInvalidRepoError, OnyoProtectedPathError
@@ -9,7 +10,7 @@ if TYPE_CHECKING:
     import argparse
 
 
-def rm(args: argparse.Namespace, opdir: str) -> None:
+def rm(args: argparse.Namespace) -> None:
     """
     Delete ``asset``\\(s) and ``directory``\\(s).
 
@@ -24,7 +25,7 @@ def rm(args: argparse.Namespace, opdir: str) -> None:
         sys.exit(1)
 
     try:
-        repo = Repo(opdir, find_root=True)
+        repo = Repo(Path.cwd(), find_root=True)
         repo.fsck()
     except OnyoInvalidRepoError:
         sys.exit(1)

--- a/onyo/commands/shell_completion.py
+++ b/onyo/commands/shell_completion.py
@@ -456,7 +456,7 @@ compdef _onyo onyo
         return case
 
 
-def shell_completion(args: argparse.Namespace, opdir: str) -> None:
+def shell_completion(args: argparse.Namespace) -> None:
     """
     Display a shell script for tab completion for Onyo.
 

--- a/onyo/commands/tree.py
+++ b/onyo/commands/tree.py
@@ -19,20 +19,21 @@ def sanitize_directories(repo: Repo, directories: list[str]) -> list[Path]:
     Check a list of directories. If any do not exist or are a file, and error
     will be printed.
 
-    Returns a string of the valid directories relative to opdir.
+    Returns a string of the valid directories.
     """
     dirs = []
     error_path_not_in_repo = []
     error_path_not_dir = []
 
     for d in directories:
-        full_path = Path(repo.opdir, d).resolve()
-        if not full_path.is_relative_to(repo.root):
-            error_path_not_in_repo.append(d)
-            continue
+        full_path = Path(d).resolve()
 
         if full_path.is_dir():
-            dirs.append(full_path.relative_to(repo.opdir))
+            try:
+                dirs.append(full_path.relative_to(repo.root))
+            except ValueError:
+                error_path_not_in_repo.append(d)
+                continue
         else:
             error_path_not_dir.append(d)
 
@@ -56,13 +57,13 @@ def sanitize_directories(repo: Repo, directories: list[str]) -> list[Path]:
     return dirs
 
 
-def tree(args: argparse.Namespace, opdir: str) -> None:
+def tree(args: argparse.Namespace) -> None:
     """
     List the assets and directories in ``directory`` using ``tree``.
     """
     repo = None
     try:
-        repo = Repo(opdir, find_root=True)
+        repo = Repo(Path.cwd(), find_root=True)
         repo.fsck(['asset-yaml'])
     except OnyoInvalidRepoError:
         sys.exit(1)

--- a/onyo/commands/unset.py
+++ b/onyo/commands/unset.py
@@ -14,9 +14,11 @@ logging.basicConfig()
 log: logging.Logger = logging.getLogger('onyo')
 
 
-def _sanitize_paths(repo: Repo, paths: list[str]) -> set[Path]:
-    """Validate paths, returning an error if paths are invalid"""
-    formatted_paths = {Path(p) for p in paths}
+def sanitize_paths(repo: Repo, paths: list[str]) -> set[Path]:
+    """
+    Validate paths, returning an error if paths are invalid.
+    """
+    formatted_paths = {Path(p).resolve() for p in paths}
     nonexistent = {p for p in formatted_paths if not p.exists()}
     if nonexistent:
         print(
@@ -36,7 +38,7 @@ def _sanitize_paths(repo: Repo, paths: list[str]) -> set[Path]:
     return formatted_paths
 
 
-def unset(args: argparse.Namespace, opdir: str) -> None:
+def unset(args: argparse.Namespace) -> None:
     """
     Remove the ``value`` of ``key`` for matching assets.
 
@@ -64,13 +66,13 @@ def unset(args: argparse.Namespace, opdir: str) -> None:
 
     repo = None
     try:
-        repo = Repo(opdir, find_root=True)
+        repo = Repo(Path.cwd(), find_root=True)
         repo.fsck()
     except OnyoInvalidRepoError:
         sys.exit(1)
 
     diff = ""
-    paths = _sanitize_paths(repo, args.path)
+    paths = sanitize_paths(repo, args.path)
     try:
         diff = repo.unset(
             paths, args.keys, args.dry_run, args.quiet, args.depth)

--- a/onyo/lib/command_utils.py
+++ b/onyo/lib/command_utils.py
@@ -545,7 +545,7 @@ def valid_asset_path_and_name_available(repo: Repo,
         raise ValueError(f"Input contains multiple '{file[0].name}'")
     if is_protected_path(asset):
         log.error(f"The path is protected by onyo: '{asset}'")
-        raise ValueError(f"Input contains multiple '{file[0].name}'")
+        raise ValueError(f"The path is protected by onyo: '{asset}'")
 
 
 def valid_name(asset: Union[Path, str]) -> bool:

--- a/onyo/lib/command_utils.py
+++ b/onyo/lib/command_utils.py
@@ -36,7 +36,7 @@ def fsck(repo: Repo, tests: Optional[list[str]] = None) -> None:
 
         if not all_tests[key](repo):
             log.debug(f"'{key}' failed")
-            raise OnyoInvalidRepoError(f"'{repo._opdir}' failed fsck test '{key}'")
+            raise OnyoInvalidRepoError(f"'{repo.root}' failed fsck test '{key}'")
 
         log.debug(f"'{key}' succeeded")
 
@@ -238,7 +238,7 @@ def mkdir_sanitize(repo: Repo, dirs: Iterable[Union[Path, str]]) -> set[Path]:
     # TODO: the set() neatly avoids creating the same dir twice. Intentional?
 
     for d in dirs:
-        full_dir = Path(repo.opdir, d).resolve()
+        full_dir = Path(repo.root, d).resolve()
 
         # check if it exists
         if full_dir.exists():
@@ -295,7 +295,7 @@ def mv(repo: Repo,
 
     # TODO: change this to info
     log.debug('The following will be moved:\n{}'.format('\n'.join(
-        map(lambda x: str(x.relative_to(repo.opdir)), src_paths))))
+        map(lambda x: str(x.relative_to(repo.root)), src_paths))))
 
     repo.clear_caches(
         assets=True,  # `onyo mv` can change the dir of assets
@@ -304,7 +304,6 @@ def mv(repo: Repo,
         templates=True)  # might move or rename templates
 
     # return a list of mv-ed assets
-    # TODO: is this relative to opdir or root? (should be opdir)
     return [r for r in re.findall('Renaming (.*) to (.*)', ret)]
 
 
@@ -315,11 +314,11 @@ def mv_move_mode(repo: Repo,
     if len(sources) > 1:
         return True
 
-    if Path(repo.opdir, destination).resolve().is_dir():
+    if Path(repo.root, destination).resolve().is_dir():
         return True
 
     # explicitly restating the source name at the destination is a move
-    if Path(sources[0]).name == Path(destination).name and not Path(repo.opdir, destination).resolve().exists():
+    if Path(sources[0]).name == Path(destination).name and not Path(repo.root, destination).resolve().exists():
         return True
 
     return False
@@ -329,7 +328,7 @@ def mv_sanitize_destination(repo: Repo,
                             sources: list[Union[Path, str]],
                             destination: Union[Path, str]) -> Path:
     error_path_conflict = []
-    dest_path = Path(repo.opdir, destination).resolve()
+    dest_path = Path(repo.root, destination).resolve()
 
     """
     Common checks
@@ -355,7 +354,7 @@ def mv_sanitize_destination(repo: Repo,
 
     # check for conflicts and general insanity
     for src in sources:
-        src_path = Path(repo.opdir, src).resolve()
+        src_path = Path(repo.root, src).resolve()
         new_path = Path(dest_path, src_path.name).resolve()
         if not dest_path.exists:
             new_path = Path(dest_path).resolve()
@@ -397,7 +396,7 @@ def mv_sanitize_destination(repo: Repo,
         """
         log.debug("'mv' in rename mode")
         # renaming files is not allowed
-        src_path = Path(repo.opdir, sources[0]).resolve()
+        src_path = Path(repo.root, sources[0]).resolve()
         if src_path.is_file() and src_path.name != dest_path.name:
             log.error(
                 f"Cannot rename asset '{src_path.name}' to "
@@ -457,7 +456,7 @@ def mv_sanitize_sources(repo: Repo, sources: list[Union[Path, str]]) -> list[Pat
 
     # validate sources
     for src in sources:
-        full_path = Path(repo.opdir, src).resolve()
+        full_path = Path(repo.root, src).resolve()
 
         # paths must exist
         if not full_path.exists():
@@ -670,7 +669,7 @@ def rm(repo: Repo,
 
     # TODO: change this to info
     log.debug('The following will be deleted:\n' +
-              '\n'.join([str(x.relative_to(repo.opdir)) for x in paths_to_rm]))
+              '\n'.join([str(x.relative_to(repo.root)) for x in paths_to_rm]))
 
     repo.clear_caches(assets=True,  # `onyo rm` can delete assets
                       dirs=True,  # can delete directories
@@ -679,7 +678,6 @@ def rm(repo: Repo,
                       )
     # return a list of rm-ed assets
     # TODO: should this also list the dirs?
-    # TODO: is this relative to opdir or root? (should be opdir)
     return [r for r in re.findall("rm '(.*)'", ret)]
 
 
@@ -689,7 +687,7 @@ def rm_sanitize(repo: Repo, paths: Iterable[Union[Path, str]]) -> list[Path]:
     paths_to_rm = []
 
     for p in paths:
-        full_path = Path(repo.opdir, p).resolve()
+        full_path = Path(repo.root, p).resolve()
 
         # paths must exist
         if not full_path.exists():

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -270,22 +270,6 @@ class Repo:
         # return the shortest possible version of the commit message as fallback
         return msg
 
-    def sanitize_path(self, path: Union[Path, str]) -> Path:
-        """
-        Expects a relative or absolute path inside inside the repository.
-        These paths do not have to exist, just lead into the repo, so that the
-        function can be used to get paths to create new assets or move to
-        another location.
-
-        Returns an absolute `Path`.
-        """
-        onyo_path = Path(path).resolve()
-
-        # TODO: raise a more reasonable error
-        if not onyo_path.is_relative_to(self.root):
-            raise ValueError(f"path {path} outside repository at {self.root}.")
-        return onyo_path
-
     def relative_to_root(self, paths: set[Path]) -> set[Path]:
         """
         Expects a list or set of absolute paths in the repository and returns a

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -46,7 +46,6 @@ class Repo:
                 log.error(f"'{path}' is no valid Onyo Repository.")
                 raise OnyoInvalidRepoError(f"'{path}' is no valid Onyo Repository.")
 
-        self._opdir: Path = path
         self._root: Path = path
         # caches
         self._assets: Union[set[Path], None] = None
@@ -122,14 +121,6 @@ class Repo:
         (according to git) of a repository.
         """
         return self._get_files_untracked()
-
-    @property
-    def opdir(self) -> Path:
-        """
-        Returns the absolute `Path` to the working directory where the
-        `Repo` object was instantiated.
-        """
-        return self._opdir
 
     @property
     def pseudo_keys(self) -> list[str]:
@@ -225,7 +216,7 @@ class Repo:
             if keys:
                 keys_str = f" ({','.join(str(x.split('=')[0]) for x in sorted(keys))})"
             if destination:
-                dest = Path(self.opdir, destination).relative_to(self.root)
+                dest = Path(self.root, destination).relative_to(self.root)
             if dest and dest.name == ".anchor":
                 dest = dest.parent
 
@@ -302,13 +293,6 @@ class Repo:
         """
         return {x.relative_to(self.root) for x in paths}
 
-    def relative_to_opdir(self, paths: set[Path]) -> set[Path]:
-        """
-        Expects a list or set of absolute paths in the repository and returns a
-        set of paths relative to the operating directory.
-        """
-        return {x.relative_to(self.opdir) for x in paths}
-
     def restore(self) -> None:
         """
         Restore all staged files with uncommitted changes in the repository.
@@ -339,9 +323,8 @@ class Repo:
         (except under .git).
         """
         log.debug('Acquiring list of directories')
-        dirs = {self.sanitize_path(x) for x in Path(self.root).glob('**/')
-                if '.git' not in x.parts and
-                not x.samefile(self.root)}
+        dirs = {self.root / x for x in Path(self.root).glob('**/')
+                if '.git' not in x.parts and not x.samefile(self.root)}
 
         return dirs
 
@@ -351,7 +334,7 @@ class Repo:
         (except under .git).
         """
         log.debug('Acquiring list of files')
-        files = {Path(self.root, x) for x in self._git(['-C', str(self.root), 'ls-files', '-z']).split('\0') if x}
+        files = {self.root / x for x in self._git(['-C', str(self.root), 'ls-files', '-z']).split('\0') if x}
         return files
 
     def _get_files_changed(self) -> set[Path]:
@@ -360,7 +343,7 @@ class Repo:
         repository.
         """
         log.debug('Acquiring list of changed files')
-        changed = {Path(self.root, x) for x in self._git(['-C', str(self.root), 'diff', '-z', '--name-only']).split('\0') if x}
+        changed = {self.root / x for x in self._git(['-C', str(self.root), 'diff', '-z', '--name-only']).split('\0') if x}
         return changed
 
     def _get_files_staged(self) -> set[Path]:
@@ -369,7 +352,7 @@ class Repo:
         repository.
         """
         log.debug('Acquiring list of staged files')
-        staged = {Path(self.root, x) for x in self._git(['-C', str(self.root), 'diff', '--name-only', '-z', '--staged']).split('\0') if x}
+        staged = {self.root / x for x in self._git(['-C', str(self.root), 'diff', '--name-only', '-z', '--staged']).split('\0') if x}
         return staged
 
     def _get_files_untracked(self) -> set[Path]:
@@ -378,7 +361,7 @@ class Repo:
         repository.
         """
         log.debug('Acquiring list of untracked files')
-        untracked = {Path(self.root, x) for x in self._git(['-C', str(self.root), 'ls-files', '-z', '--others', '--exclude-standard']).split('\0') if x}
+        untracked = {self.root / x for x in self._git(['-C', str(self.root), 'ls-files', '-z', '--others', '--exclude-standard']).split('\0') if x}
         return untracked
 
     @staticmethod
@@ -432,7 +415,7 @@ class Repo:
         """
         """
         if cwd is None:
-            cwd = self.opdir
+            cwd = self.root
 
         log.debug(f"Running 'git {args}'")
         ret = subprocess.run(["git"] + args,
@@ -448,7 +431,7 @@ class Repo:
         """
         Perform ``git add`` to stage files.
 
-        Paths are relative to ``root.opdir``.
+        Paths are relative to ``repo.root``.
         """
         if isinstance(targets, (list, set)):
             tgts = [str(x) for x in targets]
@@ -456,7 +439,7 @@ class Repo:
             tgts = [str(targets)]
 
         for t in tgts:
-            if not Path(self.opdir, t).exists():
+            if not Path(self.root, t).exists():
                 log.error(f"'{t}' does not exist.")
                 raise FileNotFoundError(f"'{t}' does not exist.")
 

--- a/onyo/lib/utils.py
+++ b/onyo/lib/utils.py
@@ -52,7 +52,7 @@ def get_assets_by_path(repo: Repo, paths: Iterable[Union[Path, str]],
         log.error(f"depth values must be positive, but is {depth}.")
         raise ValueError(f"depth values must be positive, but is {depth}.")
 
-    paths = {repo.sanitize_path(p) for p in paths}
+    paths = {Path(p).resolve() for p in paths}
     assets = [
         a for a in repo.assets if any([
             a.is_relative_to(p) and

--- a/onyo/lib/utils.py
+++ b/onyo/lib/utils.py
@@ -29,7 +29,7 @@ def get_assets(repo: Repo) -> set[Path]:
 
 
 def get_templates(repo: Repo) -> set[Path]:
-    return {repo.sanitize_path(file)
+    return {repo.root / file
             for file in Path(repo.root, ".onyo", "templates").glob('*')
             if Path(file).is_file() and not Path(file).name == ".anchor"}
 

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -6,6 +6,7 @@ import textwrap
 
 from onyo import commands
 from onyo._version import __version__
+from pathlib import Path
 from typing import Optional, Sequence, Union
 
 logging.basicConfig()
@@ -758,7 +759,13 @@ def main() -> None:
 
     # run the subcommand
     if subcmd_index:
-        args.run(args, args.opdir)
+        old_cwd = Path.cwd()
+        os.chdir(args.opdir)
+        try:
+            args.run(args)
+        finally:
+            os.chdir(old_cwd)
+
     else:
         parser.print_help()
         exit(1)

--- a/tests/commands/test_edit.py
+++ b/tests/commands/test_edit.py
@@ -321,7 +321,7 @@ def test_edit_with_dot_dot(repo: Repo, asset: str) -> None:
 
     # check edit with a path containing a ".." that leads outside the onyo repo
     # and then inside again
-    path = Path(f"../{repo.opdir.name}/{asset}")
+    path = Path(f"../{repo.root.name}/{asset}")
     assert path.is_file()
     ret = subprocess.run(['onyo', 'edit', '--yes', asset],
                          capture_output=True, text=True)

--- a/tests/lib/test_Repo.py
+++ b/tests/lib/test_Repo.py
@@ -427,63 +427,6 @@ def test_Repo_files_untracked(repo: Repo) -> None:
 
 
 #
-# Repo.opdir
-#
-def test_Repo_opdir(tmp_path: Path) -> None:
-    """
-    On instantiation the property Repo.opdir must contain the
-    operating directory of an existing repository.
-    """
-    os.chdir(tmp_path)
-
-    # setup repo
-    ret = subprocess.run(['onyo', 'init', 'opdir-repo'])
-    assert ret.returncode == 0
-
-    # test
-    repo = Repo('opdir-repo')
-    assert isinstance(repo.opdir, Path)
-    assert repo.opdir.is_absolute()
-    assert Path('opdir-repo').samefile(repo.opdir)
-
-
-def test_Repo_opdir_root(tmp_path: Path) -> None:
-    """
-    When instantiated with '.' as the path, the property Repo.opdir must contain
-    the operating directory as a Path.
-    """
-    os.chdir(tmp_path)
-
-    # setup repo
-    ret = subprocess.run(['onyo', 'init', 'opdir-root'])
-    assert ret.returncode == 0
-
-    # test
-    os.chdir('opdir-root')
-    repo = Repo('.')
-    assert Path('.').samefile(repo.opdir)
-    assert repo.opdir.is_absolute()
-    assert repo.root.samefile(repo.opdir)
-
-
-@pytest.mark.repo_dirs('1/2/3/4/5/6')
-def test_Repo_opdir_child(repo: Repo, tmp_path: Path) -> None:
-    """
-    An existing Repo must be instantiated with the root of a repository,
-    otherwise an error is raised.
-    """
-    os.chdir(repo.root / '1' / '2' / '3' / '4' / '5' / '6')
-
-    # test error response
-    with pytest.raises(OnyoInvalidRepoError):
-        repo = Repo('.')
-
-    repo = Repo('.', find_root=True)
-    assert tmp_path.samefile(repo.root)
-    assert repo.opdir.is_absolute()
-
-
-#
 # Repo.root
 #
 def test_Repo_root(tmp_path: Path) -> None:
@@ -537,28 +480,6 @@ def test_Repo_root_root(tmp_path: Path) -> None:
 #
 # Repo._find_root()
 #
-
-@pytest.mark.repo_dirs('1/2/3/4/5/6')
-def test_Repo_find_root_opdir_root(repo: Repo) -> None:
-    """
-    When the cwd is in the repo root, `Repo._find_root()` just returns the root.
-    a `Repo` can be instantiated with `Repo(<opdir>, find_root=True)`.
-    """
-    os.chdir(repo.root)
-    new_repo = Repo(repo.root, find_root=True)
-    assert new_repo.root.samefile(repo.root)
-
-
-@pytest.mark.repo_dirs('1/2/3/4/5/6')
-def test_Repo_find_root_opdir_child(repo: Repo) -> None:
-    """
-    When the cwd is inside an existing repo, a `Repo` can be instantiated with
-    `Repo(<opdir>, find_root=True)`.
-    """
-    path_deep_within = repo.root / '1' / '2' / '3' / '4' / '5' / '6'
-    os.chdir(path_deep_within)
-    new_repo = Repo(path_deep_within, find_root=True)
-    assert new_repo.root.samefile(repo.root)
 
 
 def test_Repo_find_root_with_no_repository_path(tmp_path: Path) -> None:

--- a/tests/lib/test_generate_commit_message.py
+++ b/tests/lib/test_generate_commit_message.py
@@ -34,9 +34,8 @@ def test_Repo_generate_commit_message(repo: Repo) -> None:
     to the root of the repository.
     """
     # modify the repository with some different commands:
-    repo.mkdir(repo.sanitize_path("a/new/folder"))
-    repo.mv(repo.sanitize_path("s p a c e s"),
-            repo.sanitize_path("a/new/folder"))
+    repo.mkdir(repo.root / 'a' / 'new' / 'folder')
+    repo.mv(repo.root / "s p a c e s", repo.root / "a/new/folder")
     repo.set([repo.root], {"one_key": "new_value"},
              dryrun=False, rename=False, depth=0)
     repo.unset([repo.root], ["two_key", "three_key"],


### PR DESCRIPTION
This is the next step for the efforts of simplifying path handling in onyo and commands, while removing bugs and addings tests for those changes.

- change cwd to `opdir` in `main.py`
  - `opdir` is exclusively used in `main.py`  (relevant if `onyo -C <path>` is called)
- retire `repo.opdir` and `opdir` in lib, commands and tests
- remove `repo.sanitize_path()`
  - `Path(<path>).resolve()` is now used in commands, since `repo.sanitize_path()` did nothing else after retirement of `opdir` anyways