### PR TITLE
Fix interactive testing

### DIFF
--- a/onyo/conftest.py
+++ b/onyo/conftest.py
@@ -156,3 +156,14 @@ class Helpers:
 @pytest.fixture
 def helpers() -> Type[Helpers]:
     return Helpers
+
+
+@pytest.fixture(scope='function', autouse=True)
+def set_ui(request):
+    """Set up onyo.lib.ui according to a dict provided by the 'ui' marker"""
+    from onyo.lib.ui import ui
+    m = request.node.get_closest_marker('ui')
+    if m:
+        ui.set_yes(m.args[0].get('yes', False))
+        ui.set_quiet(m.args[0].get('quiet', False))
+        ui.set_debug(m.args[0].get('debug', False))

--- a/onyo/lib/tests/test_commands_mv.py
+++ b/onyo/lib/tests/test_commands_mv.py
@@ -5,13 +5,8 @@ from onyo.lib.inventory import Inventory
 from onyo.lib.onyo import OnyoRepo
 from onyo.lib.exceptions import InvalidInventoryOperation
 
-# Note: ui settings happen to be identical throughout this file.
-#       However, we should have a ui fixture instead.
-from onyo.lib.ui import ui
-ui.set_yes(True)
-ui.set_quiet(False)
 
-
+@pytest.mark.ui({'yes': True})
 def test_onyo_mv_into_self(inventory: Inventory) -> None:
 
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
@@ -76,6 +71,7 @@ def test_onyo_mv_into_self(inventory: Inventory) -> None:
                   message="some subject\n\nAnd a body")
 
 
+@pytest.mark.ui({'yes': True})
 def test_onyo_mv_move_simple(inventory: Inventory) -> None:
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     dir_path = inventory.root / 'empty'
@@ -100,6 +96,7 @@ def test_onyo_mv_move_simple(inventory: Inventory) -> None:
     assert not dir_path.exists()
 
 
+@pytest.mark.ui({'yes': True})
 def test_onyo_mv_move_explicit(inventory: Inventory) -> None:
     dir_path = inventory.root / 'somewhere' / 'nested'
     # move by explicitly restating the source's name:
@@ -119,6 +116,7 @@ def test_onyo_mv_move_explicit(inventory: Inventory) -> None:
     assert not src.exists()
 
 
+@pytest.mark.ui({'yes': True})
 def test_onyo_mv_rename(inventory: Inventory) -> None:
     dir_path = inventory.root / 'somewhere' / 'nested'
     new_name = dir_path.parent / 'newname'

--- a/onyo/lib/tests/test_commands_new.py
+++ b/onyo/lib/tests/test_commands_new.py
@@ -30,6 +30,7 @@ def test_onyo_new_invalid(inventory: Inventory) -> None:
     pytest.raises(FileNotFoundError, onyo_new, inventory, tsv=inventory.root / "nonexisting.tsv")
 
 
+@pytest.mark.ui({'yes': True})
 @pytest.mark.parametrize('tsv', prepared_tsvs)
 def test_onyo_new_tsv(inventory: Inventory, tsv: Path) -> None:
     if tsv.name.startswith('error'):
@@ -37,15 +38,12 @@ def test_onyo_new_tsv(inventory: Inventory, tsv: Path) -> None:
         pytest.raises(ValueError, onyo_new, inventory, tsv)
     else:
         # TODO: Same here; just ensures those tables still don't crash
-        from onyo.lib.ui import ui
-        ui.set_yes(True)
         onyo_new(inventory, tsv=tsv)
         inventory.repo.git._git(['reset', '--hard', 'HEAD~1'])
 
 
+@pytest.mark.ui({'yes': True})
 def test_onyo_new_keys(inventory: Inventory) -> None:
-    from onyo.lib.ui import ui
-    ui.set_yes(True)
     specs = [{'type': 'a type',
               'make': 'I made it',
               'model': 'a model',
@@ -126,9 +124,8 @@ def test_onyo_new_keys(inventory: Inventory) -> None:
         assert asset_content[k] is None
 
 
+@pytest.mark.ui({'yes': True})
 def test_onyo_new_edit(inventory: Inventory, monkeypatch) -> None:
-    from onyo.lib.ui import ui
-    ui.set_yes(True)
 
     directory = inventory.root / "edited"
     monkeypatch.setenv('EDITOR', "printf 'key: value' >>")

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,5 +3,6 @@ markers =
     repo_dirs: populate a repo with dirs; for use with the "repo" fixture
     repo_files: populate a repo with files (parent dirs are automatically created); for use with the "repo" fixture
     repo_contents: populate files of a repo with content; for use with the "repo" fixture
+    ui: set properties of the UI object to use; dictionary {'yes': bool, 'quiet': bool, 'debug': bool}
 addopts =
     --strict-markers


### PR DESCRIPTION
This provides a fixture setting up `onyo.lib.ui`, that is run for every
test. Settings for `yes`, `quiet` and `debug` are read from a new test
marker 'ui' if given. Otherwise set to defaults (`False` for all of
them). The marker takes a dictionary, allowing to enhance this later on
for other future features of the `UI` object (like using the rich
package or redirecting logging or whatever else).

Note, that this is not going to work for CLI tests, since they spawn a
subprocess with its own python context. However, that is obviously
fine, since the CLI calls take explicit flags for that.