### PR TITLE
Restructure `set`

### DIFF
--- a/onyo/lib/assets.py
+++ b/onyo/lib/assets.py
@@ -173,6 +173,16 @@ def get_asset_files_by_path(asset_files: set[Path],
     return assets
 
 
+def dict_to_yaml(content: Dict[str, Union[float, int, str]]) -> str:
+    if not content:
+        return ""
+    from io import StringIO
+    yaml = YAML(typ='rt')
+    s = StringIO()
+    yaml.dump(content, s)
+    return s.getvalue()
+
+
 def write_asset_file(asset_path: Path,
                      asset_content: Dict[str, Union[float, int, str]]) -> None:
     if asset_content == {}:

--- a/onyo/lib/git.py
+++ b/onyo/lib/git.py
@@ -99,6 +99,9 @@ class GitRepo(object):
     def restore(self, paths: Union[list[Path], Path]) -> None:
         """Call git-restore on `paths`.
         """
+        if not paths:
+            log.debug("No paths passed to restore. Nothing to do.")
+            return
         if not isinstance(paths, list):
             paths = [paths]
         self._git(['restore'] + [str(p) for p in paths])
@@ -333,19 +336,19 @@ class GitRepo(object):
 
         return "\n".join(diff).strip()
 
-    def mv(self, source: Union[Path, list[Path]], destination: Path, dryrun: bool = False) -> str:
+    def mv(self,
+           source: Union[Path, Iterable[Path]],
+           destination: Path,
+           dryrun: bool = False) -> str:
         """Call git-mv on paths provided by `source` and `destination`.
 
         Returns
         -------
-        str
-          stdout of the git-mv subprocess
+        list of tuple of Path
+          each tuple represents a move from a source file to a destination file
         """
-        if not isinstance(source, list):
+        if isinstance(source, Path):
             source = [source]
-
-        log.debug('The following will be moved:\n{}'.format('\n'.join(
-            map(lambda x: str(x.relative_to(self.root)), source))))
 
         mv_cmd = ['mv']
         if dryrun:


### PR DESCRIPTION
This one more step working towards #370, #377, #383, and a consolidation of `assets.py` as pointed to in #386 under 4.
For the latter, follow up PRs on `unset` and `get` are necessary as well.

- Restructures the implementation of `set` mainly targeting #370
- Introduces usage of `difflib` in order to not do modifications on disc before asking the user for confirmation.
- By extension this is also addressing #377, because now a dryrun does not actually write anything
- Minor adjustment to git usage: Don't call `restore` twice for moves, but pass both paths instead.
