### PR TITLE
TST/BF: remove unneccesary `Path` invocations

### DIFF
--- a/onyo/commands/tests/test_edit.py
+++ b/onyo/commands/tests/test_edit.py
@@ -290,7 +290,7 @@ def test_continue_edit_no(repo: OnyoRepo, asset: str) -> None:
 
     # Verify that the changes are not written in to the file, and that the
     # repository stays in a clean state
-    assert 'YAML: ERROR: STRING' not in Path.read_text(Path(asset))
+    assert 'YAML: ERROR: STRING' not in Path(asset).read_text()
     assert repo.git.is_clean_worktree()
 
 

--- a/onyo/commands/tests/test_init.py
+++ b/onyo/commands/tests/test_init.py
@@ -11,13 +11,13 @@ def fully_populated_dot_onyo(directory: Path) -> bool:
     """
     dot_onyo = directory / '.onyo'
 
-    if not Path(dot_onyo).is_dir() or \
-       not Path(dot_onyo, "templates").is_dir() or \
-       not Path(dot_onyo, "validation").is_dir() or \
-       not Path(dot_onyo, "config").is_file() or \
-       not Path(dot_onyo, ".anchor").is_file() or \
-       not Path(dot_onyo, "templates/.anchor").is_file() or \
-       not Path(dot_onyo, "validation/.anchor").is_file():
+    if not dot_onyo.is_dir() or \
+       not (dot_onyo / "templates").is_dir() or \
+       not (dot_onyo / "validation").is_dir() or \
+       not (dot_onyo / "config").is_file() or \
+       not (dot_onyo / ".anchor").is_file() or \
+       not (dot_onyo / "templates/.anchor").is_file() or \
+       not (dot_onyo / "validation/.anchor").is_file():
            return False  # noqa: E111, E117
 
     assert OnyoRepo(directory).git.is_clean_worktree()

--- a/onyo/commands/tests/test_init.py
+++ b/onyo/commands/tests/test_init.py
@@ -5,11 +5,11 @@ from pathlib import Path
 from onyo.lib import OnyoRepo
 
 
-def fully_populated_dot_onyo(directory: str = '') -> bool:
+def fully_populated_dot_onyo(directory: Path) -> bool:
     """
     Assert whether a .onyo dir is fully populated.
     """
-    dot_onyo = Path(directory, '.onyo')
+    dot_onyo = directory / '.onyo'
 
     if not Path(dot_onyo).is_dir() or \
        not Path(dot_onyo, "templates").is_dir() or \
@@ -20,11 +20,11 @@ def fully_populated_dot_onyo(directory: str = '') -> bool:
        not Path(dot_onyo, "validation/.anchor").is_file():
            return False  # noqa: E111, E117
 
-    assert OnyoRepo(Path(directory)).git.is_clean_worktree()
+    assert OnyoRepo(directory).git.is_clean_worktree()
     return True
 
 
-def test_init_cwd(tmp_path: str) -> None:
+def test_init_cwd(tmp_path: Path) -> None:
     """
     Test that `onyo init` without a path argument uses the cwd to initialize a
     new onyo repository.
@@ -36,17 +36,17 @@ def test_init_cwd(tmp_path: str) -> None:
     assert "Initialized Onyo repository in" in ret.stderr
     assert ret.returncode == 0
     assert fully_populated_dot_onyo(tmp_path)
-    repo = OnyoRepo(Path(tmp_path))
+    repo = OnyoRepo(tmp_path)
     assert repo.git.root == tmp_path
     assert repo.git.is_clean_worktree()
 
 
-def test_init_with_path(tmp_path: str) -> None:
+def test_init_with_path(tmp_path: Path) -> None:
     """
     Test that `onyo init PATH` uses a provided path to initialize a new onyo
     repository.
     """
-    repo_path = Path(tmp_path).resolve()
+    repo_path = tmp_path.resolve()
     ret = subprocess.run(["onyo", "init", repo_path], capture_output=True, text=True)
 
     # verify output and that initializing the new repository was successful.
