### PR TITLE
docs: change texts for arguments in argparser and doc-strings of commands

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -30,11 +30,11 @@ Options
 
 ``onyo.history.interactive``
     The command used to display history when running ``onyo history``. (default:
-    "tig --follow")
+    ``tig --follow``)
 
 ``onyo.history.non-interactive``
     The command used to print history when running ``onyo history`` with
-    ``--non-interactive``.  (default: "git --no-pager log --follow")
+    ``--non-interactive``.  (default: ``git --no-pager log --follow``)
 
 ``onyo.new.template``
     The default template to use with ``onyo new``. (default: "empty")

--- a/onyo/commands/cat.py
+++ b/onyo/commands/cat.py
@@ -15,8 +15,7 @@ log: logging.Logger = logging.getLogger('onyo')
 
 def cat(args: argparse.Namespace) -> None:
     """
-    Print the contents of ``asset``\\(s) to the terminal without parsing or
-    validating the contents.
+    Print the contents of ``ASSET``\\(s) to the terminal without parsing.
     """
     paths = [Path(p).resolve() for p in args.asset]
 

--- a/onyo/commands/config.py
+++ b/onyo/commands/config.py
@@ -16,8 +16,8 @@ log: logging.Logger = logging.getLogger('onyo')
 def config(args: argparse.Namespace) -> None:
     """
     Set, query, and unset Onyo repository configuration options. These options
-    are stored in ``.onyo/config`` (which is tracked by git) and are shared with
-    all other consumers of an Onyo repository.
+    are stored in ``.onyo/config``. This file is tracked by git and are shared
+    with all other consumers of an Onyo repository.
 
     To set configuration options locally (and not commit them to the Onyo
     repository), use ``git config`` instead.
@@ -39,10 +39,6 @@ def config(args: argparse.Namespace) -> None:
       (default: "git --no-pager log --follow")
     - ``onyo.new.template``: The default template to use with ``onyo new``.
       (default: "empty")
-
-    Example:
-
-        $ onyo config onyo.core.editor "vim"
     """
 
     repo = OnyoRepo(Path.cwd(), find_root=True)

--- a/onyo/commands/edit.py
+++ b/onyo/commands/edit.py
@@ -15,15 +15,14 @@ log: logging.Logger = logging.getLogger('onyo')
 
 def edit(args: argparse.Namespace) -> None:
     """
-    Open the ``asset`` file(s) using the editor specified by "onyo.core.editor",
+    Open the ``ASSET``\(s) using the editor specified by "onyo.core.editor",
     the environment variable ``EDITOR``, or ``nano`` (as a final fallback).
 
-    When multiple asset files are given, Onyo will open them in sequence.
+    When multiple ``ASSET``\(s) are given, Onyo will open them in sequence.
 
-    After editing an ``asset``, the contents will be checked for valid YAML and
-    also against any matching rules in ``.onyo/validation/``. If problems are
-    found, the choice will be offered to reopen the editor to fix them, or abort
-    and return to the original state.
+    After editing an ``ASSET``, the contents will be checked for valid YAML.
+    If problems are found, the choice will be offered to reopen the editor to
+    fix them, or discard the invalid changes made.
     """
 
     paths = [Path(p).resolve() for p in args.asset]

--- a/onyo/commands/fsck.py
+++ b/onyo/commands/fsck.py
@@ -18,7 +18,7 @@ def fsck(args: argparse.Namespace) -> None:
 
     - "clean-tree": verifies that the git tree is clean ---that there are
       no changed (staged or unstaged) nor untracked files.
-    - "anchors": verifies that all folders (outside of .onyo) have an
+    - "anchors": verifies that all directories (outside of .onyo) have an
       .anchor file
     - "asset-unique": verifies that all asset names are unique
     - "asset-yaml": loads each assets and checks if it's valid YAML

--- a/onyo/commands/get.py
+++ b/onyo/commands/get.py
@@ -37,7 +37,7 @@ def get(args: argparse.Namespace) -> None:
     repo = OnyoRepo(Path.cwd(), find_root=True)
     fsck(repo, ['asset-yaml'])
 
