### PR TITLE
Fix up unset

### DIFF
--- a/onyo/lib/assets.py
+++ b/onyo/lib/assets.py
@@ -261,20 +261,6 @@ def generate_new_asset_names(repo: OnyoRepo,
     return to_move
 
 
-def unset_asset_keys(asset: Path,
-                     keys: list[str],
-                     quiet: bool):
-    # Note: This does not handle pseudo keys - see command_utils:unset
-    contents = get_asset_content(asset)
-    for field in keys:
-        try:
-            del contents[field]
-        except KeyError:
-            if not quiet:
-                log.info(f"Field {field} does not exist in {asset}")
-    write_asset_file(asset, contents)
-
-
 def read_assets_from_tsv(tsv: Path,
                          template_name: Optional[str],
                          key_values: Dict[str, str],


### PR DESCRIPTION
This is a follow up on #382, addressing #370, #377, and #383 for `unset`, which now does not stage modifications in order to roll them back, but only writes to disc if actually needed. Like `set` before via #382, it uses difflib instead of `git-diff` in order to show to-be-applied changes.
