### PR TITLE
TST/DOC: add tests and use new docstring style for class `GitRepo`

### DIFF
--- a/onyo/lib/git.py
+++ b/onyo/lib/git.py
@@ -100,21 +100,24 @@ class GitRepo(object):
             self._files = self._get_files()
         return self._files
 
-    def clear_caches(self, files: bool = True) -> None:
+    def clear_caches(self,
+                     files: bool = True) -> None:
         """
-        Clear caches of the instance of the repository object.
+        Clear caches of the instance of the GitRepo object.
 
-        Paths such as files, assets, and directories are cached, and can become
-        stale when the repository contents are modified. This function clears
-        the caches of the properties.
-
-        By default all caches are cleared, and arguments make it possible to
-        specify which caches which should remain set.
+        Paths to files in git are cached, and can become stale when the
+        repository contents are modified. By default, this function clears the
+        cache of all properties of the GitRepo.
 
         If the repository is exclusively modified via public API functions, the
-        caches of the `Repo` object are consistent. If the repository is
+        caches of the `GitRepo` object are consistent. If the repository is
         modified otherwise, this function clears the caches to ensure that the
         caches do not contain stale information.
+
+        Parameters
+        ----------
+        files: boolean
+            Deactivate the resetting of the file cache.
         """
         if files:
             self._files = None

--- a/onyo/lib/git.py
+++ b/onyo/lib/git.py
@@ -44,7 +44,26 @@ class GitRepo(object):
 
     @staticmethod
     def find_root(path: Path) -> Path:
