### PR TITLE
set/unset: add flag `--filter`

### DIFF
--- a/onyo/commands/set.py
+++ b/onyo/commands/set.py
@@ -42,4 +42,13 @@ def set(args: argparse.Namespace) -> None:
     repo = OnyoRepo(Path.cwd(), find_root=True)
     fsck(repo)
     paths = [Path(p).resolve() for p in args.path]
-    set_cmd(repo, paths, args.keys, args.dry_run, args.rename, args.depth, args.quiet, args.yes, args.message)
+    set_cmd(repo,
+            paths,
+            args.keys,
+            args.filter,
+            args.dry_run,
+            args.rename,
+            args.depth,
+            args.quiet,
+            args.yes,
+            args.message)

--- a/onyo/commands/unset.py
+++ b/onyo/commands/unset.py
@@ -38,4 +38,12 @@ def unset(args: argparse.Namespace) -> None:
     repo = OnyoRepo(Path.cwd(), find_root=True)
     fsck(repo)
     paths = [Path(p).resolve() for p in args.path]
-    unset_cmd(repo, paths, args.keys, args.dry_run, args.quiet, args.yes, args.depth, args.message)
+    unset_cmd(repo,
+              paths,
+              args.keys,
+              args.filter,
+              args.dry_run,
+              args.quiet,
+              args.yes,
+              args.depth,
+              args.message)

--- a/onyo/lib/assets.py
+++ b/onyo/lib/assets.py
@@ -418,7 +418,7 @@ def read_assets_from_CLI(assets: list[Path],
 
 
 def get_assets_by_query(asset_files: set[Path],
-                        keys: Set[str],
+                        keys: Optional[Set[str]],
                         paths: Iterable[Path],
                         depth: Union[int, None] = None,
                         filters: Union[list[Filter], None] = None) -> Generator:
@@ -440,13 +440,21 @@ def get_assets_by_query(asset_files: set[Path],
             assets[:] = filter(f.match, assets)
 
     # Obtain keys from remaining assets
-    assets = ((a, {
-        k: v
-        for k, v in (get_asset_content(a) | dict(zip(
-            PSEUDO_KEYS, re.findall(
-                r'(^[^._]+?)_([^._]+?)_([^._]+?)\.(.+)',
-                a.name)[0]))).items()
-        if k in keys}) for a in assets)
+    if keys:
+        assets = ((a, {
+            k: v
+            for k, v in (get_asset_content(a) | dict(zip(
+                PSEUDO_KEYS, re.findall(
+                    r'(^[^._]+?)_([^._]+?)_([^._]+?)\.(.+)',
+                    a.name)[0]))).items()
+            if k in keys}) for a in assets)
+    else:
+        assets = ((a, {
+            k: v
+            for k, v in (get_asset_content(a) | dict(zip(
+                PSEUDO_KEYS, re.findall(
+                    r'(^[^._]+?)_([^._]+?)_([^._]+?)\.(.+)',
+                    a.name)[0]))).items()}) for a in assets)
 
     return assets
 

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -384,7 +384,7 @@ def set_(repo: OnyoRepo,
          yes: bool,
          message: Union[list[str], None]) -> Union[str, None]:
     from onyo.lib.command_utils import set_assets
-    from .assets import get_asset_files_by_path, write_asset_file
+    from .assets import write_asset_file
 
     # check flags for conflicts
     if quiet and not yes:

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -403,6 +403,8 @@ def set_(repo: OnyoRepo,
     asset_paths_to_set = get_assets_by_query(
         repo.asset_paths, keys=None, paths=paths, depth=depth, filters=filters)
 
+    asset_paths_to_set = [a[0] for a in asset_paths_to_set]
+
     modifications, moves = set_assets(repo, asset_paths_to_set, keys)
 
     diffs = [m[2] for m in modifications if m[2] != []]
@@ -490,6 +492,7 @@ def unset(repo: OnyoRepo,
     filters = set_filters(filter_strings, repo=repo) if filter_strings else None
     paths = get_assets_by_query(
         repo.asset_paths, keys=None, paths=paths, depth=depth, filters=filters)
+    paths = [a[0] for a in paths]
 
     diff, modified = ut_unset(repo, paths, keys, dryrun, quiet, depth)
 

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -557,6 +557,16 @@ def setup_parser() -> argparse.ArgumentParser:
             'descend at most N levels of directories below the '
             'starting-point, with an N value of 0 for infinite'))
     cmd_set.add_argument(
+        '-f', '--filter',
+        metavar='FILTER',
+        nargs='+',
+        type=str,
+        default=None,
+        help=(
+            'Add a filter to only show assets matching KEY=VALUE. Multiple '
+            'filters, regular expressions, and pseudo-keys can be used.')
+    )
+    cmd_set.add_argument(
         '-m', '--message',
         metavar='MESSAGE',
         nargs=1,
@@ -663,6 +673,16 @@ def setup_parser() -> argparse.ArgumentParser:
         help=(
             'descend at most N levels of directories below the '
             'starting-point, with an N value of 0 for infinite'))
+    cmd_unset.add_argument(
+        '-f', '--filter',
+        metavar='FILTER',
+        nargs='+',
+        type=str,
+        default=None,
+        help=(
+            'Add a filter to only show assets matching KEY=VALUE. Multiple '
+            'filters, regular expressions, and pseudo-keys can be used.')
+    )
     cmd_unset.add_argument(
         '-m', '--message',
         metavar='MESSAGE',


### PR DESCRIPTION
This PR just copies the stuff from `onyo get` to the commands unset and set, too.

Close https://github.com/psyinfra/onyo/issues/113
Close https://github.com/psyinfra/onyo/issues/285

TODO: Tests are still missing.

The function used by onyo get to filter seems to me to be quite badly written, which leads to a few awkward things I had to do. IMO the function should be split up into two parts, the first doing what https://github.com/psyinfra/onyo/issues/259 describes, and a separate one should do the filtering by keys, which is just needed by onyo get.