### PR TITLE
BF: Remove multi log

### DIFF
--- a/onyo/lib/command_utils.py
+++ b/onyo/lib/command_utils.py
@@ -99,9 +99,8 @@ def sanitize_args_config(git_config_args: list[str]) -> list[str]:
 
     for a in git_config_args:
         if a in forbidden_flags:
-            log.error("The following options cannot be used with onyo config:")
-            log.error('\n'.join(forbidden_flags))
-            log.error("\nExiting. Nothing was set.")
+            log.error("The following options cannot be used with onyo config:\n%s\nExiting. Nothing was set.",
+                      '\n'.join(forbidden_flags))
             sys.exit(1)
     return git_config_args
 


### PR DESCRIPTION
This was mistaking `log.error` for some sort of print statement. In such a case one wants to generate a multiline log record instead of several records with one line messages each.

The other log related pattern mentioned in #338 was already removed, hence:
Closes #338