### PR TITLE
Operations + Inventory class

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,6 +10,7 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.9', '3.10', '3.11']
 

--- a/onyo/__init__.py
+++ b/onyo/__init__.py
@@ -4,12 +4,8 @@ from onyo.lib import (
     OnyoRepo,
     OnyoInvalidRepoError,
     OnyoProtectedPathError,
-    OnyoInvalidFilterError,
-    UI,)
+    OnyoInvalidFilterError,)
 from onyo.onyo_arguments import args_onyo
-
-# create a shared UI object to import by classes/commands
-ui = UI()
 
 __all__ = [
     '__version__',

--- a/onyo/argparse_helpers.py
+++ b/onyo/argparse_helpers.py
@@ -1,27 +1,57 @@
 import argparse
+import os
+
 from typing import Optional, Sequence, Union
 
 
 class StoreKeyValuePairs(argparse.Action):
-    def __init__(self, option_strings: Sequence[str], dest: str,
-                 nargs: Union[None, int, str] = None, **kwargs) -> None:
+    def __init__(self,
+                 option_strings: Sequence[str],
+                 dest: str,
+                 nargs: Union[None, int, str] = None,
+                 **kwargs) -> None:
         self._nargs = nargs
         super().__init__(option_strings, dest, nargs=nargs, **kwargs)
 
-    def __call__(self, parser: argparse.ArgumentParser,
-                 namespace: argparse.Namespace, key_values: list[str],
+    def __call__(self,
+                 parser: argparse.ArgumentParser,
+                 namespace: argparse.Namespace,
+                 key_values: list[str],
                  option_string: Optional[str] = None) -> None:
-        results = {}
-        for pair in key_values:
-            k, v = pair.split('=', maxsplit=1)
+        """Turn a list of 'key=value' pairs into a list of dictionaries
+
+        Every key appearing multiple times in `key=value` is applied to a new dictionary every time.
+        All keys appearing multiple times, must appear the same number of times (and thereby define the number of dicts
+        to be created). In case of different counts: raise.
+        Every key appearing once in `key_values` will be applied to all dictionaries.
+        """
+
+        pairs = [p.split('=', maxsplit=1) for p in key_values]
+        register_dict = {k: [] for k, v in pairs}
+        [register_dict[k].append(v) for k, v in pairs]
+        number_of_dicts = max(len(v) for v in register_dict.values())
+        invalid_keys = [(k, len(v)) for k, v in register_dict.items() if 1 < len(v) < number_of_dicts]
+        if invalid_keys:
+            raise ValueError(f"All keys given multiple times must be provided the same number of times.{os.linesep}"
+                             f"Got: {', '.join(['{}: {}'.format(k, c) for k, c in invalid_keys])}")
+
+        def cvt(v: str) -> Union[int, float, str]:
             try:
-                v = int(v)
+                r = int(v)
             except ValueError:
                 try:
-                    float(v)
+                    r = float(v)
                 except ValueError:
-                    pass
-            results[k] = v
+                    r = v
+            return r
+
+        results = []
+        for i in range(number_of_dicts):
+            d = dict()
+            for k, values in register_dict.items():
+                v = values[0] if len(values) == 1 else values[i]
+                d[k] = cvt(v)
+            results.append(d)
         setattr(namespace, self.dest, results)
 
 

--- a/onyo/commands/cat.py
+++ b/onyo/commands/cat.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from onyo.lib.onyo import OnyoRepo
-from onyo.lib.commands import cat as cat_cmd, fsck
+from onyo.lib.commands import onyo_cat
 from onyo.argparse_helpers import file
 
 if TYPE_CHECKING:
@@ -25,5 +25,4 @@ def cat(args: argparse.Namespace) -> None:
     paths = [Path(p).resolve() for p in args.asset]
 
     repo = OnyoRepo(Path.cwd(), find_root=True)
-    fsck(repo, ['asset-yaml'])
-    cat_cmd(repo, paths)
+    onyo_cat(repo, paths)

--- a/onyo/commands/config.py
+++ b/onyo/commands/config.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from onyo import OnyoRepo
-from onyo.lib.commands import config as config_cmd, fsck
+from onyo.lib.commands import onyo_config
 from onyo.argparse_helpers import git_config
 
 if TYPE_CHECKING:
@@ -46,6 +46,7 @@ def config(args: argparse.Namespace) -> None:
       (default: "empty")
     """
 
+    # TODO: Wouldn't we want to commit (implying message parameter)?
+
     repo = OnyoRepo(Path.cwd(), find_root=True)
-    fsck(repo, ['asset-yaml'])
-    config_cmd(repo, args.git_config_args)
+    onyo_config(repo, args.git_config_args)

--- a/onyo/commands/edit.py
+++ b/onyo/commands/edit.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from onyo.lib.commands import edit as edit_cmd
+from onyo.lib.commands import onyo_edit
 from onyo.lib.onyo import OnyoRepo
+from onyo.lib.inventory import Inventory
 from onyo.argparse_helpers import file
 from onyo.shared_arguments import shared_arg_message
 
@@ -34,5 +35,7 @@ def edit(args: argparse.Namespace) -> None:
     """
 
     paths = [Path(p).resolve() for p in args.asset]
-    repo = OnyoRepo(Path.cwd(), find_root=True)
-    edit_cmd(repo, paths, args.message)
+    inventory = Inventory(repo=OnyoRepo(Path.cwd(), find_root=True))
+    onyo_edit(inventory=inventory,
+              asset_paths=paths,
+              message='\n'.join(m for m in args.message) if args.message else None)

--- a/onyo/commands/get.py
+++ b/onyo/commands/get.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 from pathlib import Path
 
 from onyo import OnyoRepo
-from onyo.lib.commands import fsck, get as get_cmd
+from onyo.lib.commands import get as get_cmd
 from onyo.argparse_helpers import path
 from onyo.shared_arguments import shared_arg_depth, shared_arg_filter
 
@@ -71,7 +71,6 @@ def get(args: argparse.Namespace) -> None:
     """
 
     repo = OnyoRepo(Path.cwd(), find_root=True)
-    fsck(repo, ['asset-yaml'])
 
     paths = [Path(p).resolve() for p in args.path] if args.path else None
     get_cmd(repo,

--- a/onyo/commands/history.py
+++ b/onyo/commands/history.py
@@ -5,9 +5,9 @@ from pathlib import Path
 from shlex import quote
 from typing import TYPE_CHECKING
 
-from onyo import OnyoRepo, ui
+from onyo import OnyoRepo
+from onyo.lib.ui import ui
 from onyo.lib.command_utils import get_history_cmd
-from onyo.lib.commands import fsck
 from onyo.argparse_helpers import path
 
 if TYPE_CHECKING:
@@ -51,7 +51,6 @@ def history(args: argparse.Namespace) -> None:
     # TODO: Not sure about args.path not given. Doesn't necessarily work with any all history commands.
 
     repo = OnyoRepo(Path.cwd(), find_root=True)
-    fsck(repo, ['asset-yaml'])
 
     # get the command and path
     path = Path(args.path).resolve() if args.path else Path.cwd()

--- a/onyo/commands/mkdir.py
+++ b/onyo/commands/mkdir.py
@@ -3,7 +3,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from onyo import OnyoRepo
-from onyo.lib.commands import fsck, mkdir as mkdir_cmd
+from onyo.lib.inventory import Inventory
+from onyo.lib.commands import onyo_mkdir
 from onyo.argparse_helpers import directory
 from onyo.shared_arguments import shared_arg_message
 
@@ -33,6 +34,7 @@ def mkdir(args: argparse.Namespace) -> None:
     an error. All checks are performed before creating directories.
     """
     dirs = [Path(d).resolve() for d in args.directory]
-    repo = OnyoRepo(Path.cwd(), find_root=True)
-    fsck(repo)
-    mkdir_cmd(repo, dirs, args.message)
+    inventory = Inventory(repo=OnyoRepo(Path.cwd(), find_root=True))
+    onyo_mkdir(inventory,
+               dirs=dirs,
+               message='\n'.join(m for m in args.message) if args.message else None)

--- a/onyo/commands/mv.py
+++ b/onyo/commands/mv.py
@@ -3,7 +3,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from onyo import OnyoRepo
-from onyo.lib.commands import fsck, mv as mv_cmd
+from onyo.lib.commands import onyo_mv
+from onyo.lib.inventory import Inventory
 from onyo.argparse_helpers import path
 from onyo.shared_arguments import shared_arg_message
 
@@ -31,13 +32,15 @@ def mv(args: argparse.Namespace) -> None:
     Move ``SOURCE``\\(s) (assets or directories) to the ``DEST`` directory, or
     rename a ``SOURCE`` directory to ``DEST``.
 
-    Files cannot be renamed using ``onyo mv``. To do so, use ``onyo set``.
+    Files cannot be renamed using ``onyo mv``, since their names are generated from their contents.
+    To rename a file, use ``onyo set``.
     """
-    repo = OnyoRepo(Path.cwd(), find_root=True)
-    fsck(repo)
+    inventory = Inventory(repo=OnyoRepo(Path.cwd(), find_root=True))
 
-    # TODO: Figure whether args.source is actually always a list
     sources = [Path(p).resolve() for p in args.source]
     destination = Path(args.destination).resolve()
 
-    mv_cmd(repo, sources, destination, args.message)
+    onyo_mv(inventory=inventory,
+            source=sources,
+            destination=destination,
+            message='\n'.join(m for m in args.message) if args.message else None)

--- a/onyo/commands/new.py
+++ b/onyo/commands/new.py
@@ -3,7 +3,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from onyo import OnyoRepo
-from onyo.lib.commands import fsck, new as new_cmd
+from onyo.lib.inventory import Inventory
+from onyo.lib.commands import onyo_new
 from onyo.argparse_helpers import template, path, StoreKeyValuePairs
 from onyo.shared_arguments import shared_arg_message
 
@@ -39,18 +40,16 @@ args_new = {
 
     'path': dict(
         args=('-p', '--path'),
-        metavar='ASSET',
+        metavar='PATH',
         type=path,
-        nargs='*',
-        help='Path(s) of the new asset(s). Excludes usage of --tsv'),
+        help='directory to create asset(s) in'),
 
     'tsv': dict(
         args=('-tsv', '--tsv'),
         metavar='TSV',
         required=False,
         type=path,
-        help=('Path to a tsv file describing the new asset. Excludes the usage '
-              'of --path')),
+        help='Path to a tsv file describing the new asset.'),
 
     'message': shared_arg_message,
 }
@@ -65,8 +64,11 @@ def new(args: argparse.Namespace) -> None:
     After the contents are added, the new ``assets``\\(s) will be checked for
     the validity of its YAML syntax.
     """
-    repo = OnyoRepo(Path.cwd(), find_root=True)
-    fsck(repo)
-    path = [Path(p).resolve() for p in args.path] if args.path else None
-    tsv = Path(args.tsv).resolve() if args.tsv else None
-    new_cmd(repo, path, args.template, tsv, args.keys, args.edit, args.message)
+    inventory = Inventory(repo=OnyoRepo(Path.cwd(), find_root=True))
+    onyo_new(inventory=inventory,
+             path=Path(args.path).resolve() if args.path else None,
+             template=args.template,
+             tsv=Path(args.tsv).resolve() if args.tsv else None,
+             keys=args.keys,
+             edit=args.edit,
+             message='\n'.join(m for m in args.message) if args.message else None)

--- a/onyo/commands/rm.py
+++ b/onyo/commands/rm.py
@@ -3,7 +3,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from onyo import OnyoRepo
-from onyo.lib.commands import fsck, rm as rm_cmd
+from onyo.lib.inventory import Inventory
+from onyo.lib.commands import onyo_rm
 from onyo.argparse_helpers import path
 from onyo.shared_arguments import shared_arg_message
 
@@ -28,7 +29,8 @@ def rm(args: argparse.Namespace) -> None:
     A list of all files and directories to delete will be presented, and the
     user prompted for confirmation.
     """
-    repo = OnyoRepo(Path.cwd(), find_root=True)
-    fsck(repo)
+    inventory = Inventory(repo=OnyoRepo(Path.cwd(), find_root=True))
     paths = [Path(p).resolve() for p in args.path]
-    rm_cmd(repo, paths, args.message)
+    onyo_rm(inventory,
+            path=paths,
+            message='\n'.join(m for m in args.message) if args.message else None)

--- a/onyo/commands/set.py
+++ b/onyo/commands/set.py
@@ -3,7 +3,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from onyo import OnyoRepo
-from onyo.lib.commands import fsck, set_ as set_cmd
+from onyo.lib.inventory import Inventory
+from onyo.lib.commands import onyo_set
 from onyo.argparse_helpers import path, StoreKeyValuePairs
 from onyo.shared_arguments import (
     shared_arg_depth,
@@ -60,8 +61,9 @@ def set(args: argparse.Namespace) -> None:
     can be used around ``value``, which is necessary when it contains a comma,
     whitespace, etc.
 
-    The ``type``, ``make``, ``model``, and ``serial`` pseudo-keys can be set
-    when the `--rename` flag is used. It will result in the file(s) being
+    Required keys as define by the 'onyo.assets.filename' config (by default
+    ``type``, ``make``, ``model``, and ``serial``) can be set when the
+    `--rename` flag is used. It will result in the file(s) being
     renamed.
 
     If no ``asset`` or ``directory`` is specified, the current working directory
@@ -75,14 +77,14 @@ def set(args: argparse.Namespace) -> None:
     immediately.
     """
 
-    repo = OnyoRepo(Path.cwd(), find_root=True)
-    fsck(repo)
+    inventory = Inventory(repo=OnyoRepo(Path.cwd(), find_root=True))
     paths = [Path(p).resolve() for p in args.path] if args.path else None
-    set_cmd(repo,
-            paths,
-            args.keys,
-            args.filter,
-            args.dry_run,
-            args.rename,
-            args.depth,
-            args.message)
+    assert len(args.keys) == 1
+    onyo_set(inventory=inventory,
+             paths=paths,
+             keys=args.keys[0],
+             filter_strings=args.filter,
+             dryrun=args.dry_run,
+             rename=args.rename,
+             depth=args.depth,
+             message='\n'.join(m for m in args.message) if args.message else None)

--- a/onyo/commands/shell_completion.py
+++ b/onyo/commands/shell_completion.py
@@ -1,8 +1,6 @@
 import argparse
 from typing import Optional
 
-from onyo import ui
-
 args_shell_completion = {
     'shell': dict(
         args=('-s', '--shell'),
@@ -530,4 +528,4 @@ def shell_completion(args: argparse.Namespace) -> None:
 
     # TODO: add bash
 
-    ui.print(content)
+    print(content)

--- a/onyo/commands/tests/test_cat.py
+++ b/onyo/commands/tests/test_cat.py
@@ -147,6 +147,9 @@ def test_invalid_yaml(repo: OnyoRepo, variant: list[str]) -> None:
     """
     Test that `onyo cat` fails for a file with invalid yaml content.
     """
+
+    raise RuntimeError("TODO: I don't think the tested behavior makes sense. Why should I not be able to print invalid "
+                       "content and see the problem?")
     # check that yaml is invalid
     with pytest.raises(OnyoInvalidRepoError):
         fsck(repo, ['asset-yaml'])

--- a/onyo/commands/tests/test_config.py
+++ b/onyo/commands/tests/test_config.py
@@ -1,7 +1,6 @@
 import subprocess
 from pathlib import Path
 from onyo.lib import OnyoRepo
-from onyo.lib.commands import fsck
 
 
 def test_config_set(repo: OnyoRepo) -> None:
@@ -12,7 +11,7 @@ def test_config_set(repo: OnyoRepo) -> None:
     assert not ret.stderr
     assert 'set =' in Path('.onyo/config').read_text()
     assert '= set-test' in Path('.onyo/config').read_text()
-    fsck(repo)
+    assert repo.git.is_clean_worktree()
 
 
 def test_config_get_onyo(repo: OnyoRepo) -> None:
@@ -28,7 +27,7 @@ def test_config_get_onyo(repo: OnyoRepo) -> None:
     assert ret.returncode == 0
     assert ret.stdout == 'get-onyo-test\n'
     assert not ret.stderr
-    fsck(repo)
+    assert repo.git.is_clean_worktree()
 
 
 def test_config_get_pristine(repo: OnyoRepo) -> None:
@@ -55,7 +54,7 @@ def test_config_get_pristine(repo: OnyoRepo) -> None:
     assert ret.stdout == 'get-pristine-test\n'
 
     assert ret.stdout == git_config_output
-    fsck(repo)
+    assert repo.git.is_clean_worktree()
 
 
 def test_config_get_empty(repo: OnyoRepo) -> None:
@@ -65,8 +64,8 @@ def test_config_get_empty(repo: OnyoRepo) -> None:
                          capture_output=True, text=True)
     assert ret.returncode == 1
     assert not ret.stdout
-    assert not ret.stderr
-    fsck(repo)
+    # assert not ret.stderr  # Any failure currently gets an error log message.
+    assert repo.git.is_clean_worktree()
 
 
 def test_config_unset(repo: OnyoRepo) -> None:
@@ -89,8 +88,8 @@ def test_config_unset(repo: OnyoRepo) -> None:
                          capture_output=True, text=True)
     assert ret.returncode == 1
     assert not ret.stdout
-    assert not ret.stderr
-    fsck(repo)
+    # assert not ret.stderr  # Any failure currently gets an error log message.
+    assert repo.git.is_clean_worktree()
 
 
 def test_config_help(repo: OnyoRepo) -> None:
@@ -103,7 +102,7 @@ def test_config_help(repo: OnyoRepo) -> None:
         assert ret.returncode == 0
         assert 'onyo' in ret.stdout
         assert not ret.stderr
-    fsck(repo)
+    assert repo.git.is_clean_worktree()
 
 
 def test_config_forbidden_flags(repo: OnyoRepo) -> None:
@@ -116,7 +115,7 @@ def test_config_forbidden_flags(repo: OnyoRepo) -> None:
                              capture_output=True, text=True)
         assert ret.returncode == 1
         assert flag in ret.stderr
-    fsck(repo)
+    assert repo.git.is_clean_worktree()
 
 
 def test_config_bubble_retcode(repo: OnyoRepo) -> None:
@@ -130,7 +129,7 @@ def test_config_bubble_retcode(repo: OnyoRepo) -> None:
     ret = subprocess.run(["onyo", "config", "--unset", "onyo.test.not-exist"],
                          capture_output=True, text=True)
     assert ret.returncode == 5
-    fsck(repo)
+    assert repo.git.is_clean_worktree()
 
 
 def test_config_bubble_stderr(repo: OnyoRepo) -> None:
@@ -143,4 +142,4 @@ def test_config_bubble_stderr(repo: OnyoRepo) -> None:
     assert ret.returncode == 129
     assert not ret.stdout
     assert ret.stderr
-    fsck(repo)
+    assert repo.git.is_clean_worktree()

--- a/onyo/commands/tests/test_history.py
+++ b/onyo/commands/tests/test_history.py
@@ -100,7 +100,7 @@ def test_history_config_unset(repo: OnyoRepo) -> None:
                               message="Unset in .onyo/config: 'onyo.history.non-interactive'")
 
     # verify unset
