### PR TITLE
docs: correct/update existing information

### DIFF
--- a/docs/source/concepts.rst
+++ b/docs/source/concepts.rst
@@ -95,10 +95,10 @@ repository.
     - ``onyo config history.interactive "tig --follow"``
     - ``onyo config history.non-interactive "git --no-pager log --follow"``
 
-  - default template to use with ``onyo new <dir>``
+  - default template to use with ``onyo new --path <asset>``
     The standard template can be updated with e.g.:
 
-    - ``onyo config template.default standard``
+    - ``onyo config template.default empty``
 
 - ``.onyo/templates/`` contains:
 
@@ -111,14 +111,14 @@ Template Files
 **************
 
 Templates can be used with the command ``onyo new --template <template>
-<directory>`` and are stored in the folder ``.onyo/templates/``.
+--path <asset>`` and are stored in the folder ``.onyo/templates/``.
 Templates will be copied as a basis for a new asset file, and can then be
 edited. After saving the newly created asset, the file will be checked for
 valid YAML syntax.
 
 The default template that gets used when ``onyo new`` is called is
-``.onyo/templates/standard``. It can be updated with
-``onyo config template.default standard``.
+``.onyo/templates/empty``. It can be updated with
+``onyo config template.default empty``.
 
 For examples, see the section "Templates" in :doc:`examples`.
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -37,4 +37,4 @@ Options
     ``--non-interactive``.  (default: "git --no-pager log --follow")
 
 ``onyo.new.template``
-    The default template to use with ``onyo new``. (default: "standard")
+    The default template to use with ``onyo new``. (default: "empty")

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -8,13 +8,8 @@ Basic Use
 
 .. code:: shell
 
-   onyo new shelf
-   <type>*: laptop
-   <make>*: lenovo
-   <model>*: T490s
-   <serial>*: abc123
-   <spawns editor. The user edits fields>
-   <writes out to shelf/laptop_lenovo_T490s.abc123
+   onyo new --keys RAM=8GB --path shelf/laptop_lenovo_T490s.abc123
+   <writes out to shelf/laptop_lenovo_T490s.abc123>
 
 **Assign an asset:**
 
@@ -26,13 +21,13 @@ Basic Use
 
 .. code:: shell
 
-   onyo mv accounting/Bingo\ Bob/laptop_lenovo_T490s retired/
+   onyo mv accounting/Bingo\ Bob/laptop_lenovo_T490s.abc123 retired/
 
 **Upgrade an asset:**
 
 .. code:: shell
 
-   onyo set RAM=16GB accounting/Bingo\ Bob/laptop_lenovo_T490s
+   onyo set --keys RAM=16GB --path accounting/Bingo\ Bob/laptop_lenovo_T490s.abc123
    - RAM: 8GB
    + RAM: 16GB
 
@@ -40,7 +35,7 @@ or
 
 .. code:: shell
 
-   onyo edit accounting/Bingo\ Bob/laptop_lenovo_T490s
+   onyo edit accounting/Bingo\ Bob/laptop_lenovo_T490s.abc123
    <spawns $EDITOR; user edits RAM field>
 
 **List all assets on the shelf:**
@@ -53,7 +48,7 @@ or
 
 .. code:: shell
 
-   onyo history accounting/Bingo\ Bob/laptop_lenovo_T490s
+   onyo history accounting/Bingo\ Bob/laptop_lenovo_T490s.abc123
 
 **List the history of all assets of a user:**
 
@@ -67,17 +62,14 @@ Templates
 This section describes some of the templates provided with ``onyo init`` in the
 directory ``.onyo/templates/``.
 
-``onyo new <dir>`` (equivalent to ``onyo new --template standard <dir>``) as defined
-by ``.onyo/templates/standard`` is a plain YAML file:
-
-.. code:: yaml
-
-   ---
+``onyo new --path <asset>`` (equivalent to
+``onyo new --template empty --path <asset>``) as defined
+by ``.onyo/templates/empty`` is an empty YAML file.
 
 This template passes the YAML syntax check when onyo is called while the editor
-is suppressed with ``onyo new --non-interactive <directory>``.
+is suppressed with ``onyo new --non-interactive --path <asset>``.
 
-``onyo new --template laptop.example <dir>`` as defined by
+``onyo new --template laptop.example --path <asset>`` as defined by
 ``.onyo/templates/laptop.example`` contains a simple example for a laptop asset
 which already contains some fields, which are relevant for all assets of that
 device type.


### PR DESCRIPTION
This commit is not about adding new examples or use-cases, I just correct existing information which was out of date:

- `onyo new` does not read fields interactive/separately, but expects a full asset-path
- apply new syntax (e.g. new syntax for flags `--keys` and `--path`) to the commands `onyo new` and `onyo set`
- we new expect assets that expect the name-scheme to be correct, so I renamed the incorrect `laptop_lenovo_T490s` (without serial) to the correct `laptop_lenovo_T490s.abc123`
- the example template is changed to `.onyo/templates/empty` and actually an empty file, instead of the old name `standard`, which did contain `---`