### PR TITLE
Fix for mkdir + minor clean up

### DIFF
--- a/onyo/commands/tests/test_mkdir.py
+++ b/onyo/commands/tests/test_mkdir.py
@@ -132,17 +132,17 @@ def test_mkdir_quiet_flag(repo: OnyoRepo) -> None:
 
 @pytest.mark.repo_dirs(*directories)
 @pytest.mark.parametrize('directory', directories)
-def test_error_dir_exists(repo: OnyoRepo, directory: str) -> None:
+def test_dir_exists(repo: OnyoRepo, directory: str) -> None:
     """
-    Test the correct error behavior when `onyo mkdir <path>` is called on an
+    Test the correct behavior when `onyo mkdir <path>` is called on an
     existing directory name.
     """
     ret = subprocess.run(['onyo', 'mkdir', directory], capture_output=True, text=True)
 
     # verify output
-    assert not ret.stdout
-    assert "The following paths already exist:" in ret.stderr
-    assert ret.returncode == 1
+    assert "No assets updated." in ret.stdout
+    assert not ret.stderr
+    assert ret.returncode == 0
 
     assert Path(directory).is_dir()
     assert Path(directory, ".anchor").is_file()
@@ -161,7 +161,7 @@ def test_dir_exists_as_file(repo: OnyoRepo, file: str) -> None:
 
     # verify output
     assert not ret.stdout
-    assert "The following paths already exist:" in ret.stderr
+    assert "The following paths are existing files:" in ret.stderr
     assert ret.returncode == 1
 
     assert Path(file).is_file()

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -234,17 +234,18 @@ def mkdir(repo: OnyoRepo, dirs: list[Path], quiet: bool, yes: bool, message: Uni
 
     # commit changes
     staged = sorted(repo.git.files_staged)
-    if not quiet:
+    if staged and not quiet:
         print(
             'The following directories will be created:',
             *map(str, staged), sep='\n')
 
-    if yes or request_user_response(
-            "Save changes? No discards all changes. (y/n) "):
+    if staged and (yes or request_user_response(
+            "Save changes? No discards all changes. (y/n) ")):
         repo.git.commit(repo.generate_commit_message(
             message=message, cmd="mkdir"))
     else:
-        repo.git.restore_staged()
+        if staged:
+            repo.git.restore_staged()
         if not quiet:
             print('No assets updated.')
 

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -321,7 +321,7 @@ def new(repo: OnyoRepo,
         print("The following will be created:")
         for path in staged:
             # display new folders, not anchors.
-            if ".anchor" in str(path):
+            if path.name == repo.ANCHOR_FILE:
                 print(path.parent)
                 changes.append(path.parent)
             else:

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -94,7 +94,7 @@ class OnyoRepo(object):
         message_appendix = ""
 
         # staged files and directories (without ".anchor") in alphabetical order
-        staged_changes = [x if not x.name == ".anchor" else x.parent
+        staged_changes = [x if not x.name == self.ANCHOR_FILE else x.parent
                           for x in sorted(f.relative_to(self.git.root) for f in self.git.files_staged)]
 
         if message:
@@ -108,7 +108,7 @@ class OnyoRepo(object):
                 keys_str = f" ({','.join(str(x.split('=')[0]) for x in sorted(keys))})"
             if destination:
                 dest = Path(self.git.root, destination).relative_to(self.git.root)
-            if dest and dest.name == ".anchor":
+            if dest and dest.name == self.ANCHOR_FILE:
                 dest = dest.parent
 
             # the `msg_dummy` is the way all automatically generated commit

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -331,14 +331,15 @@ class OnyoRepo(object):
                 'The following paths are protected by onyo:\n{}\nNo '
                 'directories were created.'.format(
                     '\n'.join(map(str, non_inventory_paths))))
-        # Note: Why is it not okay for the dirs to exist, but the anchor files later on are?
-        #       Also: mkdir itself is called with exist_ok=True. So, why fail?
-        existent_paths = [d for d in dirs if d.exists()]
-        if existent_paths:
+
+        # Note: This check is currently done here, because we are dealing with a bunch of directories at once.
+        #       We may want to operate on single dirs, rely on mkdir throwing instead, and collect errors higher up.
+        file_paths = [d for d in dirs if d.is_file()]
+        if file_paths:
             raise FileExistsError(
-                'The following paths already exist:\n{}\nNo directories were '
+                'The following paths are existing files:\n{}\nNo directories were '
                 'created.'.format(
-                    '\n'.join(map(str, existent_paths))))
+                    '\n'.join(map(str, file_paths))))
 
         # make dirs
         for d in dirs:


### PR DESCRIPTION
- Closes #371 (`onyo mkdir` now behaves like `mkdir -p` with respect to existing directories)
- Replace remaining, hardcoded `.anchor` strings by the central definition `OnyoRepo.ANCHOR_FILE`. 