@@ -58,12 +58,12 @@ def test_init_with_path(tmp_path: str) -> None:
     assert repo.git.is_clean_worktree()
 
 
-def test_init_error_on_existing_repository(tmp_path: str) -> None:
+def test_init_error_on_existing_repository(tmp_path: Path) -> None:
     """
     Test that `onyo init PATH` errors correctly, when called on an existing
     repository.
     """
-    repo_path = Path(tmp_path).resolve()
+    repo_path = tmp_path.resolve()
     ret = subprocess.run(["onyo", "init", repo_path], capture_output=True, text=True)
     ret = subprocess.run(["onyo", "init", repo_path], capture_output=True, text=True)
 

--- a/onyo/commands/tests/test_mkdir.py
+++ b/onyo/commands/tests/test_mkdir.py
@@ -31,8 +31,8 @@ def test_mkdir(repo: OnyoRepo, directory: str) -> None:
     # verify folders and anchors exist
     d = Path(directory)
     while not d.samefile(repo.git.root):
-        assert Path(d).is_dir()
-        assert Path(d, ".anchor").is_file()
+        assert d.is_dir()
+        assert (d / ".anchor").is_file()
         d = d.parent
 
     # verify that the repository is clean
@@ -54,8 +54,8 @@ def test_mkdir_multiple_inputs(repo: OnyoRepo) -> None:
         assert directory in ret.stdout
         d = Path(directory)
         while not d.samefile(repo.git.root):
-            assert Path(d).is_dir()
-            assert Path(d, ".anchor").is_file()
+            assert d.is_dir()
+            assert (d / ".anchor").is_file()
             d = d.parent
 
     # verify that the repository is clean
@@ -76,8 +76,9 @@ def test_mkdir_no_response(repo: OnyoRepo) -> None:
     # verify folders and anchors were not created, but are mentioned in output
     for directory in directories:
         assert directory in ret.stdout
-        assert not Path(directory).is_dir()
-        assert not Path(directory, ".anchor").is_file()
+        d = Path(directory)
+        assert not d.is_dir()
+        assert not (d / ".anchor").is_file()
 
     # verify that the repository is clean
     assert repo.git.is_clean_worktree()
@@ -121,8 +122,8 @@ def test_mkdir_quiet_flag(repo: OnyoRepo) -> None:
     for directory in directories:
         d = Path(directory)
         while not d.samefile(repo.git.root):
-            assert Path(d).is_dir()
-            assert Path(d, ".anchor").is_file()
+            assert d.is_dir()
+            assert (d / ".anchor").is_file()
             d = d.parent
 
     # verify that the repository is clean
@@ -143,8 +144,9 @@ def test_dir_exists(repo: OnyoRepo, directory: str) -> None:
     assert "already exists" in ret.stderr
     assert ret.returncode == 1
 
-    assert Path(directory).is_dir()
-    assert Path(directory, ".anchor").is_file()
+    d = Path(directory)
+    assert d.is_dir()
+    assert (d / ".anchor").is_file()
 
     # verify that the repository is clean
     assert repo.git.is_clean_worktree()

