### PR TITLE
onyo: define arguments in dedicated locations, read them generically in main.py

### DIFF
--- a/demo/generate_demo_repo.sh
+++ b/demo/generate_demo_repo.sh
@@ -87,83 +87,83 @@ cd "$DEMO_DIR"
 onyo init
 
 # setup basic directory structure
-onyo mkdir --yes warehouse
-onyo mkdir --yes recycling
-onyo mkdir --yes repair
+onyo --yes mkdir warehouse
+onyo --yes mkdir recycling
+onyo --yes mkdir repair
 
 # import some existing hardware
 # TSV files can be very useful when adding large amounts of assets
-onyo new -y --tsv "${SCRIPT_DIR}/inventory.tsv"
+onyo -y new --tsv "${SCRIPT_DIR}/inventory.tsv"
 
 # add a set of newly bought assets
-onyo new -y --keys RAM=8GB display=13.3 --path warehouse/laptop_apple_macbook.9r32he
-onyo new -y --keys RAM=8GB display=13.3 --path warehouse/laptop_apple_macbook.9r5qlk
-onyo new -y --keys RAM=8GB display=14.6 --path warehouse/laptop_lenovo_thinkpad.owh8e2
-onyo new -y --keys RAM=8GB display=14.6 --path warehouse/laptop_lenovo_thinkpad.iu7h6d
-onyo new -y --keys RAM=8GB display=12.4 touchscreen=yes --path warehouse/laptop_microsoft_surface.oq782j
+onyo -y new --keys RAM=8GB display=13.3 --path warehouse/laptop_apple_macbook.9r32he
+onyo -y new --keys RAM=8GB display=13.3 --path warehouse/laptop_apple_macbook.9r5qlk
+onyo -y new --keys RAM=8GB display=14.6 --path warehouse/laptop_lenovo_thinkpad.owh8e2
+onyo -y new --keys RAM=8GB display=14.6 --path warehouse/laptop_lenovo_thinkpad.iu7h6d
+onyo -y new --keys RAM=8GB display=12.4 touchscreen=yes --path warehouse/laptop_microsoft_surface.oq782j
 # NOTE: headphones normally do not have a serial number, and thus a faux serial
 # would be generated (e.g. headphones_JBL_pro.faux). However, for the sake of a
 # reproducible demo, explicit serials are specified.
-onyo new -y --path warehouse/headphones_apple_airpods.7h8f04
-onyo new -y --path warehouse/headphones_JBL_pro.325gtt
-onyo new -y --path warehouse/headphones_JBL_pro.e98t2p
-onyo new -y --path warehouse/headphones_JBL_pro.ph9527
+onyo -y new --path warehouse/headphones_apple_airpods.7h8f04
+onyo -y new --path warehouse/headphones_JBL_pro.325gtt
+onyo -y new --path warehouse/headphones_JBL_pro.e98t2p
+onyo -y new --path warehouse/headphones_JBL_pro.ph9527
 
 # one of the headphones was added by accident; remove it.
-onyo rm -y warehouse/headphones_JBL_pro.ph9527
+onyo -y rm warehouse/headphones_JBL_pro.ph9527
 
 # a few new users join
-onyo mkdir --yes "ethics/Max Mustermann" "ethics/Achilles Book"
+onyo --yes mkdir "ethics/Max Mustermann" "ethics/Achilles Book"
 
 # assign equipment to Max and Achilles
-onyo mv -y warehouse/laptop_apple_macbook.9r32he "ethics/Max Mustermann"
-onyo mv -y warehouse/headphones_apple_airpods.7h8f04 "ethics/Max Mustermann"
+onyo -y mv warehouse/laptop_apple_macbook.9r32he "ethics/Max Mustermann"
+onyo -y mv warehouse/headphones_apple_airpods.7h8f04 "ethics/Max Mustermann"
 
-onyo mv -y warehouse/laptop_lenovo_thinkpad.owh8e2 "ethics/Achilles Book"
-onyo mv -y warehouse/headphones_JBL_pro.e98t2p "ethics/Achilles Book"
+onyo -y mv warehouse/laptop_lenovo_thinkpad.owh8e2 "ethics/Achilles Book"
+onyo -y mv warehouse/headphones_JBL_pro.e98t2p "ethics/Achilles Book"
 
 # Achilles' laptop broke; set it aside to repair and give him a new one
-onyo mv -y "ethics/Achilles Book/laptop_lenovo_thinkpad.owh8e2" repair
-onyo mv -y warehouse/laptop_microsoft_surface.oq782j "ethics/Achilles Book"
+onyo -y mv "ethics/Achilles Book/laptop_lenovo_thinkpad.owh8e2" repair
+onyo -y mv warehouse/laptop_microsoft_surface.oq782j "ethics/Achilles Book"
 
 # specify number of USB type A ports on all laptops
-onyo set -y --keys USB_A=2 --filter type=laptop
+onyo -y set --keys USB_A=2 --filter type=laptop
 
 # specify the number of USB ports (type A and C) on MacBooks
-onyo set -y --keys USB_A=2 USB_C=1 --filter model=macbook
+onyo -y set --keys USB_A=2 USB_C=1 --filter model=macbook
 
 # add three newly purchased laptops; shell brace-expansion can be very useful
-onyo new -y --keys RAM=8GB display=13.3 USB_A=2 USB_C=1 \
+onyo -y new --keys RAM=8GB display=13.3 USB_A=2 USB_C=1 \
     --path warehouse/laptop_apple_macbook.{uef82b3,9il2b4,73b2cn}
 
 # Bingo Bob was hired; and new hardware was purchased for him
-onyo mkdir --yes "accounting/Bingo Bob"
-onyo new -y --keys display=22.0 --path warehouse/monitor_dell_PH123.86JZho
-onyo new -y --keys RAM=8GB display=13.3 USB_A=2 --path warehouse/laptop_apple_macbook.oiw629
-onyo new -y --path warehouse/headphones_apple_airpods.uzl8e1
-onyo mv -y warehouse/monitor_dell_PH123.86JZho warehouse/laptop_apple_macbook.oiw629 warehouse/headphones_apple_airpods.uzl8e1 "accounting/Bingo Bob"
+onyo --yes mkdir "accounting/Bingo Bob"
+onyo -y new --keys display=22.0 --path warehouse/monitor_dell_PH123.86JZho
+onyo -y new --keys RAM=8GB display=13.3 USB_A=2 --path warehouse/laptop_apple_macbook.oiw629
+onyo -y new --path warehouse/headphones_apple_airpods.uzl8e1
+onyo -y mv warehouse/monitor_dell_PH123.86JZho warehouse/laptop_apple_macbook.oiw629 warehouse/headphones_apple_airpods.uzl8e1 "accounting/Bingo Bob"
 
 # the broken laptop has been repaired (bad RAM, which has also been increased)
-onyo set -y --keys RAM=32GB --path repair/laptop_lenovo_thinkpad.owh8e2
-onyo mv -y repair/laptop_lenovo_thinkpad.owh8e2 warehouse
+onyo -y set --keys RAM=32GB --path repair/laptop_lenovo_thinkpad.owh8e2
+onyo -y mv repair/laptop_lenovo_thinkpad.owh8e2 warehouse
 
 # Max's laptop is old; retire it and replace with a new one
-onyo mv -y ethics/Max\ Mustermann/laptop_apple_macbook.9r32he recycling
-onyo mv -y warehouse/laptop_apple_macbook.uef82b3 ethics/Max\ Mustermann/
+onyo -y mv ethics/Max\ Mustermann/laptop_apple_macbook.9r32he recycling
+onyo -y mv warehouse/laptop_apple_macbook.uef82b3 ethics/Max\ Mustermann/
 
 # a new group is created ("management"); transfer people to their new group
-onyo mkdir --yes "management"
-onyo mv -y "ethics/Max Mustermann" management
-onyo mkdir --yes "management/Alice Wonder"
-onyo new -y --keys RAM=8GB display=13.3 USB_A=2 --path "management/Alice Wonder/laptop_apple_macbook.83hd0"
+onyo -y mkdir "management"
+onyo -y mv "ethics/Max Mustermann" management
+onyo -y mkdir "management/Alice Wonder"
+onyo -y new --keys RAM=8GB display=13.3 USB_A=2 --path "management/Alice Wonder/laptop_apple_macbook.83hd0"
 
 # Theo joins; assign them a laptop from the warehouse
-onyo mkdir --yes "ethics/Theo Turtle"
-onyo mv -y warehouse/laptop_lenovo_thinkpad.owh8e2 "ethics/Theo Turtle"
+onyo -y mkdir "ethics/Theo Turtle"
+onyo -y mv warehouse/laptop_lenovo_thinkpad.owh8e2 "ethics/Theo Turtle"
 
 # Max retired; return all of his hardware and delete his directory