-    assert not repo.git.get_config('onyo.history.non-interactive')
+    assert not repo.get_config('onyo.history.non-interactive')
 
     # test
     ret = subprocess.run(['onyo', 'history', '-I', assets[0]],

--- a/onyo/commands/tests/test_init.py
+++ b/onyo/commands/tests/test_init.py
@@ -3,7 +3,6 @@ import subprocess
 from pathlib import Path
 
 from onyo.lib import OnyoRepo
-from onyo.lib.commands import fsck
 
 
 def fully_populated_dot_onyo(directory: str = '') -> bool:
@@ -21,7 +20,7 @@ def fully_populated_dot_onyo(directory: str = '') -> bool:
        not Path(dot_onyo, "validation/.anchor").is_file():
            return False  # noqa: E111, E117
 
-    fsck(OnyoRepo(Path(directory)))
+    assert OnyoRepo(Path(directory)).git.is_clean_worktree()
     return True
 
 
@@ -39,7 +38,7 @@ def test_init_cwd(tmp_path: str) -> None:
     assert fully_populated_dot_onyo(tmp_path)
     repo = OnyoRepo(Path(tmp_path))
     assert repo.git.root == tmp_path
-    fsck(repo)
+    assert repo.git.is_clean_worktree()
 
 
 def test_init_with_path(tmp_path: str) -> None:
@@ -56,7 +55,7 @@ def test_init_with_path(tmp_path: str) -> None:
     assert "Initialized Onyo repository in" in ret.stderr
     repo = OnyoRepo(repo_path)
     assert repo.git.root == repo_path
-    fsck(repo)
+    assert repo.git.is_clean_worktree()
 
 
 def test_init_error_on_existing_repository(tmp_path: str) -> None:
@@ -77,4 +76,4 @@ def test_init_error_on_existing_repository(tmp_path: str) -> None:
     assert fully_populated_dot_onyo(tmp_path)
     repo = OnyoRepo(repo_path)
     assert repo.git.root == repo_path
-    fsck(repo)
+    assert repo.git.is_clean_worktree()

--- a/onyo/commands/tests/test_mv.py
+++ b/onyo/commands/tests/test_mv.py
@@ -2,7 +2,6 @@ import subprocess
 from pathlib import Path
 
 from onyo.lib import OnyoRepo
-from onyo.lib.commands import fsck
 import pytest
 
 # These tests focus on functionality specific to the CLI for `onyo mv`.
@@ -31,7 +30,7 @@ def test_mv_interactive_missing_y(repo: OnyoRepo) -> None:
 
     assert Path('subdir/laptop_apple_macbook.abc123').exists()
     assert not Path('laptop_apple_macbook.abc123').exists()
-    fsck(repo)
+    assert repo.git.is_clean_worktree()
 
 
 @pytest.mark.repo_files('subdir/laptop_apple_macbook.abc123')
@@ -46,7 +45,7 @@ def test_mv_interactive_abort(repo: OnyoRepo) -> None:
 
     assert Path('subdir/laptop_apple_macbook.abc123').exists()
     assert not Path('laptop_apple_macbook.abc123').exists()
-    fsck(repo)
+    assert repo.git.is_clean_worktree()
 
 
 @pytest.mark.repo_files('subdir/laptop_apple_macbook.abc123')
@@ -61,7 +60,7 @@ def test_mv_interactive(repo: OnyoRepo) -> None:
 
     assert not Path('subdir/laptop_apple_macbook.abc123').exists()
     assert Path('laptop_apple_macbook.abc123').exists()
-    fsck(repo)
+    assert repo.git.is_clean_worktree()
 
 
 @pytest.mark.repo_files('subdir/laptop_apple_macbook.abc123')
@@ -76,7 +75,7 @@ def test_mv_quiet_missing_yes(repo: OnyoRepo) -> None:
 
     assert Path('subdir/laptop_apple_macbook.abc123').exists()
     assert not Path('laptop_apple_macbook.abc123').exists()
-    fsck(repo)
+    assert repo.git.is_clean_worktree()
 
 
 @pytest.mark.repo_files('subdir/laptop_apple_macbook.abc123')
@@ -91,7 +90,7 @@ def test_mv_quiet(repo: OnyoRepo) -> None:
 
     assert not Path('subdir/laptop_apple_macbook.abc123').exists()
     assert Path('laptop_apple_macbook.abc123').exists()
-    fsck(repo)
+    assert repo.git.is_clean_worktree()
 
 
 @pytest.mark.repo_files('subdir/laptop_apple_macbook.abc123')
@@ -107,7 +106,7 @@ def test_mv_yes(repo: OnyoRepo) -> None:
 
     assert not Path('subdir/laptop_apple_macbook.abc123').exists()
     assert Path('laptop_apple_macbook.abc123').exists()
-    fsck(repo)
+    assert repo.git.is_clean_worktree()
 
 
 @pytest.mark.repo_files(*assets)
@@ -127,4 +126,4 @@ def test_mv_message_flag(repo: OnyoRepo, asset: str) -> None:
     # test that the onyo history does contain the user-defined message
     ret = subprocess.run(['onyo', 'history', '-I', Path("destination") / Path(asset).name], capture_output=True, text=True)
     assert msg in ret.stdout
-    fsck(repo)
+    assert repo.git.is_clean_worktree()

--- a/onyo/commands/tests/test_onyo.py
+++ b/onyo/commands/tests/test_onyo.py
@@ -2,7 +2,6 @@ import subprocess
 from itertools import product
 
 from onyo.lib import OnyoRepo
-from onyo.lib.commands import fsck
 import pytest
 
 
@@ -13,7 +12,7 @@ def test_onyo_debug(repo: OnyoRepo, variant: str) -> None:
                          capture_output=True, text=True)
     assert ret.returncode == 0
     assert 'DEBUG:onyo' in ret.stderr
-    fsck(repo)
+    assert repo.git.is_clean_worktree()
 
 
 @pytest.mark.parametrize('variant', ['-h', '--help'])
@@ -22,7 +21,7 @@ def test_onyo_help(repo: OnyoRepo, variant: str) -> None:
     assert ret.returncode == 0
     assert 'usage: onyo [-h]' in ret.stdout
     assert not ret.stderr
-    fsck(repo)
+    assert repo.git.is_clean_worktree()
 
 
 # TODO: this would be better if parametrized
@@ -39,4 +38,4 @@ def test_onyo_without_subcommand(repo: OnyoRepo, helpers) -> None:
             assert ret.returncode == 1
             assert 'usage: onyo [-h]' in ret.stdout
             assert not ret.stderr
-    fsck(repo)
+    assert repo.git.is_clean_worktree()

--- a/onyo/commands/tests/test_rm.py
+++ b/onyo/commands/tests/test_rm.py
@@ -2,7 +2,6 @@ import subprocess
 from pathlib import Path
 
 from onyo.lib import OnyoRepo
-from onyo.lib.commands import fsck
 import pytest
 from typing import List
 
@@ -36,7 +35,7 @@ def test_rm(repo: OnyoRepo, asset: str) -> None:
 
     # verify deleting was successful and the repository is in a clean state
     assert not Path(asset).exists()
-    fsck(repo)
+    assert repo.git.is_clean_worktree()
 
 
 @pytest.mark.repo_files(*assets)
@@ -54,7 +53,7 @@ def test_rm_multiple_inputs(repo: OnyoRepo) -> None:
     # verify deleting was successful and the repository is in a clean state
     for asset in assets:
         assert not Path(asset).exists()
-    fsck(repo)
+    assert repo.git.is_clean_worktree()
 
 
 @pytest.mark.repo_files(*assets)
@@ -72,7 +71,7 @@ def test_rm_single_dirs_with_files(repo: OnyoRepo, directory: str) -> None:
 
     # verify deleting was successful and the repository is in a clean state
     assert not Path(directory).exists()
-    fsck(repo)
+    assert repo.git.is_clean_worktree()
 
 
 @pytest.mark.repo_files(*assets)
@@ -90,7 +89,7 @@ def test_rm_multiple_directories(repo: OnyoRepo) -> None:
     # verify deleting was successful and the repository is in a clean state
     for directory in directories[1:]:
         assert not Path(directory).exists()
-    fsck(repo)
+    assert repo.git.is_clean_worktree()
 
 
 @pytest.mark.repo_dirs(*directories[1:])  # skip "." for directory creation
@@ -108,7 +107,7 @@ def test_rm_empty_directories(repo: OnyoRepo) -> None:
     # verify deleting was successful and the repository is in a clean state
     for directory in directories[1:]:
         assert not Path(directory).exists()
-    fsck(repo)
+    assert repo.git.is_clean_worktree()
 
 
 @pytest.mark.repo_files(*assets)
@@ -124,7 +123,7 @@ def test_rm_interactive_missing_y(repo: OnyoRepo) -> None:
     # verify no changes were made and the repository is in a clean state
     for asset in assets:
         assert Path(asset).exists()
-    fsck(repo)
+    assert repo.git.is_clean_worktree()
 
 
 @pytest.mark.repo_files(*assets)
@@ -141,7 +140,7 @@ def test_rm_interactive_abort(repo: OnyoRepo) -> None:
     # verify no changes were made and the repository is in a clean state
     for asset in assets:
         assert Path(asset).exists()
-    fsck(repo)
+    assert repo.git.is_clean_worktree()
 
 
 @pytest.mark.repo_files(*assets)
@@ -158,7 +157,7 @@ def test_rm_interactive(repo: OnyoRepo, asset: str) -> None:
 
     # verify deleting was successful and the repository is in a clean state
     assert not Path(asset).exists()
-    fsck(repo)
+    assert repo.git.is_clean_worktree()
 
 
 @pytest.mark.repo_files(*assets)
@@ -175,7 +174,7 @@ def test_rm_quiet_missing_yes(repo: OnyoRepo) -> None:
     # verify no changes were made and the repository is in a clean state
     for asset in assets:
         assert Path(asset).exists()
-    fsck(repo)
+    assert repo.git.is_clean_worktree()
 
 
 @pytest.mark.repo_files(*assets)
@@ -192,7 +191,7 @@ def test_rm_quiet_flag(repo: OnyoRepo) -> None:
     # verify deleting was successful and the repository is in a clean state
     for asset in assets:
         assert not Path(asset).exists()
-    fsck(repo)
+    assert repo.git.is_clean_worktree()
 
 
 @pytest.mark.repo_files(*assets)
@@ -211,4 +210,4 @@ def test_rm_message_flag(repo: OnyoRepo, asset: str) -> None:
     # test that the onyo history does contain the user-defined message
     ret = subprocess.run(['onyo', 'history', '-I', '.'], capture_output=True, text=True)
     assert msg in ret.stdout
-    fsck(repo)
+    assert repo.git.is_clean_worktree()

--- a/onyo/commands/tree.py
+++ b/onyo/commands/tree.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from onyo import OnyoRepo
-from onyo.lib.commands import fsck, tree as tree_cmd
+from onyo.lib.commands import onyo_tree
 from onyo.argparse_helpers import directory
 
 if TYPE_CHECKING:
@@ -24,6 +24,5 @@ def tree(args: argparse.Namespace) -> None:
     """
 
     repo = OnyoRepo(Path.cwd(), find_root=True)
-    fsck(repo, ['asset-yaml'])
     paths = [Path(p).resolve() for p in args.directory]
-    tree_cmd(repo, paths)
+    onyo_tree(repo, paths)

--- a/onyo/commands/unset.py
+++ b/onyo/commands/unset.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from onyo import OnyoRepo
-from onyo.lib.commands import fsck, unset as unset_cmd
+from onyo.lib.commands import unset as unset_cmd
 from onyo.argparse_helpers import path
 from onyo.shared_arguments import (
     shared_arg_depth,
@@ -62,7 +62,6 @@ def unset(args: argparse.Namespace) -> None:
     """
 
     repo = OnyoRepo(Path.cwd(), find_root=True)
-    fsck(repo)
     paths = [Path(p).resolve() for p in args.path] if args.path else None
     unset_cmd(repo,
               paths,

--- a/onyo/lib/assets.py
+++ b/onyo/lib/assets.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
-import csv
-import random
+import logging
+
 import re
-import string
 from pathlib import Path
 from typing import Dict, Union, Iterable, Set, Generator, Optional
 
 from ruamel.yaml import YAML, scanner  # pyre-ignore[21]
 
-from onyo import ui
+from onyo.lib.ui import ui
 from onyo.lib.filters import Filter
-from onyo.lib.onyo import OnyoRepo
 
+
+log: logging.Logger = logging.getLogger('onyo.assets')
 
 # Note: Order in this definition likely matters, since the filename is made of them:
 PSEUDO_KEYS = ["type", "make", "model", "serial"]
@@ -50,7 +50,7 @@ def has_unique_names(asset_files: Set[Path]) -> bool:
 
     if duplicates:
         ui.error('The following file names are not unique:\n{}'.format(
-                 '\n'.join(map(str, duplicates))))
+            '\n'.join(map(str, duplicates))))
         return False
 
     return True
