### PR TITLE
BF: Disallow dirs named .anchor

### DIFF
--- a/onyo/commands/tests/test_mkdir.py
+++ b/onyo/commands/tests/test_mkdir.py
@@ -170,9 +170,8 @@ def test_dir_exists_as_file(repo: OnyoRepo, file: str) -> None:
     fsck(repo)
 
 
-#  Note: I don't think it's necessary to exclude `.anchor` as a directory name,
-#  hence deleted ".anchor" from that list for now:
-protected_paths = ["simple/.git",
+protected_paths = [".anchor",
+                   "simple/.git",
                    "simple/.onyo",
                    ".git/nope"
                    ".onyo/nope",

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -256,8 +256,7 @@ class OnyoRepo(object):
         # TODO: possibly nested assets; hence "asset path", not "asset file"
         # TODO: We are currently ignoring .gitignore w/ underlying globbing
         return self.is_inventory_path(path) and \
-            path.is_file() and \
-            path.name != self.ANCHOR_FILE
+            path.is_file()
 
     def is_inventory_path(self, path: Path) -> bool:
         # Note: path underneath an inventory location with no regard for existence of `path` itself.
@@ -267,7 +266,8 @@ class OnyoRepo(object):
         #       restriction (ANCHOR)
         return path.is_relative_to(self.git.root) and \
             not self.git.is_git_path(path) and \
-            not self.is_onyo_path(path)
+            not self.is_onyo_path(path) and \
+            self.ANCHOR_FILE not in path.parts
 
     def get_template_file(self, name: Union[Path, str, None] = None) -> Path:
         """


### PR DESCRIPTION
Previously checking path parts for being '.anchor' was reduced to only check for files, since technically only such files are relevant. However, allowing directories being named '.anchor' would take up the space of the '.anchor' file of its parent. Hence, one could only ever do that in a repo that wouldn't currently pass validation and one would end up making it harder to fix. So, go back to not allow for this.