### PR TITLE
UI: add `ui.py` and use it to replace prints, logs, etc

### DIFF
--- a/onyo/__init__.py
+++ b/onyo/__init__.py
@@ -1,16 +1,17 @@
-import logging
 from onyo._version import __version__
 from onyo.lib import (
-    Filter, OnyoRepo, OnyoInvalidRepoError,
-    OnyoProtectedPathError, OnyoInvalidFilterError)
+    Filter,
+    OnyoRepo,
+    OnyoInvalidRepoError,
+    OnyoProtectedPathError,
+    OnyoInvalidFilterError,
+    UI,)
 from onyo.onyo_arguments import args_onyo
 
-logging.basicConfig(level=logging.ERROR)  # external logging level
-log: logging.Logger = logging.getLogger('onyo')  # internal logging level
-log.setLevel(level=logging.INFO)
+# create a shared UI object to import by classes/commands
+ui = UI()
 
 __all__ = [
-    'log',
     '__version__',
     'Filter',
     'args_onyo',

--- a/onyo/commands/cat.py
+++ b/onyo/commands/cat.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -9,9 +8,6 @@ from onyo.argparse_helpers import file
 
 if TYPE_CHECKING:
     import argparse
-
-logging.basicConfig()
-log: logging.Logger = logging.getLogger('onyo')
 
 args_cat = {
     'asset': dict(

--- a/onyo/commands/config.py
+++ b/onyo/commands/config.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -9,9 +8,6 @@ from onyo.argparse_helpers import git_config
 
 if TYPE_CHECKING:
     import argparse
-
-logging.basicConfig()
-log: logging.Logger = logging.getLogger('onyo')
 
 args_config = {
     'git_config_args': dict(

--- a/onyo/commands/edit.py
+++ b/onyo/commands/edit.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -10,9 +9,6 @@ from onyo.shared_arguments import shared_arg_message
 
 if TYPE_CHECKING:
     import argparse
-
-logging.basicConfig()
-log: logging.Logger = logging.getLogger('onyo')
 
 args_edit = {
     'asset': dict(
@@ -39,4 +35,4 @@ def edit(args: argparse.Namespace) -> None:
 
     paths = [Path(p).resolve() for p in args.asset]
     repo = OnyoRepo(Path.cwd(), find_root=True)
-    edit_cmd(repo, paths, args.message, args.quiet, args.yes)
+    edit_cmd(repo, paths, args.message)

--- a/onyo/commands/get.py
+++ b/onyo/commands/get.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING
 from pathlib import Path
-import logging
 
 from onyo import OnyoRepo
 from onyo.lib.commands import fsck, get as get_cmd
@@ -10,9 +9,6 @@ from onyo.shared_arguments import shared_arg_depth, shared_arg_filter
 
 if TYPE_CHECKING:
     import argparse
-
-logging.basicConfig()
-log = logging.getLogger('onyo')
 
 args_get = {
     'machine_readable': dict(

--- a/onyo/commands/history.py
+++ b/onyo/commands/history.py
@@ -1,21 +1,17 @@
 from __future__ import annotations
-import logging
 import os
 import sys
 from pathlib import Path
 from shlex import quote
 from typing import TYPE_CHECKING
 
-from onyo import OnyoRepo
+from onyo import OnyoRepo, ui
 from onyo.lib.command_utils import get_history_cmd
 from onyo.lib.commands import fsck
 from onyo.argparse_helpers import path
 
 if TYPE_CHECKING:
     import argparse
-
-logging.basicConfig()
-log: logging.Logger = logging.getLogger('onyo')
 
 args_history = {
     'interactive': dict(
@@ -66,8 +62,8 @@ def history(args: argparse.Namespace) -> None:
     #       history cmd fails. Whatever history command one is using it needs to figure that same thing out again one
     #       way or another. Nothing gained here.
     if path and not path.exists():
-        print(f"Cannot display the history of '{path}'. It does not exist.", file=sys.stderr)
-        print("Exiting.", file=sys.stderr)
+        ui.error(f"Cannot display the history of '{path}'. It does not exist.")
+        ui.error("Exiting.")
         sys.exit(1)
 
     history_cmd = get_history_cmd(args.interactive, repo)

--- a/onyo/commands/mkdir.py
+++ b/onyo/commands/mkdir.py
@@ -35,4 +35,4 @@ def mkdir(args: argparse.Namespace) -> None:
     dirs = [Path(d).resolve() for d in args.directory]
     repo = OnyoRepo(Path.cwd(), find_root=True)
     fsck(repo)
-    mkdir_cmd(repo, dirs, args.quiet, args.yes, args.message)
+    mkdir_cmd(repo, dirs, args.message)

--- a/onyo/commands/mv.py
+++ b/onyo/commands/mv.py
@@ -40,4 +40,4 @@ def mv(args: argparse.Namespace) -> None:
     sources = [Path(p).resolve() for p in args.source]
     destination = Path(args.destination).resolve()
 
-    mv_cmd(repo, sources, destination, args.quiet, args.yes, args.message)
+    mv_cmd(repo, sources, destination, args.message)

--- a/onyo/commands/new.py
+++ b/onyo/commands/new.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -11,9 +10,6 @@ from onyo.shared_arguments import shared_arg_message
 
 if TYPE_CHECKING:
     import argparse
-
-logging.basicConfig()
-log: logging.Logger = logging.getLogger('onyo')
 
 args_new = {
 
@@ -73,4 +69,4 @@ def new(args: argparse.Namespace) -> None:
     fsck(repo)
     path = [Path(p).resolve() for p in args.path] if args.path else None
     tsv = Path(args.tsv).resolve() if args.tsv else None
-    new_cmd(repo, path, args.template, tsv, args.keys, args.edit, args.yes, args.message)
+    new_cmd(repo, path, args.template, tsv, args.keys, args.edit, args.message)

--- a/onyo/commands/rm.py
+++ b/onyo/commands/rm.py
@@ -31,4 +31,4 @@ def rm(args: argparse.Namespace) -> None:
     repo = OnyoRepo(Path.cwd(), find_root=True)
     fsck(repo)
     paths = [Path(p).resolve() for p in args.path]
-    rm_cmd(repo, paths, args.quiet, args.yes, args.message)
+    rm_cmd(repo, paths, args.message)

--- a/onyo/commands/set.py
+++ b/onyo/commands/set.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -15,9 +14,6 @@ from onyo.shared_arguments import (
 
 if TYPE_CHECKING:
     import argparse
-
-logging.basicConfig()
-log: logging.Logger = logging.getLogger('onyo')
 
 args_set = {
     'rename': dict(
@@ -89,6 +85,4 @@ def set(args: argparse.Namespace) -> None:
             args.dry_run,
             args.rename,
             args.depth,
-            args.quiet,
-            args.yes,
             args.message)

--- a/onyo/commands/shell_completion.py
+++ b/onyo/commands/shell_completion.py
@@ -1,6 +1,7 @@
 import argparse
 from typing import Optional
 
+from onyo import ui
 
 args_shell_completion = {
     'shell': dict(
@@ -529,4 +530,4 @@ def shell_completion(args: argparse.Namespace) -> None:
 
     # TODO: add bash
 
-    print(content)
+    ui.print(content)

--- a/onyo/commands/tree.py
+++ b/onyo/commands/tree.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -9,9 +8,6 @@ from onyo.argparse_helpers import directory
 
 if TYPE_CHECKING:
     import argparse
-
-logging.basicConfig()
-log: logging.Logger = logging.getLogger('onyo')
 
 args_tree = {
     'directory': dict(

--- a/onyo/commands/unset.py
+++ b/onyo/commands/unset.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -15,9 +14,6 @@ from onyo.shared_arguments import (
 
 if TYPE_CHECKING:
     import argparse
-
-logging.basicConfig()
-log: logging.Logger = logging.getLogger('onyo')
 
 args_unset = {
     'keys': dict(
@@ -73,7 +69,5 @@ def unset(args: argparse.Namespace) -> None:
               args.keys,
               args.filter,
               args.dry_run,
-              args.quiet,
-              args.yes,
               args.depth,
               args.message)

--- a/onyo/lib/__init__.py
+++ b/onyo/lib/__init__.py
@@ -1,5 +1,6 @@
 from .filters import Filter
 from .onyo import OnyoRepo
+from .ui import UI
 from .exceptions import OnyoInvalidRepoError, OnyoProtectedPathError, OnyoInvalidFilterError
 
 
@@ -9,4 +10,5 @@ __all__ = [
     'OnyoInvalidRepoError',
     'OnyoProtectedPathError',
     'OnyoInvalidFilterError',
+    'UI',
 ]

--- a/onyo/lib/assets.py
+++ b/onyo/lib/assets.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import logging
 import csv
 import random
 import re
@@ -9,11 +8,10 @@ from typing import Dict, Union, Iterable, Set, Generator, Optional
 
 from ruamel.yaml import YAML, scanner  # pyre-ignore[21]
 
+from onyo import ui
 from onyo.lib.filters import Filter
 from onyo.lib.onyo import OnyoRepo
 
-
-log: logging.Logger = logging.getLogger('onyo.assets')
 
 # Note: Order in this definition likely matters, since the filename is made of them:
 PSEUDO_KEYS = ["type", "make", "model", "serial"]
@@ -31,7 +29,7 @@ def contains_no_pseudo_keys(asset_files: Set[Path]) -> bool:
             assets_failed[asset] = violation_list
 
     if assets_failed:
-        log.error(
+        ui.error(
             "Pseudo keys {0} are reserved for asset file names, and are "
             "not allowed in the asset's contents. The following assets "
             "contain pseudo keys:\n{1}".format(
@@ -51,8 +49,8 @@ def has_unique_names(asset_files: Set[Path]) -> bool:
     duplicates.sort(key=lambda x: x.name)
 
     if duplicates:
-        log.error('The following file names are not unique:\n{}'.format(
-            '\n'.join(map(str, duplicates))))
+        ui.error('The following file names are not unique:\n{}'.format(
+                 '\n'.join(map(str, duplicates))))
         return False
 
     return True
@@ -65,7 +63,7 @@ def validate_assets(asset_files: Set[Path]) -> bool:
         pass
 
     if invalid:
-        log.error(
+        ui.error(
             'The contents of the following files fail validation:\n'
             '{}'.format(
                 '\n'.join([f'{k}\n{v}' for k, v in invalid.items()])))
@@ -87,7 +85,7 @@ def validate_yaml(asset_files: Set[Path]) -> bool:
             invalid_yaml.append(str(asset))
 
     if invalid_yaml:
-        log.error('The following files fail YAML validation:\n{}'.format(
+        ui.error('The following files fail YAML validation:\n{}'.format(
             '\n'.join(invalid_yaml)))
 
         return False
@@ -140,7 +138,7 @@ def valid_asset_name(asset_file: Path) -> bool:
     try:
         re.findall(r'(^[^._]+?)_([^._]+?)_([^._]+?)\.(.+)', asset_file.name)[0]
     except (ValueError, IndexError):
-        log.info(f"'{asset_file.name}' must be in the format '<type>_<make>_<model>.<serial>'")
+        ui.error(f"'{asset_file.name}' must be in the format '<type>_<make>_<model>.<serial>'")
         return False
 
     return True
@@ -200,7 +198,7 @@ def get_asset_content(asset_file: Path) -> Dict[str, Union[float, int, str]]:
     try:
         contents = yaml.load(asset_file)
     except scanner.ScannerError as e:
-        print(e)
+        ui.error(e)
     if contents is None:
         return dict()
     return contents

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import subprocess
-import sys
-import logging
 from typing import Optional, Union, Iterable, Dict
 from pathlib import Path
 
@@ -10,16 +8,14 @@ from rich.console import Console
 from rich import box
 from rich.table import Table
 
+from onyo import ui
 from onyo.lib.assets import PSEUDO_KEYS, get_assets_by_query
-from onyo.lib.command_utils import get_editor, edit_asset, \
-    request_user_response, sanitize_keys, set_filters, \
-    fill_unset, natural_sort, validate_args_for_new, onyo_mv, rollback_untracked
+from onyo.lib.command_utils import get_editor, edit_asset, sanitize_keys, \
+    set_filters, fill_unset, natural_sort, validate_args_for_new, onyo_mv, \
+    rollback_untracked
 from onyo.lib.exceptions import OnyoInvalidRepoError
 from onyo.lib.filters import UNSET_VALUE
 from onyo.lib.onyo import OnyoRepo
-
-
-log: logging.Logger = logging.getLogger('onyo.commands')
 
 
 def fsck(repo: OnyoRepo, tests: Optional[list[str]] = None) -> None:
@@ -61,15 +57,15 @@ def fsck(repo: OnyoRepo, tests: Optional[list[str]] = None) -> None:
     # run the selected tests
     for key in tests:
         # TODO: these should be INFO
-        log.debug(f"'{key}' starting")
+        ui.log_debug(f"'{key}' starting")
 
         if not all_tests[key]():
             # Note: What's that debug message adding? Alone it lacks the identifying path and in combination with
             #       the exception it's redundant.
-            log.debug(f"'{key}' failed")
+            ui.log_debug(f"'{key}' failed")
             raise OnyoInvalidRepoError(f"'{repo.git.root}' failed fsck test '{key}'")
 
-        log.debug(f"'{key}' succeeded")
+        ui.log_debug(f"'{key}' succeeded")
 
 
 def cat(repo: OnyoRepo, paths: Iterable[Path]) -> None:
@@ -80,7 +76,7 @@ def cat(repo: OnyoRepo, paths: Iterable[Path]) -> None:
                          "\n".join(non_asset_paths))
     # open file and print to stdout
     for path in paths:
-        print(path.read_text(), end='')
+        ui.print(path.read_text(), end='')
 
 
 def config(repo: OnyoRepo, config_args: list[str]) -> None:
@@ -97,9 +93,9 @@ def config(repo: OnyoRepo, config_args: list[str]) -> None:
 
     # print any output gathered
     if ret.stdout:
-        print(ret.stdout, end='')
+        ui.print(ret.stdout, end="")
     if ret.stderr:
-        print(ret.stderr, file=sys.stderr, end='')
+        ui.error(ret.stderr, end="")
 
     # bubble up error retval
     if ret.returncode != 0:
@@ -112,13 +108,7 @@ def config(repo: OnyoRepo, config_args: list[str]) -> None:
 
 def edit(repo: OnyoRepo,
          asset_paths: Iterable[Path],
-         message: list[str],
-         quiet: bool,
-         yes: bool) -> None:
-    # check flags for conflicts
-    if quiet and not yes:
-        raise ValueError('The --quiet flag requires --yes.')
-
+         message: list[str]) -> None:
     # "onyo fsck" is intentionally not run here.
     # This is so "onyo edit" can be used to fix an existing problem. This has
     # benefits over just simply using `vim`, etc directly, as "onyo edit" will
@@ -129,7 +119,7 @@ def edit(repo: OnyoRepo,
     valid_asset_paths = []
     for a in asset_paths:
         if not repo.is_asset_path(a):
-            print(f"\n{a} is not an asset.", file=sys.stderr)
+            ui.error(f"\n{a} is not an asset.")
         else:
             valid_asset_paths.append(a)
     if not valid_asset_paths:
@@ -144,15 +134,13 @@ def edit(repo: OnyoRepo,
         else:
             # If user wants to discard changes, restore the asset's state
             repo.git.restore(asset)
-            if not quiet:
-                print(f"'{asset}' not updated.")
+            ui.print(f"'{asset}' not updated.")
 
     diff = repo.git._diff_changes()
     if diff:
         # commit changes
-        if not quiet:
-            print(diff)
-        if yes or request_user_response("Save changes? No discards all changes. (y/n) "):
+        ui.print(diff)
+        if ui.request_user_response("Save changes? No discards all changes. (y/n) "):
             repo.git.stage_and_commit(paths=modified,
                                       message=repo.generate_commit_message(message=message,
                                                                            cmd="edit")
@@ -160,8 +148,7 @@ def edit(repo: OnyoRepo,
             return
         else:
             repo.git.restore(modified)
-    if not quiet:
-        print('No assets updated.')
+    ui.print('No assets updated.')
 
 
 def get(repo: OnyoRepo,
@@ -178,8 +165,9 @@ def get(repo: OnyoRepo,
             '--sort-ascending (-s) and --sort-descending (-S) cannot be used '
             'together')
         if machine_readable:
-            print(msg, file=sys.stderr)
+            ui.error(msg)
         else:
+            # TODO: do this with ui class too
             console = Console(stderr=True)
             console.print(f'[red]FAILED[/red] {msg}')
         raise ValueError
@@ -214,7 +202,7 @@ def get(repo: OnyoRepo,
         sep = '\t'  # column separator
         for asset, data in results:
             values = sep.join([str(value) for value in data.values()])
-            print(f'{values}{sep}{asset.relative_to(Path.cwd())}')
+            ui.print(f'{values}{sep}{asset.relative_to(Path.cwd())}')
     else:
         console = Console()
         table = Table(
@@ -230,25 +218,25 @@ def get(repo: OnyoRepo,
             for asset, data in results:
                 values = [str(value) for value in data.values()]
                 table.add_row(*values, str(asset.relative_to(Path.cwd())))
-
+            # TODO: do this with ui class, too
             console.print(table)
         else:
             console.print('No assets matching the filter(s) were found')
 
 
-def mkdir(repo: OnyoRepo, dirs: list[Path], quiet: bool, yes: bool, message: Union[list[str], None]) -> None:
+def mkdir(repo: OnyoRepo,
+          dirs: list[Path],
+          message: Union[list[str], None]) -> None:
 
     created_files = repo.mk_inventory_dirs(dirs)
 
     if created_files:
         # commit changes
-        if not quiet:
-            created_dirs = [p.parent for p in created_files]
-            print(
-                'The following directories will be created:',
-                *map(str, created_dirs), sep='\n')
+        created_dirs = [p.parent for p in created_files]
+        ui.print(['The following directories will be created:',
+                  *map(str, created_dirs)], sep='\n')
 
-        if yes or request_user_response("Save changes? No discards all changes. (y/n) "):
+        if ui.request_user_response("Save changes? No discards all changes. (y/n) "):
             repo.git.stage_and_commit(
                 paths=created_files,
                 message=repo.generate_commit_message(message=message,
@@ -258,30 +246,21 @@ def mkdir(repo: OnyoRepo, dirs: list[Path], quiet: bool, yes: bool, message: Uni
             return
         else:
             rollback_untracked(created_files)
-    if not quiet:
-        print('No directories created.')
+    ui.print('No directories created.')
 
 
 def mv(repo: OnyoRepo,
        source: Union[Iterable[Path], Path],
        destination: Path,
-       quiet: bool,
-       yes: bool,
        message: Union[list[str], None]) -> None:
 
-    # check flags
-    if quiet and not yes:
-        raise ValueError("The --quiet flag requires --yes.")
+    dryrun_list = onyo_mv(repo, source, destination, dryrun=True)
+    ui.print('The following will be moved:\n' +
+             '\n'.join(f"'{x[0]}' -> '{x[1]}'" for x in dryrun_list))
 
-    # Note: Why does the dryrun execution depend on quiet?
-    if not quiet:
-        dryrun_list = onyo_mv(repo, source, destination, dryrun=True)
-        print('The following will be moved:\n' +
-              '\n'.join(f"'{x[0]}' -> '{x[1]}'" for x in dryrun_list))
-
-        if not yes and not request_user_response("Save changes? No discards all changes. (y/n) "):
-            print('Nothing was moved.')
-            return
+    if not ui.request_user_response("Save changes? No discards all changes. (y/n) "):
+        ui.print('Nothing was moved.')
+        return
 
     onyo_mv(repo, source, destination)
     repo.git.commit(repo.generate_commit_message(message=message, cmd="mv",
@@ -294,7 +273,6 @@ def new(repo: OnyoRepo,
         tsv: Optional[Path],
         keys: Dict[str, str],
         edit: bool,
-        yes: bool,
         message: Union[list[str], None]) -> None:
 
     from onyo.lib.assets import read_assets_from_tsv, create_assets_in_destination, read_assets_from_CLI
@@ -328,19 +306,19 @@ def new(repo: OnyoRepo,
     # print diff-like output and remember new directories and assets
     changes = []
     if new_files:
-        print("The following will be created:")
+        ui.print("The following will be created:")
         for path in new_files:
             # display new folders, not anchors.
             if path.name == repo.ANCHOR_FILE:
-                print(path.parent)
+                ui.print(path.parent)
                 changes.append(path.parent)
             else:
-                print(path)
+                ui.print(path)
                 changes.append(path)
 
     # commit or discard changes
     if new_files:
-        if yes or request_user_response("Create assets? (y/n) "):
+        if ui.request_user_response("Create assets? (y/n) "):
             repo.git.stage_and_commit(paths=new_files,
                                       message=repo.generate_commit_message(message=message,
                                                                            cmd="new",
@@ -349,27 +327,19 @@ def new(repo: OnyoRepo,
             return
         else:
             rollback_untracked(new_files)
-    print('No new assets created.')
+    ui.print('No new assets created.')
 
 
 def rm(repo: OnyoRepo,
        path: list[Path],
-       quiet: bool,
-       yes: bool,
        message: Union[list[str], None]) -> None:
     from onyo.lib.command_utils import rm as onyo_rm
-    # check flags
-    if quiet and not yes:
-        raise ValueError('The --quiet flag requires --yes.')
+    dryrun_list = onyo_rm(repo, path, dryrun=True)
+    ui.print('The following will be deleted:\n' + '\n'.join(dryrun_list))
 
-    if not quiet:
-        dryrun_list = onyo_rm(repo, path, dryrun=True)
-        print('The following will be deleted:\n' +
-              '\n'.join(dryrun_list))
-
-        if not yes and not request_user_response("Save changes? No discards all changes. (y/n) "):
-            print('Nothing was deleted.')
-            return
+    if not ui.request_user_response("Save changes? No discards all changes. (y/n) "):
+        ui.print('Nothing was deleted.')
+        return
 
     onyo_rm(repo, path)
     repo.git.commit(repo.generate_commit_message(message=message,
@@ -383,15 +353,9 @@ def set_(repo: OnyoRepo,
          dryrun: bool,
          rename: bool,
          depth: Union[int],
-         quiet: bool,
-         yes: bool,
          message: Union[list[str], None]) -> Union[str, None]:
     from onyo.lib.command_utils import set_assets
     from .assets import write_asset_file
-
-    # check flags for conflicts
-    if quiet and not yes:
-        raise ValueError('The --quiet flag requires --yes.')
 
     if not paths:
         paths = [Path.cwd()]
@@ -415,18 +379,17 @@ def set_(repo: OnyoRepo,
 
     diffs = [m[2] for m in modifications if m[2] != []]
     # display changes
-    if not quiet:
-        if diffs or moves:
-            print("The following assets will be changed:")
-            for src, dst in moves:
-                print(f"Rename {src} to {dst}")
-            if diffs:
-                for d in diffs:
-                    for line in d:
-                        print(line)
-        else:
-            print("The values are already set. No assets updated.")
-            return
+    if diffs or moves:
+        ui.print("The following assets will be changed:")
+        for src, dst in moves:
+            ui.print(f"Rename {src} to {dst}")
+        if diffs:
+            for d in diffs:
+                for line in d:
+                    ui.print(line)
+    else:
+        ui.print("The values are already set. No assets updated.")
+        return
 
     # Note: This needs to go again, when dryrun (gh-377) and convolution of name generation,
     #       git-mv, etc. is resolved.
@@ -444,7 +407,7 @@ def set_(repo: OnyoRepo,
 
         # commit or discard changes
         if diffs or moves:
-            if yes or request_user_response("Update assets? (y/n) "):
+            if ui.request_user_response("Update assets? (y/n) "):
                 repo.git.commit(repo.generate_commit_message(message=message,
                                                              cmd="set",
                                                              keys=[f"{k}={v}" for k, v in keys.items()]))
@@ -455,8 +418,7 @@ def set_(repo: OnyoRepo,
                     to_restore.append(s)
                     to_restore.append(d)
                 repo.git.restore_staged()
-    if not quiet:
-        print("No assets updated.")
+    ui.print("No assets updated.")
 
 
 def tree(repo: OnyoRepo, paths: list[Path]) -> None:
@@ -473,7 +435,7 @@ def tree(repo: OnyoRepo, paths: list[Path]) -> None:
     if ret.stderr:
         raise RuntimeError(ret.stderr)
     # print tree output
-    print(ret.stdout)
+    ui.print(ret.stdout)
 
 
 def unset(repo: OnyoRepo,
@@ -481,15 +443,10 @@ def unset(repo: OnyoRepo,
           keys: list[str],
           filter_strings: list[str],
           dryrun: bool,
-          quiet: bool,
-          yes: bool,
           depth: Union[int, None],
           message: Union[list[str], None]) -> None:
     from onyo.lib.command_utils import unset as ut_unset
     from .assets import write_asset_file
-    # check flags for conflicts
-    if quiet and not yes:
-        raise ValueError("The --quiet flag requires --yes.")
 
     if not paths:
         paths = [Path.cwd()]
@@ -504,23 +461,22 @@ def unset(repo: OnyoRepo,
         repo.asset_paths, keys=None, paths=paths, depth=depth, filters=filters)
     paths = [a[0] for a in paths]
 
-    modifications = ut_unset(repo, paths, keys, dryrun, quiet, depth)
+    modifications = ut_unset(repo, paths, keys, dryrun, depth)
 
     diffs = [m[2] for m in modifications if m[2] != []]
     # display changes
-    if not quiet:
+    if diffs:
+        ui.print("The following assets will be changed:")
         if diffs:
-            print("The following assets will be changed:")
-            if diffs:
-                for d in diffs:
-                    for line in d:
-                        print(line)
-        else:
-            print("No assets containing the specified key(s) could be found. No assets updated.")
-            return
+            for d in diffs:
+                for line in d:
+                    ui.print(line)
+    else:
+        ui.print("No assets containing the specified key(s) could be found. No assets updated.")
+        return
 
     if diffs and not dryrun:
-        if yes or request_user_response("Update assets? (y/n) "):
+        if ui.request_user_response("Update assets? (y/n) "):
             to_commit = []
             for m in modifications:
                 write_asset_file(m[0], m[1])
@@ -531,5 +487,4 @@ def unset(repo: OnyoRepo,
                                                                            keys=keys)
                                       )
             return
-    if not quiet:
-        print("No assets updated.")
+    ui.print("No assets updated.")

--- a/onyo/lib/filters.py
+++ b/onyo/lib/filters.py
@@ -1,13 +1,9 @@
 from __future__ import annotations
-import logging
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
 from onyo.lib.exceptions import OnyoInvalidFilterError
-
-
-log: logging.Logger = logging.getLogger('onyo.filters')
 
 
 # TODO: Move this to a place specifically meant for defaults, along with

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -8,6 +8,7 @@ from .git import GitRepo
 from .exceptions import OnyoInvalidRepoError, OnyoProtectedPathError
 
 log: logging.Logger = logging.getLogger('onyo.onyo')
+log.setLevel(logging.INFO)
 
 
 class OnyoRepo(object):

--- a/onyo/lib/tests/test_onyo.py
+++ b/onyo/lib/tests/test_onyo.py
@@ -76,9 +76,16 @@ def test_Repo_generate_commit_message(repo: OnyoRepo) -> None:
     modified = [repo.git.root / 's p a c e s',
                 repo.git.root / 'a/new/folder']
 
+    # set ui.yes temporarily to `True` to suppress user-interaction
+    from onyo import ui
+    ui.set_yes(True)
+
     # modify the repository with some different commands:
-    mkdir(repo, modified, quiet=True, yes=True, message=None)
-    mv(repo, *modified, quiet=True, yes=True, message=None)
+    mkdir(repo, modified, message=None)
+    mv(repo, *modified, message=None)
+
+    # deactivate `yes` again
+    ui.set_yes(False)
 
     # generate a commit message:
     message = repo.generate_commit_message(cmd='TST', modified=modified)

--- a/onyo/lib/ui.py
+++ b/onyo/lib/ui.py
@@ -1,0 +1,210 @@
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Union
+
+from traceback import format_exception
+
+logging.basicConfig()
+log: logging.Logger = logging.getLogger('onyo')
+
+
+class UI(object):
+    """
+    An object handling user interaction, including printing, errors, requests,
+    and others.
+
+    Attributes
+    ----------
+    log: Logger
+        The logger to display information with.
+    quiet: boolean
+        Activate the quiet mode (requires that `yes=True`).
+        This will suppresses all output generation.
+    yes: boolean
+        Activate the yes mode, which suppresses all interactive requests to the
+        user, and instead answers them with yes.
+    """
+
+    def __init__(self,
+                 debug: bool = False,
+                 quiet: bool = False,
+                 yes: bool = False) -> None:
+        # TODO: interactive mode with default values or autodetecting tty? And
+        # should this be unified with the whole business of rich-coloring etc?
+        """
+        Initialize the User Interface object for user communication of Onyo.
+
+        Parameters
+        ----------
+        debug: boolean
+            Activate the debug mode to display additional information via Onyo,
+            and to print the full traceback stack if errors occur.
+
+        quiet: boolean
+            Activate the quiet mode (requires that `yes=True`) to suppress all
+            output generation.
+
+        yes: boolean
+            Activate the yes mode to suppress all interactive requests to the
+            user, and instead answers them with yes.
+        """
+        # set the the attributes of the UI object
+        self.quiet = quiet
+        self.yes = yes
+        self.logger = logging.getLogger('onyo')
+
+        # set the debug level
+        if debug:
+            self.logger.setLevel(logging.DEBUG)
+        else:
+            self.logger.setLevel(logging.INFO)
+
+    def set_debug(self,
+                  debug: bool = False) -> None:
+        """
+        Set the log level to activate debug mode.
+
+        Parameters
+        ----------
+        debug: boolean
+            Activates debug mode, and configures the log level of the logger.
+        """
+        if debug:
+            self.logger.setLevel(logging.DEBUG)
+        else:
+            self.logger.setLevel(logging.INFO)
+
+    def set_quiet(self,
+                  quiet: bool = False) -> None:
+        """
+        Set `quiet` to suppress terminal output.
+
+        Parameters
+        ----------
+        quiet: boolean
+            `True` suppresses of all user output.
+            Requires `yes` mode to be active.
+
+        Raises
+        ------
+        ValueError
+            If tried to activate quiet mode without `yes=True`.
+        """
+        if quiet and not self.yes:
+            raise ValueError("The --quiet flag requires --yes.")
+        self.quiet = quiet
+
+    def set_yes(self,
+                yes: bool = False) -> None:
+        """
+        Set `yes` to answer all requests to user with "yes".
+
+        Parameters
+        ----------
+        yes: boolean
+            Activate yes mode, which suppresses all user requests and answers
+            them positively. Allows the activation of the quiet mode.
+        """
+        self.yes = yes
+
+    def error(self,
+              error: Union[str, Exception],
+              end: str = os.linesep) -> None:
+        """
+        Print an error message, if the UI is not set to `quiet`.
+
+        Parameters
+        ----------
+        error: string or Exception
+            Prints the string, or the message of an error.
+            If debug mode is activated, displays the full traceback of an
+            exception.
+
+        end: str
+            Specify the string at the end of prints.
+            Per default, prints end with a line break.
+        """
+        if not self.quiet:
+            print(f"ERROR: {error}", file=sys.stderr, end=end)
+        if isinstance(error, Exception):
+            self.logger.debug("".join(format_exception(
+                etype=error,  # pyre-ignore[6]
+                value=error,
+                tb=error.__traceback__)))
+
+    def log(self,
+            message: str) -> None:
+        """
+        Display a message via the logger if the log level is at least `info`.
+
+        Parameters
+        ----------
+        message: string
+            The string to display as an info.
+        """
+        self.logger.info(message)
+
+    def log_debug(self,
+                  message: str) -> None:
+        """
+        Display debug information if debug mode is activated.
+
+        Parameters
+        ----------
+        message: string
+            The string to display as debug information.
+        """
+        self.logger.debug(message)
+
+    def print(self,
+              message: Union[str, list, Path] = os.linesep,
+              end: str = os.linesep,
+              sep: str = os.linesep) -> None:
+        """
+        Print a message, if the UI is not set to `quiet`.
+
+        Parameters
+        ----------
+        message: string, list or Path
+
+        end: str
+            Specify the string at the end of prints.
+            Per default, prints end with a linebreak.
+
+        sep: str
+            Specify a string to concatenate message if it is a list.
+            By default lists are concatenated with line breaks.
+        """
+        if not self.quiet:
+            if isinstance(message, list):
+                print(sep.join(message), end=end)
+            else:
+                print(str(message), end=end)
+
+    def request_user_response(self,
+                              question: str) -> bool:
+        """
+        Opens a dialog for the user and reads an answer from the keyboard.
+        Returns True when user answers yes, False when no, and asks again if the
+        input is neither.
+
+        If the UI is set to `yes=True` returns automatically True, without
+        asking the user.
+
+        Parameters
+        ----------
+        question: string
+            A string asking the question to which the user should respond.
+        """
+        if self.yes:
+            return True
+
+        while True:
+            answer = input(question)
+            if answer in ['y', 'Y', 'yes']:
+                return True
+            elif answer in ['n', 'N', 'no']:
+                return False
+        return False

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -1,16 +1,11 @@
 import argparse
-import logging
 import os
 import sys
 import textwrap
 
-from onyo import commands
+from onyo import commands, ui
 from pathlib import Path
 from typing import Union
-
-logging.basicConfig()
-log: logging.Logger = logging.getLogger('onyo')
-log.setLevel(logging.INFO)
 
 
 # credit: https://stackoverflow.com/a/13429281
@@ -293,9 +288,10 @@ def main() -> None:
     parser = setup_parser()
     args = parser.parse_args()
 
-    # debugging
-    if args.debug:
-        log.setLevel(logging.DEBUG)
+    # configure user interface
+    ui.set_debug(args.debug)
+    ui.set_yes(args.yes)
+    ui.set_quiet(args.quiet)
 
     # run the subcommand
     if subcmd_index:
@@ -306,7 +302,7 @@ def main() -> None:
         except Exception as e:
             # TODO: This may need to be nicer, but in any case: Turn any exception/error into a message and exit
             #       non-zero here, in order to have this generic last catcher.
-            log.error(str(e))
+            ui.error(e)
             sys.exit(1)
         finally:
             os.chdir(old_cwd)


### PR DESCRIPTION
This PR will close #255

Main changes:
- The UI object is once created
- parameters (e.g. `--yes`, `--quiet`, `--debug`) are set in `main.py`
- all other parts of Onyo import the ui object (except if it would cause circular imports)
- all printing, logging, erroring, and other user interactions are handled with this object

TODOs:
- `onyo get` is implemented quite differently to the rest; still need to unify for UI:
  - rich
  - machine_readable
  - sort ascending/descending
  - interactive
- unify `interactive`/`non-interactive` for all commands
- should everything, including assets.py use the new form ui-logging? This leads to Circular imports
- add tests