### PR TITLE
`set`: remove dry-run

### DIFF
--- a/onyo/commands/set.py
+++ b/onyo/commands/set.py
@@ -8,7 +8,6 @@ from onyo.lib.commands import onyo_set
 from onyo.argparse_helpers import path, StoreKeyValuePairs
 from onyo.shared_arguments import (
     shared_arg_depth,
-    shared_arg_dry_run,
     shared_arg_filter,
     shared_arg_message,
 )
@@ -44,7 +43,6 @@ args_set = {
         help='Asset(s) and/or directorie(s) to set KEY=VALUE in'),
 
     'depth': shared_arg_depth,
-    'dry_run': shared_arg_dry_run,
     'filter': shared_arg_filter,
     'message': shared_arg_message,
 }
@@ -84,7 +82,6 @@ def set(args: argparse.Namespace) -> None:
              paths=paths,
              keys=args.keys[0],
              filter_strings=args.filter,
-             dryrun=args.dry_run,
              rename=args.rename,
              depth=args.depth,
              message='\n\n'.join(m for m in args.message) if args.message else None)

--- a/onyo/commands/tests/test_set.py
+++ b/onyo/commands/tests/test_set.py
@@ -338,36 +338,6 @@ def test_set_quiet_flag(repo: OnyoRepo, asset: str, set_values: list[str]) -> No
 
 @pytest.mark.repo_contents(*assets)
 @pytest.mark.parametrize('set_values', values)
-def test_set_dryrun_flag(repo: OnyoRepo, set_values: list[str]) -> None:
-    """
-    Test that `onyo set --dry-run KEY=VALUE <asset>` displays correct
-    diff-output without actually changing any assets.
-    """
-    ret = subprocess.run(['onyo', 'set', '--dry-run', '--keys', *set_values,
-                          '--path', *asset_paths], capture_output=True, text=True)
-
-    # verify output
-    assert "The following assets will be changed:" in ret.stdout
-    assert not ret.stderr
-    assert ret.returncode == 0
-
-    # should not be asked if no real changes are made
-    assert "Update assets? (y/n) " not in ret.stdout
-
-    # verify that all assets and changes are in diff output, but no changes in
-    # the asset files are made
-    for asset in asset_paths:
-        assert str(Path(asset)) in ret.stdout
-        for value in set_values:
-            assert f"+{value.replace('=', ': ')}" in ret.stdout
-            assert value.replace("=", ": ") not in Path.read_text(Path(asset))
-
-    # check that the repository is still clean
-    assert repo.git.is_clean_worktree()
-
-
-@pytest.mark.repo_contents(*assets)
-@pytest.mark.parametrize('set_values', values)
 @pytest.mark.parametrize('depth', ['0', '1', '3', '10'])
 def test_set_depth_flag(
         repo: OnyoRepo, set_values: list[str], depth: str) -> None:

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -595,7 +595,6 @@ def onyo_set(inventory: Inventory,
              paths: Optional[Iterable[Path]],
              keys: Dict[str, Union[str, int, float]],
              filter_strings: list[str],
-             dryrun: bool,
              rename: bool,
              depth: int,
              message: Optional[str] = None) -> Union[str, None]:
@@ -632,19 +631,18 @@ def onyo_set(inventory: Inventory,
         for line in inventory.diff():
             ui.print(line)
 
-        if not dryrun:
-            if ui.request_user_response("Update assets? (y/n) "):
-                if not message:
-                    operation_paths = [
-                        op.operands[0].get("path")
-                        for op in inventory.operations
-                        if op.operator == OPERATIONS_MAPPING['modify_assets']]
-                    message = inventory.repo.generate_commit_message(
-                        cmd="set",
-                        keys=[str(k) for k in keys.keys()],
-                        modified=operation_paths)
-                inventory.commit(message=message)
-                return
+        if ui.request_user_response("Update assets? (y/n) "):
+            if not message:
+                operation_paths = [
+                    op.operands[0].get("path")
+                    for op in inventory.operations
+                    if op.operator == OPERATIONS_MAPPING['modify_assets']]
+                message = inventory.repo.generate_commit_message(
+                    cmd="set",
+                    keys=[str(k) for k in keys.keys()],
+                    modified=operation_paths)
+            inventory.commit(message=message)
+            return
     ui.print("No assets updated.")
 
 

--- a/onyo/lib/inventory.py
+++ b/onyo/lib/inventory.py
@@ -71,11 +71,6 @@ class InventoryOperation(object):
         return self.operator.executor(repo=self.repo, operands=self.operands)
 
 
-# NOTE: Order of keys in this mapping matters! It's the order of execution during `Inventory.commit`.
-#       We'd need new directories before new assets for example. Or remove something before putting something else in
-#       its place.
-#       Solution may be to change implementation and really register a single list of operations so call-order is
-#       preserved.  -> speaks for class InventoryOperation?
 OPERATIONS_MAPPING: dict = {'new_directories': InventoryOperator(executor=exec_new_directories,
                                                                  differ=differ_new_directories,
                                                                  recorder=record_new_directories),


### PR DESCRIPTION
Removes now superfluous dryrun option for `set`. Note, that dryun still exists for `unset`, because that command still needs a rewrite anyway.