-onyo mv -y management/Max\ Mustermann/* warehouse
-onyo rm -y "management/Max Mustermann"
+onyo -y mv management/Max\ Mustermann/* warehouse
+onyo -y rm "management/Max Mustermann"
 
 # test the validity of the inventory's state
 onyo fsck

--- a/onyo/__init__.py
+++ b/onyo/__init__.py
@@ -3,7 +3,7 @@ from onyo._version import __version__
 from onyo.lib import (
     Filter, OnyoRepo, OnyoInvalidRepoError,
     OnyoProtectedPathError, OnyoInvalidFilterError)
-
+from onyo.onyo_arguments import args_onyo
 
 logging.basicConfig(level=logging.ERROR)  # external logging level
 log: logging.Logger = logging.getLogger('onyo')  # internal logging level
@@ -13,6 +13,7 @@ __all__ = [
     'log',
     '__version__',
     'Filter',
+    'args_onyo',
     'OnyoInvalidRepoError',
     'OnyoProtectedPathError',
     'OnyoInvalidFilterError',

--- a/onyo/argparse_helpers.py
+++ b/onyo/argparse_helpers.py
@@ -1,0 +1,84 @@
+import argparse
+from typing import Optional, Sequence, Union
+
+
+class StoreKeyValuePairs(argparse.Action):
+    def __init__(self, option_strings: Sequence[str], dest: str,
+                 nargs: Union[None, int, str] = None, **kwargs) -> None:
+        self._nargs = nargs
+        super().__init__(option_strings, dest, nargs=nargs, **kwargs)
+
+    def __call__(self, parser: argparse.ArgumentParser,
+                 namespace: argparse.Namespace, key_values: list[str],
+                 option_string: Optional[str] = None) -> None:
+        results = {}
+        for pair in key_values:
+            k, v = pair.split('=', maxsplit=1)
+            try:
+                v = int(v)
+            except ValueError:
+                try:
+                    float(v)
+                except ValueError:
+                    pass
+            results[k] = v
+        setattr(namespace, self.dest, results)
+
+
+def parse_key_values(string):
+    """
+    Convert a string of key-value pairs to a dictionary.
+
+    The shell interprets the key-value string before it is passed to argparse.
+    As a result, no quotes are passed through, but the chunking follows what the
+    quoting declared.
+
+    Because of the lack of quoting, this function cannot handle a comma in
+    either the key or value.
+    """
+    results = {k: v for k, v in (pair.split('=') for pair in string.split(','))}
+    for k, v in results.items():
+        try:
+            results.update({k: int(v)})
+        except ValueError:
+            try:
+                results.update({k: float(v)})
+            except ValueError:
+                pass
+
+    return results
+
+
+def directory(string: str) -> str:
+    """
+    A no-op type-check for ArgParse. Used to hint for shell tab-completion.
+    """
+    return string
+
+
+def file(string: str) -> str:
+    """
+    A no-op type-check for ArgParse. Used to hint for shell tab-completion.
+    """
+    return string
+
+
+def git_config(string: str) -> str:
+    """
+    A no-op type-check for ArgParse. Used to hint for shell tab-completion.
+    """
+    return string
+
+
+def path(string: str) -> str:
+    """
+    A no-op type-check for ArgParse. Used to hint for shell tab-completion.
+    """
+    return string
+
+
+def template(string: str) -> str:
+    """
+    A no-op type-check for ArgParse. Used to hint for shell tab-completion.
+    """
+    return string

--- a/onyo/commands/cat.py
+++ b/onyo/commands/cat.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 from onyo.lib.onyo import OnyoRepo
 from onyo.lib.commands import cat as cat_cmd, fsck
-from onyo.shared_arguments import file
+from onyo.argparse_helpers import file
 
 if TYPE_CHECKING:
     import argparse
@@ -13,12 +13,13 @@ if TYPE_CHECKING:
 logging.basicConfig()
 log: logging.Logger = logging.getLogger('onyo')
 
-arg_asset = dict(
-    dest='asset',
-    metavar='ASSET',
-    nargs='+',
-    type=file,
-    help='Paths of asset(s) to print')
+args_cat = {
+    'asset': dict(
+        metavar='ASSET',
+        nargs='+',
+        type=file,
+        help='Paths of asset(s) to print'),
+}
 
 
 def cat(args: argparse.Namespace) -> None:

--- a/onyo/commands/config.py
+++ b/onyo/commands/config.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 from onyo import OnyoRepo
 from onyo.lib.commands import config as config_cmd, fsck
-from onyo.shared_arguments import git_config
+from onyo.argparse_helpers import git_config
 
 if TYPE_CHECKING:
     import argparse
@@ -13,12 +13,13 @@ if TYPE_CHECKING:
 logging.basicConfig()
 log: logging.Logger = logging.getLogger('onyo')
 
-arg_git_config_args = dict(
-    dest='git_config_args',
-    metavar='ARGS',
-    nargs='+',
-    type=git_config,
-    help='Config options to set in .onyo/config')
+args_config = {
+    'git_config_args': dict(
+        metavar='ARGS',
+        nargs='+',
+        type=git_config,
+        help='Config options to set in .onyo/config'),
+}
 
 
 def config(args: argparse.Namespace) -> None:

--- a/onyo/commands/edit.py
+++ b/onyo/commands/edit.py
@@ -5,7 +5,8 @@ from typing import TYPE_CHECKING
 
 from onyo.lib.commands import edit as edit_cmd
 from onyo.lib.onyo import OnyoRepo
-from onyo.shared_arguments import file
+from onyo.argparse_helpers import file
+from onyo.shared_arguments import shared_arg_message
 
 if TYPE_CHECKING:
     import argparse
@@ -13,12 +14,15 @@ if TYPE_CHECKING:
 logging.basicConfig()
 log: logging.Logger = logging.getLogger('onyo')
 
-arg_asset = dict(
-    dest='asset',
-    metavar='ASSET',
-    nargs='+',
-    type=file,
-    help='Paths of asset(s) to edit')
+args_edit = {
+    'asset': dict(
+        metavar='ASSET',
+        nargs='+',
+        type=file,
+        help='Paths of asset(s) to edit'),
+
+    'message': shared_arg_message,
+}
 
 
 def edit(args: argparse.Namespace) -> None:

--- a/onyo/commands/get.py
+++ b/onyo/commands/get.py
@@ -5,7 +5,8 @@ import logging
 
 from onyo import OnyoRepo
 from onyo.lib.commands import fsck, get as get_cmd
-from onyo.shared_arguments import path
+from onyo.argparse_helpers import path
+from onyo.shared_arguments import shared_arg_depth, shared_arg_filter
 
 if TYPE_CHECKING:
     import argparse
@@ -13,42 +14,44 @@ if TYPE_CHECKING:
 logging.basicConfig()
 log = logging.getLogger('onyo')
 
-arg_machine_readable = dict(
-    args=('-H', '--machine-readable'),
-    dest='machine_readable',
-    action='store_true',
-    help=(
-        'Display asset(s) separated by new lines, and keys by tabs instead '
-        'of printing a formatted table'))
+args_get = {
+    'machine_readable': dict(
+        args=('-H', '--machine-readable'),
+        action='store_true',
+        help=(
+            'Display asset(s) separated by new lines, and keys by tabs instead '
+            'of printing a formatted table')),
 
-arg_keys = dict(
-    args=('-k', '--keys'),
-    metavar='KEYS',
-    nargs='+',
-    help=(
-        'Key value(s) to return. Pseudo-keys (information not stored in '
-        'the asset file, e.g. filename) are also available for queries'))
+    'keys': dict(
+        args=('-k', '--keys'),
+        metavar='KEYS',
+        nargs='+',
+        help=(
+            'Key value(s) to return. Pseudo-keys (information not stored in '
+            'the asset file, e.g. filename) are also available for queries')),
 
-arg_path = dict(
-    args=('-p', '--path'),
-    metavar='PATH',
-    type=path,
-    nargs='+',
-    help='Asset(s) or directory(s) to search through')
+    'path': dict(
+        args=('-p', '--path'),
+        metavar='PATH',
+        type=path,
+        nargs='+',
+        help='Asset(s) or directory(s) to search through'),
 
-arg_sort_ascending = dict(
-    args=('-s', '--sort-ascending'),
-    dest='sort_ascending',
-    action='store_true',
-    default=False,
-    help='Sort output in ascending order (excludes --sort-descending)')
+    'sort_ascending': dict(
+        args=('-s', '--sort-ascending'),
+        action='store_true',
+        default=False,
+        help='Sort output in ascending order (excludes --sort-descending)'),
 
-arg_sort_descending = dict(
-    args=('-S', '-sort-descending'),
-    dest='sort_descending',
-    action='store_true',
-    default=False,
-    help='Sort output in descending order (excludes --sort-ascending)')
+    'sort_descending': dict(
+        args=('-S', '-sort-descending'),
+        action='store_true',
+        default=False,
+        help='Sort output in descending order (excludes --sort-ascending)'),
+
+    'depth': shared_arg_depth,
+    'filter': shared_arg_filter
+}
 
 
 def get(args: argparse.Namespace) -> None:

--- a/onyo/commands/history.py
+++ b/onyo/commands/history.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 from onyo import OnyoRepo
 from onyo.lib.command_utils import get_history_cmd
 from onyo.lib.commands import fsck
-from onyo.shared_arguments import path
+from onyo.argparse_helpers import path
 
 if TYPE_CHECKING:
     import argparse
@@ -17,23 +17,23 @@ if TYPE_CHECKING:
 logging.basicConfig()
 log: logging.Logger = logging.getLogger('onyo')
 
-arg_interactive = dict(
-    args=('-I', '--non-interactive'),
-    dest='interactive',
-    required=False,
-    default=True,
-    action='store_false',
-    help=(
-        "Use the interactive history tool (specified in '.onyo/config' "
-        "under 'onyo.history.interactive') to display the history of the "
-        "repository, an asset or a directory"))
+args_history = {
+    'interactive': dict(
+        args=('-I', '--non-interactive'),
+        required=False,
+        default=True,
+        action='store_false',
+        help=(
+            "Use the interactive history tool (specified in '.onyo/config' "
+            "under 'onyo.history.interactive') to display the history of the "
+            "repository, an asset or a directory")),
 
-arg_path = dict(
-    dest='path',
-    metavar='PATH',
-    nargs='?',
-    type=path,
-    help='Specify an asset or a directory to show the history of')
+    'path': dict(
+        metavar='PATH',
+        nargs='?',
+        type=path,
+        help='Specify an asset or a directory to show the history of'),
+}
 
 
 def history(args: argparse.Namespace) -> None:

--- a/onyo/commands/init.py
+++ b/onyo/commands/init.py
@@ -3,17 +3,18 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from onyo.lib.onyo import OnyoRepo
-from onyo.shared_arguments import directory
+from onyo.argparse_helpers import directory
 
 if TYPE_CHECKING:
     import argparse
 
-arg_directory = dict(
-    dest='directory',
-    metavar='DIR',
-    nargs='?',
-    type=directory,
-    help='Initialize DIR as an onyo repository')
+args_init = {
+    'directory': dict(
+        metavar='DIR',
+        nargs='?',
+        type=directory,
+        help='Initialize DIR as an onyo repository')
+}
 
 
 def init(args: argparse.Namespace) -> None:

--- a/onyo/commands/mkdir.py
+++ b/onyo/commands/mkdir.py
@@ -4,17 +4,21 @@ from typing import TYPE_CHECKING
 
 from onyo import OnyoRepo
 from onyo.lib.commands import fsck, mkdir as mkdir_cmd
-from onyo.shared_arguments import directory
+from onyo.argparse_helpers import directory
+from onyo.shared_arguments import shared_arg_message
 
 if TYPE_CHECKING:
     import argparse
 
-arg_directory = dict(
-    dest='directory',
-    metavar='DIR',
-    nargs='+',
-    type=directory,
-    help='Directory(s) to create')
+args_mkdir = {
+    'directory': dict(
+        metavar='DIR',
+        nargs='+',
+        type=directory,
+        help='Directory(s) to create'),
+
+    'message': shared_arg_message,
+}
 
 
 def mkdir(args: argparse.Namespace) -> None:

--- a/onyo/commands/mv.py
+++ b/onyo/commands/mv.py
@@ -4,23 +4,26 @@ from typing import TYPE_CHECKING
 
 from onyo import OnyoRepo
 from onyo.lib.commands import fsck, mv as mv_cmd
-from onyo.shared_arguments import path
+from onyo.argparse_helpers import path
+from onyo.shared_arguments import shared_arg_message
 
 if TYPE_CHECKING:
     import argparse
 
-arg_source = dict(
-    dest='source',
-    metavar='SOURCE',
-    nargs='+',
-    type=path,
-    help='Asset(s) and/or directory(s) to move into DEST')
+args_mv = {
+    'source': dict(
+        metavar='SOURCE',
+        nargs='+',
+        type=path,
+        help='Asset(s) and/or directory(s) to move into DEST'),
 
-arg_destination = dict(
-    dest='destination',
-    metavar='DEST',
-    type=path,
-    help='Destination to move SOURCE(s) into')
+    'destination': dict(
+        metavar='DEST',
+        type=path,
+        help='Destination to move SOURCE(s) into'),
+
+    'message': shared_arg_message,
+}
 
 
 def mv(args: argparse.Namespace) -> None:

--- a/onyo/commands/new.py
+++ b/onyo/commands/new.py
@@ -5,7 +5,9 @@ from typing import TYPE_CHECKING
 
 from onyo import OnyoRepo
 from onyo.lib.commands import fsck, new as new_cmd
-from onyo.shared_arguments import template, path
+from onyo.argparse_helpers import template, path, StoreKeyValuePairs
+from onyo.shared_arguments import shared_arg_message
+
 
 if TYPE_CHECKING:
     import argparse
@@ -13,43 +15,49 @@ if TYPE_CHECKING:
 logging.basicConfig()
 log: logging.Logger = logging.getLogger('onyo')
 
-arg_template = dict(
-    args=('-t', '--template'),
-    metavar='TEMPLATE',
-    required=False,
-    type=template,
-    help='Name of the template to seed the new asset(s)')
+args_new = {
 
-arg_edit = dict(
-    args=('-e', '--edit'),
-    required=False,
-    default=False,
-    action='store_true',
-    help='Open new assets in editor before creation')
+    'template': dict(
+        args=('-t', '--template'),
+        metavar='TEMPLATE',
+        required=False,
+        type=template,
+        help='Name of the template to seed the new asset(s)'),
 
-arg_keys = dict(
-    args=('-k', '--keys'),
-    required=False,
-    metavar="KEYS",
-    nargs='+',
-    help=(
-        'Key-value pairs to set in the new asset(s). Multiple pairs can be '
-        'specified (e.g. key=value key2=value2)'))
+    'edit': dict(
+        args=('-e', '--edit'),
+        required=False,
+        default=False,
+        action='store_true',
+        help='Open new assets in editor before creation'),
 
-arg_path = dict(
-    args=('-p', '--path'),
-    metavar='ASSET',
-    type=path,
-    nargs='*',
-    help='Path(s) of the new asset(s). Excludes usage of --tsv')
+    'keys': dict(
+        args=('-k', '--keys'),
+        required=False,
+        action=StoreKeyValuePairs,
+        metavar="KEYS",
+        nargs='+',
+        help=(
+            'Key-value pairs to set in the new asset(s). Multiple pairs can be '
+            'specified (e.g. key=value key2=value2)')),
 
-arg_tsv = dict(
-    args=('-tsv', '--tsv'),
-    metavar='TSV',
-    required=False,
-    type=path,
-    help=('Path to a tsv file describing the new asset. Excludes the usage of '
-          '--path'))
+    'path': dict(
+        args=('-p', '--path'),
+        metavar='ASSET',
+        type=path,
+        nargs='*',
+        help='Path(s) of the new asset(s). Excludes usage of --tsv'),
+
+    'tsv': dict(
+        args=('-tsv', '--tsv'),
+        metavar='TSV',
+        required=False,
+        type=path,
+        help=('Path to a tsv file describing the new asset. Excludes the usage '
+              'of --path')),
+
+    'message': shared_arg_message,
+}
 
 
 def new(args: argparse.Namespace) -> None:

--- a/onyo/commands/rm.py
+++ b/onyo/commands/rm.py
@@ -4,17 +4,21 @@ from typing import TYPE_CHECKING
 
 from onyo import OnyoRepo
 from onyo.lib.commands import fsck, rm as rm_cmd
-from onyo.shared_arguments import path
+from onyo.argparse_helpers import path
+from onyo.shared_arguments import shared_arg_message
 
 if TYPE_CHECKING:
     import argparse
 
-arg_path = dict(
-    dest='path',
-    metavar='PATH',
-    nargs='+',
-    type=path,
-    help='Asset(s) and/or directory(s) to delete')
+args_rm = {
+    'path': dict(
+        metavar='PATH',
+        nargs='+',
+        type=path,
+        help='Asset(s) and/or directory(s) to delete'),
+
+    'message': shared_arg_message,
+}
 
 
 def rm(args: argparse.Namespace) -> None:

--- a/onyo/commands/set.py
+++ b/onyo/commands/set.py
@@ -5,7 +5,13 @@ from typing import TYPE_CHECKING
 
 from onyo import OnyoRepo
 from onyo.lib.commands import fsck, set_ as set_cmd
-from onyo.shared_arguments import path
+from onyo.argparse_helpers import path, StoreKeyValuePairs
+from onyo.shared_arguments import (
+    shared_arg_depth,
+    shared_arg_dry_run,
+    shared_arg_filter,
+    shared_arg_message,
+)
 
 if TYPE_CHECKING:
     import argparse
@@ -13,30 +19,38 @@ if TYPE_CHECKING:
 logging.basicConfig()
 log: logging.Logger = logging.getLogger('onyo')
 
-arg_rename = dict(
-    args=('-r', '--rename'),
-    required=False,
-    default=False,
-    action='store_true',
-    help=(
-        'Permit assigning values to pseudo-keys that would result in the '
-        'asset(s) being renamed.'))
+args_set = {
+    'rename': dict(
+        args=('-r', '--rename'),
+        required=False,
+        default=False,
+        action='store_true',
+        help=(
+            'Permit assigning values to pseudo-keys that would result in the '
+            'asset(s) being renamed.')),
 
-arg_keys = dict(
-    args=('-k', '--keys'),
-    required=True,
-    metavar="KEYS",
-    nargs='+',
-    help=(
-        'Specify key-value pairs to set in asset(s). Multiple pairs can '
-        'be specified (e.g. key=value key2=value2)'))
+    'keys': dict(
+        args=('-k', '--keys'),
+        required=True,
+        action=StoreKeyValuePairs,
+        metavar="KEYS",
+        nargs='+',
+        help=(
+            'Specify key-value pairs to set in asset(s). Multiple pairs can '
+            'be specified (e.g. key=value key2=value2)')),
 
-arg_path = dict(
-    args=('-p', '--path'),
-    metavar='PATH',
-    nargs='*',
-    type=path,
-    help='Asset(s) and/or directorie(s) to set KEY=VALUE in')
+    'path': dict(
+        args=('-p', '--path'),
+        metavar='PATH',
+        nargs='*',
+        type=path,
+        help='Asset(s) and/or directorie(s) to set KEY=VALUE in'),
+
+    'depth': shared_arg_depth,
+    'dry_run': shared_arg_dry_run,
+    'filter': shared_arg_filter,
+    'message': shared_arg_message,
+}
 
 
 def set(args: argparse.Namespace) -> None:

--- a/onyo/commands/shell_completion.py
+++ b/onyo/commands/shell_completion.py
@@ -2,13 +2,15 @@ import argparse
 from typing import Optional
 
 
-arg_shell = dict(
-    args=('-s', '--shell'),
-    metavar='SHELL',
-    required=False,
-    default='zsh',
-    choices=['zsh'],
-    help='Specify the shell for which to generate tab completion for')
+args_shell_completion = {
+    'shell': dict(
+        args=('-s', '--shell'),
+        metavar='SHELL',
+        required=False,
+        default='zsh',
+        choices=['zsh'],
+        help='Specify the shell for which to generate tab completion for')
+}
 
 
 class TabCompletion:

--- a/onyo/commands/tests/test_edit.py
+++ b/onyo/commands/tests/test_edit.py
@@ -86,7 +86,7 @@ def test_edit_single_asset(repo: OnyoRepo, asset: str) -> None:
     os.environ['EDITOR'] = "printf 'key: single_asset' >"
 
     # test `onyo edit` on a single asset
-    ret = subprocess.run(['onyo', 'edit', '--yes', asset],
+    ret = subprocess.run(['onyo', '--yes', 'edit', asset],
                          capture_output=True, text=True)
     assert ret.returncode == 0
     assert "+key: single_asset" in ret.stdout
@@ -107,7 +107,7 @@ def test_edit_multiple_assets(repo: OnyoRepo) -> None:
     repo_assets = repo.asset_paths
 
     # test edit for a list of assets all at once
-    ret = subprocess.run(['onyo', 'edit', '--yes', *repo_assets],
+    ret = subprocess.run(['onyo', '--yes', 'edit', *repo_assets],
                          capture_output=True, text=True)
     assert ret.returncode == 0
     assert ret.stdout.count("+key: multiple_assets") == len(repo_assets)
@@ -149,7 +149,7 @@ def test_edit_message_flag(repo: OnyoRepo, asset: str) -> None:
     msg = "I am here to test the --message flag with spe\"cial\\char\'acteஞrs!"
 
     # test `onyo edit --message msg`
-    ret = subprocess.run(['onyo', 'edit', '--yes', '--message', msg, asset],
+    ret = subprocess.run(['onyo', '--yes', 'edit', '--message', msg, asset],
                          capture_output=True, text=True)
     assert ret.returncode == 0
     assert not ret.stderr
@@ -169,7 +169,7 @@ def test_quiet_flag(repo: OnyoRepo) -> None:
     os.environ['EDITOR'] = "printf 'key: quiet' >"
 
     # edit a list of assets all at once
-    ret = subprocess.run(['onyo', 'edit', '--yes', '--quiet', *assets],
+    ret = subprocess.run(['onyo', '--yes', '--quiet', 'edit', *assets],
                          capture_output=True, text=True)
     assert ret.returncode == 0
 
@@ -191,7 +191,7 @@ def test_quiet_errors_without_yes_flag(repo: OnyoRepo) -> None:
     os.environ['EDITOR'] = "printf 'key: quiet' >"
 
     # edit a list of assets all at once
-    ret = subprocess.run(['onyo', 'edit', '--quiet', *assets],
+    ret = subprocess.run(['onyo', '--quiet', 'edit', *assets],
                          capture_output=True, text=True)
 
     # verify correct error.
@@ -325,7 +325,7 @@ def test_edit_with_dot_dot(repo: OnyoRepo, asset: str) -> None:
     # Note: Strange. That path isn't used with `edit` at all.
     path = Path(f"../{repo.git.root.name}/{asset}")
     assert path.is_file()
-    ret = subprocess.run(['onyo', 'edit', '--yes', asset],
+    ret = subprocess.run(['onyo', '--yes', 'edit', asset],
                          capture_output=True, text=True)
     assert ret.returncode == 0
     assert "+key: dot_dot" in ret.stdout

--- a/onyo/commands/tests/test_mkdir.py
+++ b/onyo/commands/tests/test_mkdir.py
@@ -22,7 +22,7 @@ def test_mkdir(repo: OnyoRepo, directory: str) -> None:
     Test that `onyo mkdir <dir>` creates new directories correctly for different
     depths and directory names.
     """
-    ret = subprocess.run(['onyo', 'mkdir', '--yes', directory], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', '--yes', 'mkdir', directory], capture_output=True, text=True)
 
     # verify output
     assert directory in ret.stdout
@@ -45,7 +45,7 @@ def test_mkdir_multiple_inputs(repo: OnyoRepo) -> None:
     Test that `onyo mkdir <dirs>` creates new directories all in one call when
     given a list of inputs.
     """
-    ret = subprocess.run(['onyo', 'mkdir', '--yes', *directories], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', '--yes', 'mkdir', *directories], capture_output=True, text=True)
 
     assert not ret.stderr
     assert ret.returncode == 0
@@ -92,7 +92,7 @@ def test_mkdir_message_flag(repo: OnyoRepo) -> None:
     msg = "I am here to test the --message flag with spe\"cial\\char\'acteஞrs!"
 
     # test `onyo mkdir --message msg`
-    ret = subprocess.run(['onyo', 'mkdir', '--yes', '--message', msg, *directories], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', '--yes', 'mkdir', '--message', msg, *directories], capture_output=True, text=True)
 
     assert ret.returncode == 0
     assert not ret.stderr
@@ -110,7 +110,7 @@ def test_mkdir_quiet_flag(repo: OnyoRepo) -> None:
     Test that `onyo mkdir --yes --quiet <dirs>` creates new directories without
     printing output.
     """
-    ret = subprocess.run(['onyo', 'mkdir', '--yes', '--quiet', *directories],
+    ret = subprocess.run(['onyo', '--yes', '--quiet', 'mkdir', *directories],
                          capture_output=True, text=True)
 
     # verify that all output is empty
@@ -201,7 +201,7 @@ def test_mkdir_relative_path(repo: OnyoRepo) -> None:
     """
     Test `onyo mkdir <path>` with a relative path given as input.
     """
-    ret = subprocess.run(["onyo", "mkdir", "--yes", "simple/../relative"], capture_output=True, text=True)
+    ret = subprocess.run(["onyo", "--yes", "mkdir", "simple/../relative"], capture_output=True, text=True)
 
     # verify output
     assert "relative" in ret.stdout

--- a/onyo/commands/tests/test_mv.py
+++ b/onyo/commands/tests/test_mv.py
@@ -69,7 +69,7 @@ def test_mv_quiet_missing_yes(repo: OnyoRepo) -> None:
     """
     ``--quiet`` requires ``--yes``
     """
-    ret = subprocess.run(['onyo', 'mv', '--quiet', 'subdir/laptop_apple_macbook.abc123', './'], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', '--quiet', 'mv', 'subdir/laptop_apple_macbook.abc123', './'], capture_output=True, text=True)
     assert ret.returncode == 1
     assert not ret.stdout
     assert ret.stderr
@@ -84,7 +84,7 @@ def test_mv_quiet(repo: OnyoRepo) -> None:
     """
     ``--quiet`` requires ``--yes``
     """
-    ret = subprocess.run(['onyo', 'mv', '--yes', '--quiet', 'subdir/laptop_apple_macbook.abc123', './'], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', '--yes', '--quiet', 'mv', 'subdir/laptop_apple_macbook.abc123', './'], capture_output=True, text=True)
     assert ret.returncode == 0
     assert not ret.stdout
     assert not ret.stderr
@@ -99,7 +99,7 @@ def test_mv_yes(repo: OnyoRepo) -> None:
     """
     --yes removes any prompts and auto-approves the move.
     """
-    ret = subprocess.run(['onyo', 'mv', '--yes', 'subdir/laptop_apple_macbook.abc123', './'], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', '--yes', 'mv', 'subdir/laptop_apple_macbook.abc123', './'], capture_output=True, text=True)
     assert ret.returncode == 0
     assert "The following will be moved:" in ret.stdout
     assert "Save changes? No discards all changes. (y/n) " not in ret.stdout
@@ -119,7 +119,7 @@ def test_mv_message_flag(repo: OnyoRepo, asset: str) -> None:
     with one specified by the user containing different special characters.
     """
     msg = "I am here to test the --message flag with spe\"cial\\char\'acteஞrs!"
-    ret = subprocess.run(['onyo', 'mv', '--yes', '--message', msg, asset,
+    ret = subprocess.run(['onyo', '--yes', 'mv', '--message', msg, asset,
                           "destination/"], capture_output=True, text=True)
     assert ret.returncode == 0
     assert not ret.stderr

--- a/onyo/commands/tests/test_new.py
+++ b/onyo/commands/tests/test_new.py
@@ -27,7 +27,7 @@ def test_new(repo: OnyoRepo, directory: str) -> None:
     Test that `onyo new` can create an asset in different directories.
     """
     file_ = f'{directory}/laptop_apple_macbookpro.0'
-    ret = subprocess.run(['onyo', 'new', '--yes', '--path', file_],
+    ret = subprocess.run(['onyo', '--yes', 'new', '--path', file_],
                          capture_output=True, text=True)
 
     # verify correct output
@@ -71,7 +71,7 @@ def test_new_top_level(repo: OnyoRepo) -> None:
     the repository.
     """
     file_ = 'laptop_apple_macbookpro.0'
-    ret = subprocess.run(['onyo', 'new', '--yes', '--path', file_],
+    ret = subprocess.run(['onyo', '--yes', 'new', '--path', file_],
                          capture_output=True, text=True)
 
     # verify correct output
@@ -99,7 +99,7 @@ def test_new_sub_dir_absolute_path(repo: OnyoRepo) -> None:
     # build a path for the new asset as an absolute path
     file_ = repo.git.root / "just another path" / "laptop_apple_macbookpro.0"
 
-    ret = subprocess.run(['onyo', 'new', '--yes', '--path', file_],
+    ret = subprocess.run(['onyo', '--yes', 'new', '--path', file_],
                          capture_output=True, text=True)
 
     # verify correct output
@@ -130,7 +130,7 @@ def test_new_sub_dir_relative_path(repo: OnyoRepo) -> None:
     # build a path for the new asset as a relative path
     file_ = Path(var, "just another path", "laptop_apple_macbookpro.0")
 
-    ret = subprocess.run(['onyo', 'new', '--yes', '--path', file_],
+    ret = subprocess.run(['onyo', '--yes', 'new', '--path', file_],
                          capture_output=True, text=True)
 
     # verify correct output
@@ -153,7 +153,7 @@ def test_folder_creation_with_new(repo: OnyoRepo, directory: str) -> None:
     existing dir 'overlap'.
     """
     asset = f"{directory}/laptop_apple_macbookpro.0"
-    ret = subprocess.run(['onyo', 'new', '--yes', '--path', asset],
+    ret = subprocess.run(['onyo', '--yes', 'new', '--path', asset],
                          capture_output=True, text=True)
 
     # verify correct output
@@ -178,7 +178,7 @@ def test_with_faux_serial_number(repo: OnyoRepo) -> None:
     file_ = "laptop_apple_macbookpro.faux"
     num = 10
     assets = [f"{d}/{file_}" for d in directories for i in range(0, num)]
-    ret = subprocess.run(['onyo', 'new', '--yes', '--path', *assets],
+    ret = subprocess.run(['onyo', '--yes', 'new', '--path', *assets],
                          capture_output=True, text=True)
 
     # verify correct output
@@ -199,7 +199,7 @@ def test_new_assets_in_multiple_directories_at_once(repo: OnyoRepo) -> None:
     """
     assets = [f'{directory}/laptop_apple_macbookpro.{i}'
               for i, directory in enumerate(directories)]
-    ret = subprocess.run(['onyo', 'new', '--yes', '--path', *assets],
+    ret = subprocess.run(['onyo', '--yes', 'new', '--path', *assets],
                          capture_output=True, text=True)
 
     # verify correct output
@@ -224,7 +224,7 @@ def test_yes_flag(repo: OnyoRepo, directory: str) -> None:
     Test that `onyo new --yes` creates assets in different directories.
     """
     asset = f'{directory}/laptop_apple_macbookpro.0'
-    ret = subprocess.run(['onyo', 'new', '--yes', '--path', asset],
+    ret = subprocess.run(['onyo', '--yes', 'new', '--path', asset],
                          capture_output=True, text=True)
 
     # verify correct output
@@ -254,7 +254,7 @@ def test_keys_flag(repo: OnyoRepo, directory: str) -> None:
     key_values = "mode=keys_flag"
 
     # create asset with --keys
-    ret = subprocess.run(['onyo', 'new', '--yes', '--keys', key_values,
+    ret = subprocess.run(['onyo', '--yes', 'new', '--keys', key_values,
                           '--path', asset], capture_output=True, text=True)
 
     # verify output
@@ -278,7 +278,7 @@ def test_new_message_flag(repo: OnyoRepo, directory: str) -> None:
     msg = "I am here to test the --message flag with spe\"cial\\char\'acteஞrs!"
 
     asset = f'{directory}/laptop_apple_macbookpro.0'
-    ret = subprocess.run(['onyo', 'new', '--yes', '--message', msg,
+    ret = subprocess.run(['onyo', '--yes', 'new', '--message', msg,
                           '--path', asset], capture_output=True, text=True)
     assert ret.returncode == 0
     assert not ret.stderr
@@ -353,7 +353,7 @@ def test_new_with_flags_edit_keys_template(repo: OnyoRepo, directory: str) -> No
     key_values = "mode=keys"
 
     # create asset with --edit, --template and --keys
-    ret = subprocess.run(['onyo', 'new', '--yes', '--edit',
+    ret = subprocess.run(['onyo', '--yes', 'new', '--edit',
                           '--template', template, '--keys', key_values,
                           '--path', str(asset)], capture_output=True, text=True)
 
@@ -389,7 +389,7 @@ def test_new_with_keys_overwrite_template(repo: OnyoRepo, directory: str) -> Non
     key_values = ["RAM=16GB", "Size=24.2", "USB=3"]
 
     # create asset with --template and --keys
-    ret = subprocess.run(['onyo', 'new', '--yes', '--template', template,
+    ret = subprocess.run(['onyo', '--yes', 'new', '--template', template,
                           '--keys', *key_values, '--path', str(asset)],
                          capture_output=True, text=True)
 
@@ -425,7 +425,7 @@ def test_with_special_characters(
     Test `onyo new` with names containing special characters.
     """
     asset = f'{directory}/{variant}'
-    ret = subprocess.run(['onyo', 'new', '--yes', '--path', asset],
+    ret = subprocess.run(['onyo', '--yes', 'new', '--path', asset],
                          capture_output=True, text=True)
 
     # verify correct output
@@ -521,7 +521,7 @@ def test_tsv(repo: OnyoRepo) -> None:
     assert table_path.is_file()
 
     # create assets with table
-    ret = subprocess.run(['onyo', 'new', '--yes', "--tsv", table_path],
+    ret = subprocess.run(['onyo', '--yes', 'new', "--tsv", table_path],
                          capture_output=True, text=True)
     assert not ret.stderr
     assert "The following will be created:" in ret.stdout
@@ -541,7 +541,7 @@ def test_tsv_with_value_columns(repo: OnyoRepo) -> None:
     of the device and a group to which it belongs.
     """
     table_path = prepared_tsvs / "table_with_key_values.tsv"
-    ret = subprocess.run(['onyo', 'new', '--yes', '--tsv', table_path],
+    ret = subprocess.run(['onyo', '--yes', 'new', '--tsv', table_path],
                          capture_output=True, text=True)
 
     assert "The following will be created:" in ret.stdout
@@ -575,7 +575,7 @@ def test_tsv_with_flags_template_keys_edit(repo: OnyoRepo) -> None:
     assert table_path.is_file()
 
     # create assets with table
-    ret = subprocess.run(['onyo', 'new', '--yes', '--edit',
+    ret = subprocess.run(['onyo', '--yes', 'new', '--edit',
                           '--keys', key_values, '--tsv', table_path,
                           '--template', template],
                          capture_output=True, text=True)
@@ -612,7 +612,7 @@ def test_tsv_with_template_column(repo: OnyoRepo) -> None:
     assert table_path.is_file()
 
     # create assets with table
-    ret = subprocess.run(['onyo', 'new', '--yes', '--tsv', table_path],
+    ret = subprocess.run(['onyo', '--yes', 'new', '--tsv', table_path],
                          capture_output=True, text=True)
     assert not ret.stderr
     assert ret.returncode == 0

--- a/onyo/commands/tests/test_onyo.py
+++ b/onyo/commands/tests/test_onyo.py
@@ -9,7 +9,7 @@ import pytest
 @pytest.mark.repo_dirs('just-a-dir')
 @pytest.mark.parametrize('variant', ['-d', '--debug'])
 def test_onyo_debug(repo: OnyoRepo, variant: str) -> None:
-    ret = subprocess.run(['onyo', variant, 'mkdir', '--yes', f'flag{variant}'],
+    ret = subprocess.run(['onyo', variant, '--yes', 'mkdir', f'flag{variant}'],
                          capture_output=True, text=True)
     assert ret.returncode == 0
     assert 'DEBUG:onyo' in ret.stderr

--- a/onyo/commands/tests/test_rm.py
+++ b/onyo/commands/tests/test_rm.py
@@ -28,7 +28,7 @@ def test_rm(repo: OnyoRepo, asset: str) -> None:
     Test that `onyo rm ASSET` deletes assets and leaves the repository in a
     clean state.
     """
-    ret = subprocess.run(['onyo', 'rm', '--yes', asset],
+    ret = subprocess.run(['onyo', '--yes', 'rm', asset],
                          capture_output=True, text=True)
     assert ret.returncode == 0
     assert "The following will be deleted:" in ret.stdout
@@ -45,7 +45,7 @@ def test_rm_multiple_inputs(repo: OnyoRepo) -> None:
     Test that `onyo rm ASSET` deletes a list of assets all at once and leaves
     the repository in a clean state.
     """
-    ret = subprocess.run(['onyo', 'rm', '--yes', *assets],
+    ret = subprocess.run(['onyo', '--yes', 'rm', *assets],
                          capture_output=True, text=True)
     assert ret.returncode == 0
     assert "The following will be deleted:" in ret.stdout
@@ -64,7 +64,7 @@ def test_rm_single_dirs_with_files(repo: OnyoRepo, directory: str) -> None:
     Test that `onyo rm DIRECTORY` deletes directories successfully and leaves
     the repository in a clean state.
     """
-    ret = subprocess.run(['onyo', 'rm', '--yes', directory],
+    ret = subprocess.run(['onyo', '--yes', 'rm', directory],
                          capture_output=True, text=True)
     assert ret.returncode == 0
     assert "The following will be deleted:" in ret.stdout
@@ -81,7 +81,7 @@ def test_rm_multiple_directories(repo: OnyoRepo) -> None:
     Test that `onyo rm DIRECTORY` deletes a list of directories all at once and
     leaves the repository in a clean state.
     """
-    ret = subprocess.run(['onyo', 'rm', '--yes', *directories[1:]],
+    ret = subprocess.run(['onyo', '--yes', 'rm', *directories[1:]],
                          capture_output=True, text=True)
     assert ret.returncode == 0
     assert "The following will be deleted:" in ret.stdout
@@ -99,7 +99,7 @@ def test_rm_empty_directories(repo: OnyoRepo) -> None:
     Test that `onyo rm DIRECTORY` deletes empty directories and leaves the
     repository in a clean state.
     """
-    ret = subprocess.run(['onyo', 'rm', '--yes', *directories[1:]],
+    ret = subprocess.run(['onyo', '--yes', 'rm', *directories[1:]],
                          capture_output=True, text=True)
     assert ret.returncode == 0
     assert "The following will be deleted:" in ret.stdout
@@ -167,7 +167,7 @@ def test_rm_quiet_missing_yes(repo: OnyoRepo) -> None:
     Test that `onyo rm --quiet` errors correctly, when the required flag
     `--yes` is missing.
     """
-    ret = subprocess.run(['onyo', 'rm', '--quiet', *assets], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', '--quiet', 'rm', *assets], capture_output=True, text=True)
     assert ret.returncode == 1
     assert not ret.stdout
     assert ret.stderr
@@ -184,7 +184,7 @@ def test_rm_quiet_flag(repo: OnyoRepo) -> None:
     Test that `onyo rm --quiet --yes` deletes a list of assets successfully
     without printing any output or error.
     """
-    ret = subprocess.run(['onyo', 'rm', '--yes', '--quiet', *assets], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', '--yes', '--quiet', 'rm', *assets], capture_output=True, text=True)
     assert ret.returncode == 0
     assert not ret.stdout
     assert not ret.stderr
@@ -203,7 +203,7 @@ def test_rm_message_flag(repo: OnyoRepo, asset: str) -> None:
     with one specified by the user containing different special characters.
     """
     msg = "I am here to test the --message flag with spe\"cial\\char\'acteஞrs!"
-    ret = subprocess.run(['onyo', 'rm', '--yes', '--message', msg, asset],
+    ret = subprocess.run(['onyo', '--yes', 'rm', '--message', msg, asset],
                          capture_output=True, text=True)
     assert ret.returncode == 0
     assert not ret.stderr

--- a/onyo/commands/tests/test_set.py
+++ b/onyo/commands/tests/test_set.py
@@ -32,7 +32,7 @@ def test_set(repo: OnyoRepo, asset: str, set_values: list[str]) -> None:
     """
     Test that `onyo set KEY=VALUE <asset>` updates contents of assets.
     """
-    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', *set_values, '--path', asset], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', *set_values, '--path', asset], capture_output=True, text=True)
 
     # verify output
     assert "The following assets will be changed:" in ret.stdout
@@ -75,7 +75,7 @@ def test_set_multiple_assets(repo: OnyoRepo, set_values: list[str]) -> None:
     Test that `onyo set KEY=VALUE <asset>` can update the contents of multiple
     assets in a single call.
     """
-    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', *set_values, '--path', *assets], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', *set_values, '--path', *assets], capture_output=True, text=True)
 
     # verify output
     assert "The following assets will be changed:" in ret.stdout
@@ -123,7 +123,7 @@ def test_set_with_dot_recursive(repo: OnyoRepo, set_values: list[str]) -> None:
     Test that when `onyo set KEY=VALUE .` is called from the repository root,
     onyo selects all assets in the complete repo recursively.
     """
-    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', *set_values,
+    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', *set_values,
                           '--path', "."], capture_output=True, text=True)
 
     # verify that output mentions every asset
@@ -146,7 +146,7 @@ def test_set_without_path(repo: OnyoRepo, set_values: list[str]) -> None:
     Test that `onyo set KEY=VALUE` without a given path selects all assets in
     the repository, beginning with cwd.
     """
-    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', *set_values], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', *set_values], capture_output=True, text=True)
 
     # verify that output contains one line per asset
     assert "The following assets will be changed:" in ret.stdout
@@ -170,7 +170,7 @@ def test_set_recursive_directories(repo: OnyoRepo, directory: str, set_values: l
     Test that `onyo set KEY=VALUE <directory>` updates contents of assets
     correctly.
     """
-    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', *set_values, '--path', directory], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', *set_values, '--path', directory], capture_output=True, text=True)
 
     # verify output
     assert "The following assets will be changed:" in ret.stdout
@@ -239,7 +239,7 @@ def test_set_yes_flag(repo: OnyoRepo, asset: str, set_values: list[str]) -> None
     """
     Test that `onyo set --yes KEY=VALUE <asset>` updates assets without prompt.
     """
-    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', *set_values, '--path', asset], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', *set_values, '--path', asset], capture_output=True, text=True)
 
     # verify output
     assert "The following assets will be changed:" in ret.stdout
@@ -266,7 +266,7 @@ def test_set_message_flag(repo: OnyoRepo, asset: str, set_values: list[str]) -> 
     with one specified by the user containing different special characters.
     """
     msg = "I am here to test the --message flag with spe\"cial\\char\'acteஞrs!"
-    ret = subprocess.run(['onyo', 'set', '--yes', '--message', msg,
+    ret = subprocess.run(['onyo', '--yes', 'set', '--message', msg,
                           '--keys', *set_values, '--path', asset],
                          capture_output=True, text=True)
     assert ret.returncode == 0
@@ -287,7 +287,7 @@ def test_set_quiet_without_yes_flag(repo: OnyoRepo) -> None:
     Test that `onyo set --quiet KEY=VALUE <asset>` errors correctly without the
     --yes flag.
     """
-    ret = subprocess.run(['onyo', 'set', '--quiet', '--keys', "mode=single", '--path', asset], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', '--quiet', 'set', '--keys', "mode=single", '--path', asset], capture_output=True, text=True)
 
     # verify output
     assert not ret.stdout
@@ -306,7 +306,7 @@ def test_set_quiet_flag(repo: OnyoRepo, asset: str, set_values: list[str]) -> No
     Test that `onyo set --quiet --yes KEY=VALUE <asset>` works correctly without
     output and user-response.
     """
-    ret = subprocess.run(['onyo', 'set', '--yes', '--quiet', '--keys', *set_values, '--path', asset], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', '--yes', '--quiet', 'set', '--keys', *set_values, '--path', asset], capture_output=True, text=True)
 
     # verify that output is completely empty
     assert not ret.stdout
@@ -423,7 +423,7 @@ def test_add_new_key_to_existing_content(repo: OnyoRepo, asset: str) -> None:
     different `KEY`, and adds it without overwriting existing values.
     """
     set_1 = "change=one"
-    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', set_1, '--path', asset], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', set_1, '--path', asset], capture_output=True, text=True)
 
     # verify output
     assert "The following assets will be changed:" in ret.stdout
@@ -435,7 +435,7 @@ def test_add_new_key_to_existing_content(repo: OnyoRepo, asset: str) -> None:
 
     # call again and add a different KEY, without overwriting existing contents
     set_2 = "different=key"
-    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', set_2, '--path', asset], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', set_2, '--path', asset], capture_output=True, text=True)
 
     # verify output
     assert "The following assets will be changed:" in ret.stdout
@@ -463,7 +463,7 @@ def test_set_overwrite_key(repo: OnyoRepo, asset: str) -> None:
     different VALUE for the same KEY, and overwrites existing values correctly.
     """
     set_value = "value=original"
-    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', set_value, '--path', asset], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', set_value, '--path', asset], capture_output=True, text=True)
 
     # verify output
     assert "The following assets will be changed:" in ret.stdout
@@ -475,7 +475,7 @@ def test_set_overwrite_key(repo: OnyoRepo, asset: str) -> None:
 
     # call again with same key, but different value
     set_value_2 = "value=updated"
-    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', set_value_2, '--path', asset], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', set_value_2, '--path', asset], capture_output=True, text=True)
 
     # verify output
     assert "The following assets will be changed:" in ret.stdout
@@ -500,7 +500,7 @@ def test_setting_new_values_if_some_values_already_set(repo: OnyoRepo, asset: st
     the correct output if called multiple times, and that the output is correct.
     """
     set_values = "change=one"
-    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', set_values, '--path', asset], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', set_values, '--path', asset], capture_output=True, text=True)
 
     # verify output
     assert "The following assets will be changed:" in ret.stdout
@@ -512,7 +512,7 @@ def test_setting_new_values_if_some_values_already_set(repo: OnyoRepo, asset: st
     # call with two values, one of which is already set and should not appear
     # again in the output.
     set_values = ["change=one", "different=key"]
-    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', *set_values, '--path', asset], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', *set_values, '--path', asset], capture_output=True, text=True)
 
     # verify output
     assert "The following assets will be changed:" in ret.stdout
@@ -541,7 +541,7 @@ def test_values_already_set(repo: OnyoRepo, asset: str, set_values: list[str]) -
     if called again with same valid values the command does display the correct
     info message without error, and the repository stays in a clean state.
     """
-    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', *set_values, '--path', asset], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', *set_values, '--path', asset], capture_output=True, text=True)
 
     # verify output
     assert "The following assets will be changed:" in ret.stdout
@@ -552,7 +552,7 @@ def test_values_already_set(repo: OnyoRepo, asset: str, set_values: list[str]) -
     assert ret.returncode == 0
 
     # call `onyo set` again with the same values
-    ret = subprocess.run(['onyo', 'set', '--yes', '--keys', *set_values, '--path', asset], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', *set_values, '--path', asset], capture_output=True, text=True)
 
     # verify second output
     assert "The values are already set. No assets updated." in ret.stdout
@@ -582,7 +582,7 @@ def test_set_update_name_fields(repo: OnyoRepo, asset: str, set_values: list[str
     faux serials can be set and name fields are recognized and can be updated
     when they are `onyo set` together with a list of content fields.
     """
-    ret = subprocess.run(['onyo', 'set', '--yes', '--rename', '--keys', *set_values,
+    ret = subprocess.run(['onyo', '--yes', 'set', '--rename', '--keys', *set_values,
                           '--path', asset], capture_output=True, text=True)
 
     # verify output
@@ -607,7 +607,7 @@ def test_update_many_faux_serial_numbers(repo: OnyoRepo) -> None:
     """
     # remember old assets before renaming
     old_asset_names = repo.asset_paths
-    ret = subprocess.run(['onyo', 'set', '--yes', '--rename', '--keys',
+    ret = subprocess.run(['onyo', '--yes', 'set', '--rename', '--keys',
                           'serial=faux', '--path', *assets], capture_output=True, text=True)
 
     # verify output

--- a/onyo/commands/tests/test_unset.py
+++ b/onyo/commands/tests/test_unset.py
@@ -37,7 +37,7 @@ def test_unset(repo: OnyoRepo, asset: str) -> None:
     Test that `onyo unset KEY <asset>` removes keys from of assets.
     """
     key = list(content_dict.keys())[0]
-    ret = subprocess.run(['onyo', 'unset', '--yes', '--keys', key, '--path', asset], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', '--yes', 'unset', '--keys', key, '--path', asset], capture_output=True, text=True)
 
     # verify output
     assert "The following assets will be changed:" in ret.stdout
@@ -81,7 +81,7 @@ def test_unset_subset_of_keys(repo: OnyoRepo, asset: str) -> None:
     assets with many other keys.
     """
     key = list(content_dict.keys())[0]
-    ret = subprocess.run(['onyo', 'unset', '--yes', '--keys', key, '--path', asset],
+    ret = subprocess.run(['onyo', '--yes', 'unset', '--keys', key, '--path', asset],
                          capture_output=True, text=True)
 
     # verify output
@@ -110,7 +110,7 @@ def test_unset_info_empty_asset(repo: OnyoRepo, asset: str) -> None:
     no_key = "non_existing"
 
     # test un-setting a non-existing key from an empty file
-    ret = subprocess.run(['onyo', 'unset', '--yes', '--keys', no_key,
+    ret = subprocess.run(['onyo', '--yes', 'unset', '--keys', no_key,
                           '--path', asset], capture_output=True, text=True)
 
     # verify reaction of onyo
@@ -130,7 +130,7 @@ def test_unset_key_does_not_exist(repo: OnyoRepo, asset: str) -> None:
     no_key = "non_existing"
 
     # test un-setting a non-existing key from an empty file
-    ret = subprocess.run(['onyo', 'unset', '--yes', '--keys', no_key,
+    ret = subprocess.run(['onyo', '--yes', 'unset', '--keys', no_key,
                           '--path', asset], capture_output=True, text=True)
 
     # verify reaction of onyo
@@ -148,7 +148,7 @@ def test_unset_multiple_assets(repo: OnyoRepo) -> None:
     key = list(content_dict.keys())[0]
 
     # test unsetting keys for multiple assets:
-    ret = subprocess.run(['onyo', 'unset', '--yes', '--keys', key, '--path', *assets], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', '--yes', 'unset', '--keys', key, '--path', *assets], capture_output=True, text=True)
 
     # verify output
     assert "The following assets will be changed:" in ret.stdout
@@ -196,7 +196,7 @@ def test_unset_with_dot(repo: OnyoRepo) -> None:
     repository root, onyo uses all assets in the completely repo recursively.
     """
     key = list(content_dict.keys())[0]
-    ret = subprocess.run(['onyo', 'unset', '--yes', '--keys', key,
+    ret = subprocess.run(['onyo', '--yes', 'unset', '--keys', key,
                           '--path', "."], capture_output=True, text=True)
 
     assert "The following assets will be changed:" in ret.stdout
@@ -214,7 +214,7 @@ def test_unset_without_path(repo: OnyoRepo) -> None:
     assets recursively.
     """
     key = list(content_dict.keys())[0]
-    ret = subprocess.run(['onyo', 'unset', '--yes', '--keys', key],
+    ret = subprocess.run(['onyo', '--yes', 'unset', '--keys', key],
                          capture_output=True, text=True)
 
     # verify the output
@@ -233,7 +233,7 @@ def test_unset_recursive_directories(repo: OnyoRepo, directory: str) -> None:
     assets in DIRECTORY.
     """
     key = list(content_dict.keys())[0]
-    ret = subprocess.run(['onyo', 'unset', '--yes', '--keys', key, '--path', directory], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', '--yes', 'unset', '--keys', key, '--path', directory], capture_output=True, text=True)
 
     # verify changes, and the repository clean
     # TODO: update this after solving #259
@@ -294,7 +294,7 @@ def test_unset_yes_flag(repo: OnyoRepo, asset: str) -> None:
     Test that `onyo unset --yes KEY <asset>` updates assets without prompt.
     """
     key = list(content_dict.keys())[0]
-    ret = subprocess.run(['onyo', 'unset', '--yes', '--keys', key, '--path', asset], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', '--yes', 'unset', '--keys', key, '--path', asset], capture_output=True, text=True)
 
     # verify output
     assert "The following assets will be changed:" in ret.stdout
@@ -320,7 +320,7 @@ def test_unset_quiet_without_yes_flag(repo: OnyoRepo) -> None:
     Test that `onyo unset --quiet --keys KEY --path ASSET` errors correctly
     without the --yes flag.
     """
-    ret = subprocess.run(['onyo', 'unset', '--quiet', '--keys', 'dummy_key',
+    ret = subprocess.run(['onyo', '--quiet', 'unset', '--keys', 'dummy_key',
                           '--path', asset], capture_output=True, text=True)
 
     # verify output
@@ -340,7 +340,7 @@ def test_unset_quiet_flag(repo: OnyoRepo, asset: str) -> None:
     without output and user-response.
     """
     key = list(content_dict.keys())[0]
-    ret = subprocess.run(['onyo', 'unset', '--yes', '--quiet', '--keys', key,
+    ret = subprocess.run(['onyo', '--yes', '--quiet', 'unset', '--keys', key,
                           '--path', asset], capture_output=True, text=True)
     # verify that output is completely empty
     assert not ret.stdout
@@ -363,7 +363,7 @@ def test_unset_message_flag(repo: OnyoRepo, asset: str) -> None:
     """
     msg = "I am here to test the --message flag with spe\"cial\\char\'acteஞrs!"
     key = list(content_dict.keys())[0]
-    ret = subprocess.run(['onyo', 'unset', '--yes', '--message', msg,
+    ret = subprocess.run(['onyo', '--yes', 'unset', '--message', msg,
                           '--keys', key, '--path', asset],
                          capture_output=True, text=True)
     assert ret.returncode == 0

--- a/onyo/commands/tree.py
+++ b/onyo/commands/tree.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 from onyo import OnyoRepo
 from onyo.lib.commands import fsck, tree as tree_cmd
-from onyo.shared_arguments import directory
+from onyo.argparse_helpers import directory
 
 if TYPE_CHECKING:
     import argparse
@@ -13,12 +13,13 @@ if TYPE_CHECKING:
 logging.basicConfig()
 log: logging.Logger = logging.getLogger('onyo')
 
-arg_directory = dict(
-    dest='directory',
-    metavar='DIR',
-    nargs='*',
-    type=directory,
-    help='Directory(s) to print tree of')
+args_tree = {
+    'directory': dict(
+        metavar='DIR',
+        nargs='*',
+        type=directory,
+        help='Directory(s) to print tree of')
+}
 
 
 def tree(args: argparse.Namespace) -> None:

--- a/onyo/commands/unset.py
+++ b/onyo/commands/unset.py
@@ -5,7 +5,13 @@ from typing import TYPE_CHECKING
 
 from onyo import OnyoRepo
 from onyo.lib.commands import fsck, unset as unset_cmd
-from onyo.shared_arguments import path
+from onyo.argparse_helpers import path
+from onyo.shared_arguments import (
+    shared_arg_depth,
+    shared_arg_dry_run,
+    shared_arg_filter,
+    shared_arg_message,
+)
 
 if TYPE_CHECKING:
     import argparse
@@ -13,22 +19,29 @@ if TYPE_CHECKING:
 logging.basicConfig()
 log: logging.Logger = logging.getLogger('onyo')
 
-arg_keys = dict(
-    args=('-k', '--keys'),
-    required=True,
-    metavar="KEYS",
-    nargs='+',
-    type=str,
-    help=(
-        'Specify keys to unset in assets. Multiple keys can be given '
-        '(e.g. key key2 key3)'))
+args_unset = {
+    'keys': dict(
+        args=('-k', '--keys'),
+        required=True,
+        metavar="KEYS",
+        nargs='+',
+        type=str,
+        help=(
+            'Specify keys to unset in assets. Multiple keys can be given '
+            '(e.g. key key2 key3)')),
 
-arg_path = dict(
-    args=('-p', '--path'),
-    metavar="PATH",
-    nargs='*',
-    type=path,
-    help='Asset(s) and/or directory(s) for which to unset values in')
+    'path': dict(
+        args=('-p', '--path'),
+        metavar="PATH",
+        nargs='*',
+        type=path,
+        help='Asset(s) and/or directory(s) for which to unset values in'),
+
+    'depth': shared_arg_depth,
+    'dry-run': shared_arg_dry_run,
+    'filter': shared_arg_filter,
+    'message': shared_arg_message,
+}
 
 
 def unset(args: argparse.Namespace) -> None:

--- a/onyo/onyo_arguments.py
+++ b/onyo/onyo_arguments.py
@@ -1,0 +1,45 @@
+from onyo._version import __version__
+from pathlib import Path
+
+from onyo.argparse_helpers import directory
+
+args_onyo = {
+    'opdir': dict(
+        args=('-C', '--onyopath'),
+        metavar='DIR',
+        required=False,
+        default=Path.cwd(),
+        type=directory,
+        help='Run Onyo commands from inside of DIR'),
+
+    'debug': dict(
+        args=('-d', '--debug'),
+        required=False,
+        default=False,
+        action='store_true',
+        help='Enable debug logging'),
+
+    'version': dict(
+        args=('-v', '--version'),
+        action='version',
+        version='%(prog)s {version}'.format(version=__version__),
+        help="Print onyo's version and exit"),
+
+    'quiet': dict(
+        args=('-q', '--quiet'),
+        required=False,
+        default=False,
+        action='store_true',
+        help=(
+            'Silence messages printed to stdout. Does not suppress interactive '
+            'editors. Requires the --yes flag')),
+
+    'yes': dict(
+        args=('-y', '--yes'),
+        required=False,
+        default=False,
+        action='store_true',
+        help=(
+            'Respond "yes" to any prompts. The --yes flag is required to use '
+            '--quiet')),
+}

--- a/onyo/shared_arguments.py
+++ b/onyo/shared_arguments.py
@@ -1,38 +1,3 @@
-def directory(string: str) -> str:
-    """
-    A no-op type-check for ArgParse. Used to hint for shell tab-completion.
-    """
-    return string
-
-
-def file(string: str) -> str:
-    """
-    A no-op type-check for ArgParse. Used to hint for shell tab-completion.
-    """
-    return string
-
-
-def git_config(string: str) -> str:
-    """
-    A no-op type-check for ArgParse. Used to hint for shell tab-completion.
-    """
-    return string
-
-
-def path(string: str) -> str:
-    """
-    A no-op type-check for ArgParse. Used to hint for shell tab-completion.
-    """
-    return string
-
-
-def template(string: str) -> str:
-    """
-    A no-op type-check for ArgParse. Used to hint for shell tab-completion.
-    """
-    return string
-
-
 shared_arg_depth = dict(
     args=('-d', '--depth'),
     metavar='DEPTH',
@@ -69,25 +34,4 @@ shared_arg_message = dict(
     help=(
         'Use the given MESSAGE as the commit message (rather than the '
         'default). If multiple -m options are given, their values are '
-        'concatenated as separate paragraphs')
-)
-
-shared_arg_quiet = dict(
-    args=('-q', '--quiet'),
-    required=False,
-    default=False,
-    action='store_true',
-    help=(
-        'Silence messages printed to stdout. Does not suppress interactive '
-        'editors. Requires the --yes flag')
-)
-
-shared_arg_yes = dict(
-    args=('-y', '--yes'),
-    required=False,
-    default=False,
-    action='store_true',
-    help=(
-        'Respond "yes" to any prompts. The --yes flag is required to use '
-        '--quiet')
-)
+        'concatenated as separate paragraphs'))

--- a/onyo/tests/test_usecases.py
+++ b/onyo/tests/test_usecases.py
@@ -31,7 +31,7 @@ def test_workflow_cli(repo: OnyoRepo) -> None:
 
     # 1. create new group
     workgroup = Path("newgroup")
-    cmd = ['onyo', 'mkdir', '--yes', '--quiet', str(workgroup)]
+    cmd = ['onyo', '--yes', '--quiet', 'mkdir', str(workgroup)]
     ret = subprocess.run(cmd, capture_output=True, text=True)
     assert ret.returncode == 0
 
@@ -39,7 +39,7 @@ def test_workflow_cli(repo: OnyoRepo) -> None:
     member = workgroup / "Sam User"
 
     # 2a. Create the user
-    cmd = ['onyo', 'mkdir', '--yes', '--quiet', str(member)]
+    cmd = ['onyo', '--yes', '--quiet', 'mkdir', str(member)]
     ret = subprocess.run(cmd, capture_output=True, text=True)
     assert ret.returncode == 0
 
@@ -50,23 +50,23 @@ def test_workflow_cli(repo: OnyoRepo) -> None:
     monitor = Path(ret.stdout.splitlines()[0].split('\t')[-1])
 
     # 2c. Assign display to user
-    cmd = ['onyo', 'mv', '--yes', '--quiet', str(monitor), str(member)]
+    cmd = ['onyo', '--yes', '--quiet', 'mv', str(monitor), str(member)]
     ret = subprocess.run(cmd, capture_output=True, text=True)
     assert ret.returncode == 0
 
     # 2d. Assign newly purchased laptop to user
     laptop = member / "lenovo_thinkpad_laptop.123"
-    cmd = ['onyo', 'new', '--yes', '-p', str(laptop), '-m', "New purchase: ThinkPad", '--keys', 'memory=8GB']
+    cmd = ['onyo', '--yes', 'new', '-p', str(laptop), '-m', "New purchase: ThinkPad", '--keys', 'memory=8GB']
     ret = subprocess.run(cmd, capture_output=True, text=True)
     assert ret.returncode == 0
     # 2e. That was completely wrong data entry. Essentially all the wrong keys.
     # Let's remove asset entirely and redo.
-    cmd = ['onyo', 'rm', '--yes', str(laptop), '-m', "Delete asset due to erroneous data enty"]
+    cmd = ['onyo', '--yes', 'rm', str(laptop), '-m', "Delete asset due to erroneous data enty"]
     ret = subprocess.run(cmd, capture_output=True, text=True)
     assert ret.returncode == 0
 
     laptop = member / "laptop_lenovo_thinkpad.SN123Z"
-    cmd = ['onyo', 'new', '--yes', '-p', str(laptop), '-m', "New purchase: ThinkPad",
+    cmd = ['onyo', '--yes', 'new', '-p', str(laptop), '-m', "New purchase: ThinkPad",
            '--keys', 'RAM=8GB', 'build-date=20160310']
     ret = subprocess.run(cmd, capture_output=True, text=True)
     assert ret.returncode == 0
@@ -79,7 +79,7 @@ def test_workflow_cli(repo: OnyoRepo) -> None:
     laptop = Path(ret.stdout.splitlines()[0].split('\t')[-1])
 
     # 3b. Set the inventory number
-    cmd = ['onyo', 'set', '--yes', '-k', 'fzj_inventory=123A4', '-p', str(laptop)]
+    cmd = ['onyo', '--yes', 'set', '-k', 'fzj_inventory=123A4', '-p', str(laptop)]
     ret = subprocess.run(cmd, capture_output=True, text=True)
     assert ret.returncode == 0
 
@@ -89,12 +89,12 @@ def test_workflow_cli(repo: OnyoRepo) -> None:
     ret = subprocess.run(cmd, capture_output=True, text=True)
     assert ret.returncode == 0
     display = Path(ret.stdout.splitlines()[0].split('\t')[-1])
-    cmd = ['onyo', 'mv', '--yes', '--quiet', str(display), str(member.parent)]
+    cmd = ['onyo', '--yes', '--quiet', 'mv', str(display), str(member.parent)]
     ret = subprocess.run(cmd, capture_output=True, text=True)
     assert ret.returncode == 0
 
     # 4b. Move the user with remaining assets
-    cmd = ['onyo', 'mv', '--yes', '--quiet', str(member), 'somegroup']
+    cmd = ['onyo', '--yes', '--quiet', 'mv', str(member), 'somegroup']
     ret = subprocess.run(cmd, capture_output=True, text=True)
     assert ret.returncode == 0
     member = Path('somegroup') / member.name
@@ -106,13 +106,13 @@ def test_workflow_cli(repo: OnyoRepo) -> None:
     assert ret.returncode == 0
     laptop = Path(ret.stdout.splitlines()[0].split('\t')[-1])
     # 5b. Change recorded RAM size
-    cmd = ['onyo', 'set', '--yes', '-k', 'RAM=16GB', '-p', str(laptop)]
+    cmd = ['onyo', '--yes', 'set', '-k', 'RAM=16GB', '-p', str(laptop)]
     ret = subprocess.run(cmd, capture_output=True, text=True)
     assert ret.returncode == 0
 
     # 6. Member changes name
     member_new = member.parent / "Sam Married"
-    cmd = ['onyo', 'mv', '--yes', str(member), str(member_new)]
+    cmd = ['onyo', '--yes', 'mv', str(member), str(member_new)]
     ret = subprocess.run(cmd, capture_output=True, text=True)
     assert ret.returncode == 0
     member = member_new
@@ -123,12 +123,12 @@ def test_workflow_cli(repo: OnyoRepo) -> None:
     ret = subprocess.run(cmd, capture_output=True, text=True)
     assert ret.returncode == 0
     laptop = Path(ret.stdout.splitlines()[0].split('\t')[-1])
-    cmd = ['onyo', 'mv', '--yes', str(laptop), "retired"]
+    cmd = ['onyo', '--yes', 'mv', str(laptop), "retired"]
     ret = subprocess.run(cmd, capture_output=True, text=True)
     assert ret.returncode == 0
     laptop = Path("retired") / laptop.name
     # 7b. Remove member
-    cmd = ['onyo', 'rm', '--yes', str(member)]
+    cmd = ['onyo', '--yes', 'rm', str(member)]
     ret = subprocess.run(cmd, capture_output=True, text=True)
     assert ret.returncode == 0
 


### PR DESCRIPTION
This continues the efforts to define the arguments in dedicated locations (either in the commands itself, in shared_arguments.py or in the newonyo_arguments.py) instead of in main.py; main.py just reads the other locations and creates the parsers for arguments generically.

The main changes are:
1. every command has just one argument dictionary which can be read in main.py
2. shared_arguments get imported in commando-scripts and removed from main.py
3. onyo_args are moved/defined in a seperate file, this includes:
	- yes and quiet are now onyo flags, not command flags
	- --version, -C, and --debug are also there
4. corrects tests, removes old code, etc