@@ -93,37 +93,6 @@ def validate_yaml(asset_files: Set[Path]) -> bool:
     return True
 
 
-def get_faux_serials(asset_files: Set[Path],
-                     length: int = 6,
-                     num: int = 1) -> set[str]:
-    """
-    Generate a unique faux serial and verify that it is not used by any
-    other asset in the repository. The length of the faux serial must be 4
-    or greater.
-
-    Returns a set of unique faux serials.
-    """
-    if length < 4:
-        # 62^4 is ~14.7 million combinations. Which is the lowest acceptable
-        # risk of collisions between independent checkouts of a repo.
-        raise ValueError('The length of faux serial numbers must be >= 4.')
-
-    if num < 1:
-        raise ValueError('The length of faux serial numbers must be >= 1.')
-
-    alphanum = string.ascii_letters + string.digits
-    faux_serials = set()
-    # Note: Here we are effectively accessing existing pseudo-keys via asset_files; The paths themselves are irrelevant.
-    repo_faux_serials = {str(x.name).split('faux')[-1] for x in asset_files}
-
-    while len(faux_serials) < num:
-        serial = ''.join(random.choices(alphanum, k=length))
-        if serial not in repo_faux_serials:
-            faux_serials.add(f'faux{serial}')
-
-    return faux_serials
-
-
 def valid_asset_name(asset_file: Path) -> bool:
     """
     Verify that an asset name complies with the name scheme:
@@ -138,13 +107,13 @@ def valid_asset_name(asset_file: Path) -> bool:
     try:
         re.findall(r'(^[^._]+?)_([^._]+?)_([^._]+?)\.(.+)', asset_file.name)[0]
     except (ValueError, IndexError):
-        ui.error(f"'{asset_file.name}' must be in the format '<type>_<make>_<model>.<serial>'")
+        ui.log(f"'{asset_file.name}' must be in the format '<type>_<make>_<model>.<serial>'")
         return False
 
     return True
 
 
-def get_asset_files_by_path(asset_files: set[Path],
+def get_asset_files_by_path(asset_files: list[Path],
                             paths: Iterable[Path],
                             depth: Union[int, None]) -> list[Path]:
     """