-        """Returns the git worktree root `path` belongs to"""
+        """
+        Returns the git worktree root `path` belongs to.
+
+        Parameters
+        ----------
+        path: Path
+            The path to identify the git worktree root for. This can be any
+            sub-directory of the repository, or the root directory itself.
+
+        Returns
+        -------
+        Path
+            An absolute path to the root of the git worktree where `.git/` is
+            located.
+
+        Raises
+        ------
+        OnyoInvalidRepoError
+            If `path` is not inside a git repository at all.
+        """
         root = None
         try:
             ret = subprocess.run(["git", "rev-parse", "--show-toplevel"],

--- a/onyo/lib/git.py
+++ b/onyo/lib/git.py
@@ -211,7 +211,12 @@ class GitRepo(object):
 
     def is_clean_worktree(self) -> bool:
         """
-        Check if the working tree for git is clean. Returns True or False.
+        Check if the working tree for git is clean.
+
+        Returns
+        -------
+        Boolean
+            True if the git worktree is clean, otherwise False.
         """
 
         changed = {str(x) for x in self.files_changed}

--- a/onyo/lib/git.py
+++ b/onyo/lib/git.py
@@ -8,6 +8,20 @@ log: logging.Logger = logging.getLogger('onyo.git')
 
 
 class GitRepo(object):
+    """
+    An object to get and set git information, and to call git functions with.
+
+    Attributes
+    ----------
+    root: Path
+        The absolute path to the directory of the git worktree root.
+
+    files: set of Paths
+        A property containing the absolute Path to all files tracked in git.
+        This property is cached and consistent when only the public functions of
+        GitRepo are called. Usage of private or external functions might
+        require a manual reset of the cache with `GitRepo.clear_caches()`.
+    """
 
     def __init__(self,
                  path: Path,
@@ -15,11 +29,18 @@ class GitRepo(object):
         """
         Instantiates a `GitRepo` object with `path` as the root directory.
 
-        If `find_root=True` searches the root of a worktree from `path`.
+        Parameters
+        ----------
+        path: Path
+            An absolute path to the root of a git repository.
+
+        find_root: bool
+            `find_root=True` allows to search the root of a git worktree from a
+            sub-directory, beginning at `path`, instead of requiring the root.
         """
         self.root = GitRepo.find_root(path) if find_root else path.resolve()
 
-        self._files: Union[set[Path], None] = None
+        self._files: Optional[set[Path]] = None
 
     @staticmethod
     def find_root(path: Path) -> Path:

--- a/onyo/lib/git.py
+++ b/onyo/lib/git.py
@@ -312,11 +312,22 @@ class GitRepo(object):
         # call. To always secure the integrity of the caches, we reset them all.
         self.clear_caches()
 
-    def commit(self, *args) -> None:
+    def commit(self,
+               *args) -> None:
         """
-        Perform a ``git commit``. The first message argument is the title; each
-        argument after is a new paragraph. Messages are converted to strings.
-        Lists are printed one item per line, also converted to a string.
+        Perform a ``git commit``.
+
+        Parameters
+        ----------
+        args: tuple
+            Components to compose the commit message from. At least one is
+            required. The first argument is the title; each argument after it is
+            a new paragraph. Lists and sets are printed one item per line.
+
+        Raises
+        ------
+        ValueError
+            If no commit message is provided.
         """
         if not args:
             raise ValueError('at least one commit message is required')

--- a/onyo/lib/git.py
+++ b/onyo/lib/git.py
@@ -141,8 +141,19 @@ class GitRepo(object):
         # subprocess).
         self.clear_caches()
 
-    def restore(self, paths: Union[list[Path], Path]) -> None:
-        """Call git-restore on `paths`.
+    def restore(self,
+                paths: Union[list[Path], Path]) -> None:
+        """
+        Call git-restore on `paths`.
+
+        This does restore files which contain changes, but it does not restore
+        changes that are already staged.
+
+        Parameters
+        ----------
+        paths: List of Paths
+            The absolute Paths to the files or directories which are to be
+            `git restore`d.
         """
         if not paths:
             log.debug("No paths passed to restore. Nothing to do.")

--- a/onyo/lib/git.py
+++ b/onyo/lib/git.py
@@ -279,11 +279,22 @@ class GitRepo(object):
         """
         return '.git' in path.parts or path.name.startswith('.git')
 
-    def add(self, targets: Union[Iterable[Path], Path, str]) -> None:
+    def add(self,
+            targets: Union[Iterable[Path], Path]) -> None:
         """
         Perform ``git add`` to stage files.
 
-        Paths are relative to ``repo.root``.
+        If called on files without changes, it does not raise an error.
+
+        Parameters
+        ----------
+        targets: List of paths
+            Paths are relative to ``repo.root``.
+
+        Raises
+        ------
+        FileNotFoundError
+            If a path in `targets` does not exist.
         """
         if isinstance(targets, (list, set)):
             tgts = [str(x) for x in targets]

--- a/onyo/lib/git.py
+++ b/onyo/lib/git.py
@@ -89,7 +89,8 @@ class GitRepo(object):
     @property
     def files(self) -> set[Path]:
         """
-        A `set` containing the absolute `Paths` of all files of a repository.
+        Get a `set` containing the absolute `Paths` of all files of a
+        repository.
 
         This property is cached, and the cache is consistent with the state of
         the repository when only `Repo`s public functions are used. Use of
@@ -188,7 +189,7 @@ class GitRepo(object):
     @property
     def files_changed(self) -> set[Path]:
         """
-        Returns a `set` containing the absolute `Path`s of all changed files
+        Get a `set` containing the absolute `Path`s of all changed files
         (according to git) of a repository.
         """
         return self._get_files_changed()
@@ -196,7 +197,7 @@ class GitRepo(object):
     @property
     def files_staged(self) -> set[Path]:
         """
-        Returns a `set` containing the absolute `Path`s of all staged files
+        Get a `set` containing the absolute `Path`s of all staged files
         (according to git) of a repository.
         """
         return self._get_files_staged()
@@ -204,7 +205,7 @@ class GitRepo(object):
     @property
     def files_untracked(self) -> set[Path]:
         """
-        Returns a `set` containing the absolute `Path`s of all untracked files
+        Get a `set` containing the absolute `Path`s of all untracked files
         (according to git) of a repository.
         """
         return self._get_files_untracked()

--- a/onyo/lib/git.py
+++ b/onyo/lib/git.py
@@ -262,7 +262,20 @@ class GitRepo(object):
 
     @staticmethod
     def is_git_path(path: Path) -> bool:
-        # .git/*, .gitignore, .gitattributes, .gitmodules, etc.
+        """
+        Identifies if a path is a git file or directory, e.g.
+        `.git/*`, `.gitignore`, `.gitattributes`, `.gitmodules`, etc.
+
+        Parameters
+        ----------
+        path: Path
+            The path to identify if it is a git file or directory, or if not.
+
+        Returns
+        -------
+        boolean
+            True if path is a git file or directory, otherwise False.
+        """
         return '.git' in path.parts or path.name.startswith('.git')
 
     def add(self, targets: Union[Iterable[Path], Path, str]) -> None:

--- a/onyo/lib/git.py
+++ b/onyo/lib/git.py
@@ -255,7 +255,21 @@ class GitRepo(object):
             log.info(ret.strip())
         self.root = target_dir
 
-    def stage_and_commit(self, paths: Union[Iterable[Path], Path], message: str) -> None:
+    def stage_and_commit(self,
+                         paths: Union[Iterable[Path], Path],
+                         message: str) -> None:
+        """
+        Stage and commit changes in git.
+
+        Parameters
+        ----------
+        paths: Paths
+            List of paths to files or directories for which to commit changes to
+            git.
+
+        message: str
+            Specify the git commit message.
+        """
         if isinstance(paths, Path):
             paths = [paths]
         self._git(['add'] + [str(p) for p in paths])

--- a/onyo/lib/git.py
+++ b/onyo/lib/git.py
@@ -124,7 +124,8 @@ class GitRepo(object):
             self._files = None
 
     def restore_staged(self) -> None:
-        """Restore all staged files with uncommitted changes in the repository.
+        """
+        Restore all staged files with uncommitted changes in the repository.
 
         If nothing is staged, returns with no error.
         """

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -271,7 +271,8 @@ class OnyoRepo(object):
     @property
     def asset_paths(self) -> set[Path]:
         """
-        A `set` containing the absolute `Path`s of all assets of a repository.
+        Get a `set` containing the absolute `Path`s of all assets of a
+        repository.
 
         This property is cached, and the cache is consistent with the state of
         the repository when only `OnyoRepo`s public functions are used. Use of

--- a/onyo/lib/tests/test_git.py
+++ b/onyo/lib/tests/test_git.py
@@ -127,3 +127,32 @@ def test_GitRepo_is_clean_worktree(tmp_path: Path) -> None:
     # when commit-ed, the function must return True again
     new_git.commit(test_file, 'commit-ed again!')
     assert new_git.is_clean_worktree()
+
+
+@pytest.mark.repo_files('existing/directory/test_file.txt')
+def test_GitRepo_is_git_path(tmp_path: Path) -> None:
+    """
+    `GitRepo.is_git_path()` needs to identify and return True for `.git/*`,
+    `.gitignore`, `.gitattributes`, `.gitmodules`, etc., and otherwise return
+    False.
+    """
+    subprocess.run(['git', 'init', tmp_path])
+    subprocess.run(['mkdir', '-p', tmp_path / 'existing' / 'directory' /
+                    'test_file.txt'])
+    new_git = GitRepo(tmp_path)
+
+    # Test the examples listed above:
+    assert new_git.is_git_path(new_git.root / ".git")
+    assert new_git.is_git_path(new_git.root / ".git" / "HEAD")
+    assert new_git.is_git_path(new_git.root / ".git" / "doesnotexist")
+    assert new_git.is_git_path(new_git.root / ".gitignore")
+    assert new_git.is_git_path(new_git.root / ".gitdoesnotexist")
+    assert new_git.is_git_path(new_git.root / "existing" / ".gitattributes")
+
+    # Must return False
+    assert not new_git.is_git_path(new_git.root)
+    assert not new_git.is_git_path(new_git.root / ".onyo")
+    assert not new_git.is_git_path(new_git.root / "existing")
+    assert not new_git.is_git_path(new_git.root / "existing" / "git_no_.git")
+    assert not new_git.is_git_path(new_git.root / "existing" / "directory" /
+                                   "test_file.txt")

--- a/onyo/lib/tests/test_git.py
+++ b/onyo/lib/tests/test_git.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+import subprocess
+
+import pytest
+from onyo import OnyoRepo, OnyoInvalidRepoError
+from onyo.lib.git import GitRepo
+
+
+def test_GitRepo_instantiation(tmp_path: Path) -> None:
+    """
+    The `GitRepo` class must instantiate and set the root correctly for paths
+    to existing repositories.
+    """
+    # initialize the temp_path as an git repository
+    subprocess.run(['git', 'init', tmp_path])
+
+    # test that `GitRepo()` instantiates (and sets the root to) the object
+    # correctly
+    new_repo = GitRepo(tmp_path)
+    assert new_repo.root.samefile(tmp_path)
+
+    # create a sub-directory to test the find-root behavior
+    subprocess.run(['mkdir', '-p', tmp_path / "sub-directory"])
+
+    # with `find_root=False` it excepts other existing paths e.g. sub-dirs
+    new_repo = GitRepo(tmp_path / "sub-directory", find_root=False)
+    assert new_repo.root.samefile(tmp_path / "sub-directory")
+
+    # with `find_root=True` it must find the root and set it appropriately
+    new_repo = GitRepo(tmp_path / "sub-directory", find_root=True)
+    assert new_repo.root.samefile(tmp_path)
+
+
+@pytest.mark.repo_dirs('existing/directory')
+def test_GitRepo_instantiation_find_root(repo: OnyoRepo) -> None:
+    """
+    The GitRepo class must instantiate correctly with paths to sub-directories
+    in a repository when `find_root=True`.
+    """
+    new_repo = GitRepo(repo.git.root / 'existing/directory', find_root=True)
+    assert new_repo.root.samefile(repo.git.root)
+    assert (new_repo.root / '.git').exists()

--- a/onyo/lib/tests/test_git.py
+++ b/onyo/lib/tests/test_git.py
@@ -80,6 +80,7 @@ def test_GitRepo_restore_staged(tmp_path: Path) -> None:
 
     # test that no error is raised, when called on a clean repository
     new_git.restore_staged()
+    assert new_git.is_clean_worktree()
 
     # have an untracked, a changed and a staged file
     untracked_file = new_git.root / 'asset_for_test.1'
@@ -122,6 +123,7 @@ def test_GitRepo_restore(tmp_path: Path) -> None:
 
     # Test that no error is raised, when called on a clean file
     new_git.restore(test_file)
+    assert new_git.is_clean_worktree()
 
     # Test that calling `GitRepo.restore()` on a file with already staged
     # changes does not effect the file
@@ -266,6 +268,7 @@ def test_GitRepo_add(tmp_path: Path) -> None:
     # test that GitRepo.add() does not raise an error on files that exist and
     # have no changes
     new_git.add(existing_file)
+    assert new_git.is_clean_worktree()
 
     # test that GitRepo.add() raises a FileNotFoundError for `new_file`, an
     # absolute path to a file that do not yet exist

--- a/onyo/lib/tests/test_git.py
+++ b/onyo/lib/tests/test_git.py
@@ -63,3 +63,30 @@ def test_GitRepo_find_root(tmp_path: Path) -> None:
     # a non-existing sub-path under an existing root
     with pytest.raises(OnyoInvalidRepoError):
         GitRepo.find_root(tmp_path / 'non-existing/directory')
+
+
+def test_GitRepo_clear_caches(tmp_path: Path) -> None:
+    """
+    The function `GitRepo.clear_caches()` must allow to empty the cache of the
+    GitRepo, so that an invalid cache can be re-loaded by a new call of the
+    property.
+    """
+    # initialize and instantiate `GitRepo`, and create+add a file so it is
+    # cached in the new_git.files
+    subprocess.run(['git', 'init', tmp_path])
+    new_git = GitRepo(tmp_path)
+    file = new_git.root / 'asset_for_test.0'
+    file.touch()
+    new_git.stage_and_commit(file, message="Create file for test")
+    assert file in new_git.files
+
+    # delete the file (with a non-onyo function to invalid the cache) and then
+    # verify that the file stays in the cache after the deletion
+    Path.unlink(file)
+    new_git.stage_and_commit(file, message="Delete file for test")
+    assert file in new_git.files
+    assert not file.exists()
+
+    # test GitRepo.clear_caches() fixes the cache
+    new_git.clear_caches(files=True)
+    assert file not in new_git.files

--- a/onyo/lib/tests/test_git.py
+++ b/onyo/lib/tests/test_git.py
@@ -230,3 +230,28 @@ def test_GitRepo_commit(tmp_path: Path) -> None:
     # properties GitRepo.files_changed or GitRepo.files_staged anymore
     assert test_file not in new_git.files_changed
     assert test_file not in new_git.files_staged
+
+
+def test_GitRepo_stage_and_commit(tmp_path: Path) -> None:
+    """
+    `GitRepo.stage_and_commit()` must allow to add+commit changed files.
+
+    This test follows the scheme of `test_GitRepo_add()`.
+    """
+    subprocess.run(['git', 'init', tmp_path])
+    new_git = GitRepo(tmp_path)
+    test_file = new_git.root / 'test_file.txt'
+
+    # add a file
+    test_file.open('w').write('Test: content')
+    assert test_file in new_git.files_untracked
+
+    # add+commit a changed file
+    new_git.stage_and_commit(test_file, "Test commit message")
+    assert test_file in new_git.files
+
+    # after files are `GitRepo.stage_and_commit()`ed they should not be cached
+    # in the properties GitRepo.files_changed or GitRepo.files_staged
+    assert test_file not in new_git.files_untracked
+    assert test_file not in new_git.files_changed
+    assert test_file not in new_git.files_staged


### PR DESCRIPTION
This PR adds tests and docstrings for the `GitRepo` class, in parallel to the changes for `OnyoRepo` during #394.

Changes:
- adds tests to some functions of `GitRepo`
- adds or normalizes docstrings (based on discussion in #339)