-    paths = [Path(p).resolve() for p in args.path]
+    paths = [Path(p).resolve() for p in args.path] if args.path else None
     get_cmd(repo,
             args.sort_ascending,
             args.sort_descending,

--- a/onyo/commands/get.py
+++ b/onyo/commands/get.py
@@ -16,7 +16,8 @@ log = logging.getLogger('onyo')
 
 def get(args: argparse.Namespace) -> None:
     """
-    Return matching asset(s) and values corresponding to the requested key(s).
+    Return matching ``ASSET``\(s) and values corresponding to the requested
+    ``KEY``\(s).
 
     If no key(s) are given, the pseudo-keys are returned instead.
     If no ``asset`` or ``directory`` is specified, the current working directory

--- a/onyo/commands/history.py
+++ b/onyo/commands/history.py
@@ -19,11 +19,13 @@ log: logging.Logger = logging.getLogger('onyo')
 
 def history(args: argparse.Namespace) -> None:
     """
-    Display the history of an ``asset`` or ``directory``.
+    Display the history of an ``ASSET`` or ``DIRECTORY``.
 
-    Onyo detects whether an interactive TTY is in use, and will launch either an
-    interactive display (default ``tig``) or a non-interactive one (default
-    ``git log``) accordingly.
+    Onyo detects whether an interactive TTY is in use, and will either use
+    the interactive display tool (specified in ``.onyo/config`` under
+    ``onyo.history.interactive``; default ``tig –-follow``) or the
+    non-interactive one (``onyo.history.non-interactive``; default ``git log``)
+    accordingly.
 
     The commands to display history are configurable using ``onyo config``.
     """

--- a/onyo/commands/init.py
+++ b/onyo/commands/init.py
@@ -12,13 +12,14 @@ def init(args: argparse.Namespace) -> None:
     """
     Initialize an Onyo repository. The directory will be initialized as a git
     repository (if it is not one already), the ``.onyo/`` directory created and
-    populated with config files, templates, etc. Everything will be committed.
+    populated with config files, templates, etc. If the directory specified does
+    not exist, it will be created. Everything will be committed.
 
     The current working directory will be initialized if neither ``directory``
-    nor the ``onyo -C <dir>`` option are specified.
+    nor the ``onyo -C DIR`` option are specified.
 
     Running ``onyo init`` on an existing repository is safe. It will not
-    overwrite anything; it will exit with an error.
+    overwrite anything.
     """
     target_dir = Path(args.directory).resolve() if args.directory else Path.cwd()
     OnyoRepo(target_dir, init=True)

--- a/onyo/commands/mkdir.py
+++ b/onyo/commands/mkdir.py
@@ -15,7 +15,7 @@ def mkdir(args: argparse.Namespace) -> None:
     needed (i.e. parent and child directories can be created in one call).
 
     An empty ``.anchor`` file is added to each directory, to ensure that git
-    tracks it even when empty.
+    tracks them even when empty.
 
     If the directory already exists, or the path is protected, Onyo will throw
     an error. All checks are performed before creating directories.

--- a/onyo/commands/mv.py
+++ b/onyo/commands/mv.py
@@ -11,8 +11,8 @@ if TYPE_CHECKING:
 
 def mv(args: argparse.Namespace) -> None:
     """
-    Move ``source``\\(s) (assets or directories) to the ``destination``
-    directory, or rename a ``source`` directory to ``destination``.
+    Move ``SOURCE``\\(s) (assets or directories) to the ``DEST`` directory, or
+    rename a ``SOURCE`` directory to ``DEST``.
 
     Files cannot be renamed using ``onyo mv``. To do so, use ``onyo set``.
     """

--- a/onyo/commands/new.py
+++ b/onyo/commands/new.py
@@ -15,7 +15,7 @@ log: logging.Logger = logging.getLogger('onyo')
 
 def new(args: argparse.Namespace) -> None:
     """
-    Create new ``<path>/<asset>``\\(s) and add contents with ``--template``,
+    Create new ``DIRECTORY/ASSET``\\(s), and add contents with ``--template``,
     ``--keys`` and ``--edit``. If the directories do not exist, they will be
     created.
 

--- a/onyo/commands/rm.py
+++ b/onyo/commands/rm.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 def rm(args: argparse.Namespace) -> None:
     """
-    Delete ``asset``\\(s) and ``directory``\\(s).
+    Delete ``ASSET``\\(s) and ``DIRECTORY``\\(s).
 
     A list of all files and directories to delete will be presented, and the
     user prompted for confirmation.

--- a/onyo/commands/set.py
+++ b/onyo/commands/set.py
@@ -41,7 +41,7 @@ def set(args: argparse.Namespace) -> None:
 
     repo = OnyoRepo(Path.cwd(), find_root=True)
     fsck(repo)
-    paths = [Path(p).resolve() for p in args.path]
+    paths = [Path(p).resolve() for p in args.path] if args.path else None
     set_cmd(repo,
             paths,
             args.keys,

--- a/onyo/commands/set.py
+++ b/onyo/commands/set.py
@@ -15,7 +15,7 @@ log: logging.Logger = logging.getLogger('onyo')
 
 def set(args: argparse.Namespace) -> None:
     """
-    Set the ``value`` of ``key`` for matching assets. If the key does not exist,
+    Set the ``value`` of ``key`` for matching assets. If a key does not exist,
     it is added and set appropriately.
 
     Key names can be any valid YAML key name.

--- a/onyo/commands/tree.py
+++ b/onyo/commands/tree.py
@@ -15,7 +15,7 @@ log: logging.Logger = logging.getLogger('onyo')
 
 def tree(args: argparse.Namespace) -> None:
     """
-    List the assets and directories in ``directory`` using ``tree``.
+    List the assets and directories in ``DIRECTORY`` in the ``tree`` format.
     """
 
     repo = OnyoRepo(Path.cwd(), find_root=True)

--- a/onyo/commands/unset.py
+++ b/onyo/commands/unset.py
@@ -36,7 +36,7 @@ def unset(args: argparse.Namespace) -> None:
 
     repo = OnyoRepo(Path.cwd(), find_root=True)
     fsck(repo)
-    paths = [Path(p).resolve() for p in args.path]
+    paths = [Path(p).resolve() for p in args.path] if args.path else None
     unset_cmd(repo,
               paths,
               args.keys,

--- a/onyo/commands/unset.py
+++ b/onyo/commands/unset.py
@@ -15,7 +15,7 @@ log: logging.Logger = logging.getLogger('onyo')
 
 def unset(args: argparse.Namespace) -> None:
     """
-    Remove the ``value`` of ``key`` for matching assets.
+    Remove the ``value`` of ``key`` for matching ``ASSET``\s.
 
     Multiple ``key=value`` pairs can be declared and divided by spaces. Quotes
     can be used around ``value``, which is necessary when it contains a comma,
@@ -25,8 +25,7 @@ def unset(args: argparse.Namespace) -> None:
     changed, to rename a file(s) use ``onyo set --rename``.
 
     If no ``asset`` or ``directory`` is specified, the current working directory
-    is used. If Onyo is invoked from outside of the Onyo repository, the root of
-    the repository is used.
+    is used.
 
     Changes are printed to the terminal in the style of ``diff``.
 

--- a/onyo/lib/command_utils.py
+++ b/onyo/lib/command_utils.py
@@ -149,14 +149,14 @@ def edit_asset(editor: str, asset: Path) -> bool:
                 return False
 
 
-def sanitize_keys(k: list[str], defaults: list) -> list[str]:
+def sanitize_keys(k: Optional[list[str]],
+                  defaults: list) -> list[str]:
     """
     Remove duplicates from k while preserving key order and return default
     (pseudo) keys if k is empty
     """
     seen = set()
-    k = [x for x in k if not (x in seen or seen.add(x))]
-    return k if k else defaults
+    return [x for x in k if not (x in seen or seen.add(x))] if k else defaults
 
 
 def set_filters(

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -167,11 +167,11 @@ def edit(repo: OnyoRepo,
 def get(repo: OnyoRepo,
         sort_ascending: bool,
         sort_descending: bool,
-        paths: list[Path],
+        paths: Optional[list[Path]],
         depth: int,
         machine_readable: bool,
         filter_strings: list[str],
-        keys: list[str]) -> None:
+        keys: Optional[list[str]]) -> None:
 
     if sort_ascending and sort_descending:
         msg = (
@@ -183,6 +183,9 @@ def get(repo: OnyoRepo,
             console = Console(stderr=True)
             console.print(f'[red]FAILED[/red] {msg}')
         raise ValueError
+
+    if not paths:
+        paths = [Path.cwd()]
 
     # validate path arguments
     invalid_paths = set(p for p in paths if not repo.is_inventory_dir(p))
@@ -374,7 +377,7 @@ def rm(repo: OnyoRepo,
 
 
 def set_(repo: OnyoRepo,
-         paths: Iterable[Path],
+         paths: Optional[Iterable[Path]],
          keys: Dict[str, Union[str, int, float]],
          filter_strings: list[str],
          dryrun: bool,
@@ -389,6 +392,9 @@ def set_(repo: OnyoRepo,
     # check flags for conflicts
     if quiet and not yes:
         raise ValueError('The --quiet flag requires --yes.')
+
+    if not paths:
+        paths = [Path.cwd()]
 
     if not rename and any(k in PSEUDO_KEYS for k in keys.keys()):
         raise ValueError("Can't change pseudo keys without --rename.")
@@ -471,7 +477,7 @@ def tree(repo: OnyoRepo, paths: list[Path]) -> None:
 
 
 def unset(repo: OnyoRepo,
-          paths: Iterable[Path],
+          paths: Optional[Iterable[Path]],
           keys: list[str],
           filter_strings: list[str],
           dryrun: bool,
@@ -483,6 +489,9 @@ def unset(repo: OnyoRepo,
     # check flags for conflicts
     if quiet and not yes:
         raise ValueError("The --quiet flag requires --yes.")
+
+    if not paths:
+        paths = [Path.cwd()]
 
     non_inventory_paths = [str(p) for p in paths if not repo.is_asset_path(p) and not repo.is_inventory_dir(p)]
     if non_inventory_paths:

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -134,9 +134,9 @@ def setup_parser() -> argparse.ArgumentParser:
         dest='opdir',
         metavar='DIR',
         required=False,
-        default=os.getcwd(),
+        default=Path.cwd(),
         type=directory,
-        help='run as if onyo was started in DIR'
+        help='Run Onyo commands from inside of DIR'
     )
     parser.add_argument(
         '-d',
@@ -144,17 +144,17 @@ def setup_parser() -> argparse.ArgumentParser:
         required=False,
         default=False,
         action='store_true',
-        help='enable debug logging'
+        help='Enable debug logging'
     )
     parser.add_argument(
         '--version',
         action='version',
         version='%(prog)s {version}'.format(version=__version__),
-        help="print onyo's version and exit"
+        help="Print onyo's version and exit"
     )
     # subcommands
     subcmds = parser.add_subparsers(
-        title="commands"
+        title='commands'
     )
     subcmds.metavar = '<command>'
     #
@@ -164,7 +164,7 @@ def setup_parser() -> argparse.ArgumentParser:
         'cat',
         description=textwrap.dedent(commands.cat.__doc__),
         formatter_class=SubcommandHelpFormatter,
-        help='print the contents of an asset'
+        help=textwrap.dedent(commands.cat.__doc__)
     )
     cmd_cat.set_defaults(run=commands.cat)
     cmd_cat.add_argument(
@@ -172,7 +172,7 @@ def setup_parser() -> argparse.ArgumentParser:
         metavar='ASSET',
         nargs='+',
         type=file,
-        help='asset(s) to print'
+        help='List paths of asset(s) to print'
     )
     #
     # subcommand "config"
@@ -181,7 +181,7 @@ def setup_parser() -> argparse.ArgumentParser:
         'config',
         description=textwrap.dedent(commands.config.__doc__),
         formatter_class=SubcommandHelpFormatter,
-        help='set, query, and unset Onyo repository configuration options'
+        help=textwrap.dedent(commands.config.__doc__)
     )
     cmd_config.set_defaults(run=commands.config)
     cmd_config.add_argument(
@@ -189,7 +189,7 @@ def setup_parser() -> argparse.ArgumentParser:
         metavar='ARGS',
         nargs='+',
         type=git_config,
-        help='arguments to set config options in .onyo/config'
+        help='Arguments configure the options in .onyo/config'
     )
     #
     # subcommand "edit"
@@ -198,7 +198,7 @@ def setup_parser() -> argparse.ArgumentParser:
         'edit',
         description=textwrap.dedent(commands.edit.__doc__),
         formatter_class=SubcommandHelpFormatter,
-        help='open asset with a text editor'
+        help=textwrap.dedent(commands.edit.__doc__)
     )
     cmd_edit.set_defaults(run=commands.edit)
     cmd_edit.add_argument(
@@ -207,28 +207,35 @@ def setup_parser() -> argparse.ArgumentParser:
         nargs=1,
         action='append',
         type=str,
-        help='Use the given MESSAGE as the commit message (rather than the default). If multiple -m options are given, their values are concatenated as separate paragraphs'
+        help=(
+            'Use the given MESSAGE as the commit message (rather than the '
+            'default). If multiple -m options are given, their values are '
+            'concatenated as separate paragraphs')
     )
     cmd_edit.add_argument(
         '-q', '--quiet',
         required=False,
         default=False,
         action='store_true',
-        help='silence messages to stdout (does not suppress interactive editors; requires the --yes flag)'
+        help=(
+            'Silence messages printed to stdout. Does not suppress interactive '
+            'editors. Requires the --yes flag')
     )
     cmd_edit.add_argument(
         '-y', '--yes',
         required=False,
         default=False,
         action='store_true',
-        help='respond "yes" to any prompts'
+        help=(
+            'Respond "yes" to any prompts. The --yes flag is required to '
+            'use --quiet')
     )
     cmd_edit.add_argument(
         'asset',
         metavar='ASSET',
         nargs='+',
         type=file,
-        help='asset(s) to edit'
+        help='List paths of asset(s) to edit'
     )
     #
     # subcommand "fsck"
@@ -237,10 +244,9 @@ def setup_parser() -> argparse.ArgumentParser:
         'fsck',
         description=textwrap.dedent(commands.fsck.__doc__),
         formatter_class=SubcommandHelpFormatter,
-        help='verify the integrity and validity of an onyo repository and its contents'
+        help=textwrap.dedent(commands.fsck.__doc__)
     )
     cmd_fsck.set_defaults(run=commands.fsck)
-
     #
     # subcommand "get"
     #
@@ -248,10 +254,8 @@ def setup_parser() -> argparse.ArgumentParser:
         'get',
         description=textwrap.dedent(commands.get.__doc__),
         formatter_class=SubcommandHelpFormatter,
-        help=(
-            'Return matching asset(s) and values corresponding to the '
-            'requested key(s). If no key(s) are given, the pseudo-keys are'
-            'returned instead.'))
+        help=textwrap.dedent(commands.get.__doc__)
+    )
     cmd_get.set_defaults(run=commands.get)
     cmd_get.add_argument(
         '-d', '--depth',
@@ -260,8 +264,9 @@ def setup_parser() -> argparse.ArgumentParser:
         required=False,
         default=0,
         help=(
-            'descend at most DEPTH levels of directories below the '
-            'starting-point, with a DEPTH value of 0 having no descend limit'))
+            'Descent up to DEPTH levels into directories specified. DEPTH=0 '
+            'descends recursively without limit')
+    )
     cmd_get.add_argument(
         '-f', '--filter',
         metavar='FILTER',
@@ -269,46 +274,47 @@ def setup_parser() -> argparse.ArgumentParser:
         type=str,
         default=None,
         help=(
-            'filter the results by key=value conditional statement(s) '
-            'to return only assets matching the condition. Multiple '
-            'conditions are separated by spaces and function as a logical '
-            'conjunction. Regular expressions can be used as a value and '
-            'pseudo-keys can also be used'))
+            'Add a filter to only show assets matching KEY=VALUE. Multiple '
+            'filters, regular expressions, and pseudo-keys can be used.')
+    )
     cmd_get.add_argument(
         '-H', '--machine-readable',
         dest='machine_readable',
         action='store_true',
         help=(
-            'return output separating assets by new lines and keys by tabs '
-            'instead of a formatted table'))
+            'Display asset(s) separated by new lines, and keys by tabs instead '
+            'of printing a formatted table')
+    )
     cmd_get.add_argument(
         '-k', '--keys',
         metavar='KEYS',
         nargs='+',
         default=[],
         help=(
-            'key value(s) to return. Pseudo-keys (i.e., keys for which the '
-            'values are only stored in the asset name) are also available '
-            'for queries'))
+            'Key value(s) to return. Pseudo-keys (information not stored in '
+            'the asset file, e.g. filename) are also available for queries')
+    )
     cmd_get.add_argument(
         '-p', '--path',
         metavar='PATH',
         default=['.'],
         nargs='+',
-        help='asset(s) or directory(s) to search through')
+        help='List asset(s) or directory(s) to search through'
+    )
     cmd_get.add_argument(
         '-s', '--sort-ascending',
         dest='sort_ascending',
         action='store_true',
         default=False,
-        help='sort output by keys in ascending order')
+        help='Sort output in ascending order (excludes --sort-descending)'
+    )
     cmd_get.add_argument(
         '-S', '--sort-descending',
         dest='sort_descending',
         action='store_true',
         default=False,
-        help='sort output by keys in descending order')
-
+        help='Sort output in descending order (excludes --sort-ascending)'
+    )
     #
     # subcommand "history"
     #
@@ -316,7 +322,7 @@ def setup_parser() -> argparse.ArgumentParser:
         'history',
         description=textwrap.dedent(commands.history.__doc__),
         formatter_class=SubcommandHelpFormatter,
-        help='show the history of an asset or directory'
+        help=textwrap.dedent(commands.history.__doc__)
     )
     cmd_history.set_defaults(run=commands.history)
     cmd_history.add_argument(
@@ -325,14 +331,17 @@ def setup_parser() -> argparse.ArgumentParser:
         required=False,
         default=True,
         action='store_false',
-        help='print the git log instead of opening an interactive tig session'
+        help=(
+            "Use the interactive history tool (specified in '.onyo/config' "
+            "under 'onyo.history.interactive') to display the history of the "
+            "repository, an asset or a directory")
     )
     cmd_history.add_argument(
         'path',
         metavar='PATH',
         nargs='?',
         type=path,
-        help='asset or directory to show the history of'
+        help='Specify an asset or a directory to show the history of'
     )
     #
     # subcommand "init"
@@ -341,7 +350,7 @@ def setup_parser() -> argparse.ArgumentParser:
         'init',
         description=textwrap.dedent(commands.init.__doc__),
         formatter_class=SubcommandHelpFormatter,
-        help='initialize an onyo repository'
+        help=textwrap.dedent(commands.init.__doc__)
     )
     cmd_init.set_defaults(run=commands.init)
     cmd_init.add_argument(
@@ -349,7 +358,7 @@ def setup_parser() -> argparse.ArgumentParser:
         metavar='DIR',
         nargs='?',
         type=directory,
-        help='initialize DIR as an onyo repository'
+        help='Initialize DIR as an onyo repository'
     )
     #
     # subcommand "mkdir"
@@ -358,7 +367,7 @@ def setup_parser() -> argparse.ArgumentParser:
         'mkdir',
         description=textwrap.dedent(commands.mkdir.__doc__),
         formatter_class=SubcommandHelpFormatter,
-        help='create a directory (with git anchor)'
+        help=textwrap.dedent(commands.mkdir.__doc__)
     )
     cmd_mkdir.set_defaults(run=commands.mkdir)
     cmd_mkdir.add_argument(
@@ -367,28 +376,33 @@ def setup_parser() -> argparse.ArgumentParser:
         nargs=1,
         action='append',
         type=str,
-        help='Use the given MESSAGE as the commit message (rather than the default). If multiple -m options are given, their values are concatenated as separate paragraphs'
+        help=(
+            'Use the given MESSAGE as the commit message (rather than the '
+            'default). If multiple -m options are given, their values are '
+            'concatenated as separate paragraphs')
     )
     cmd_mkdir.add_argument(
         '-q', '--quiet',
         required=False,
         default=False,
         action='store_true',
-        help='silence messages to stdout; requires the --yes flag'
+        help='Silence messages printed to stdout. Requires the --yes flag'
     )
     cmd_mkdir.add_argument(
         '-y', '--yes',
         required=False,
         default=False,
         action='store_true',
-        help='respond "yes" to any prompts'
+        help=(
+            'Respond "yes" to any prompts. The --yes flag is required to '
+            'use --quiet')
     )
     cmd_mkdir.add_argument(
         'directory',
         metavar='DIR',
         nargs='+',
         type=directory,
-        help='directory to create'
+        help='List directory(s) to create'
     )
     #
     # subcommand "mv"
@@ -397,7 +411,7 @@ def setup_parser() -> argparse.ArgumentParser:
         'mv',
         description=textwrap.dedent(commands.mv.__doc__),
         formatter_class=SubcommandHelpFormatter,
-        help='move an asset'
+        help=textwrap.dedent(commands.mv.__doc__)
     )
     cmd_mv.set_defaults(run=commands.mv)
     cmd_mv.add_argument(
@@ -406,34 +420,37 @@ def setup_parser() -> argparse.ArgumentParser:
         nargs=1,
         action='append',
         type=str,
-        help='Use the given MESSAGE as the commit message (rather than the default). If multiple -m options are given, their values are concatenated as separate paragraphs'
+        help=(
+            'Use the given MESSAGE as the commit message (rather than the '
+            'default). If multiple -m options are given, their values are '
+            'concatenated as separate paragraphs')
     )
     cmd_mv.add_argument(
         '-q', '--quiet',
         required=False,
         default=False,
         action='store_true',
-        help='silence messages to stdout (requires the --yes flag)'
+        help='Silence messages to stdout. Requires the --yes flag'
     )
     cmd_mv.add_argument(
         '-y', '--yes',
         required=False,
         default=False,
         action='store_true',
-        help='respond "yes" to any prompts'
+        help='Respond "yes" to any prompts. Is required to use --yes flag'
     )
     cmd_mv.add_argument(
         'source',
         metavar='SOURCE',
         nargs='+',
         type=path,
-        help='source ...'
+        help='List asset(s) and/or directory(s) to move into DEST'
     )
     cmd_mv.add_argument(
         'destination',
         metavar='DEST',
         type=path,
-        help='destination'
+        help='Destination to move SOURCE(s) into'
     )
     #
     # subcommand "new"
@@ -442,7 +459,7 @@ def setup_parser() -> argparse.ArgumentParser:
         'new',
         description=textwrap.dedent(commands.new.__doc__),
         formatter_class=SubcommandHelpFormatter,
-        help='create a new asset'
+        help=textwrap.dedent(commands.new.__doc__)
     )
     cmd_new.set_defaults(run=commands.new)
     cmd_new.add_argument(
@@ -451,7 +468,10 @@ def setup_parser() -> argparse.ArgumentParser:
         nargs=1,
         action='append',
         type=str,
-        help='Use the given MESSAGE as the commit message (rather than the default). If multiple -m options are given, their values are concatenated as separate paragraphs'
+        help=(
+            'Use the given MESSAGE as the commit message (rather than the '
+            'default). If multiple -m options are given, their values are '
+            'concatenated as separate paragraphs')
     )
     cmd_new.add_argument(
         '-t', '--template',
@@ -459,7 +479,7 @@ def setup_parser() -> argparse.ArgumentParser:
         required=False,
         default=[],
         type=template,
-        help='the template to seed the new asset'
+        help='Specify the template to seed the new asset(s)'
     )
     cmd_new.add_argument(
         '-e', '--edit',
@@ -474,14 +494,18 @@ def setup_parser() -> argparse.ArgumentParser:
         action=StoreKeyValuePairs,
         metavar="KEYS",
         nargs='+',
-        help='key-value pairs to set in assets; multiple pairs can be given (e.g. key=value key2=value2)'
+        help=(
+            'Set key-value pairs in the new asset(s). Multiple pairs can be '
+            'specified (e.g. key=value key2=value2)')
     )
     cmd_new.add_argument(
         '-p', '--path',
         metavar='ASSET',
         type=path,
         nargs='*',
-        help='add new assets'
+        help=(
+            'Specify the directory and name of the new asset(s) '
+            '(in the format DIR/ASSET). Excludes usage of --tsv')
     )
     cmd_new.add_argument(
         '-tsv', '--tsv',
@@ -489,14 +513,16 @@ def setup_parser() -> argparse.ArgumentParser:
         required=False,
         default=None,
         type=path,
-        help='tsv file describing new assets'
+        help=(
+            'Read information of new assets from a tsv file describing them. '
+            'Excludes the usage of --path')
     )
     cmd_new.add_argument(
         '-y', '--yes',
         required=False,
         default=False,
         action='store_true',
-        help='respond "yes" to any prompts'
+        help='Respond "yes" to any prompts. Is required to use --yes flag'
     )
     #
     # subcommand "rm"
@@ -505,7 +531,7 @@ def setup_parser() -> argparse.ArgumentParser:
         'rm',
         description=textwrap.dedent(commands.rm.__doc__),
         formatter_class=SubcommandHelpFormatter,
-        help='delete asset(s) and directories'
+        help=textwrap.dedent(commands.rm.__doc__)
     )
     cmd_rm.set_defaults(run=commands.rm)
     cmd_rm.add_argument(
@@ -514,28 +540,31 @@ def setup_parser() -> argparse.ArgumentParser:
         nargs=1,
         action='append',
         type=str,
-        help='Use the given MESSAGE as the commit message (rather than the default). If multiple -m options are given, their values are concatenated as separate paragraphs'
+        help=(
+            'Use the given MESSAGE as the commit message (rather than the '
+            'default). If multiple -m options are given, their values are '
+            'concatenated as separate paragraphs')
     )
     cmd_rm.add_argument(
         '-q', '--quiet',
         required=False,
         default=False,
         action='store_true',
-        help='silence messages to stdout (requires the --yes flag)'
+        help='Silence messages to stdout. Requires the --yes flag'
     )
     cmd_rm.add_argument(
         '-y', '--yes',
         required=False,
         default=False,
         action='store_true',
-        help='respond "yes" to any prompts'
+        help='Respond "yes" to any prompts. Is required for usage of --quiet'
     )
     cmd_rm.add_argument(
         'path',
         metavar='PATH',
         nargs='+',
         type=path,
-        help='assets or directories to delete'
+        help='List asset(s) and/or directory(s) to delete'
     )
     #
     # subcommand "set"
@@ -544,18 +573,19 @@ def setup_parser() -> argparse.ArgumentParser:
         'set',
         description=textwrap.dedent(commands.set.__doc__),
         formatter_class=SubcommandHelpFormatter,
-        help='set values in assets'
+        help=textwrap.dedent(commands.set.__doc__)
     )
     cmd_set.set_defaults(run=commands.set)
     cmd_set.add_argument(
         '-d', '--depth',
-        metavar='N',
+        metavar='DEPTH',
         type=int,
         required=False,
         default=0,
         help=(
-            'descend at most N levels of directories below the '
-            'starting-point, with an N value of 0 for infinite'))
+            'Descent up to DEPTH levels into directories specified. DEPTH=0 '
+            'descends recursively without limit')
+    )
     cmd_set.add_argument(
         '-f', '--filter',
         metavar='FILTER',
@@ -572,35 +602,40 @@ def setup_parser() -> argparse.ArgumentParser:
         nargs=1,
         action='append',
         type=str,
-        help='Use the given MESSAGE as the commit message (rather than the default). If multiple -m options are given, their values are concatenated as separate paragraphs'
+        help=(
+            'Use the given MESSAGE as the commit message (rather than the '
+            'default). If multiple -m options are given, their values are '
+            'concatenated as separate paragraphs')
     )
     cmd_set.add_argument(
-        '-n', "--dry-run",
+        '-n', '--dry-run',
         required=False,
         default=False,
         action='store_true',
-        help='perform a non-interactive trial-run without making any changes'
+        help='Perform a non-interactive trial-run without making any changes'
     )
     cmd_set.add_argument(
         '-q', '--quiet',
         required=False,
         default=False,
         action='store_true',
-        help='silence output (requires the --yes flag)'
+        help='Silence messages printed to stdout. Requires the --yes flag'
     )
     cmd_set.add_argument(
         '-r', '--rename',
         required=False,
         default=False,
         action='store_true',
-        help='Permit assigning values to pseudo-keys that would result in the file(s) being renamed.'
+        help=(
+            'Permit assigning values to pseudo-keys that would result in the '
+            'file(s) being renamed.')
     )
     cmd_set.add_argument(
         '-y', '--yes',
         required=False,
         default=False,
         action='store_true',
-        help='respond "yes" to any prompts'
+        help='Respond "yes" to any prompts. Is required to use --yes flag'
     )
     cmd_set.add_argument(
         '-k', '--keys',
@@ -608,7 +643,9 @@ def setup_parser() -> argparse.ArgumentParser:
         action=StoreKeyValuePairs,
         metavar="KEYS",
         nargs='+',
-        help='key-value pairs to set in assets; multiple pairs can be given (e.g. key=value key2=value2)'
+        help=(
+            'Specify key-value pairs to set in asset(s). Multiple pairs can '
+            'be specified (e.g. key=value key2=value2)')
     )
     cmd_set.add_argument(
         '-p', '--path',
@@ -616,7 +653,7 @@ def setup_parser() -> argparse.ArgumentParser:
         metavar='PATH',
         nargs='*',
         type=path,
-        help='assets or directories to set keys/values in'
+        help='List asset(s) and/or directorie(s) to set KEY=VALUE in'
     )
     #
     # subcommand "shell-completion"
@@ -625,7 +662,7 @@ def setup_parser() -> argparse.ArgumentParser:
         'shell-completion',
         description=textwrap.dedent(commands.shell_completion.__doc__),
         formatter_class=SubcommandHelpFormatter,
-        help='shell completion for Onyo, suitable for use with "source"'
+        help=textwrap.dedent(commands.shell_completion.__doc__)
     )
     cmd_shell_completion.set_defaults(run=commands.shell_completion,
                                       parser=parser)
@@ -635,7 +672,7 @@ def setup_parser() -> argparse.ArgumentParser:
         required=False,
         default='zsh',
         choices=['zsh'],
-        help='shell to generate tab completion for'
+        help='Specify the shell for which to generate tab completion for'
     )
     #
     # subcommand "tree"
@@ -644,7 +681,7 @@ def setup_parser() -> argparse.ArgumentParser:
         'tree',
         description=textwrap.dedent(commands.tree.__doc__),
         formatter_class=SubcommandHelpFormatter,
-        help='print the contents of a directory in a tree-like format'
+        help=textwrap.dedent(commands.tree.__doc__)
     )
     cmd_tree.set_defaults(run=commands.tree)
     cmd_tree.add_argument(
@@ -652,7 +689,7 @@ def setup_parser() -> argparse.ArgumentParser:
         metavar='DIR',
         nargs='*',
         type=directory,
-        help='directories to print'
+        help='List directory(s) to print tree of'
     )
     #
     # subcommand "unset"
@@ -661,18 +698,19 @@ def setup_parser() -> argparse.ArgumentParser:
         'unset',
         description=textwrap.dedent(commands.unset.__doc__),
         formatter_class=SubcommandHelpFormatter,
-        help='remove values from assets'
+        help=textwrap.dedent(commands.unset.__doc__)
     )
     cmd_unset.set_defaults(run=commands.unset)
     cmd_unset.add_argument(
         '-d', '--depth',
-        metavar='N',
+        metavar='DEPTH',
         type=int,
         required=False,
         default=0,
         help=(
-            'descend at most N levels of directories below the '
-            'starting-point, with an N value of 0 for infinite'))
+            'Descent up to DEPTH levels into directories specified. DEPTH=0 '
+            'descends recursively without limit')
+    )
     cmd_unset.add_argument(
         '-f', '--filter',
         metavar='FILTER',
@@ -689,28 +727,34 @@ def setup_parser() -> argparse.ArgumentParser:
         nargs=1,
         action='append',
         type=str,
-        help='Use the given MESSAGE as the commit message (rather than the default). If multiple -m options are given, their values are concatenated as separate paragraphs'
+        help=(
+            'Use the given MESSAGE as the commit message (rather than the '
+            'default). If multiple -m options are given, their values are '
+            'concatenated as separate paragraphs')
     )
     cmd_unset.add_argument(
-        '-n', "--dry-run",
+        '-n', '--dry-run',
         required=False,
         default=False,
         action='store_true',
-        help='perform a non-interactive trial-run without making any changes'
+        help=(
+            'Perform a non-interactive trial-run without making any changes '
+            'on assets')
+
     )
     cmd_unset.add_argument(
         '-q', '--quiet',
         required=False,
         default=False,
         action='store_true',
-        help='silence output (requires the --yes flag)'
+        help='Silence messages printed to stdout. Requires the --yes flag'
     )
     cmd_unset.add_argument(
         '-y', '--yes',
         required=False,
         default=False,
         action='store_true',
-        help='respond "yes" to any prompts'
+        help='Respond "yes" to any prompts. Is required to use --yes flag'
     )
     cmd_unset.add_argument(
         '-k', '--keys',
@@ -718,7 +762,9 @@ def setup_parser() -> argparse.ArgumentParser:
         metavar="KEYS",
         nargs='+',
         type=str,
-        help='keys to unset in assets; multiple keys can be given (e.g. key key2 key3)'
+        help=(
+            'Specify keys to unset in assets. Multiple keys can be given '
+            '(e.g. key key2 key3)')
     )
     cmd_unset.add_argument(
         '-p', '--path',
@@ -726,7 +772,7 @@ def setup_parser() -> argparse.ArgumentParser:
         metavar="PATH",
         nargs='*',
         type=path,
-        help='assets or directories for which to unset values'
+        help='List asset(s) and/or directory(s) for which to unset values in'
     )
 
     return parser

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -289,7 +289,6 @@ def setup_parser() -> argparse.ArgumentParser:
         '-k', '--keys',
         metavar='KEYS',
         nargs='+',
-        default=[],
         help=(
             'Key value(s) to return. Pseudo-keys (information not stored in '
             'the asset file, e.g. filename) are also available for queries')
@@ -297,7 +296,7 @@ def setup_parser() -> argparse.ArgumentParser:
     cmd_get.add_argument(
         '-p', '--path',
         metavar='PATH',
-        default=['.'],
+        type=path,
         nargs='+',
         help='List asset(s) or directory(s) to search through'
     )
@@ -477,7 +476,6 @@ def setup_parser() -> argparse.ArgumentParser:
         '-t', '--template',
         metavar='TEMPLATE',
         required=False,
-        default=[],
         type=template,
         help='Specify the template to seed the new asset(s)'
     )
@@ -511,7 +509,6 @@ def setup_parser() -> argparse.ArgumentParser:
         '-tsv', '--tsv',
         metavar='TSV',
         required=False,
-        default=None,
         type=path,
         help=(
             'Read information of new assets from a tsv file describing them. '
@@ -649,7 +646,6 @@ def setup_parser() -> argparse.ArgumentParser:
     )
     cmd_set.add_argument(
         '-p', '--path',
-        default=["."],
         metavar='PATH',
         nargs='*',
         type=path,
@@ -768,7 +764,6 @@ def setup_parser() -> argparse.ArgumentParser:
     )
     cmd_unset.add_argument(
         '-p', '--path',
-        default=["."],
         metavar="PATH",
         nargs='*',
         type=path,


### PR DESCRIPTION
We have multiple places in the python code that are used to auto-generate our onyo docs: https://onyo.readthedocs.io/en/latest/index.html

The changes of this PR focus on updating these texts to have better onyo docs; this PR does not contain the discussed move of arg-parser code into the commands (I was unable to do this, and after some hours I decided to focus on the texts for now).

Some of my changes correct text, others remove incorrect (or unneeded) information, sometimes I add something, or I just normalize information, so that we use the same terms along commands.

The relevant main changes of this PR:
- change texts in (sub-)command flags and arguments
- change docstrings in command-functions used to autogenerate docs
- normalize empty/None default values in argparser (works toward #341 
  - this is the only change were I had to update some 3 lines of actual code. We had so many different ways in which we declared that default values are None (actual "None", but also empty arrays, "." and such), that were visible in the command line reference of the docs. Basically, I removed all of those None values, since None is the default anyways.