@@ -171,16 +140,6 @@ def get_asset_files_by_path(asset_files: set[Path],
     return assets
 
 
-def dict_to_yaml(content: Dict[str, Union[float, int, str]]) -> str:
-    if not content:
-        return ""
-    from io import StringIO
-    yaml = YAML(typ='rt')
-    s = StringIO()
-    yaml.dump(content, s)
-    return s.getvalue()
-
-
 def write_asset_file(asset_path: Path,
                      asset_content: Dict[str, Union[float, int, str]]) -> None:
     if asset_content == {}:
@@ -191,217 +150,18 @@ def write_asset_file(asset_path: Path,
 
 
 def get_asset_content(asset_file: Path) -> Dict[str, Union[float, int, str]]:
-    # asset_file: absolute
-
     yaml = YAML(typ='rt', pure=True)
     contents = dict()
     try:
         contents = yaml.load(asset_file)
     except scanner.ScannerError as e:
-        ui.error(e)
+        ui.print(e)
     if contents is None:
         return dict()
     return contents
 
 
-def generate_new_asset_names(repo: OnyoRepo,
-                             existing_asset_files: set[Path],
-                             assets_to_set: list[Path],
-                             name_values: Dict[str, Union[float, int, str]]) -> list[tuple[Path, Path]]:
-    """
-    Generate the pseudo key fields of an assets name (rename an asset file) from
-    values of a dictionary and test that the new name is valid and
-    available.
-    Returns a list of tuples containing the mapping of old and new names or raises.
-    """
-
-    new_assets = []
-    to_move = []
-
-    # count and request the needed faux serial numbers
-    faux_serial_list = []
-    if 'serial' in name_values.keys() and name_values['serial'] == 'faux':
-        faux_number = len(assets_to_set)
-        if faux_number > 0:
-            faux_serial_list = get_faux_serials(existing_asset_files, num=faux_number)
-
-    for asset in assets_to_set:
-        # split old name into parts
-        [serial, model, make, type] = [field[::-1] for field in re.findall(r'(.*)\.(.*)_(.*)_(.*)', asset.name[::-1])[0]]
-        fields = name_values.keys()
-
-        # update name fields and build new asset name
-        if "serial" in fields:
-            if name_values["serial"] == "faux":
-                serial = faux_serial_list.pop()
-            else:
-                serial = name_values["serial"]
-        if "model" in fields:
-            model = name_values["model"]
-        if "make" in fields:
-            make = name_values["make"]
-        if "type" in fields:
-            type = name_values["type"]
-        new_name = Path(asset.parent, f"{type}_{make}_{model}.{serial}")
-
-        # Check validity of the new asset name
-        if new_name == asset.name:
-            raise ValueError(f"New asset names must be different than old names: '{new_name}'")
-
-        if not valid_asset_name(new_name):
-            raise ValueError(f"New asset name is not valid: '{new_name}'")
-
-        # God damnit. This check needs to go up:
-
-        asset_path_available(repo, existing_asset_files, new_name, new_assets)
-        new_assets.append(asset)
-        to_move.append((asset, new_name))
-    return to_move
-
-
-def read_assets_from_tsv(tsv: Path,
-                         template_name: Optional[str],
-                         key_values: Dict[str, str],
-                         repo: OnyoRepo) -> Dict[Path, Dict[str, Union[float, int, str]]]:
-    """
-    Read a tsv table with a header row and one row for each new asset to
-    create. Check the information (e.g. filenames correct and unique), and add
-    faux serial numbers to the name if needed.
-
-    Returns a dictionary with paths and contents of assets on success, or
-    informs the user about missing or invalid information and exits with error.
-    """
-    new_assets = {}
-    row_count = 0
-
-    with tsv.open('r') as tsv_file:
-        # count and request the faux serial numbers needed
-        table = csv.DictReader(tsv_file, delimiter='\t')
-        faux_number = sum([1 for row in table if row['serial'] == 'faux'])
-        if faux_number > 0:
-            faux_serial_list = get_faux_serials(repo.asset_paths, num=faux_number)
-
-        # iterate over the table from the beginning to read asset information.
-        tsv_file.seek(0)
-        table = csv.DictReader(tsv_file, delimiter='\t')
-        for row in table:
-            row_count += 1
-            new_path = ""
-            contents = {}
-
-            # error if any required field is empty
-            if not all([row['type'], row['make'], row['model'], row['serial'], row['directory']]):
-                row_str = "\t".join([value for value in row.values() if value])
-                raise ValueError(f"The fields 'type', 'make', 'model', 'serial' and 'directory' are required, "
-                                 f"but missing in line {row_count}: '{row_str}'")
-
-            # set asset name and directory, add faux serial numbers if needed
-            if row['serial'] == 'faux':
-                row['serial'] = faux_serial_list.pop()
-            filename = f"{row['type']}_{row['make']}_{row['model']}.{row['serial']}"
-            directory = row['directory']
-            new_path = Path(repo.git.root, directory, filename).resolve()
-
-            # verify that the asset name is valid and unique in repo and table
-            asset_path_available(repo, repo.asset_paths, new_path, [*new_assets])
-
-            # either a template is given in table, CLI, or onyo config
-            template = None
-            if "template" in row.keys():
-                if row['template'] == "":
-                    raise ValueError(f"Template value missing in {row_count}")
-                template = repo.get_template_file(row['template'])
-            elif template_name:
-                template = repo.get_template_file(template_name)
-            else:
-                template = repo.get_template_file()
-
-            # set the values from --keys and TSV columns, check for conflicts
-            contents = get_asset_content(template)
-
-            if key_values:
-                contents.update(key_values)
-            for col in row.keys():
-                # these fields contain meta information, not values for content
-                if col in ['type', 'make', 'model', 'serial', 'directory', 'template']:
-                    continue
-                # information from --keys is not allowed to conflict with columns
-                if key_values and col in key_values.keys():
-                    raise ValueError(f"Can't use --keys '{col}' and have tsv column '{col}'")
-                contents[col] = row[col]
-
-            new_assets[new_path] = contents
-
-    return new_assets
-
-
-def create_assets_in_destination(assets: Dict[Path, Dict[str, Union[float, int, str]]],
-                                 repo: OnyoRepo) -> list[Path]:
-    """
-    Create and populate assets. Parent directories are created if necessary.
-    """
-    created_files = []
-    for asset in assets.keys():
-        # create missing directories
-        if not asset.parent.exists():
-            created_files.extend(repo.mk_inventory_dirs([asset.parent]))
-        if not asset.is_file():
-            asset.touch()
-        write_asset_file(asset, assets[asset])
-        created_files.append(asset)
-    return created_files
-
-
-def read_assets_from_CLI(assets: list[Path],
-                         template_name: Optional[str],
-                         key_values: Dict[str, str],
-                         repo: OnyoRepo) -> Dict[Path, Dict[str, Union[float, int, str]]]:
-    """
-    Read information from `assets`, with a new asset file for each entry.
-    Check the information (e.g. filename correct and unique), and add
-    faux serial numbers to the names if needed.
-
-    Returns a dictionary with paths and contents of assets on success, or
-    informs the user about missing or invalid information and exits with error.
-    """
-    # Note: Optional declaration for `template_name` is misleading. It's being passed down from command implementation
-    # where it is indeed optional, but in opposition to other params, it's invalid absence is only picked up in here
-    # (via `get_template_file`, which raises)
-    new_assets = {}
-
-    # count and request the faux serial numbers needed
-    faux_number = sum([1 for asset in assets if "faux" in asset.name.split('.')[-1]])
-    if faux_number > 0:
-        faux_serial_list = get_faux_serials(repo.asset_paths, num=faux_number)
-
-    for asset in assets:
-        new_path = ""
-        contents = dict()
-
-        # set paths
-        if asset.name[-5:] == ".faux":
-            new_name = asset.name[:-5] + asset.name[-5:].replace("faux", faux_serial_list.pop())
-            new_path = asset.parent / new_name
-        else:
-            new_path = asset
-
-        # verify that the asset name is valid and unique in repo and table
-        asset_path_available(repo, repo.asset_paths, new_path, [*new_assets])
-
-        # get template and check its existence and validity
-        template = repo.get_template_file(template_name)
-
-        # add values from --keys and template to asset:
-        contents = get_asset_content(template)
-        if key_values:
-            contents.update(key_values)
-
-        new_assets[new_path] = contents
-
-    return new_assets
-
-
-def get_assets_by_query(asset_files: set[Path],
+def get_assets_by_query(asset_files: list[Path],
                         keys: Optional[Set[str]],
                         paths: Iterable[Path],
                         depth: Union[int, None] = None,
@@ -409,6 +169,7 @@ def get_assets_by_query(asset_files: set[Path],
     """
     Get keys from assets matching paths and filters.
     """
+    from .filters import asset_name_to_keys
     # Note: This is interested in the key-value pairs of assets, not their paths exactly.
     #       But tries to not read a file when pseudo keys are considered only
 
@@ -427,40 +188,16 @@ def get_assets_by_query(asset_files: set[Path],
     if keys:
         assets = ((a, {
             k: v
-            for k, v in (get_asset_content(a) | dict(zip(
-                PSEUDO_KEYS, re.findall(
-                    r'(^[^._]+?)_([^._]+?)_([^._]+?)\.(.+)',
-                    a.name)[0]))).items()
+            for k, v in (get_asset_content(a) | asset_name_to_keys(a, PSEUDO_KEYS)).items()
             if k in keys}) for a in assets)
     else:
         assets = ((a, {
             k: v
-            for k, v in (get_asset_content(a) | dict(zip(
-                PSEUDO_KEYS, re.findall(
-                    r'(^[^._]+?)_([^._]+?)_([^._]+?)\.(.+)',
-                    a.name)[0]))).items()}) for a in assets)
+            for k, v in (get_asset_content(a) | asset_name_to_keys(a, PSEUDO_KEYS)).items()}) for a in assets)
 
     return assets
 
 
-def asset_path_available(repo: OnyoRepo,
-                         existing_asset_files: Set[Path],
-                         asset: Path,
-                         new_assets: list[Path]) -> None:
-    """
-    Test for an assets path and name if it can be used to create a new asset.
-    """
-
-    # Check Usage: First highlevel: have a valid name, then trigger lower-level "path available" or validation
-    #  -> one level up (generate): Same story.
-
-    if not valid_asset_name(asset):
-        raise ValueError(f"'{asset}' is not a valid asset name.")
-    # Note: Not clear why to go over all existing files; Path.exists() should suffice
-    if file := [file for file in existing_asset_files if asset.name == file.name]:
-        raise ValueError(f"Filename '{asset.name}' already exists as '{file[0]}'.")
-    elif file := [file for file in new_assets if asset.name == file.name]:
-        raise ValueError(f"Input contains multiple '{file[0].name}'")
-    # Note: We already know it's a valid_asset_name and doesn't exist, so all that remains is:
-    if not repo.is_inventory_path(asset):
-        raise ValueError(f"The path is protected by onyo: '{asset}'")
+# The idea of an Asset class is currently abandoned. If not re-introduced, can go entirely.
+# It would, however, be a dict-like in any case (prob. derived from UserDict, though)
+Asset = dict

--- a/onyo/lib/differs.py
+++ b/onyo/lib/differs.py
@@ -1,0 +1,72 @@
+from functools import partial
+from pathlib import Path
+from difflib import unified_diff
+from typing import Union, Generator
+
+from onyo.lib.onyo import dict_to_yaml, OnyoRepo
+
+# Differs signature: (repo: OnyoRepo, operands: tuple) -> Generator[str, None, None]:
+# yielded strings are supposed to be lines of a diff for a given operation
+
+# TODO: Double-check we always report posix paths!
+
+
+def diff_assets(asset_old: dict, asset_new: dict):
+    yield from unified_diff(dict_to_yaml(asset_old).splitlines(keepends=False),
+                            dict_to_yaml(asset_new).splitlines(keepends=False),
+                            fromfile=str(asset_old.get('path', '')),
+                            tofile=str(asset_new.get('path', '')),
+                            lineterm="")
+
+
+def diff_path_change(src: Path, dst: Path):
+    yield f"{str(src)} -> {str(dst)}"
+
+
+diff_new_asset = partial(diff_assets, asset_old={})
+diff_rm_asset = partial(diff_assets, asset_new={})
+diff_modified_asset = diff_assets
+diff_renamed_asset = diff_assets  # This is the same, because a rename requires a change in keys composing the name (or change in config).
+
+
+def diff_moved_asset(asset_old: Union[dict, Path], asset_new: Path):
+    # could be same. Just check isinstance?
+    yield from diff_path_change(asset_old if isinstance(asset_old, Path) else asset_old.get('path'),
+                                asset_new)
+
+
+def differ_new_assets(repo: OnyoRepo, operands: tuple) -> Generator[str, None, None]:
+    yield from diff_assets(asset_old={}, asset_new=operands[0])
+
+
+def differ_new_directories(repo: OnyoRepo, operands: tuple) -> Generator[str, None, None]:
+    yield f"+{str(operands[0])}"
+
+
+def differ_remove_assets(repo: OnyoRepo, operands: tuple) -> Generator[str, None, None]:
+    yield f"-{str(operands[0]) if isinstance(operands[0], Path) else operands[0].get('path')}"
+
+
+def differ_remove_directories(repo: OnyoRepo, operands: tuple) -> Generator[str, None, None]:
+    yield f"-{str(operands[0])}"
+
+
+def differ_move_assets(repo: OnyoRepo, operands: tuple) -> Generator[str, None, None]:
+    yield from diff_path_change(operands[0], operands[1])
+
+
+def differ_move_directories(repo: OnyoRepo, operands: tuple) -> Generator[str, None, None]:
+    yield from diff_path_change(operands[0], operands[1])
+    # TODO: Fuse w/ differ_move_asset
+
+
+def differ_rename_directories(repo: OnyoRepo, operands: tuple) -> Generator[str, None, None]:
+    yield from diff_path_change(operands[0], operands[1].name)
+
+
+def differ_modify_assets(repo: OnyoRepo, operands: tuple) -> Generator[str, None, None]:
+    yield from diff_assets(operands[0], operands[1])
+
+
+def differ_rename_assets(repo: OnyoRepo, operands: tuple) -> Generator[str, None, None]:
+    yield from diff_path_change(operands[0], operands[1])

--- a/onyo/lib/exceptions.py
+++ b/onyo/lib/exceptions.py
@@ -11,3 +11,15 @@ class OnyoProtectedPathError(Exception):
 
 class OnyoInvalidFilterError(Exception):
     """Raise if filters are invalidly defined"""
+
+
+class InvalidInventoryOperation(Exception):
+    """TODO  -> enhance message w/ hint to Inventory.reset/commit"""
+
+
+class NoopError(Exception):
+    """Thrown if a requested operation is a Noop."""
+
+
+class NotAnAssetError(Exception):
+    """Thrown if an object was expected to be an asset but isn't"""

--- a/onyo/lib/executors.py
+++ b/onyo/lib/executors.py
@@ -1,0 +1,114 @@
+from pathlib import Path
+from onyo.lib.onyo import OnyoRepo
+
+# Executors signature: (repo: OnyoRepo, operands: tuple) -> tuple[list[Path], list[Path]]
+#                      first returned list are the paths that need to be committed
+#                      second list are the paths that need to be staged (not previously tracked)
+
+# Attention! No input validation in executors -> document "not intended for direct use"
+# Those callables are to be registered with operators. Operations have to make sure to deliver
+# valid objects. We don't want to issue a ton of stat calls just to validate the same paths
+# throughout every layer of onyo over and over.
+
+
+def exec_new_assets(repo: OnyoRepo, operands: tuple) -> tuple[list[Path], list[Path]]:
+    """Executor for the 'new_asset' operation
+
+    Parameters
+    ----------
+    repo: OnyoRepo
+      Onyo repository to operate on
+    operands: list
+      Each item of the list is a tuple of operation operands.
+      Here a single item per tuple is expected: The to-be-added `Asset`
+
+    Returns
+    -------
+    list of Path
+      paths to the newly added assets
+    """
+    # Note: No need to account for implicitly to create dirs herein. That would be its own operation done before.
+    asset = operands[0]
+    repo.write_asset_content(asset)  # TODO: a = ...; reassignment for potential updates on metadata
+    path = asset.get('path')
+    return [path], [path]
+
+
+def exec_new_directories(repo: OnyoRepo, operands: tuple) -> tuple[list[Path], list[Path]]:
+    """Executor for the 'new_directory' operation
+    """
+    paths = repo.mk_inventory_dirs(operands[0])
+    return paths, paths
+
+
+def exec_remove_assets(repo: OnyoRepo, operands: tuple) -> tuple[list[Path], list[Path]]:
+    p = operands[0] if isinstance(operands[0], Path) else operands[0].get('path')
+    paths = []
+    if p.is_dir():
+        paths.append(p / OnyoRepo.ANCHOR_FILE)
+        # we were told p is an asset. It's also a dir, ergo an asset dir
+        paths.append(p / OnyoRepo.ASSET_DIR_FILE)
+    else:
+        paths = [p]
+    for p in paths:
+        # missing_ok=True, b/c several operations may want to remove the same thing. No reason to fail here.
+        p.unlink(missing_ok=True)
+    return paths, []
+
+
+def exec_remove_directories(repo: OnyoRepo, operands: tuple) -> tuple[list[Path], list[Path]]:
+    paths = []
+    p = operands[0]
+    is_asset_dir = repo.is_asset_dir(p)  # required after dir was removed, therefore store
+    asset = dict()
+    anchor = p / repo.ANCHOR_FILE
+    anchor.unlink()
+    paths.append(anchor)
+    if is_asset_dir:
+        asset = repo.get_asset_content(p)
+        asset_dir_file = p / repo.ASSET_DIR_FILE
+        asset_dir_file.unlink()
+        paths.append(asset_dir_file)
+    p.rmdir()
+    if is_asset_dir:
+        asset['is_asset_directory'] = False
+        repo.write_asset_content(asset)
+        paths.append(p)  # TODO: Does this need staging? Don't think so, but make sure.
+    return paths, []
+
+
+def mover(src: Path, dst: Path) -> list[Path]:
+    """helper function for move assets/directories executors"""
+    # expected: dst is inventory dir!
+    src.rename(dst / src.name)
+    return [src, dst / src.name]
+
+
+def exec_move_assets(repo: OnyoRepo, operands: tuple) -> tuple[list[Path], list[Path]]:
+    return mover(operands[0], operands[1]), []
+
+
+def exec_move_directories(repo: OnyoRepo, operands: tuple) -> tuple[list[Path], list[Path]]:
+    return mover(operands[0], operands[1]), []
+
+
+def renamer(src: Path, dst: Path) -> list[Path]:
+    # expected: full path as dst
+    # TODO: Fuse w/ mover() - distinction superfluous by now
+    src.rename(dst)
+    return [src, dst]
+
+
+def exec_rename_directories(repo: OnyoRepo, operands: tuple) -> tuple[list[Path], list[Path]]:
+    return renamer(operands[0], operands[1]), []
+
+
+def exec_rename_assets(repo: OnyoRepo, operands: tuple) -> tuple[list[Path], list[Path]]:
+    return renamer(operands[0], operands[1]), []
+
+
+def exec_modify_assets(repo: OnyoRepo, operands: tuple) -> tuple[list[Path], list[Path]]:
+    # expected: (Asset, Asset)
+    new = operands[1]
+    repo.write_asset_content(new)
+    return [new['path']], []

--- a/onyo/lib/filters.py
+++ b/onyo/lib/filters.py
@@ -7,7 +7,8 @@ from onyo.lib.exceptions import OnyoInvalidFilterError
 
 
 # TODO: Move this to a place specifically meant for defaults, along with
-#  other defaults like <list>, <dict>, and potentially <none> or <null>
+#       other defaults like <list>, <dict>, and potentially <none> or <null>
+#       Actually: This should be covered by an Asset class (providing the content of an asset)
 UNSET_VALUE = '<unset>'
 
 

--- a/onyo/lib/inventory.py
+++ b/onyo/lib/inventory.py
@@ -1,0 +1,466 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Union, Iterable, Optional, Set, Generator
+from dataclasses import dataclass
+from typing import Callable
+
+from onyo.lib.assets import Asset
+from onyo.lib.onyo import OnyoRepo
+from onyo.lib.filters import Filter
+from onyo.lib.executors import (
+    exec_new_assets,
+    exec_new_directories,
+    exec_modify_assets,
+    exec_remove_assets,
+    exec_move_assets,
+    exec_rename_assets,
+    exec_remove_directories,
+    exec_rename_directories,
+    exec_move_directories
+)
+from onyo.lib.recorders import (
+    record_new_assets,
+    record_new_directories,
+    record_rename_assets,
+    record_modify_assets,
+    record_move_assets,
+    record_remove_assets,
+    record_remove_directories,
+    record_rename_directories,
+    record_move_directories
+)
+from onyo.lib.differs import (
+    differ_new_assets,
+    differ_new_directories,
+    differ_rename_directories,
+    differ_modify_assets,
+    differ_move_assets,
+    differ_remove_assets,
+    differ_rename_assets,
+    differ_remove_directories,
+    differ_move_directories,
+)
+from onyo.lib.exceptions import (
+    NotAnAssetError,
+    NoopError,
+    InvalidInventoryOperation,
+)
+
+# The following keys have functional meaning for onyo and must not be part of user-defined asset content
+RESERVED_KEYS = ['directory', 'is_asset_directory', 'template']
+
+
+@dataclass
+class InventoryOperator:
+    executor: Callable
+    differ: Callable
+    recorder: Callable
+
+
+@dataclass
+class InventoryOperation(object):
+    operator: InventoryOperator
+    operands: tuple
+    repo: OnyoRepo
+
+    def diff(self) -> Generator[str, None, None]:
+        yield from self.operator.differ(repo=self.repo, operands=self.operands)
+
+    def execute(self) -> tuple[list[Path], list[Path]]:
+        return self.operator.executor(repo=self.repo, operands=self.operands)
+
+
+# NOTE: Order of keys in this mapping matters! It's the order of execution during `Inventory.commit`.
+#       We'd need new directories before new assets for example. Or remove something before putting something else in
+#       its place.
+#       Solution may be to change implementation and really register a single list of operations so call-order is
+#       preserved.  -> speaks for class InventoryOperation?
+OPERATIONS_MAPPING: dict = {'new_directories': InventoryOperator(executor=exec_new_directories,
+                                                                 differ=differ_new_directories,
+                                                                 recorder=record_new_directories),
+                            'new_assets': InventoryOperator(executor=exec_new_assets,
+                                                            differ=differ_new_assets,
+                                                            recorder=record_new_assets),
+                            'remove_assets': InventoryOperator(executor=exec_remove_assets,
+                                                               differ=differ_remove_assets,
+                                                               recorder=record_remove_assets),
+                            'modify_assets': InventoryOperator(executor=exec_modify_assets,
+                                                               differ=differ_modify_assets,
+                                                               recorder=record_modify_assets),
+                            'rename_assets': InventoryOperator(executor=exec_rename_assets,
+                                                               differ=differ_rename_assets,
+                                                               recorder=record_rename_assets),
+                            'remove_directories': InventoryOperator(executor=exec_remove_directories,
+                                                                    differ=differ_remove_directories,
+                                                                    recorder=record_remove_directories),
+                            'move_directories': InventoryOperator(executor=exec_move_directories,
+                                                                  differ=differ_move_directories,
+                                                                  recorder=record_move_directories),
+                            'rename_directories': InventoryOperator(executor=exec_rename_directories,
+                                                                    differ=differ_rename_directories,
+                                                                    recorder=record_rename_directories),
+                            'move_assets': InventoryOperator(executor=exec_move_assets,
+                                                             differ=differ_move_assets,
+                                                             recorder=record_move_assets),
+                            }
+
+
+# TODO: Conflict w/ existing operations?
+#       operations: raise InvalidInventoryOperationError on conflicts with pending operations,
+#       like removing something that is to be created. -> reset() or commit()
+# TODO: clear_caches from within commit? What about operations?
+class Inventory(object):
+    """"""
+
+    def __init__(self, repo: OnyoRepo):
+        self.repo: OnyoRepo = repo
+        self.operations: list[InventoryOperation] = []
+
+    @property
+    def root(self):
+        """Path to root inventory directory"""
+        return self.repo.git.root
+
+    def reset(self):
+        """throw away pending operations"""
+        self.operations = []
+
+    def commit(self, message: str):
+        """Execute and git-commit pending operations"""
+        # get user message + generate appendix from operations
+        # does order matter for execution? Prob.
+        # ^  Nope. Fail on conflicts.
+        from os import linesep
+        paths_to_commit = []
+        paths_to_stage = []
+        commit_msg = message + f"{linesep}{linesep}--- Inventory Operations ---{linesep}"
+        operations_record = dict()
+
+        for operation in self.operations:
+            to_commit, to_stage = operation.execute()
+            paths_to_commit.extend(to_commit)
+            paths_to_stage.extend(to_stage)
+            record_snippets = operation.operator.recorder(repo=self.repo, operands=operation.operands)
+            for k, v in record_snippets.items():
+                if k not in operations_record:
+                    operations_record[k] = v
+                else:
+                    operations_record[k].extend(v)
+
+        for title, snippets in operations_record.items():
+            commit_msg += title + ''.join(line for line in set(snippets))
+
+        # TODO: Actually: staging (only new) should be done in execute. committing is then unified
+        self.repo.git.stage_and_commit(set(paths_to_commit + paths_to_stage), commit_msg)
+        self.reset()
+
+    def diff(self) -> Generator[str, None, None]:
+        for operation in self.operations:
+            yield from operation.diff()
+
+    def operations_pending(self) -> bool:
+        """Returns whether there's something to commit"""
+        # Note: Seems superfluous now (operations is a list rather than dict of lists)
+        return bool(self.operations)
+
+    #
+    # Operations
+    #
+
+    def _add_operation(self, name: str, operands: tuple) -> None:
+        """Internal convenience helper to register an operation"""
+        self.operations.append(InventoryOperation(operator=OPERATIONS_MAPPING[name],
+                                                  operands=operands,
+                                                  repo=self.repo)
+                               )
+
+    def add_asset(self, asset: Asset) -> None:
+        # TODO: This could actually contain a lot of what's in `new`. directory, template, validation, faux-serials, ...
+        #       Except this does not work because of --edit, which requires things being written to disc already.
+        #       Could use a temp file, but kinda weird for users seeing that path in their editor.
+        #       However, chat decision: temp path in editor is fine
+
+        # what if I call this with a modified (possibly moved) asset?
+
+        # validation (of path, name, etc) required! (Otherwise it would be delayed until execution!)
+        # TODO: Just like the validation should be included (see above), we also want to pass `directory` instead of
+        #       `path` since filename needs to be generated.
+        path = asset.get('path', None)
+        if not path:
+            raise ValueError("Unknown asset path")
+        if self.repo.is_asset_path(path):
+            raise ValueError(f"Asset {path} already exists.")
+            # Note: We may want to reconsider this case.
+            # Shouldn't there be a way to write files (or asset dirs) directly and then add them as new assets?
+        if not self.repo.is_inventory_path(path):
+            raise ValueError(f"{path} is not a valid inventory path.")
+
+        if asset.get('is_asset_directory', False):
+            if self.repo.is_inventory_dir(path):
+                # We want to turn an existing dir into an asset dir.
+                self.rename_directory(path, self.generate_asset_name(asset))
+                # Temporary hack: Adjust the asset's path to the renamed one.
+                # TODO: Actual solution: This entire method must not be based on the dict's 'path', but 'directory' +
+                #       generated name. This ties in with pulling parts of `onyo_new` in here.
+                asset['path'] = path.parent / self.generate_asset_name(asset)
+            else:
+                # The directory does not yet exist.
+                self.add_directory(path)
+        elif not self.repo.is_inventory_dir(path.parent):
+            self.add_directory(path.parent)
+
+        # record operation
+        self._add_operation('new_assets', (asset,))
+
+    def add_directory(self, path: Path) -> None:
+        if not self.repo.is_inventory_path(path):
+            raise ValueError(f"{path} is not a valid inventory path.")
+        if path.exists():
+            raise ValueError(f"{path} already exists.")
+
+        self._add_operation('new_directories', (path,))
+        [self._add_operation('new_directories', (p,)) for p in path.parents if not p.exists()]
+
+    def remove_asset(self, asset: Union[Asset, Path]) -> None:
+        path = asset if isinstance(asset, Path) else asset.get('path')
+        if not self.repo.is_asset_path(path):
+            raise NotAnAssetError(f"No such asset: {path}")
+        self._add_operation('remove_assets', (asset,))
+
+    def move_asset(self, src: Union[Path, Asset], dst: Path) -> None:
+        if isinstance(src, Asset):
+            src = Path(src.get('path'))
+        if not self.repo.is_asset_path(src):
+            raise NotAnAssetError(f"No such asset: {src}.")
+        if src.parent == dst:
+            # TODO: Instead of raise could be a silent noop.
+            raise ValueError(f"Cannot move {src}: Destination {dst} is the current location.")
+        if not self.repo.is_inventory_dir(dst):
+            raise ValueError(f"Cannot move {src}: Destination {dst} is not in inventory directory.")
+
+        self._add_operation('move_assets', (src, dst))
+
+    def rename_asset(self, asset: Union[Asset, Path], name: Optional[str] = None) -> None:
+        # ??? Do we need that? On the command level it's only accessible via modify_asset.
+        # But: A config change is sufficient to make it not actually an asset modification.
+        # Also: If we later on want to allow it under some circumstances, it would be good have it as a formally
+        #       separate operation already.
+
+        path = Path(asset.get('path')) if isinstance(asset, Asset) else asset
+        if not self.repo.is_asset_path(path):
+            raise ValueError(f"No such asset: {path}")
+
+        # Note: For now we force the asset name (via config) from its content. Hence, `name` is optional and when it's
+        #       given it needs to match.
+        #       TODO: This may, however, need to go. When rename is implicit, it would need to account for already
+        #             registered modify operations. It's easier to not force compliance here, but simply let
+        #             modify_asset generate the name and pass it.
+        generated_name = self.generate_asset_name(
+            asset if isinstance(asset, Asset)
+            else self.repo.get_asset_content(path)
+        )
+        if name and name != generated_name:
+            raise ValueError(f"Renaming asset {path.name} to {name} is invalid."
+                             f"Config 'onyo.assets.filename' suggests '{generated_name}' as its name")
+        if not name:
+            name = generated_name
+        if path.name == name:
+            # TODO: This should be a different exception, so that callers can decide on their failure paradigm:
+            #       "Result oriented already-fine-no-failure" vs "Task oriented can't-do-failure".
+            raise NoopError(f"Cannot rename asset {name}: This is already its name.")
+
+        destination = path.parent / name
+        if destination.exists():
+            raise ValueError(f"Cannot rename asset {path.name} to {destination}. Already exists.")
+        # TODO: Do we need to update asset['path'] here? See also modify_asset!
+        self._add_operation('rename_assets', (path, destination))
+
+    def modify_asset(self, asset: Union[Asset, Path], content: Asset) -> None:
+        # TODO: Straight-up dict for `content`?
+
+        path = Path(asset.get('path')) if isinstance(asset, Asset) else asset
+        if not self.repo.is_asset_path(path):
+            raise ValueError(f"No such asset: {path}")
+        asset = Asset(self.repo.get_asset_content(path)) if isinstance(asset, Path) else asset
+        new_asset = asset.copy()
+        new_asset.update(content)
+
+        self._add_operation('modify_assets', (asset, new_asset))
+        # Abuse the fact that new_asset has the same 'path' at this point, regardless of potential renaming and let
+        # rename handle it. Note, that this way the rename operation MUST come after the modification during execution.
+        # Otherwise, we'd move the old asset and write the modified one to the old place.
+        try:
+            self.rename_asset(new_asset)
+        except NoopError:
+            # Modification did not imply a rename
+            pass
+
+    def remove_directory(self, directory: Path) -> None:
+        if not self.repo.is_inventory_dir(directory):
+            raise ValueError(f"Not an inventory directory: {directory}")
+        # TODO: `force` for removing non-empty??? (-> implicit remove_asset OPs)
+        #       But: What about non-asset files (.onyoignore)
+        if [p for p in directory.iterdir()
+                if p.name != self.repo.ANCHOR_FILE and not self.repo.is_onyo_path(p)]:
+            raise InvalidInventoryOperation(f"Cannot remove inventory directory {directory}: Not empty.")
+        self._add_operation('remove_directories', (directory,))
+
+    def move_directory(self, src: Path, dst: Path) -> None:
+        if not self.repo.is_inventory_dir(src):
+            raise ValueError(f"Not an inventory directory: {src}")
+        if not self.repo.is_inventory_dir(dst):
+            raise ValueError(f"Destination is not an inventory directory: {dst}")
+        if src.parent == dst:
+            raise InvalidInventoryOperation(f"Cannot move {src} -> {dst}. Consider renaming instead.")
+        self._add_operation('move_directories', (src, dst))
+
+    def rename_directory(self, src: Path, dst: Union[str, Path]) -> None:
+        if not self.repo.is_inventory_dir(src):
+            raise ValueError(f"Not an inventory directory: {src}")
+        if self.repo.is_asset_dir(src):
+            raise ValueError("Renaming an asset directory must be done via `rename_asset`.")
+        if isinstance(dst, str):
+            dst = src.parent / dst
+        if src.parent != dst.parent:
+            raise InvalidInventoryOperation(f"Cannot rename {src} -> {dst}. Consider moving instead.")
+        if not self.repo.is_inventory_path(dst) or dst.exists():
+            raise ValueError(f"Not a valid destination: {dst}")
+
+        self._add_operation('rename_directories', (src, dst))
+
+    #
+    # non-operation methods
+    #
+
+    def get_asset(self, path: Path):
+        # read and return Asset
+        if self.repo.is_asset_path(path):
+            return Asset(**self.repo.get_asset_content(path))
+        else:
+            raise ValueError(f"{path} is not an asset.")
+
+    def get_assets(self):
+        # plural/query/property?
+        # git ls-files?
+        # Redirect to get_assets_by_query (making paths optional)
+        pass
+
+    def get_asset_from_template(self, template: str) -> Asset:
+        # TODO: Possibly join with get_asset (path optional)
+        return Asset(self.repo.get_template(template))
+
+    def get_assets_by_query(self,
+                            keys: Optional[Set[str]],
+                            paths: Iterable[Path],
+                            depth: Union[int, None] = None,
+                            filters: Union[list[Filter], None] = None) -> Generator:
+        # filters + path/depth limit (TODO: turn into filters as well)
+        # self.repo.get_asset_paths(subtrees=, depth=)
+
+        # Note: This is interested in the key-value pairs of assets, not their paths exactly.
+        #       But tries to not read a file when pseudo keys are considered only.
+        #       This is outdated but also requires adjustment of Filters.
+
+        """
+        Get keys from assets matching paths and filters.
+        """
+        # TODO: This won't be necessary anymore
+        from .filters import asset_name_to_keys
+        from .assets import PSEUDO_KEYS, get_asset_content
+
+        # filter assets by path and depth relative to paths
+        asset_paths = self.repo.get_asset_paths(subtrees=paths, depth=depth)
+
+        if filters:
+            # Filters that do not require loading an asset are applied first
+            filters.sort(key=lambda x: x.is_pseudo, reverse=True)
+
+            # Remove assets that do not match all filters
+            for f in filters:
+                asset_paths[:] = filter(f.match, asset_paths)
+
+        # Obtain keys from remaining assets
+        if keys:
+            assets = ((a, {
+                k: v
+                for k, v in (get_asset_content(a) | asset_name_to_keys(a, PSEUDO_KEYS)).items()
+                if k in keys}) for a in asset_paths)
+        else:
+            assets = ((a, {
+                k: v
+                for k, v in (get_asset_content(a) | asset_name_to_keys(a, PSEUDO_KEYS)).items()}) for a in asset_paths)
+
+        return assets
+
+    def asset_paths_available(self, assets: Union[Asset, list[Asset]]) -> None:
+        """Test whether path(s) used by `assets` are available in the inventory.
+
+        Availability not only requires the path to not yet exist, but also the filename to be unique.
+
+        Raises
+        ------
+        ValueError
+          if any of the paths can not be used for a new asset
+        """
+
+        # TODO: Used to test valid asset name first. Do we need that?
+        #       Not in context of `new`, because the name is generated.
+        paths_to_test = [a.get('path') for a in assets]
+        for path in paths_to_test:
+            if not path:
+                continue  # TODO: raise or ignore?
+            if path.exists():
+                raise ValueError(f"{str(path)} already exists in inventory")
+            if len([p.name for p in paths_to_test if p.name == path.name]) > 1:
+                raise ValueError(f"Multiple {path.name} given. Asset names must be unique.")
+            if not self.repo.is_inventory_path(path):
+                raise ValueError(f"{str(path)} is not a valid asset path.")
+            if path.name in [p.name for p in self.repo.asset_paths]:
+                raise ValueError(f"Asset name '{path.name}' already exists in inventory.")
+
+    def generate_asset_name(self, asset: Asset) -> str:
+
+        config_str = self.repo.get_config("onyo.assets.filename")
+        if not config_str:
+            raise ValueError("Missing config 'onyo.assets.filename'.")
+        # TODO: Problem: Empty string could be a valid value for some keys. But not for the required name fields?!
+        #       -> doesn't raise, because that's not something `format` would stumble upon.
+        try:
+            name = config_str.format(**asset)  # TODO: Only pass non-pseudo keys?! What if there is no config?
+        except KeyError as e:
+            raise ValueError(f"Asset missing value for required field {str(e)}.") from e
+        return name
+
+    def get_faux_serials(self,
+                         length: int = 6,
+                         num: int = 1) -> set[str]:
+        """
+        Generate a unique faux serial and verify that it is not used by any
+        other asset in the repository. The length of the faux serial must be 4
+        or greater.
+
+        Returns a set of unique faux serials.
+        """
+        import random
+        import string
+
+        if length < 4:
+            # 62^4 is ~14.7 million combinations. Which is the lowest acceptable
+            # risk of collisions between independent checkouts of a repo.
+            raise ValueError('The length of faux serial numbers must be >= 4.')
+
+        if num < 1:
+            raise ValueError('The length of faux serial numbers must be >= 1.')
+
+        alphanum = string.ascii_letters + string.digits
+        faux_serials = set()
+        # TODO: This split actually puts the entire filename in the set if there's no "faux".
+        repo_faux_serials = {str(x.name).split('faux')[-1] for x in self.repo.asset_paths}
+
+        while len(faux_serials) < num:
+            serial = ''.join(random.choices(alphanum, k=length))
+            if serial not in repo_faux_serials:
+                faux_serials.add(f'faux{serial}')
+
+        return faux_serials

--- a/onyo/lib/recorders.py
+++ b/onyo/lib/recorders.py
@@ -1,0 +1,79 @@
+from os import linesep
+from pathlib import Path
+from typing import Union
+
+from onyo.lib.onyo import OnyoRepo
+
+# Recorders signature: (repo: OnyoRepo, operands: tuple) -> dict[str, list[str]]
+# Returned dict: {<title for operations record section>: [<snippet recording concrete operation>, ..]
+#
+# This is meant to result in a commit message footer composed by `Inventory.commit()`:
+#
+# --- Inventory Operations ---
+# <title for operations record section>:
+#   <snippet recording concrete operation>
+#   <snippet recording concrete operation>
+# <title for operations record section>:
+#   <snippet recording concrete operation>
+#   <snippet recording concrete operation>
+#
+# While a recorder currently only ever returns a single snippet (line) for an operation,
+# the dict assumes a list in order to provide the option to deliver several.
+
+# TODO: Double-check we always report posix paths!
+
+
+def record_item(repo: OnyoRepo, item: Union[Path, dict]) -> str:
+    path = item if isinstance(item, Path) else item['path']
+    return f"\t- {path.relative_to(repo.git.root).as_posix()}{linesep}"
+
+
+def record_move(repo: OnyoRepo, src: Union[Path, dict], dst: Path) -> str:
+    # Attention: This currently expects `dst` to be the dir to move src into,
+    # rather than already containing src' name at the destination. This may not be consistent yet.
+    src_path = src if isinstance(src, Path) else src['path']
+    dst_path = (dst / src_path.name).relative_to(repo.git.root).as_posix()
+    src_path = src_path.relative_to(repo.git.root).as_posix()
+    return f"\t- {src_path} -> {dst_path}{linesep}"
+
+
+def record_new_assets(repo: OnyoRepo, operands: tuple) -> dict[str, list[str]]:
+    return {f"New assets:{linesep}": [record_item(repo, operands[0])]}
+
+
+def record_new_directories(repo: OnyoRepo, operands: tuple) -> dict[str, list[str]]:
+    return {f"New directories:{linesep}": [record_item(repo, operands[0])]}
+
+
+def record_remove_assets(repo: OnyoRepo, operands: tuple) -> dict[str, list[str]]:
+    return {f"Removed assets:{linesep}": [record_item(repo, operands[0])]}
+
+
+def record_remove_directories(repo: OnyoRepo, operands: tuple) -> dict[str, list[str]]:
+    return {f"Removed directories:{linesep}": [record_item(repo, operands[0])]}
+
+
+def record_move_assets(repo: OnyoRepo, operands: tuple) -> dict[str, list[str]]:
+    return {f"Moved assets:{linesep}": [record_move(repo, operands[0], operands[1])]}
+
+
+def record_move_directories(repo: OnyoRepo, operands: tuple) -> dict[str, list[str]]:
+    return {f"Moved directories:{linesep}": [record_move(repo, operands[0], operands[1])]}
+
+
+def record_rename_directories(repo: OnyoRepo, operands: tuple) -> dict[str, list[str]]:
+    return {f"Renamed directories:{linesep}": [record_move(repo, operands[0], operands[1])]}
+
+
+def record_rename_assets(repo: OnyoRepo, operands: tuple) -> dict[str, list[str]]:
+    # TODO: This needs a special case for asset dirs. Record both - an
+    # asset renamed and a directory renamed. This cannot be addressed by an
+    # actual rename directory operation being executed and then recorded, because renaming
+    # of asset depends on content and config. (Plus: We can't actually rename the same thing twice)
+    #
+    # This type of double recording may need to be done for other operations on asset dirs - double-check!
+    return {f"Renamed assets:{linesep}": [record_move(repo, operands[0], operands[1])]}
+
+
+def record_modify_assets(repo: OnyoRepo, operands: tuple) -> dict[str, list[str]]:
+    return {f"Modified assets:{linesep}": [record_item(repo, operands[0])]}

--- a/onyo/lib/tests/test_commands_mv.py
+++ b/onyo/lib/tests/test_commands_mv.py
@@ -1,0 +1,134 @@
+import pytest
+
+from ..commands import onyo_mv
+from onyo.lib.inventory import Inventory
+from onyo.lib.onyo import OnyoRepo
+from onyo.lib.exceptions import InvalidInventoryOperation
+
+# Note: ui settings happen to be identical throughout this file.
+#       However, we should have a ui fixture instead.
+from onyo.lib.ui import ui
+ui.set_yes(True)
+ui.set_quiet(False)
+
+
+def test_onyo_mv_into_self(inventory: Inventory) -> None:
+
+    asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    dir_path = inventory.root / 'empty'
+
+    # move into itself:
+    pytest.raises(InvalidInventoryOperation,
+                  onyo_mv,
+                  inventory,
+                  source=dir_path,
+                  destination=dir_path,
+                  message="some subject\n\nAnd a body")
+
+    # move asset into non-existing
+    pytest.raises(ValueError,
+                  onyo_mv,
+                  inventory,
+                  source=asset_path,
+                  destination=dir_path / "doesnotexist",
+                  message="some subject\n\nAnd a body")
+
+    # move dir into non-existing
+    pytest.raises(ValueError,
+                  onyo_mv,
+                  inventory,
+                  source=inventory.root / "somewhere",
+                  destination=dir_path / "doesnotexist" / "somewhere",
+                  message="some subject\n\nAnd a body")
+
+    # rename including a move
+    pytest.raises(InvalidInventoryOperation,
+                  onyo_mv,
+                  inventory,
+                  source=inventory.root / "somewhere",
+                  destination=dir_path / "newname",
+                  message="some subject\n\nAnd a body")
+
+    # move to existing file
+    pytest.raises(ValueError,
+                  onyo_mv,
+                  inventory,
+                  source=dir_path,
+                  destination=asset_path,
+                  message="some subject\n\nAnd a body")
+
+    # rename asset file
+    pytest.raises(ValueError,
+                  onyo_mv,
+                  inventory,
+                  source=asset_path,
+                  destination=asset_path.parent / "new_asset_name",
+                  message="some subject\n\nAnd a body")
+
+    # target already exists
+    inventory.add_directory(asset_path.parent / dir_path.name)
+    inventory.commit("add target dir")
+    pytest.raises(OSError,  # TODO: This says "directory not empty" (anchor file) - should probably be changed
+                  onyo_mv,
+                  inventory,
+                  source=dir_path,
+                  destination=asset_path.parent,
+                  message="some subject\n\nAnd a body")
+
+
+def test_onyo_mv_move_simple(inventory: Inventory) -> None:
+    asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    dir_path = inventory.root / 'empty'
+    destination_path = inventory.root / 'different' / 'place'
+
+    # move an asset and a dir to the same destination
+    onyo_mv(inventory,
+            source=[asset_path, dir_path],
+            destination=destination_path,
+            message="some subject\n\nAnd a body")
+
+    # asset was moved
+    assert inventory.repo.is_asset_path(destination_path / asset_path.name)
+    assert (destination_path / asset_path.name) not in inventory.repo.git.files_untracked
+    assert (destination_path / asset_path.name) not in inventory.repo.git.files_staged
+    assert not asset_path.exists()
+    # dir was moved
+    assert inventory.repo.is_inventory_dir(destination_path / dir_path.name)
+    assert (destination_path / dir_path.name / OnyoRepo.ANCHOR_FILE).is_file()
+    assert (destination_path / dir_path.name / OnyoRepo.ANCHOR_FILE) not in inventory.repo.git.files_untracked
+    assert (destination_path / dir_path.name / OnyoRepo.ANCHOR_FILE) not in inventory.repo.git.files_staged
+    assert not dir_path.exists()
+
+
+def test_onyo_mv_move_explicit(inventory: Inventory) -> None:
+    dir_path = inventory.root / 'somewhere' / 'nested'
+    # move by explicitly restating the source's name:
+    src = dir_path
+    # `dst` does not yet exist, which would indicate a renaming if it wasn't the same name as the source.
+    # If recognized as a renaming, however, it should fail because not only the name but also the parent changed, which
+    # implies two operations: A move and a renaming (with no order given).
+    dst = inventory.root / src.name
+    onyo_mv(inventory,
+            source=src,
+            destination=dst,
+            message="some subject\n\nAnd a body")
+
+    assert inventory.repo.is_inventory_dir(dst)
+    assert (dst / OnyoRepo.ANCHOR_FILE) not in inventory.repo.git.files_untracked
+    assert (dst / OnyoRepo.ANCHOR_FILE) not in inventory.repo.git.files_staged
+    assert not src.exists()
+
+
+def test_onyo_mv_rename(inventory: Inventory) -> None:
+    dir_path = inventory.root / 'somewhere' / 'nested'
+    new_name = dir_path.parent / 'newname'
+
+    onyo_mv(inventory,
+            source=dir_path,
+            destination=new_name,
+            message="some subject\n\nAnd a body")
+
+    assert inventory.repo.is_inventory_dir(new_name)
+    assert (new_name / OnyoRepo.ANCHOR_FILE) not in inventory.repo.git.files_untracked
+    assert (new_name / OnyoRepo.ANCHOR_FILE) not in inventory.repo.git.files_staged
+    assert not dir_path.exists()

--- a/onyo/lib/tests/test_commands_new.py
+++ b/onyo/lib/tests/test_commands_new.py
@@ -1,0 +1,165 @@
+import os
+
+import pytest
+import subprocess
+from pathlib import Path
+
+from ..commands import onyo_new
+import onyo
+from onyo.lib.onyo import OnyoRepo
+from onyo.lib.inventory import Inventory
+
+
+# TODO: Derive path from installed package resources (and don't place it within a specific test location):
+prepared_tsvs = [p for p in (Path(onyo.__file__).parent / "commands" / "tests" / "tables").iterdir()]
+
+
+# TODO: Asset dirs!
+# TODO: Commit message!
+# TODO: Changed name scheme config
+
+
+def test_onyo_new_invalid(inventory: Inventory) -> None:
+    # no arguments is insufficient
+    pytest.raises(ValueError, onyo_new, inventory)
+    # empty `keys` is not good enough either
+    pytest.raises(ValueError, onyo_new, inventory, keys=[])
+    # edit should fail in non-interactive test
+    pytest.raises(subprocess.CalledProcessError, onyo_new, inventory, edit=True)
+    # tsv must exist:
+    pytest.raises(FileNotFoundError, onyo_new, inventory, tsv=inventory.root / "nonexisting.tsv")
+
+
+@pytest.mark.parametrize('tsv', prepared_tsvs)
+def test_onyo_new_tsv(inventory: Inventory, tsv: Path) -> None:
+    if tsv.name.startswith('error'):
+        # TODO: Be more specific about the errors
+        pytest.raises(ValueError, onyo_new, inventory, tsv)
+    else:
+        # TODO: Same here; just ensures those tables still don't crash
+        from onyo.lib.ui import ui
+        ui.set_yes(True)
+        onyo_new(inventory, tsv=tsv)
+        inventory.repo.git._git(['reset', '--hard', 'HEAD~1'])
+
+
+def test_onyo_new_keys(inventory: Inventory) -> None:
+    from onyo.lib.ui import ui
+    ui.set_yes(True)
+    specs = [{'type': 'a type',
+              'make': 'I made it',
+              'model': 'a model',
+              'serial': '002'},
+             {'type': 'a type',
+              'make': 'I made it',
+              'model': 'a model',
+              'serial': '003'}]
+    onyo_new(inventory,
+             path=inventory.root / "empty",
+             keys=specs)
+    for s in specs:
+        p = inventory.root / "empty" / f"{s['type']}_{s['make']}_{s['model']}.{s['serial']}"
+        assert inventory.repo.is_asset_path(p)
+        assert p not in inventory.repo.git.files_untracked
+        new_asset = inventory.get_asset(p)
+        assert new_asset.get("path") == p
+        assert all(new_asset[k] == s[k] for k in s.keys())
+
+    # faux serial and 'directory' key
+    specs = [{'type': 'A',
+              'make': 'faux',
+              'model': 'serial',
+              'directory': 'brandnew',
+              'serial': 'faux'},
+             {'type': 'Another',
+              'make': 'faux',
+              'model': 'serial',
+              'directory': 'completely/elsewhere',
+              'serial': 'faux'}]
+    # 'directory' is in conflict with `path` being given:
+    pytest.raises(ValueError,
+                  onyo_new,
+                  inventory,
+                  path=inventory.root / "empty",
+                  keys=specs)
+    # w/o `path` everything is fine:
+    onyo_new(inventory, keys=specs)
+
+    for s in specs:
+        files = [p
+                 for p in (inventory.root / f"{s['directory']}").iterdir()
+                 if p.name != OnyoRepo.ANCHOR_FILE
+                 ]
+        assert len(files) == 1
+        # expected filename (except serial):
+        assert files[0].name.startswith(f"{s['type']}_{s['make']}_{s['model']}.")
+        assert inventory.repo.is_asset_path(files[0])
+        assert files[0] not in inventory.repo.git.files_untracked
+        new_asset = inventory.get_asset(files[0])
+        assert new_asset.get("path") == files[0]
+        # reserved key 'directory' is not part of the asset's content
+        assert 'directory' not in new_asset.keys()
+        # content equals spec:
+        assert all(new_asset[k] == s[k]
+                   for k in s.keys()
+                   if k not in ['directory', 'serial'])
+
+    # missing required field:
+    specs = [{'somekey': 'somevalue'}]
+    pytest.raises(ValueError, onyo_new, inventory, keys=specs)
+
+    # use templates and `path`'s default - CWD.
+    # Attention: CWD being inventory.root relies on current implementation of
+    # the repo fixture, which the inventory fixture builds upon.
+    specs = [{'type': 'flavor',
+              'make': 'manufacturer',
+              'model': 'exquisite',
+              'template': 'laptop.example',
+              'serial': '1234'}]
+    onyo_new(inventory, keys=specs)
+    expected_path = inventory.root / f"{specs[0]['type']}_{specs[0]['make']}_{specs[0]['model']}.{specs[0]['serial']}"
+    assert inventory.repo.is_asset_path(expected_path)
+    asset_content = inventory.repo.get_asset_content(expected_path)
+    # check for template keys:
+    # (Note: key must be there - no `KeyError`; but content is `None`)
+    for k in ['RAM', 'Size', 'USB']:
+        assert asset_content[k] is None
+
+
+def test_onyo_new_edit(inventory: Inventory, monkeypatch) -> None:
+    from onyo.lib.ui import ui
+    ui.set_yes(True)
+
+    directory = inventory.root / "edited"
+    monkeypatch.setenv('EDITOR', "printf 'key: value' >>")
+
+    specs = [{'template': 'empty',
+              'model': 'MODEL',
+              'make': 'MAKER',
+              'type': 'TYPE',
+              'serial': 'totally_random'}]
+    onyo_new(inventory, keys=specs, path=directory, edit=True)
+
+    expected_path = directory / "TYPE_MAKER_MODEL.totally_random"
+    assert inventory.repo.is_asset_path(expected_path)
+    assert expected_path not in inventory.repo.git.files_untracked
+    asset_content = inventory.repo.get_asset_content(expected_path)
+    assert asset_content['key'] == 'value'
+
+    # missing required fields:
+    specs = [{'template': 'empty'}]
+    pytest.raises(ValueError, onyo_new, inventory, keys=specs, path=directory, edit=True)
+
+    # file already exists:
+    edit_str = f"model: MODEL{os.linesep}make: MAKER{os.linesep}type: TYPE{os.linesep}"
+    monkeypatch.setenv('EDITOR', f"printf '{edit_str}' >>")
+    specs = [{'template': 'empty',
+              'serial': 'totally_random'}]
+
+    pytest.raises(ValueError, onyo_new, inventory, keys=specs, path=directory, edit=True)
+
+    # asset already exists (but elsewhere - see fixture):
+    edit_str = f"model: MODEL{os.linesep}make: MAKER{os.linesep}type: TYPE{os.linesep}serial: SERIAL{os.linesep}"
+    monkeypatch.setenv('EDITOR', f"printf '{edit_str}' >>")
+    specs = [{'template': 'empty'}]
+    pytest.raises(ValueError, onyo_new, inventory, keys=specs, path=directory, edit=True)

--- a/onyo/lib/tests/test_inventory_operations.py
+++ b/onyo/lib/tests/test_inventory_operations.py
@@ -1,0 +1,719 @@
+import pytest
+
+from onyo.lib.onyo import OnyoRepo
+from onyo.lib.inventory import Inventory, OPERATIONS_MAPPING
+from onyo.lib.assets import Asset
+from onyo.lib.exceptions import InvalidInventoryOperation, NoopError, NotAnAssetError
+
+# TODO: - Inventory fixture(s)
+#       - mocks
+
+
+# TODO: Parameterize tests? run a method with different paths/objects(Asset); especially asset/dir vs asset dir
+#       wherever the outcome should be identical (like move)
+
+# TODO: Should an asset dir be able to contain a plain dir? Think so.
+
+
+def num_operations(inventory: Inventory, name: str) -> int:
+    """Helper to get number of registered operations in `inventory` of type `name`."""
+    return len([op for op in inventory.operations if op.operator is OPERATIONS_MAPPING[name]])
+
+
+def test_Inventory_instantiation(repo: OnyoRepo) -> None:
+
+    inventory = Inventory(repo)
+    # operations registry is initialized:
+    assert inventory.operations == []
+
+
+def test_add_asset(repo: OnyoRepo) -> None:
+    # TODO: mock repo? Real one not needed here.
+    #       Possibly also mock add_directory instead.
+
+    # TODO: check validation? (not yet integrated)
+
+    inventory = Inventory(repo)
+
+    newdir1 = inventory.root / "somewhere"
+    newdir2 = newdir1 / "new"
+    asset_file = newdir2 / "asset_file"
+    asset = Asset(some_key="some_value",
+                  other=1,
+                  path=asset_file
+                  )
+    assert num_operations(inventory, 'new_assets') == 0
+    assert num_operations(inventory, 'new_directories') == 0
+
+    inventory.add_asset(asset)
+
+    # operations to add new asset and two dirs are registered:
+    assert num_operations(inventory, 'new_assets') == 1
+    assert num_operations(inventory, 'new_directories') == 2
+    operands = [op.operands for op in inventory.operations]
+    assert all(isinstance(o, tuple) for o in operands)
+    assert (asset,) in operands
+    assert (newdir1,) in operands
+    assert (newdir2,) in operands
+
+    # nothing done on disc yet:
+    assert not asset_file.exists()
+    assert not newdir2.exists()
+    assert not newdir1.exists()
+
+    # TODO: test diff
+
+    # now commit:
+    inventory.commit("Add a new asset")
+    assert repo.is_inventory_dir(newdir1)
+    assert repo.is_inventory_dir(newdir2)
+    assert repo.is_asset_path(asset_file)
+    assert repo.get_asset_content(asset_file) == dict(**asset)
+    # TODO: check commit message
+
+    # To be added Asset requires a path:
+    asset = Asset(a_key='a_value')
+    pytest.raises(ValueError, inventory.add_asset, asset)
+
+    # Asset must not yet exist:  (TODO: This may be wrong. Seems better if it must not yet exist as an asset,
+    #                                   but may exist as an untracked file! Note, that this is not testing a command,
+    #                                   but an inventory operation.)
+    existing_asset_file = repo.git.root / 'root_asset'
+    existing_asset_file.touch()
+    asset = Asset(some='whatever', path=existing_asset_file)
+    pytest.raises(ValueError, inventory.add_asset, asset)
+
+    # TODO: should also fail when adding an asset that is already pending? Or one that is also being removed, etc?
+
+
+def test_remove_asset(inventory: Inventory) -> None:
+
+    # NOTE: First trial using inventory fixture
+
+    doesnotexist = inventory.root / "root_asset"
+    pytest.raises(NotAnAssetError, inventory.remove_asset, doesnotexist)
+
+    isadir = inventory.root / "a_dir"
+    isadir.mkdir()
+    pytest.raises(NotAnAssetError, inventory.remove_asset, isadir)
+
+    # TODO: Can't remove untracked?? See similar cases in new_asset, new_dir
+
+    # TODO: We should get such paths from the fixture! Otherwise it doesn't make things easier.
+    asset_file = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    assert asset_file.exists()
+
+    asset = inventory.get_asset(asset_file)
+    inventory.remove_asset(asset)
+    # operation registered:
+    assert num_operations(inventory, 'remove_assets') == 1
+    assert isinstance(inventory.operations[0].operands, tuple)
+    assert asset in inventory.operations[0].operands
+
+    # Still on disc:
+    assert asset_file.exists()
+
+    # TODO: test diff
+
+    # now commit:
+    inventory.commit("Remove an asset")
+    # asset file is removed (but not the containing dir):
+    assert not asset_file.exists()
+    assert asset_file.parent.is_dir()
+    # path does not qualify as an asset path anymore:
+    assert not inventory.repo.is_asset_path(asset_file)
+    # but parent dir still is an inventory dir:
+    assert inventory.repo.is_inventory_dir(asset_file.parent)
+
+
+def test_move_asset(repo: OnyoRepo) -> None:
+    inventory = Inventory(repo)
+    newdir1 = repo.git.root / "somewhere"
+    newdir2 = newdir1 / "new"
+    asset_file = newdir2 / "asset_file"
+    asset = Asset(some_key="some_value",
+                  other=1,
+                  path=asset_file
+                  )
+    inventory.add_asset(asset)
+    inventory.commit("First asset added")
+
+    # non-existing destination raises:
+    pytest.raises(ValueError, inventory.move_asset, asset, newdir1 / "doesnotexist")
+
+    # move to same place:
+    pytest.raises(ValueError, inventory.move_asset, asset, newdir2)
+
+    # valid target:
+    inventory.move_asset(asset, newdir1)
+    assert num_operations(inventory, 'move_assets') == 1
+    assert isinstance(inventory.operations[0].operands, tuple)
+    assert asset_file in inventory.operations[0].operands
+    assert newdir1 in inventory.operations[0].operands
+
+    # nothing done on disc yet:
+    assert asset_file.is_file()
+    assert not (newdir1 / "asset_file").exists()
+
+    # TODO: test diff
+
+    # now commit:
+    inventory.commit("Move an asset")
+    assert not asset_file.exists()
+    assert (newdir1 / "asset_file").is_file()
+
+
+def test_rename_asset(repo: OnyoRepo) -> None:
+    inventory = Inventory(repo)
+    newdir1 = repo.git.root / "somewhere"
+    newdir2 = newdir1 / "new"
+    asset_file = newdir2 / "TYPE_MAKER_MODEL.SERIAL"
+    asset = Asset(some_key="some_value",
+                  type="TYPE",
+                  make="MAKER",
+                  model="MODEL",
+                  serial="SERIAL",
+                  other=1,
+                  path=asset_file
+                  )
+    inventory.add_asset(asset)
+    inventory.commit("First asset added")
+
+    # invalid name according to default config:
+    pytest.raises(ValueError, inventory.rename_asset, asset, "new_name")
+
+    # rename to itself raises:  TODO: This test case currently adds nothing b/c the name is invalid until add_asset has
+    #                                 validation integrated and we start with a valid name.
+    pytest.raises(NoopError, inventory.rename_asset, asset, "TYPE_MAKER_MODEL.SERIAL")
+
+    # Note: No commit here. Valid rename only via modify ATM. Hence, tested in modify asset instead.
+    # Alternative: Modify file directly instead and rename here?
+
+
+def test_modify_asset(repo: OnyoRepo) -> None:
+    inventory = Inventory(repo)
+    newdir1 = repo.git.root / "somewhere"
+    newdir2 = newdir1 / "new"
+    asset_file = newdir2 / "TYPE_MAKER_MODEL.SERIAL"
+    asset = Asset(some_key="some_value",
+                  type="TYPE",
+                  make="MAKER",
+                  model="MODEL",
+                  serial="SERIAL",
+                  other=1,
+                  path=asset_file
+                  )
+    inventory.add_asset(asset)
+    inventory.commit("First asset added")
+
+    asset_changes = Asset(some_key="new_value",  # arbitrary content change
+                          model="CORRECTED-MODEL"  # implies rename w/ default name config
+                          )
+    # raises on non-existing asset
+    pytest.raises(ValueError, inventory.modify_asset, repo.git.root / "doesnotexist", asset_changes)
+    # raises on non-asset
+    pytest.raises(ValueError, inventory.modify_asset, newdir1, asset_changes)
+
+    inventory.modify_asset(asset, asset_changes)
+    # modify operation:
+    assert num_operations(inventory, 'modify_assets') == 1
+    assert isinstance(inventory.operations[0].operands, tuple)
+    assert asset in inventory.operations[0].operands
+    new_asset = asset.copy()
+    new_asset.update(asset_changes)
+    new_asset_file = newdir2 / "TYPE_MAKER_CORRECTED-MODEL.SERIAL"
+    assert new_asset in inventory.operations[0].operands
+    # implicit rename operation:
+    assert num_operations(inventory, 'rename_assets') == 1
+    assert isinstance(inventory.operations[1].operands, tuple)
+    assert asset_file in inventory.operations[1].operands
+    assert new_asset_file in inventory.operations[1].operands
+
+    # nothing done on disc yet:
+    assert asset_file.is_file()
+    assert not new_asset_file.exists()
+    assert asset == Asset(**repo.get_asset_content(asset_file))
+
+    # TODO: diff
+
+    # now commit:
+    inventory.commit("Modify an asset")
+    assert not asset_file.exists()
+    assert repo.is_asset_path(new_asset_file)
+    expected_asset = Asset(**new_asset)
+    expected_asset['path'] = new_asset_file
+    assert repo.get_asset_content(new_asset_file) == expected_asset
+
+
+def test_add_directory(repo: OnyoRepo) -> None:
+    inventory = Inventory(repo)
+
+    # can not add non-inventory paths:
+    invalid_inventory_dir = repo.git.root / '.git' / 'new'
+    pytest.raises(ValueError, inventory.add_directory, invalid_inventory_dir)
+
+    # can not add existing dirs:  (TODO: Same as new_asset - this behavior is not entirely correct at this level.
+    #                                    dir w/o anchor could get one. Could also be untracked and now to be added.
+    existing_inventory_dir = repo.git.root / 'exists'
+    existing_inventory_dir.mkdir()
+    pytest.raises(ValueError, inventory.add_directory, existing_inventory_dir)
+
+    new_dir = repo.git.root / 'newdir'
+    inventory.add_directory(new_dir)
+
+    # operation is registered:
+    assert num_operations(inventory, 'new_directories') == 1
+    assert isinstance(inventory.operations[0].operands, tuple)
+    assert new_dir in inventory.operations[0].operands
+
+    # nothing done on disc yet:
+    assert not new_dir.exists()
+
+    # TODO: diff
+
+    # now commit
+    inventory.commit("Add new directory")
+    assert repo.is_inventory_dir(new_dir)
+    assert (new_dir / repo.ANCHOR_FILE).is_file()
+
+
+def test_remove_directory(repo: OnyoRepo) -> None:
+    inventory = Inventory(repo)
+    newdir1 = repo.git.root / "somewhere"
+    newdir2 = newdir1 / "new"
+    emptydir = newdir1 / "empty"
+    asset_file = newdir2 / "asset_file"
+    asset = Asset(some_key="some_value",
+                  type="TYPE",
+                  make="MAKER",
+                  model="MODEL",
+                  serial="SERIAL",
+                  other=1,
+                  path=asset_file
+                  )
+    inventory.add_asset(asset)
+    inventory.add_directory(emptydir)
+    inventory.commit("First asset added")
+
+    # raise on non-dir
+    pytest.raises(ValueError, inventory.remove_directory, asset_file)
+    # raise on non-empty
+    pytest.raises(InvalidInventoryOperation, inventory.remove_directory, newdir1)
+
+    inventory.remove_directory(emptydir)
+    assert num_operations(inventory, 'remove_directories') == 1
+    assert isinstance(inventory.operations[0].operands, tuple)
+    assert emptydir in inventory.operations[0].operands
+
+    # nothing done on disc yet:
+    assert emptydir.is_dir()
+
+    # TODO: diff
+
+    # now commit
+    inventory.commit("Remove directory")
+    assert not emptydir.exists()
+
+    # TODO: recursive? Or leave that to the caller? See also: remove asset_dir
+
+
+def test_move_directory(repo: OnyoRepo) -> None:
+    inventory = Inventory(repo)
+    newdir1 = repo.git.root / "somewhere"
+    newdir2 = newdir1 / "new"
+    emptydir = newdir1 / "empty"
+    asset_file = newdir2 / "asset_file"
+    asset = Asset(some_key="some_value",
+                  type="TYPE",
+                  make="MAKER",
+                  model="MODEL",
+                  serial="SERIAL",
+                  other=1,
+                  path=asset_file
+                  )
+    inventory.add_asset(asset)
+    inventory.add_directory(emptydir)
+    inventory.commit("First asset added")
+
+    # raise on non-dir:
+    pytest.raises(ValueError, inventory.move_directory, asset_file, repo.git.root / "doesnotexist")
+    pytest.raises(ValueError, inventory.move_directory, asset_file, (repo.git.root / "isafile").touch())
+    # raise on rename:
+    pytest.raises(InvalidInventoryOperation, inventory.move_directory, newdir2, newdir1)
+
+    inventory.move_directory(newdir2, emptydir)
+    assert num_operations(inventory, 'move_directories') == 1
+    assert (newdir2, emptydir) == inventory.operations[0].operands
+
+    # nothing happened on disc yet:
+    assert newdir2.is_dir()
+    assert not (emptydir / newdir2.name).exists()
+
+    # TODO diff
+
+    # now commit:
+    inventory.commit("Move a directory")
+    assert not newdir2.exists()
+    assert repo.is_inventory_dir(emptydir / newdir2.name)
+
+
+def test_rename_directory(repo: OnyoRepo) -> None:
+    inventory = Inventory(repo)
+    newdir1 = repo.git.root / "somewhere"
+    newdir2 = newdir1 / "new"
+    emptydir = newdir1 / "empty"
+    asset_file = newdir2 / "asset_file"
+    asset = Asset(some_key="some_value",
+                  type="TYPE",
+                  make="MAKER",
+                  model="MODEL",
+                  serial="SERIAL",
+                  other=1,
+                  path=asset_file
+                  )
+    inventory.add_asset(asset)
+    inventory.add_directory(emptydir)
+    inventory.commit("First asset added")
+
+    new_place = repo.git.root / "new_place"
+    # raise on non-dir:
+    pytest.raises(ValueError, inventory.rename_directory, asset_file, new_place)
+    # raise on existing destination:
+    pytest.raises(InvalidInventoryOperation, inventory.rename_directory, newdir1, emptydir)
+    # raise on move:
+    pytest.raises(InvalidInventoryOperation, inventory.rename_directory, newdir2, new_place)
+
+    new_name = newdir1 / "new_name"
+    inventory.rename_directory(newdir2, new_name)
+    assert num_operations(inventory, 'rename_directories') == 1
+    assert (newdir2, new_name) == inventory.operations[0].operands
+
+    # nothing happened on disc yet:
+    assert newdir2.is_dir()
+    assert not new_name.exists()
+
+    # TODO: diff
+
+    # now commit:
+    inventory.commit("Renamed directory")
+    assert not newdir2.exists()
+    assert repo.is_inventory_dir(new_name)
+
+
+def test_add_asset_dir(repo: OnyoRepo) -> None:
+    inventory = Inventory(repo)
+
+    asset_dir_path = inventory.root / "TYPE_MAKE_MODEL.SERIAL"
+    asset = Asset(some_key="some_value",
+                  other=1,
+                  type="TYPE",
+                  make="MAKE",
+                  model="MODEL",
+                  serial="SERIAL",
+                  is_asset_directory=True,
+                  path=asset_dir_path
+                  )
+
+    # TODO: THIS NEEDS TESTING WITH NON-COMPLIANT DIRECTORY NAME BEFORE -> implicit rename operation!
+
+    inventory.add_asset(asset)
+    # operations to add new asset and a dir are registered:
+    assert num_operations(inventory, 'new_assets') == 1
+    assert num_operations(inventory, 'new_directories') == 1
+    operands = [op.operands for op in inventory.operations]
+    assert all(isinstance(o, tuple) for o in operands)
+    assert (asset_dir_path,) in operands
+    assert (asset,) in operands
+
+    # nothing executed yet:
+    assert not asset_dir_path.exists()
+
+    # execute
+    inventory.commit("add asset dir")
+    assert inventory.repo.git.is_clean_worktree()
+    # dir and yaml file are created:
+    assert asset_dir_path.is_dir()
+    assert (asset_dir_path / OnyoRepo.ASSET_DIR_FILE).is_file()
+    # an asset dir is both - an inventory directory and an asset:
+    assert inventory.repo.is_asset_path(asset_dir_path)
+    assert inventory.repo.is_inventory_dir(asset_dir_path)
+    assert inventory.repo.is_asset_dir(asset_dir_path)
+    # TODO: should the yaml file within be a valid asset path as well? Think not.
+    # assert inventory.repo.is_asset_path(asset_dir_path / OnyoRepo.ASSET_DIR_FILE)
+
+    # add asset aspect to existing directory, which does not yet comply with asset naming scheme
+    dir_path = inventory.root / "newdir"
+    inventory.add_directory(dir_path)
+    inventory.commit("New inventory dir")
+
+    asset = Asset(some_key="some_value",
+                  other=1,
+                  type="TYPE1",
+                  make="MAKE1",
+                  model="MODEL1",
+                  serial="1X2",
+                  is_asset_directory=True,
+                  path=dir_path
+                  )
+    expected_name = "{type}_{make}_{model}.{serial}".format(**asset)
+    expected_path = dir_path.parent / expected_name
+    inventory.add_asset(asset)
+
+    # registered operations:
+    # 1. new asset
+    assert num_operations(inventory, 'new_assets') == 1
+    # 2. rename dir
+    assert num_operations(inventory, 'rename_directories') == 1
+    operands = [op.operands for op in inventory.operations]
+    assert all(isinstance(o, tuple) for o in operands)
+    assert (asset,) in operands
+    assert (dir_path, expected_path) in operands
+
+    # nothing done on disc yet
+    assert inventory.repo.is_inventory_dir(dir_path)
+    assert not inventory.repo.is_asset_path(dir_path)
+    assert not inventory.repo.is_asset_dir(expected_path)
+    assert not expected_path.exists()
+
+    # execute
+    inventory.commit("Turn inventory dir into asset dir")
+
+    assert not inventory.repo.is_inventory_dir(dir_path)
+    assert not inventory.repo.is_asset_path(dir_path)
+    assert not dir_path.exists()
+
+    assert expected_path.exists()
+    assert inventory.repo.is_inventory_dir(expected_path)
+    assert inventory.repo.is_asset_path(expected_path)
+    assert inventory.repo.is_asset_dir(expected_path)
+    assert inventory.repo.git.is_clean_worktree()
+
+
+def test_remove_asset_dir_directory(repo: OnyoRepo):
+    inventory = Inventory(repo)
+    asset_dir_path = inventory.root / "TYPE_MAKE_MODEL.SERIAL"
+    asset = Asset(some_key="some_value",
+                  other=1,
+                  type="TYPE",
+                  make="MAKE",
+                  model="MODEL",
+                  serial="SERIAL",
+                  is_asset_directory=True,
+                  path=asset_dir_path
+                  )
+    inventory.add_asset(asset)
+    inventory.commit("Whatever")
+
+    inventory.remove_directory(asset_dir_path)
+    # Nothing done on disc yet:
+    assert inventory.repo.is_inventory_dir(asset_dir_path)
+    assert inventory.repo.is_asset_path(asset_dir_path)
+    assert asset_dir_path.is_dir()
+    assert num_operations(inventory, 'remove_directories') == 1
+    assert (asset_dir_path,) == inventory.operations[0].operands
+
+    inventory.commit("Remove dir from asset dir")
+    assert not inventory.repo.is_asset_dir(asset_dir_path)
+    assert not inventory.repo.is_inventory_dir(asset_dir_path)
+    assert inventory.repo.is_asset_path(asset_dir_path)
+    assert asset_dir_path.is_file()
+    assert inventory.repo.git.is_clean_worktree()
+
+
+def test_remove_asset_dir_asset(repo: OnyoRepo):
+    inventory = Inventory(repo)
+    asset_dir_path = inventory.root / "TYPE_MAKE_MODEL.SERIAL"
+    asset = Asset(some_key="some_value",
+                  other=1,
+                  type="TYPE",
+                  make="MAKE",
+                  model="MODEL",
+                  serial="SERIAL",
+                  is_asset_directory=True,
+                  path=asset_dir_path
+                  )
+    inventory.add_asset(asset)
+    inventory.commit("Whatever")
+
+    # TODO: What if there are assets within? Auto-recurse? Switch?
+    #       Operation needs to be atomic. Hence, must be empty!
+    # TODO: What about an implicit remove_directory?
+    #       -> NOPE! That would mean to not be able to disentangle the two ever again, because this operation will be
+    #       recorded with this meaning.
+    inventory.remove_asset(asset)
+
+    # Nothing done on disc yet:
+    assert inventory.repo.is_inventory_dir(asset_dir_path)
+    assert inventory.repo.is_asset_path(asset_dir_path)
+    # Operation registered
+    assert num_operations(inventory, 'remove_assets') == 1
+    assert isinstance(inventory.operations[0].operands, tuple)
+    assert asset in inventory.operations[0].operands
+
+    # Execute:
+    inventory.commit("Turn asset dir into plain dir")
+    # It's still an inventory dir:
+    assert inventory.repo.is_inventory_dir(asset_dir_path)
+    # but not an asset anymore:
+    assert not inventory.repo.is_asset_path(asset_dir_path)
+    assert not (asset_dir_path / OnyoRepo.ASSET_DIR_FILE).exists()
+    assert inventory.repo.git.is_clean_worktree()
+
+
+def test_move_asset_dir(repo: OnyoRepo) -> None:
+    # An asset dir could be moved by either move_dir or move_asset. Since it's both, there's no difference when we treat
+    # it as either one.
+
+    # TODO: Similar to rename, moving an asset dir needs to record two operations, while technically executing only one.
+    #       That is true for move_directory as well as move_asset
+    #       For both - rename and move - it's also possible to actually register two operations, but turn the directory
+    #       operation into a noop executor (but normal recorder) in case of an asset dir. However, that would somewhat
+    #       imply that such calls are only valid as an internal operation rather than an arbitrary caller calling
+    #       `move_directory(asset_dir)`. This in turn would suggest an ad-hoc "empty" Operation object instead of
+    #       internally calling `move_directory`! This might be the nicest approach so far.
+
+    inventory = Inventory(repo)
+    asset_dir_path = inventory.root / "TYPE_MAKE_MODEL.SERIAL"
+    dir_path = inventory.root / "destination"
+    asset = Asset(some_key="some_value",
+                  other=1,
+                  type="TYPE",
+                  make="MAKE",
+                  model="MODEL",
+                  serial="SERIAL",
+                  is_asset_directory=True,
+                  path=asset_dir_path
+                  )
+    inventory.add_asset(asset)
+    inventory.add_directory(dir_path)
+    inventory.commit("Whatever")
+
+    inventory.move_asset(asset_dir_path, dir_path)
+    assert num_operations(inventory, 'move_assets') == 1
+    assert (asset_dir_path, dir_path) == inventory.operations[0].operands
+
+    # nothing done on disc yet:
+    assert inventory.repo.is_asset_dir(asset_dir_path)
+    assert asset_dir_path.is_dir()
+    assert not (dir_path / asset_dir_path.name).exists()
+
+    inventory.commit("Move asset dir")
+    new_path = dir_path / asset_dir_path.name
+    assert not asset_dir_path.exists()
+    assert inventory.repo.is_asset_dir(new_path)
+
+    # Now move back but via `move_directory` instead.
+    inventory.move_directory(new_path, inventory.root)
+    assert num_operations(inventory, 'move_directories') == 1
+    assert (new_path, inventory.root) == inventory.operations[0].operands
+
+    # nothing done on disc
+    assert inventory.repo.is_asset_dir(new_path)
+    assert not asset_dir_path.exists()
+
+    inventory.commit("Move asset dir back")
+
+    assert inventory.repo.is_asset_dir(asset_dir_path)
+    assert not new_path.exists()
+
+
+def test_rename_asset_dir(repo: OnyoRepo) -> None:
+    # While an asset dir is both - an asset and a dir - it can't be renamed by a rename_dir operations, because it
+    # needs to comply to the naming scheme configuration for assets. For renaming we can't treat it as just a dir.
+    # However, renaming the asset must also rename the dir. While on disc there's no difference, this would need to be
+    # recorded separately!
+    # TODO: This needs to be dealt with by the recorder generating an entry for both operations while technically only
+    # rename_asset is executed.
+
+    inventory = Inventory(repo)
+    asset_dir_path = inventory.root / "TYPE_MAKE_MODEL.SERIAL"
+    asset = Asset(some_key="some_value",
+                  other=1,
+                  type="TYPE",
+                  make="MAKE",
+                  model="MODEL",
+                  serial="SERIAL",
+                  is_asset_directory=True,
+                  path=asset_dir_path
+                  )
+    inventory.add_asset(asset)
+    inventory.commit("Whatever")
+
+    # renaming the asset dir as a dir needs to fail
+    pytest.raises(ValueError, inventory.rename_directory, asset_dir_path, "newname")
+
+    # renaming as an asset by changing the naming config
+    inventory.repo.git.set_config("onyo.assets.filename", "{serial}_{other}", "onyo")
+    inventory.repo.git.stage_and_commit(inventory.root / OnyoRepo.ONYO_CONFIG, "Change asset name config")
+    new_asset_dir_path = asset_dir_path.parent / "SERIAL_1"
+
+    inventory.rename_asset(asset_dir_path)
+    # no change on disc:
+    assert inventory.repo.is_inventory_dir(asset_dir_path)
+    assert inventory.repo.is_asset_path(asset_dir_path)
+    assert inventory.repo.is_asset_dir(asset_dir_path)
+    assert inventory.repo.git.is_clean_worktree()
+
+    # operation registered
+    assert num_operations(inventory, 'rename_assets') == 1
+    assert (asset_dir_path, new_asset_dir_path) == inventory.operations[0].operands
+
+    # execute
+    inventory.commit("rename asset dir")
+    assert not asset_dir_path.exists()
+    assert inventory.repo.is_asset_dir(new_asset_dir_path)
+    assert inventory.repo.is_asset_path(new_asset_dir_path)
+    assert inventory.repo.is_inventory_dir(new_asset_dir_path)
+    assert inventory.repo.git.is_clean_worktree()
+
+
+def test_modify_asset_dir(repo: OnyoRepo) -> None:
+    # This should make no difference to modify any other asset
+
+    inventory = Inventory(repo)
+    newdir1 = repo.git.root / "somewhere"
+    newdir2 = newdir1 / "new"
+    asset_path = newdir2 / "TYPE_MAKER_MODEL.SERIAL"
+    asset = Asset(some_key="some_value",
+                  type="TYPE",
+                  make="MAKER",
+                  model="MODEL",
+                  serial="SERIAL",
+                  other=1,
+                  is_asset_directory=True,
+                  path=asset_path
+                  )
+    inventory.add_asset(asset)
+    inventory.commit("asset dir added")
+    assert inventory.repo.is_asset_dir(asset_path)
+
+    asset_changes = Asset(some_key="new_value",  # arbitrary content change
+                          model="CORRECTED-MODEL"  # implies rename w/ default name config
+                          )
+
+    inventory.modify_asset(asset, asset_changes)
+    # modify operation:
+    assert num_operations(inventory, 'modify_assets') == 1
+    new_asset = asset.copy()
+    new_asset.update(asset_changes)
+    new_asset_path = newdir2 / "TYPE_MAKER_CORRECTED-MODEL.SERIAL"
+    assert (asset, new_asset) == inventory.operations[0].operands
+    # implicit rename operation:
+    assert num_operations(inventory, 'rename_assets') == 1
+    assert (asset_path, new_asset_path) == inventory.operations[1].operands
+
+    # nothing done on disc yet:
+    assert inventory.repo.is_asset_dir(asset_path)
+    assert not new_asset_path.exists()
+    assert asset == Asset(**repo.get_asset_content(asset_path))
+    assert inventory.repo.git.is_clean_worktree()
+
+    # now commit:
+    inventory.commit("Modify an asset")
+    assert not asset_path.exists()
+    assert inventory.repo.is_asset_dir(new_asset_path)
+    assert inventory.repo.git.is_clean_worktree()
+
+    expected_asset = Asset(**new_asset)
+    expected_asset['path'] = new_asset_path
+    assert repo.get_asset_content(new_asset_path) == expected_asset

--- a/onyo/lib/utils.py
+++ b/onyo/lib/utils.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import sys
+import subprocess
+
+from pathlib import Path
+from shlex import quote
+from ruamel.yaml import YAML, scanner  # pyre-ignore[21]
+
+from onyo.lib.ui import ui
+from onyo.lib.inventory import RESERVED_KEYS
+from onyo.lib.onyo import NEW_PSEUDO_KEYS
+
+
+def anything2bool(val):
+    """Convert various representations of boolean values into actual bool"""
+    # Credit: datalad
+
+    if hasattr(val, 'lower'):
+        val = val.lower()
+    if val in {"off", "no", "false", "0"} or not bool(val):
+        return False
+    elif val in {"on", "yes", "true", True} \
+            or (hasattr(val, 'isdigit') and val.isdigit() and int(val)) \
+            or isinstance(val, int) and val:
+        return True
+    else:
+        raise TypeError(
+            "Got value %s which could not be interpreted as a boolean"
+            % repr(val))
+
+
+def edit_asset(asset: dict, editor: str) -> dict:
+    """Edit `asset` with a file editor
+
+    This is using a temporary YAML file, prefilled with the current content
+    of `asset`. Validation of the asset is included.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
+    Raises
+    ------
+    """
+    # TODO: WE DO NOT END UP HERE, WHEN THERE WAS NO ASSET CONTENT DEFINED YET!
+    # TODO: name generation/validation into edit routine! (Incl. available paths!)
+    # get a tempfile
+    from tempfile import mkstemp
+    from .assets import write_asset_file, get_asset_content
+    fd, tmp_path = mkstemp(prefix='onyo_', text=True)
+    tmp_path = Path(tmp_path)
+    # We must not write pseudo-keys to the file:
+    asset_content = {k: v for k, v in asset.items() if k not in NEW_PSEUDO_KEYS + RESERVED_KEYS}
+    write_asset_file(tmp_path, dict(**asset_content))
+
+    edit_asset_file(editor, tmp_path)  # TODO: This returns False on "discard changes". Figure this out.
+    #       Also: May be useful to return content dict. Because `edit_asset` is
+    #       reading the content afterwards already for validation.
+    #       Hence, currently read twice (see below).
+    # reload from tempfile
+    asset = get_asset_content(tmp_path)
+    return asset
+
+
+def edit_asset_file(editor: str, path: Path) -> bool:
+    """
+    Open an existing file at `path` with `editor`. After changes are made, check the
+    file content for validity as an asset file. If valid, write the changes,
+    otherwise open a dialog and ask the user if the asset should be corrected
+    or the changes discarded.
+
+    Returns True when the file was changed and saved without errors, and False
+    if the user wants to discard the changes.
+    """
+    # TODO: Fuse with edit_asset_file above (RF'd for `onyo new`, to be adjusted for `onyo edit`)
+
+    while True:
+        # Note: shell=True would be needed for a setting like the one used in tests:
+        #       EDITOR="printf 'some: thing' >>". Piping needs either shell, or we must
+        #       understand what needs piping at the python level here and create several
+        #       subprocesses piped together.
+        subprocess.run(f'{editor} {quote(str(path))}', check=True, shell=True)
+        try:
+            YAML(typ='rt').load(path)
+            # TODO: add asset validation here
+            return True
+        except scanner.ScannerError:
+            ui.print(f"{path} has invalid YAML syntax.", file=sys.stderr)
+            if not ui.request_user_response("Continue editing? No discards changes. (y/n) "):
+                return False

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -3,7 +3,8 @@ import os
 import sys
 import textwrap
 
-from onyo import commands, ui
+from onyo import commands
+from onyo.lib.ui import ui
 from pathlib import Path
 from typing import Union
 

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -303,7 +303,8 @@ def main() -> None:
             # TODO: This may need to be nicer, but in any case: Turn any exception/error into a message and exit
             #       non-zero here, in order to have this generic last catcher.
             ui.error(e)
-            sys.exit(1)
+            code = e.returncode if hasattr(e, 'returncode') else 1  # pyre-ignore
+            sys.exit(code)
         finally:
             os.chdir(old_cwd)
 

--- a/onyo/shared_arguments.py
+++ b/onyo/shared_arguments.py
@@ -28,7 +28,6 @@ shared_arg_filter = dict(
 shared_arg_message = dict(
     args=('-m', '--message'),
     metavar='MESSAGE',
-    nargs=1,
     action='append',
     type=str,
     help=(

--- a/onyo/skel/config
+++ b/onyo/skel/config
@@ -3,3 +3,7 @@
 	non-interactive = git --no-pager log --follow
 [onyo "new"]
 	template = empty
+[onyo "assets"]
+	filename = "{type}_{make}_{model}.{serial}"
+[onyo "repo"]
+	version = 1


### PR DESCRIPTION
Closed somewhat pre-maturely, but this PR actually fixes #301 and #281.

The following issues are either invalidated or addressed by the PR:
Closes https://github.com/psyinfra/onyo/issues/387
Closes https://github.com/psyinfra/onyo/issues/383
Closes https://github.com/psyinfra/onyo/issues/377
Closes https://github.com/psyinfra/onyo/issues/370
Closes https://github.com/psyinfra/onyo/issues/360
Closes https://github.com/psyinfra/onyo/issues/336
Closes https://github.com/psyinfra/onyo/issues/317
Closes https://github.com/psyinfra/onyo/issues/296
Closes https://github.com/psyinfra/onyo/issues/284
Closes https://github.com/psyinfra/onyo/issues/276
Closes https://github.com/psyinfra/onyo/issues/269
Closes https://github.com/psyinfra/onyo/issues/107
Closes https://github.com/psyinfra/onyo/issues/101
Closes https://github.com/psyinfra/onyo/issues/18

While this is a pretty huge PR, that includes a couple of other changes and fixes, the most important piece is the commit introducing the `Inventory` class and the concept of inventory operations. Hence, putting its message here:

This introduces an `Inventory` class and the concept of inventory operations. An `Inventory` is meant to be the main python interface for onyo.lib. Command implementations (as well as arbitrary python users, of course) are meant to operate on an `Inventory` object.
Anything an onyo command can do, boils down to basic operations on an inventory with to types of entities an inventory knows: Directories and Assets. A directory is represented by a `Path`, an Asset is expected to be a dictionary (or at least a dict-like object).
Basic operations are creating, removing, moving, renaming of assets or directories and modifying an asset's data. Hence, there are 9 such operations. The `Inventory` class comes with methods to "register" operations, such as `add_asset()` or `move_directory()`. These methods generate the required `InventoryOperation` objects and register them in a list (`Inventory.operations`). At this point nothing is executed yet - the operations are pending. Execution happens only upon
`Inventory.commit()`.
The `commit()` method will not only execute and git-commit what needs to be done, but also generate a footer in the commit message that records the basic operations done in that commit. This is somewhat different from the information already contained in a git commit, because of semantics and the fact that a directory is an actually relevant entity
in the inventory (as opposed to git). Hence, from the commit itself it's hard to tell, whether assets where moved or an entire directory. But this is different from an inventory point of view. Recording it like that should allow for audits that are unaware of git, a relatively straight-forward implementation of a history command that focuses on an inventory view rather than a git view that needs interpretation by a user and for things like a migration of the entire history to a
different inventory system.

Since onyo commands want to tell the user what would be done by a this command, asking for confirmation before actually changing anything, `Inventory.diff()` gives a git-diff-like view of what the currently pending operations would do. In opposition to previous onyo versions, this is done entirely in memory rather than first executing things, then querying git for a diff and finally trying to rollback changes, if the user didn't confirm.

An `InventoryOperation` is broken down into an `InventoryOperator` and a tuple of operands. The `InventoryOperator` references three Callables that implement an executor, a differ, and a recorder. An executor's job is to actually perform the operation. A differ returns a diff for a given operation (used by `Inventory.diff()` to assemble a diff for all of the pending operations) and a recorder generates the necessary snippet for the operations record in a commit message.
Operands can obviously be directories and/or assets, depending on the operation. The low-level executors, differs, and recorders do no input validation whatsoever. This is intentional, since the `Inventory` methods passing the operands are supposed to already do that to avoid partial execution later on. Running something like `path.exists()` over and over at every abstraction layer seems like an unnecessary burden on performance.


Note also, that this PR finally introduces asset directories. :)
