### PR TITLE
TST/DOC: bump Python baseline 3.9 -> 3.11

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.11']
+        python-version: ['3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ and general information about Onyo.
 ### Installation
 
 #### Non-Python Dependencies:
-In addition to Python >= 3.9, Onyo depends on a few system utilities.
+In addition to Python >= 3.11, Onyo depends on a few system utilities.
 
 Debian/Ubuntu:
 ```

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -4,7 +4,7 @@ Installation
 Non-Python Dependencies
 ***********************
 
-In addition to Python >= 3.9 and a few Python modules, Onyo depends on a few
+In addition to Python >= 3.11 and a few Python modules, Onyo depends on a few
 system utilities.
 
 **Debian/Ubuntu**:

--- a/onyo/lib/git.py
+++ b/onyo/lib/git.py
@@ -187,7 +187,7 @@ class GitRepo(object):
         """"""
         # TODO: - We might want to consider untracked files as well. Would need `--others` in addition.
         #       - turn into issue
-        ui.log_debug("Looking up tracked files%s", f" underneath {', '.join([str(p) for p in paths]) }" if paths else "")
+        ui.log_debug("Looking up tracked files%s", f" underneath {', '.join([str(p) for p in paths])}" if paths else "")
         git_cmd = ['ls-files', '-z']
         if paths:
             git_cmd.extend([str(p) for p in paths])

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
             'sphinx-rtd-theme>=0.5.2'
         ]
     },
-    python_requires=">=3.9",
+    python_requires=">=3.11",
     entry_points={
         'console_scripts': [
             'onyo=onyo.main:main'


### PR DESCRIPTION
And add `3.12` to the test matrix.