--- a/onyo/conftest.py
+++ b/onyo/conftest.py
@@ -52,7 +52,7 @@ def repo(tmp_path: Path, monkeypatch, request) -> Generator[OnyoRepo, None, None
     # collect files to populate the repo
     m = request.node.get_closest_marker('repo_files')
     if m:
-        files = {Path(repo_path, x) for x in m.args}
+        files = {(repo_path / x) for x in m.args}
 
     # collect dirs to populate the repo
     m = request.node.get_closest_marker('repo_dirs')
@@ -65,7 +65,7 @@ def repo(tmp_path: Path, monkeypatch, request) -> Generator[OnyoRepo, None, None
         contents = list(m.args)
 
     # collect files from contents list too
-    files |= {Path(repo_path, x[0]) for x in contents}
+    files |= {(repo_path / x[0]) for x in contents}
 
     # collect dirs from files list too
     dirs |= {x.parent for x in files if not x.parent.exists()}
@@ -82,7 +82,7 @@ def repo(tmp_path: Path, monkeypatch, request) -> Generator[OnyoRepo, None, None
     if files:
         if contents:
             for file in contents:
-                Path(repo_path, file[0]).write_text(file[1])
+                (repo_path / file[0]).write_text(file[1])
         repo_.git.stage_and_commit(paths=files,
                                    message="populate files for tests")
 

--- a/onyo/conftest.py
+++ b/onyo/conftest.py
@@ -29,7 +29,7 @@ def params(d: dict) -> MarkDecorator:
 
 
 @pytest.fixture(scope='function')
-def repo(tmp_path: str, monkeypatch, request) -> Generator[OnyoRepo, None, None]:
+def repo(tmp_path: Path, monkeypatch, request) -> Generator[OnyoRepo, None, None]:
     """
     This fixture:
     - creates a new repository in a temporary directory
@@ -41,7 +41,7 @@ def repo(tmp_path: str, monkeypatch, request) -> Generator[OnyoRepo, None, None]
     - repo_files()
       - parent directories of files are automatically created
     """
-    repo_path = Path(tmp_path)
+    repo_path = tmp_path
     dirs = set()
     files = set()
     contents = list()

--- a/onyo/lib/git.py
+++ b/onyo/lib/git.py
@@ -291,7 +291,7 @@ class GitRepo(object):
         target_dir.mkdir(exist_ok=True)
 
         # git init (if needed)
-        if Path(target_dir, '.git').exists():
+        if (target_dir / '.git').exists():
             log.info(f"'{target_dir}' is already a git repository.")
         else:
             ret = self._git(['init'], cwd=target_dir)
@@ -360,7 +360,7 @@ class GitRepo(object):
             tgts = [str(targets)]
 
         for t in tgts:
-            if not Path(self.root, t).exists():
+            if not (self.root / t).exists():
                 raise FileNotFoundError(f"'{t}' does not exist.")
 
         self._git(['add'] + tgts)
@@ -478,7 +478,7 @@ class GitRepo(object):
             If the config file was not found to set the value in.
         """
         location_options = {
-            'onyo': ['--file', str(Path(self.root, '.onyo/config'))],
+            'onyo': ['--file', str(self.root / '.onyo/config')],
             'system': ['--system'],
             'global': ['--global'],
             'local': ['--local'],

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -284,7 +284,7 @@ class OnyoRepo(object):
                 #       turns it into absolute and back into relative.
                 #       Double-check where `destination` is used and remove
                 #       resolution:
-                dest = Path(self.git.root, destination).relative_to(self.git.root)
+                dest = (self.git.root / destination).relative_to(self.git.root)
             if dest and dest.name == self.ANCHOR_FILE:
                 dest = dest.parent
 
@@ -439,7 +439,7 @@ class OnyoRepo(object):
 
         # Note: Why is this a requirement? Why not only add what's missing in
         # case of apparent re-init? cannot already be an .onyo repo
-        dot_onyo = Path(path, '.onyo')
+        dot_onyo = path / '.onyo'
         if dot_onyo.exists():
             raise FileExistsError(f"'{dot_onyo}' already exists.")
 


### PR DESCRIPTION
This addresses an issue identified in #349

The issue specifically identifies an anti-pattern in the tests of wrapping a `path` object with `Path()` when concatenating.

The majority of changes in this PR are indeed that, but I did not limit myself to the tests, nor just that particular unnecessary use of `Path()`. I made others simplifications when I encountered them.

I did not go through all invocations of `Path()` exhaustively, as that would be an extraordinary amount of effort. However, `git grep 'Path(' | grep ','` is now clean of this pattern, and I can say that likely the majority of these have been fixed.