### PR TITLE
UI: add `ui.py` and use it to replace prints, logs, etc

### DIFF
--- a/onyo/__init__.py
+++ b/onyo/__init__.py
@@ -1,16 +1,17 @@
-import logging
 from onyo._version import __version__
 from onyo.lib import (
-    Filter, OnyoRepo, OnyoInvalidRepoError,
-    OnyoProtectedPathError, OnyoInvalidFilterError)
+    Filter,
+    OnyoRepo,
+    OnyoInvalidRepoError,
+    OnyoProtectedPathError,
+    OnyoInvalidFilterError,
+    UI,)
 from onyo.onyo_arguments import args_onyo
 
-logging.basicConfig(level=logging.ERROR)  # external logging level
-log: logging.Logger = logging.getLogger('onyo')  # internal logging level
-log.setLevel(level=logging.INFO)
+# create a shared UI object to import by classes/commands
+ui = UI()
 
 __all__ = [
-    'log',
     '__version__',
     'Filter',
     'args_onyo',

--- a/onyo/commands/cat.py
+++ b/onyo/commands/cat.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -9,9 +8,6 @@ from onyo.argparse_helpers import file
 
 if TYPE_CHECKING:
     import argparse
-
-logging.basicConfig()
-log: logging.Logger = logging.getLogger('onyo')
 
 args_cat = {
     'asset': dict(

--- a/onyo/commands/config.py
+++ b/onyo/commands/config.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -9,9 +8,6 @@ from onyo.argparse_helpers import git_config
 
 if TYPE_CHECKING:
     import argparse
-
-logging.basicConfig()
-log: logging.Logger = logging.getLogger('onyo')
 
 args_config = {
     'git_config_args': dict(

--- a/onyo/commands/edit.py
+++ b/onyo/commands/edit.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -10,9 +9,6 @@ from onyo.shared_arguments import shared_arg_message
 
 if TYPE_CHECKING:
     import argparse
-
-logging.basicConfig()
-log: logging.Logger = logging.getLogger('onyo')
 
 args_edit = {
     'asset': dict(
@@ -39,4 +35,4 @@ def edit(args: argparse.Namespace) -> None:
 
     paths = [Path(p).resolve() for p in args.asset]
     repo = OnyoRepo(Path.cwd(), find_root=True)
-    edit_cmd(repo, paths, args.message, args.quiet, args.yes)
+    edit_cmd(repo, paths, args.message)

--- a/onyo/commands/get.py
+++ b/onyo/commands/get.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING
 from pathlib import Path
-import logging
 
 from onyo import OnyoRepo
 from onyo.lib.commands import fsck, get as get_cmd
@@ -10,9 +9,6 @@ from onyo.shared_arguments import shared_arg_depth, shared_arg_filter
 
 if TYPE_CHECKING:
     import argparse
-
-logging.basicConfig()
-log = logging.getLogger('onyo')
 
 args_get = {
     'machine_readable': dict(

--- a/onyo/commands/history.py
+++ b/onyo/commands/history.py
@@ -1,21 +1,17 @@
 from __future__ import annotations
-import logging
 import os
 import sys
 from pathlib import Path
 from shlex import quote
 from typing import TYPE_CHECKING
 
-from onyo import OnyoRepo
+from onyo import OnyoRepo, ui
 from onyo.lib.command_utils import get_history_cmd
 from onyo.lib.commands import fsck
 from onyo.argparse_helpers import path
 
 if TYPE_CHECKING:
     import argparse
-
-logging.basicConfig()
-log: logging.Logger = logging.getLogger('onyo')
 
 args_history = {
     'interactive': dict(
@@ -66,8 +62,8 @@ def history(args: argparse.Namespace) -> None:
     #       history cmd fails. Whatever history command one is using it needs to figure that same thing out again one
     #       way or another. Nothing gained here.
     if path and not path.exists():
-        print(f"Cannot display the history of '{path}'. It does not exist.", file=sys.stderr)
-        print("Exiting.", file=sys.stderr)
+        ui.error(f"Cannot display the history of '{path}'. It does not exist.")
+        ui.error("Exiting.")
         sys.exit(1)
 
     history_cmd = get_history_cmd(args.interactive, repo)

--- a/onyo/commands/mkdir.py
+++ b/onyo/commands/mkdir.py
@@ -35,4 +35,4 @@ def mkdir(args: argparse.Namespace) -> None:
     dirs = [Path(d).resolve() for d in args.directory]
     repo = OnyoRepo(Path.cwd(), find_root=True)
     fsck(repo)
-    mkdir_cmd(repo, dirs, args.quiet, args.yes, args.message)
+    mkdir_cmd(repo, dirs, args.message)

--- a/onyo/commands/mv.py
+++ b/onyo/commands/mv.py
@@ -40,4 +40,4 @@ def mv(args: argparse.Namespace) -> None:
     sources = [Path(p).resolve() for p in args.source]
     destination = Path(args.destination).resolve()
 
-    mv_cmd(repo, sources, destination, args.quiet, args.yes, args.message)
+    mv_cmd(repo, sources, destination, args.message)

--- a/onyo/commands/new.py
+++ b/onyo/commands/new.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -11,9 +10,6 @@ from onyo.shared_arguments import shared_arg_message
 
 if TYPE_CHECKING:
     import argparse
-
-logging.basicConfig()
-log: logging.Logger = logging.getLogger('onyo')
 
 args_new = {
 
@@ -73,4 +69,4 @@ def new(args: argparse.Namespace) -> None:
     fsck(repo)
     path = [Path(p).resolve() for p in args.path] if args.path else None
     tsv = Path(args.tsv).resolve() if args.tsv else None
-    new_cmd(repo, path, args.template, tsv, args.keys, args.edit, args.yes, args.message)
+    new_cmd(repo, path, args.template, tsv, args.keys, args.edit, args.message)

--- a/onyo/commands/rm.py
+++ b/onyo/commands/rm.py
@@ -31,4 +31,4 @@ def rm(args: argparse.Namespace) -> None:
     repo = OnyoRepo(Path.cwd(), find_root=True)
     fsck(repo)
     paths = [Path(p).resolve() for p in args.path]
-    rm_cmd(repo, paths, args.quiet, args.yes, args.message)
+    rm_cmd(repo, paths, args.message)

--- a/onyo/commands/set.py
+++ b/onyo/commands/set.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -15,9 +14,6 @@ from onyo.shared_arguments import (
 
 if TYPE_CHECKING:
     import argparse
-
-logging.basicConfig()
-log: logging.Logger = logging.getLogger('onyo')
 
 args_set = {
     'rename': dict(
@@ -89,6 +85,4 @@ def set(args: argparse.Namespace) -> None:
             args.dry_run,
             args.rename,
             args.depth,
-            args.quiet,
-            args.yes,
             args.message)

--- a/onyo/commands/shell_completion.py
+++ b/onyo/commands/shell_completion.py
@@ -1,6 +1,7 @@
 import argparse
 from typing import Optional
 
+from onyo import ui
 
 args_shell_completion = {
     'shell': dict(
@@ -529,4 +530,4 @@ def shell_completion(args: argparse.Namespace) -> None:
 
     # TODO: add bash
 
-    print(content)
+    ui.print(content)

--- a/onyo/commands/tree.py
+++ b/onyo/commands/tree.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -9,9 +8,6 @@ from onyo.argparse_helpers import directory
 
 if TYPE_CHECKING:
     import argparse
-
-logging.basicConfig()
-log: logging.Logger = logging.getLogger('onyo')
 
 args_tree = {
     'directory': dict(

--- a/onyo/commands/unset.py
+++ b/onyo/commands/unset.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -15,9 +14,6 @@ from onyo.shared_arguments import (
 
 if TYPE_CHECKING:
     import argparse
-
-logging.basicConfig()
-log: logging.Logger = logging.getLogger('onyo')
 
 args_unset = {
     'keys': dict(
@@ -73,7 +69,5 @@ def unset(args: argparse.Namespace) -> None:
               args.keys,
               args.filter,
               args.dry_run,
-              args.quiet,
-              args.yes,
               args.depth,
               args.message)

--- a/onyo/lib/__init__.py
+++ b/onyo/lib/__init__.py
@@ -1,5 +1,6 @@
 from .filters import Filter
 from .onyo import OnyoRepo
+from .ui import UI
 from .exceptions import OnyoInvalidRepoError, OnyoProtectedPathError, OnyoInvalidFilterError
 
 
@@ -9,4 +10,5 @@ __all__ = [
     'OnyoInvalidRepoError',
     'OnyoProtectedPathError',
     'OnyoInvalidFilterError',
+    'UI',
 ]

--- a/onyo/lib/assets.py
+++ b/onyo/lib/assets.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import logging
 import csv
 import random
 import re
@@ -9,11 +8,10 @@ from typing import Dict, Union, Iterable, Set, Generator, Optional
 
 from ruamel.yaml import YAML, scanner  # pyre-ignore[21]
 
+from onyo import ui
 from onyo.lib.filters import Filter
 from onyo.lib.onyo import OnyoRepo
 
-
-log: logging.Logger = logging.getLogger('onyo.assets')
 
 # Note: Order in this definition likely matters, since the filename is made of them:
 PSEUDO_KEYS = ["type", "make", "model", "serial"]
@@ -31,7 +29,7 @@ def contains_no_pseudo_keys(asset_files: Set[Path]) -> bool:
             assets_failed[asset] = violation_list
 
     if assets_failed:
-        log.error(
+        ui.error(
             "Pseudo keys {0} are reserved for asset file names, and are "
             "not allowed in the asset's contents. The following assets "
             "contain pseudo keys:\n{1}".format(
@@ -51,8 +49,8 @@ def has_unique_names(asset_files: Set[Path]) -> bool:
     duplicates.sort(key=lambda x: x.name)
 
     if duplicates:
-        log.error('The following file names are not unique:\n{}'.format(
-            '\n'.join(map(str, duplicates))))
+        ui.error('The following file names are not unique:\n{}'.format(
+                 '\n'.join(map(str, duplicates))))
         return False
 
     return True
@@ -65,7 +63,7 @@ def validate_assets(asset_files: Set[Path]) -> bool:
         pass
 
     if invalid:
-        log.error(
+        ui.error(
             'The contents of the following files fail validation:\n'
             '{}'.format(
                 '\n'.join([f'{k}\n{v}' for k, v in invalid.items()])))
@@ -87,7 +85,7 @@ def validate_yaml(asset_files: Set[Path]) -> bool:
             invalid_yaml.append(str(asset))
 
     if invalid_yaml:
-        log.error('The following files fail YAML validation:\n{}'.format(
+        ui.error('The following files fail YAML validation:\n{}'.format(
             '\n'.join(invalid_yaml)))
 
         return False
@@ -140,7 +138,7 @@ def valid_asset_name(asset_file: Path) -> bool:
     try:
         re.findall(r'(^[^._]+?)_([^._]+?)_([^._]+?)\.(.+)', asset_file.name)[0]
     except (ValueError, IndexError):
-        log.info(f"'{asset_file.name}' must be in the format '<type>_<make>_<model>.<serial>'")
+        ui.log(f"'{asset_file.name}' must be in the format '<type>_<make>_<model>.<serial>'")
         return False
 
     return True
@@ -200,7 +198,7 @@ def get_asset_content(asset_file: Path) -> Dict[str, Union[float, int, str]]:
     try:
         contents = yaml.load(asset_file)
     except scanner.ScannerError as e:
-        print(e)
+        ui.error(e)
     if contents is None:
         return dict()
     return contents

--- a/onyo/lib/tests/test_onyo.py
+++ b/onyo/lib/tests/test_onyo.py
@@ -76,9 +76,16 @@ def test_Repo_generate_commit_message(repo: OnyoRepo) -> None:
     modified = [repo.git.root / 's p a c e s',
                 repo.git.root / 'a/new/folder']
 
+    # set ui.yes temporarily to `True` to suppress user-interaction
+    from onyo import ui
+    ui.set_yes(True)
+
     # modify the repository with some different commands:
-    mkdir(repo, modified, quiet=True, yes=True, message=None)
-    mv(repo, *modified, quiet=True, yes=True, message=None)
+    mkdir(repo, modified, message=None)
+    mv(repo, *modified, message=None)
+
+    # deactivate `yes` again
+    ui.set_yes(False)
 
     # generate a commit message:
     message = repo.generate_commit_message(cmd='TST', modified=modified)

--- a/onyo/lib/ui.py
+++ b/onyo/lib/ui.py
@@ -1,0 +1,133 @@
+import logging
+import sys
+from pathlib import Path
+from typing import Union
+
+from traceback import format_exc
+
+# TODO: remove "Console" prints in commands.py and command_utils.py
+#       - add rich to print function?
+# TODO: remove logging in other onyo-places?
+
+logging.basicConfig()
+log: logging.Logger = logging.getLogger('onyo')
+log.setLevel(logging.INFO)
+
+
+class UI(object):
+    """
+    """
+
+    def __init__(self,
+                 debug: bool = False,
+                 quiet: bool = False,
+                 yes: bool = False) -> None:  # TODO: interactive="defaults or autodetect?"):
+        """
+        Initialize the User Interface object for user communication of Onyo.
+        """
+        self.debug = debug
+        self.quiet = quiet
+        self.yes = yes
+
+        # set external logging level
+        logging.basicConfig(level=logging.ERROR)
+        # set internal logging level
+        self.logger = logging.getLogger('onyo')
+        self.logger.setLevel(level=logging.INFO)
+
+    def set_debug(self,
+                  debug: bool = False) -> None:
+        """
+        Set the log level to activate debug mode.
+        """
+        if debug:
+            self.debug = debug
+            self.logger.setLevel(logging.DEBUG)
+
+    def set_quiet(self,
+                  quiet: bool = False) -> None:
+        """
+        Set the quiet parameter to suppress terminal output.
+        """
+        if quiet and not self.yes:
+            raise ValueError("The --quiet flag requires --yes.")
+        self.quiet = quiet
+
+    def set_yes(self,
+                yes: bool = False) -> None:
+        """
+        Set `yes` to answer all requests to user with "yes".
+        """
+        self.yes = yes
+
+    def error(self,
+              error: Union[str, Exception],
+              end: str = "\n") -> None:
+        """
+        Print an error message, if the ui is not set to `quiet`.
+        """
+        if not self.quiet:
+            print(f"ERROR: {error}", file=sys.stderr, end=end)
+        # ....
+        # if isinstance(error, Exception):
+        #    for path in error.paths:
+        #        print()
+        # elif isinstance(error, Exception):
+            # ....
+        #    return
+        if self.debug:
+            # TODO: print whole error stack, not just message
+            log.error(format_exc())
+            return
+
+    def log(self,
+            message: str) -> None:
+        """
+        """
+        # TODO: signature like other logger
+        # self.logger.log(*args, **kwargs)
+        self.logger.info(message)
+
+    def log_debug(self,
+                  message: str) -> None:
+        """
+        Debug logging
+        """
+        if self.debug:
+            self.logger.debug(message)
+
+    def print(self,
+              message: Union[str, list, Path] = "\n",
+              end: str = "\n",
+              sep: str = "\n") -> None:
+        """
+        Print a message, if the ui is not set to `quiet`.
+        """
+        if not self.quiet:
+            if isinstance(message, list):
+                print(sep.join(message), end=end)
+            else:
+                print(str(message), end=end)
+
+    def request_user_response(self,
+                              question: str) -> bool:
+        """
+        Opens a dialog for the user and reads an answer from the keyboard.
+        Returns True when user answers yes, False when no, and asks again if the
+        input is neither.
+
+        If the UI is set to `yes=True` returns automatically True, without
+        asking the user.
+        """
+        # TODO: should tty always return true?
+        # if self.yes or not sys.stdout.isatty():
+        if self.yes:
+            return True
+
+        while True:
+            answer = input(question)
+            if answer in ['y', 'Y', 'yes']:
+                return True
+            elif answer in ['n', 'N', 'no']:
+                return False
+        return False

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -4,7 +4,7 @@ import os
 import sys
 import textwrap
 
-from onyo import commands
+from onyo import commands, ui
 from pathlib import Path
 from typing import Union
 
@@ -293,9 +293,10 @@ def main() -> None:
     parser = setup_parser()
     args = parser.parse_args()
 
-    # debugging
-    if args.debug:
-        log.setLevel(logging.DEBUG)
+    # configure user interface
+    ui.set_debug(args.debug)
+    ui.set_yes(args.yes)
+    ui.set_quiet(args.quiet)
 
     # run the subcommand
     if subcmd_index:
@@ -306,7 +307,7 @@ def main() -> None:
         except Exception as e:
             # TODO: This may need to be nicer, but in any case: Turn any exception/error into a message and exit
             #       non-zero here, in order to have this generic last catcher.
-            log.error(str(e))
+            ui.error(e)
             sys.exit(1)
         finally:
             os.chdir(old_cwd)


### PR DESCRIPTION
This PR will close #255

Main changes:
- The UI object is once created
- parameters (e.g. `--yes`, `--quiet`, `--debug`) are set in `main.py`
- all other parts of Onyo import the ui object
- all printing, logging, erroring, and other user interactions are handled with this object!

TODOs:
- `onyo get` is implemented quite differently to the rest; still need to unify for UI:
  - rich
  - machine_readable
  - sort ascending/descending
  - interactive
- unify `interactive`/`non-interactive` for all commands
- improve logging:
  - should everything, including assets.py use the new form ui-logging?
  - currently logging functions of `UI` just receive a string
- add comments etc
- add tests
