### PR TITLE
Iron out behavior when commands have nothing to do

### DIFF
--- a/onyo/commands/tests/test_edit.py
+++ b/onyo/commands/tests/test_edit.py
@@ -290,7 +290,7 @@ def test_continue_edit_no(repo: OnyoRepo, asset: str) -> None:
 
     # Verify that the changes are not written in to the file, and that the
     # repository stays in a clean state
-    assert 'YAML: ERROR: STRING' not in Path(asset).read_text()
+    assert 'YAML: ERROR' not in Path(asset).read_text()
     assert repo.git.is_clean_worktree()
 
 

--- a/onyo/commands/tests/test_set.py
+++ b/onyo/commands/tests/test_set.py
@@ -530,7 +530,7 @@ def test_setting_new_values_if_some_values_already_set(repo: OnyoRepo, asset: st
 
 
 @pytest.mark.repo_contents(assets[0])
-@pytest.mark.parametrize('asset', asset_paths[0])
+@pytest.mark.parametrize('asset', [asset_paths[0]])
 @pytest.mark.parametrize('set_values', values)
 def test_values_already_set(repo: OnyoRepo, asset: str, set_values: list[str]) -> None:
     """
@@ -539,7 +539,6 @@ def test_values_already_set(repo: OnyoRepo, asset: str, set_values: list[str]) -
     info message without error, and the repository stays in a clean state.
     """
 
-    raise RuntimeError("TODO: detecting noop for modify_asset (edit, set, etc.)")
     ret = subprocess.run(['onyo', '--yes', 'set', '--keys', *set_values, '--path', asset], capture_output=True, text=True)
 
     # verify output
@@ -554,7 +553,7 @@ def test_values_already_set(repo: OnyoRepo, asset: str, set_values: list[str]) -
     ret = subprocess.run(['onyo', '--yes', 'set', '--keys', *set_values, '--path', asset], capture_output=True, text=True)
 
     # verify second output
-    assert "The values are already set. No assets updated." in ret.stdout
+    assert "No assets updated." in ret.stdout
     assert not ret.stderr
     assert ret.returncode == 0
 

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -15,7 +15,7 @@ from onyo.lib.inventory import Inventory, OPERATIONS_MAPPING
 from onyo.lib.assets import PSEUDO_KEYS, get_assets_by_query
 from onyo.lib.command_utils import sanitize_keys, set_filters, \
     fill_unset, natural_sort
-from onyo.lib.exceptions import OnyoInvalidRepoError, NotAnAssetError
+from onyo.lib.exceptions import OnyoInvalidRepoError, NotAnAssetError, NoopError
 from onyo.lib.filters import UNSET_VALUE
 from onyo.lib.onyo import OnyoRepo
 from onyo.lib.utils import edit_asset
@@ -138,17 +138,12 @@ def onyo_edit(inventory: Inventory,
     for path in valid_asset_paths:
         asset = inventory.get_asset(path)
         modified_asset = edit_asset(asset, editor)
-        # TODO: Would be good to detect that no modification was actually done.
-        #       edit_asset knows and could raise NoopError or return None or whatever.
-        #       Alternatively, operations could figure that there's nothing to be done
-        #       and simply not register. As a consequence, inventory could then be
-        #       queried for actually pending operations. That's actually better,
-        #       so we don't end up recording noop operations.
-        #       Implementing this implies to not rely on `valid_asset_paths` below
-        #       when building the commit message.
-        inventory.modify_asset(asset, modified_asset)
+        try:
+            inventory.modify_asset(asset, modified_asset)
+        except NoopError:
+            pass
 
-    if valid_asset_paths:
+    if inventory.operations_pending():
         ui.print("Changes:")
         for line in inventory.diff():
             ui.print(line)
@@ -259,20 +254,21 @@ def onyo_mkdir(inventory: Inventory,
 
     for d in set(dirs):  # explicit duplicates would make auto-generating message subject more complicated ATM
         inventory.add_directory(d)
-    ui.print('The following directories will be created:')
-    for line in inventory.diff():
-        ui.print(line)
-    if ui.request_user_response("Save changes? No discards all changes. (y/n) "):
-        if not message:
-            operation_paths = [
-                op.operands[0]
-                for op in inventory.operations
-                if op.operator == OPERATIONS_MAPPING['new_directories']]
-            message = inventory.repo.generate_commit_message(
-                cmd="mkdir",
-                modified=operation_paths)
-        inventory.commit(message=message)
-        return
+    if inventory.operations_pending():
+        ui.print('The following directories will be created:')
+        for line in inventory.diff():
+            ui.print(line)
+        if ui.request_user_response("Save changes? No discards all changes. (y/n) "):
+            if not message:
+                operation_paths = [
+                    op.operands[0]
+                    for op in inventory.operations
+                    if op.operator == OPERATIONS_MAPPING['new_directories']]
+                message = inventory.repo.generate_commit_message(
+                    cmd="mkdir",
+                    modified=operation_paths)
+            inventory.commit(message=message)
+            return
     ui.print('No directories created.')
 
 
@@ -327,24 +323,25 @@ def onyo_mv(inventory: Inventory,
         else:
             inventory.rename_directory(sources[0], destination)
 
-    ui.print('The following will be moved:')
-    for line in inventory.diff():
-        ui.print(line)
-    if ui.request_user_response("Save changes? No discards all changes. (y/n) "):
-        if not message:
-            operation_paths = [
-                op.operands[0]
-                for op in inventory.operations
-                if op.operator == OPERATIONS_MAPPING['rename_assets'] or
-                op.operator == OPERATIONS_MAPPING['move_assets'] or
-                op.operator == OPERATIONS_MAPPING['move_directories'] or
-                op.operator == OPERATIONS_MAPPING['rename_directories']]
-            message = inventory.repo.generate_commit_message(
-                cmd=subject,
-                destination=destination,
-                modified=operation_paths)
-        inventory.commit(message=message)
-        return
+    if inventory.operations_pending():
+        ui.print('The following will be moved:')
+        for line in inventory.diff():
+            ui.print(line)
+        if ui.request_user_response("Save changes? No discards all changes. (y/n) "):
+            if not message:
+                operation_paths = [
+                    op.operands[0]
+                    for op in inventory.operations
+                    if op.operator == OPERATIONS_MAPPING['rename_assets'] or
+                    op.operator == OPERATIONS_MAPPING['move_assets'] or
+                    op.operator == OPERATIONS_MAPPING['move_directories'] or
+                    op.operator == OPERATIONS_MAPPING['rename_directories']]
+                message = inventory.repo.generate_commit_message(
+                    cmd=subject,
+                    destination=destination,
+                    modified=operation_paths)
+            inventory.commit(message=message)
+            return
     ui.print('Nothing was moved.')
 
 
@@ -542,7 +539,7 @@ def onyo_new(inventory: Inventory,
 
         inventory.add_asset(asset)
 
-    if assets:
+    if inventory.operations_pending():
         ui.print("The following will be created:")
         for line in inventory.diff():
             ui.print(line)
@@ -575,21 +572,22 @@ def onyo_rm(inventory: Inventory,
         if not is_asset or inventory.repo.is_asset_dir(p):
             inventory.remove_directory(p)
 
-    ui.print('The following will be deleted:')
-    for line in inventory.diff():
-        ui.print(line)
-    if ui.request_user_response("Save changes? No discards all changes. (y/n) "):
-        if not message:
-            operation_paths = [
-                op.operands[0]
-                for op in inventory.operations
-                if op.operator == OPERATIONS_MAPPING['remove_assets'] or
-                op.operator == OPERATIONS_MAPPING['remove_directories']]
-            message = inventory.repo.generate_commit_message(
-                cmd="rm",
-                modified=operation_paths)
-        inventory.commit(message)
-        return
+    if inventory.operations_pending():
+        ui.print('The following will be deleted:')
+        for line in inventory.diff():
+            ui.print(line)
+        if ui.request_user_response("Save changes? No discards all changes. (y/n) "):
+            if not message:
+                operation_paths = [
+                    op.operands[0]
+                    for op in inventory.operations
+                    if op.operator == OPERATIONS_MAPPING['remove_assets'] or
+                    op.operator == OPERATIONS_MAPPING['remove_directories']]
+                message = inventory.repo.generate_commit_message(
+                    cmd="rm",
+                    modified=operation_paths)
+            inventory.commit(message)
+            return
     ui.print('Nothing was deleted.')
 
 
@@ -623,26 +621,30 @@ def onyo_set(inventory: Inventory,
         asset = inventory.get_asset(path)
         new_content = asset.copy()
         new_content.update(keys)
-        inventory.modify_asset(asset, new_content)
+        try:
+            inventory.modify_asset(asset, new_content)
+        except NoopError:
+            pass
 
-    # display changes
-    ui.print("The following assets will be changed:")
-    for line in inventory.diff():
-        ui.print(line)
+    if inventory.operations_pending():
+        # display changes
+        ui.print("The following assets will be changed:")
+        for line in inventory.diff():
+            ui.print(line)
 
-    if not dryrun:
-        if ui.request_user_response("Update assets? (y/n) "):
-            if not message:
-                operation_paths = [
-                    op.operands[0].get("path")
-                    for op in inventory.operations
-                    if op.operator == OPERATIONS_MAPPING['modify_assets']]
-                message = inventory.repo.generate_commit_message(
-                    cmd="set",
-                    keys=[str(k) for k in keys.keys()],
-                    modified=operation_paths)
-            inventory.commit(message=message)
-            return
+        if not dryrun:
+            if ui.request_user_response("Update assets? (y/n) "):
+                if not message:
+                    operation_paths = [
+                        op.operands[0].get("path")
+                        for op in inventory.operations
+                        if op.operator == OPERATIONS_MAPPING['modify_assets']]
+                    message = inventory.repo.generate_commit_message(
+                        cmd="set",
+                        keys=[str(k) for k in keys.keys()],
+                        modified=operation_paths)
+                inventory.commit(message=message)
+                return
     ui.print("No assets updated.")
 
 

--- a/onyo/lib/exceptions.py
+++ b/onyo/lib/exceptions.py
@@ -19,6 +19,9 @@ class InvalidInventoryOperation(Exception):
 
 class NoopError(Exception):
     """Thrown if a requested operation is a Noop."""
+    # This is intended to signal that an inventory operation would not result in any change, so that callers can decide
+    # on their failure paradigm:
+    # "Result oriented already-fine-no-failure" vs "Task oriented can't-do-failure".
 
 
 class NotAnAssetError(Exception):

--- a/onyo/lib/inventory.py
+++ b/onyo/lib/inventory.py
@@ -268,8 +268,6 @@ class Inventory(object):
         if not name:
             name = generated_name
         if path.name == name:
-            # TODO: This should be a different exception, so that callers can decide on their failure paradigm:
-            #       "Result oriented already-fine-no-failure" vs "Task oriented can't-do-failure".
             raise NoopError(f"Cannot rename asset {name}: This is already its name.")
 
         destination = path.parent / name
@@ -279,15 +277,14 @@ class Inventory(object):
         self._add_operation('rename_assets', (path, destination))
 
     def modify_asset(self, asset: Union[Asset, Path], content: Asset) -> None:
-        # TODO: Straight-up dict for `content`?
-
         path = Path(asset.get('path')) if isinstance(asset, Asset) else asset
         if not self.repo.is_asset_path(path):
             raise ValueError(f"No such asset: {path}")
         asset = Asset(self.repo.get_asset_content(path)) if isinstance(asset, Path) else asset
         new_asset = asset.copy()
         new_asset.update(content)
-
+        if asset == new_asset:
+            raise NoopError
         self._add_operation('modify_assets', (asset, new_asset))
         # Abuse the fact that new_asset has the same 'path' at this point, regardless of potential renaming and let
         # rename handle it. Note, that this way the rename operation MUST come after the modification during execution.
@@ -344,6 +341,9 @@ class Inventory(object):
             raise InvalidInventoryOperation(f"Cannot rename {src} -> {dst}. Consider moving instead.")
         if not self.repo.is_inventory_path(dst) or dst.exists():
             raise ValueError(f"Not a valid destination: {dst}")
+        name = dst if isinstance(dst, str) else dst.name
+        if src.name == name:
+            raise NoopError(f"Cannot rename directory {str(src)}: This is already its name.")
 
         self._add_operation('rename_directories', (src, dst))
 


### PR DESCRIPTION
This patch lets commands uniformly check the `Inventory` for pending
operations before trying to display a diff and asking for confirmation,
avoiding pointless empty lines and "questions about nothing".

`Inventory.modify_asset`, `Inventory.rename_asset` and
`Inventory.rename_directory` can potentially raise a `NoopError`,
allowing the caller to decide whether this should lead to failure or not
(following a result-oriented approach where a call to these methods is
not looked at as "do this" but as "make sure this the state afterwards").

This was partially implemented before, but not yet uniformly.
This should reduce current test failures to 3 (my local result - to be confirmed by CI)