### PR TITLE
Towards re-establishing CI baseline

### DIFF
--- a/onyo/commands/tests/test_cat.py
+++ b/onyo/commands/tests/test_cat.py
@@ -145,11 +145,10 @@ def test_no_trailing_newline_with_many_empty_assets(repo: OnyoRepo) -> None:
                          [["bad_yaml_file.test", "I: \nam:bad:\nbad:yaml\n"]])
 def test_invalid_yaml(repo: OnyoRepo, variant: list[str]) -> None:
     """
-    Test that `onyo cat` fails for a file with invalid yaml content.
+    Test that `onyo cat` returns non-zero for a file with invalid yaml content,
+    but does print the content plus an error message.
     """
 
-    raise RuntimeError("TODO: I don't think the tested behavior makes sense. Why should I not be able to print invalid "
-                       "content and see the problem?")
     # check that yaml is invalid
     with pytest.raises(OnyoInvalidRepoError):
         fsck(repo, ['asset-yaml'])
@@ -158,5 +157,6 @@ def test_invalid_yaml(repo: OnyoRepo, variant: list[str]) -> None:
     ret = subprocess.run(['onyo', 'cat', variant[0]],
                          capture_output=True, text=True)
     assert ret.returncode == 1
-    assert ret.stderr
-    assert not ret.stdout
+    assert "YAML validation" in ret.stderr
+    assert variant[0] in ret.stderr
+    assert variant[1] in ret.stdout

--- a/onyo/commands/tests/test_get.py
+++ b/onyo/commands/tests/test_get.py
@@ -11,6 +11,9 @@ from onyo.lib.exceptions import OnyoInvalidFilterError
 from onyo.lib import OnyoRepo, Filter
 
 
+pytest.skip("GET not currently implemented", allow_module_level=True)
+
+
 def convert_contents(
         raw_assets: list[tuple[str, dict[str, Any]]]) -> Generator:
     """Convert content dictionary to a plain-text string"""

--- a/onyo/commands/tests/test_unset.py
+++ b/onyo/commands/tests/test_unset.py
@@ -30,6 +30,9 @@ content_str: str = "\n".join([f"{elem}: {content_dict.get(elem)}"
 contents: List[List[str]] = [[x, content_str] for x in assets]
 
 
+pytest.skip("UNSET not currently implemented", allow_module_level=True)
+
+
 @pytest.mark.repo_contents(*contents)
 @pytest.mark.parametrize('asset', assets)
 def test_unset(repo: OnyoRepo, asset: str) -> None:

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -78,18 +78,21 @@ def fsck(repo: OnyoRepo, tests: Optional[list[str]] = None) -> None:
 
 
 def onyo_cat(repo: OnyoRepo, paths: Iterable[Path]) -> None:
-
+    from .assets import validate_yaml
     non_asset_paths = [str(p) for p in paths if not repo.is_asset_path(p)]
     if non_asset_paths:
         raise ValueError("The following paths are not asset files:\n%s",
                          "\n".join(non_asset_paths))
+    # TODO: "Full" asset validation. Address when fsck is reworked
+    assets_valid = validate_yaml(set(paths))
     # open file and print to stdout
     for path in paths:
-        # TODO: Do we really not want to separate assets like print(f"{path.name}:{os.linesep}")?
         # TODO: Probably better to simply print dict_to_yaml(repo.get_asset_content(path)) - no need to distinguish
         #       asset and asset dir at this level. However, need to make sure to not print pointless empty lines.
         f = path / OnyoRepo.ASSET_DIR_FILE if repo.is_asset_dir(path) else path
         ui.print(f.read_text(), end='')
+    if not assets_valid:
+        raise OnyoInvalidRepoError("Invalid assets")
 
 
 def onyo_config(repo: OnyoRepo, config_args: list[str]) -> None:

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -570,7 +570,10 @@ def onyo_rm(inventory: Inventory,
     for p in paths:
         try:
             inventory.remove_asset(p)
+            is_asset = True
         except NotAnAssetError:
+            is_asset = False
+        if not is_asset or inventory.repo.is_asset_dir(p):
             inventory.remove_directory(p)
 
     ui.print('The following will be deleted:')

--- a/onyo/lib/executors.py
+++ b/onyo/lib/executors.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Callable
 from onyo.lib.onyo import OnyoRepo
 
 # Executors signature: (repo: OnyoRepo, operands: tuple) -> tuple[list[Path], list[Path]]
@@ -112,3 +113,11 @@ def exec_modify_assets(repo: OnyoRepo, operands: tuple) -> tuple[list[Path], lis
     new = operands[1]
     repo.write_asset_content(new)
     return [new['path']], []
+
+
+def generic_executor(func: Callable, repo: OnyoRepo, operands: tuple) -> tuple[list[Path], list[Path]]:
+    """This is intended for simple FS operations on non-inventory files
+
+    only current usecase is recursive remove_directory. Not yet meant to be a stable implementation"""
+    func(operands)
+    return [operands[0]], []

--- a/onyo/lib/tests/test_inventory_operations.py
+++ b/onyo/lib/tests/test_inventory_operations.py
@@ -296,9 +296,7 @@ def test_remove_directory(repo: OnyoRepo) -> None:
     inventory.commit("First asset added")
 
     # raise on non-dir
-    pytest.raises(ValueError, inventory.remove_directory, asset_file)
-    # raise on non-empty
-    pytest.raises(InvalidInventoryOperation, inventory.remove_directory, newdir1)
+    pytest.raises(InvalidInventoryOperation, inventory.remove_directory, asset_file)
 
     inventory.remove_directory(emptydir)
     assert num_operations(inventory, 'remove_directories') == 1
@@ -314,7 +312,15 @@ def test_remove_directory(repo: OnyoRepo) -> None:
     inventory.commit("Remove directory")
     assert not emptydir.exists()
 
-    # TODO: recursive? Or leave that to the caller? See also: remove asset_dir
+    # recursive
+    inventory.remove_directory(newdir1)
+    assert num_operations(inventory, 'remove_directories') == 2
+    assert num_operations(inventory, 'remove_assets') == 1
+
+    inventory.commit("Remove dir recursively")
+    assert not asset_file.exists()
+    assert not newdir2.exists()
+    assert not newdir1.exists()
 
 
 def test_move_directory(repo: OnyoRepo) -> None:


### PR DESCRIPTION
This patch: 
- fixes `onyo cat` for the case of invalid assets files. New behavior is: Issue an error message, still print the content and return non-zero.
- fixes `onyo rm` for the case of removing a non-empty directory
- skips the tests for `unset` and `get` , since they are not currently expected to work

Should bring the number failures down to 87, 82(?) of which are actually the same issue in `set`.
