### PR TITLE
Docs: Overhaul "Command Line Reference"

### DIFF
--- a/docs/source/cmd_get.rst
+++ b/docs/source/cmd_get.rst
@@ -1,0 +1,8 @@
+onyo get
+=========
+
+.. argparse::
+   :module: onyo.main
+   :func: setup_parser
+   :prog: onyo
+   :path: get

--- a/docs/source/cmd_unset.rst
+++ b/docs/source/cmd_unset.rst
@@ -1,0 +1,8 @@
+onyo unset
+==========
+
+.. argparse::
+   :module: onyo.main
+   :func: setup_parser
+   :prog: onyo
+   :path: unset

--- a/docs/source/command_line_reference.rst
+++ b/docs/source/command_line_reference.rst
@@ -9,6 +9,7 @@ Command Line Reference
    cmd_config
    cmd_edit
    cmd_fsck
+   cmd_get
    cmd_history
    cmd_init
    cmd_mkdir
@@ -18,3 +19,4 @@ Command Line Reference
    cmd_set
    cmd_shell-completion
    cmd_tree
+   cmd_unset

--- a/onyo/commands/get.py
+++ b/onyo/commands/get.py
@@ -17,13 +17,18 @@ log = logging.getLogger('onyo')
 def get(args: argparse.Namespace) -> None:
     """
     Return matching asset(s) and values corresponding to the requested key(s).
+
     If no key(s) are given, the pseudo-keys are returned instead.
+    If no ``asset`` or ``directory`` is specified, the current working directory
+    is used.
 
     Filters can make use of pseudo-keys (i.e., keys for which the values are
     only stored in the asset name). Values of the dictionary or list type, as
     well as assets missing a value can be referenced as '<dict>', '<list>',
     or '<unset>' instead of their contents, respectively. If a requested key
     does not exist, its output is displayed as '<unset>'.
+
+    The ``value`` of filters can be a string or a Python regular expression.
 
     By default, the returned assets are sorted by their paths.
     """


### PR DESCRIPTION
Build of docs with the changes of this PR:
https://onyo--364.org.readthedocs.build/en/364/

Everybody of us knows that the docs are not up to date.
Everybody of the developers wants to have a place to look up how Onyo commands *should* behave.
Everybody who uses Onyo wants to know what commands do.

- I added the missing parts for `onyo get`/`onyo unset` to the docs, so that these get auto-generated pages, too
- I updated the description of `onyo get` with information from issue #18

Currently this does not add new information, I will begin the work through the documentation and ambitously hope that in the end we have a reference for all commands, that everybody agreees with.