### PR TITLE
Don't deduplicate lists by casting as set

### DIFF
--- a/onyo/lib/command_utils.py
+++ b/onyo/lib/command_utils.py
@@ -68,8 +68,8 @@ def sanitize_keys(k: Optional[list[str]],
     Remove duplicates from k while preserving key order and return default
     (pseudo) keys if k is empty
     """
-    seen = set()
-    return [x for x in k if not (x in seen or seen.add(x))] if k else defaults
+    from .utils import deduplicate
+    return deduplicate(k) if k else defaults
 
 
 def set_filters(

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -18,7 +18,7 @@ from onyo.lib.command_utils import sanitize_keys, set_filters, \
 from onyo.lib.exceptions import OnyoInvalidRepoError, NotAnAssetError
 from onyo.lib.filters import UNSET_VALUE
 from onyo.lib.onyo import OnyoRepo
-from onyo.lib.utils import edit_asset
+from onyo.lib.utils import edit_asset, deduplicate
 
 log: logging.Logger = logging.getLogger('onyo.commands')
 
@@ -257,7 +257,7 @@ def onyo_mkdir(inventory: Inventory,
                dirs: list[Path],
                message: Optional[str]) -> None:
 
-    for d in set(dirs):  # explicit duplicates would make auto-generating message subject more complicated ATM
+    for d in deduplicate(dirs):  # explicit duplicates would make auto-generating message subject more complicated ATM
         inventory.add_directory(d)
     ui.print('The following directories will be created:')
     for line in inventory.diff():

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -400,7 +400,7 @@ def onyo_new(inventory: Inventory,
     -------
 
     """
-    from onyo.lib.onyo import NEW_PSEUDO_KEYS
+    from onyo.lib.consts import NEW_PSEUDO_KEYS
     from copy import deepcopy
 
     keys = keys or []

--- a/onyo/lib/consts.py
+++ b/onyo/lib/consts.py
@@ -1,0 +1,4 @@
+# TODO: pseudo-key generation mapping
+NEW_PSEUDO_KEYS = ['path']  # TODO: name temporary b/c RF (old idea of pseudo-keys doesn't match)
+# The following keys have functional meaning for onyo and must not be part of user-defined asset content
+RESERVED_KEYS = ['directory', 'is_asset_directory', 'template']

--- a/onyo/lib/inventory.py
+++ b/onyo/lib/inventory.py
@@ -49,9 +49,6 @@ from onyo.lib.exceptions import (
     InvalidInventoryOperation,
 )
 
-# The following keys have functional meaning for onyo and must not be part of user-defined asset content
-RESERVED_KEYS = ['directory', 'is_asset_directory', 'template']
-
 
 @dataclass
 class InventoryOperator:

--- a/onyo/lib/inventory.py
+++ b/onyo/lib/inventory.py
@@ -48,6 +48,7 @@ from onyo.lib.exceptions import (
     NoopError,
     InvalidInventoryOperation,
 )
+from onyo.lib.utils import deduplicate
 
 
 @dataclass
@@ -148,7 +149,7 @@ class Inventory(object):
                     operations_record[k].extend(v)
 
         for title, snippets in operations_record.items():
-            commit_msg += title + ''.join(sorted(line for line in set(snippets)))
+            commit_msg += title + ''.join(sorted(line for line in deduplicate(snippets)))
 
         # TODO: Actually: staging (only new) should be done in execute. committing is then unified
         self.repo.git.stage_and_commit(set(paths_to_commit + paths_to_stage), commit_msg)

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -9,15 +9,12 @@ from typing import Iterable, Optional, Union, List, Dict
 
 from ruamel.yaml import YAML  # pyre-ignore[21]
 
+from .consts import NEW_PSEUDO_KEYS
 from .ui import ui
 from .git import GitRepo
 from .exceptions import OnyoInvalidRepoError, OnyoProtectedPathError
 
 log: logging.Logger = logging.getLogger('onyo.onyo')
-
-
-# TODO: pseudo-key generation mapping
-NEW_PSEUDO_KEYS = ['path']  # TODO: name temporary b/c RF (old idea of pseudo-keys doesn't match)
 
 
 def dict_to_yaml(d: Dict[str, Union[float, int, str]]) -> str:

--- a/onyo/lib/utils.py
+++ b/onyo/lib/utils.py
@@ -8,8 +8,7 @@ from shlex import quote
 from ruamel.yaml import YAML, scanner  # pyre-ignore[21]
 
 from onyo.lib.ui import ui
-from onyo.lib.inventory import RESERVED_KEYS
-from onyo.lib.onyo import NEW_PSEUDO_KEYS
+from onyo.lib.consts import NEW_PSEUDO_KEYS, RESERVED_KEYS
 
 
 def anything2bool(val):

--- a/onyo/lib/utils.py
+++ b/onyo/lib/utils.py
@@ -90,3 +90,9 @@ def edit_asset_file(editor: str, path: Path) -> bool:
             ui.print(f"{path} has invalid YAML syntax.", file=sys.stderr)
             if not ui.request_user_response("Continue editing? No discards changes. (y/n) "):
                 return False
+
+
+def deduplicate(sequence: list) -> list:
+    """Get a deduplicated list, while preserving order"""
+    seen = set()
+    return [x for x in sequence if not (x in seen or seen.add(x))]


### PR DESCRIPTION
While using sets is obviously fine in some places, don't use it for the sole purpose of deduplicating a list, since this is loosing order.
In addition introduces `lib/consts.py` to hold constants. Added to this PR to avoid circular imports.

Closes #440
Closes #318