### PR TITLE
Fix test failures

### DIFF
--- a/onyo/commands/tests/test_new.py
+++ b/onyo/commands/tests/test_new.py
@@ -704,10 +704,11 @@ def test_tsv_errors(repo: OnyoRepo) -> None:
     table = prepared_tsvs / "error_empty_table.tsv"
     ret = subprocess.run(['onyo', 'new', "--tsv", table],
                          capture_output=True, text=True)
-    # Note: This is currently not a failure, just a no-op.
-    assert "No new assets created" in ret.stdout
-    assert not ret.stderr
-    assert ret.returncode == 0
+
+    assert not ret.stdout
+    assert "No header fields" in ret.stderr
+    assert str(table) in ret.stderr
+    assert ret.returncode == 1
 
     # <TSV> contains 5 assets, but each misses one field
     table = prepared_tsvs / "error_incomplete_rows.tsv"

--- a/onyo/commands/tests/test_new.py
+++ b/onyo/commands/tests/test_new.py
@@ -714,7 +714,7 @@ def test_tsv_errors(repo: OnyoRepo) -> None:
     table = prepared_tsvs / "error_incomplete_rows.tsv"
     ret = subprocess.run(['onyo', 'new', "--tsv", table],
                          capture_output=True, text=True)
-    raise RuntimeError("TODO: 'Missing' fields, but unique asset names -> Feature or Bug?")
+    pytest.skip("TODO: 'Missing' fields, but unique asset names -> Feature or Bug?")
 
     assert not ret.stdout
     assert "The fields 'type', 'make', 'model', 'serial' and 'directory' are required" in ret.stderr

--- a/onyo/commands/tests/test_set.py
+++ b/onyo/commands/tests/test_set.py
@@ -592,7 +592,7 @@ def test_update_many_faux_serial_numbers(repo: OnyoRepo) -> None:
     many assets with new faux serial numbers in one call.
     """
 
-    raise RuntimeError("TODO: faux serials not yet considered outside new. Needs to move (modify_asset)")
+    pytest.skip("TODO: faux serials not yet considered outside new. Needs to move (modify_asset)")
     # remember old assets before renaming
     old_asset_names = repo.asset_paths
     ret = subprocess.run(['onyo', '--yes', 'set', '--rename', '--keys',

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -427,7 +427,7 @@ def onyo_new(inventory: Inventory,
         with tsv.open('r', newline='') as tsv_file:
             reader = csv.DictReader(tsv_file, delimiter='\t')
             if reader.fieldnames is None:
-                raise ValueError(f"No header fields in tsv {str(tsv_file)}")
+                raise ValueError(f"No header fields in tsv {str(tsv)}")
             if template and 'template' in reader.fieldnames:
                 raise ValueError("Can't use '--template' option and 'template' column in tsv.")
             if path and 'directory' in reader.fieldnames:

--- a/onyo/tests/test_usecases.py
+++ b/onyo/tests/test_usecases.py
@@ -56,18 +56,18 @@ def test_workflow_cli(repo: OnyoRepo) -> None:
 
     # 2d. Assign newly purchased laptop to user
     laptop = member / "lenovo_thinkpad_laptop.123"
-    cmd = ['onyo', '--yes', 'new', '-p', str(laptop), '-m', "New purchase: ThinkPad", '--keys', 'memory=8GB']
+    cmd = ['onyo', '--yes', 'new', '-p', str(member), '-m', "New purchase: ThinkPad",
+           '--keys', 'memory=8GB', 'model=laptop', 'type=lenovo', 'make=thinkpad', 'serial=123']
     ret = subprocess.run(cmd, capture_output=True, text=True)
     assert ret.returncode == 0
     # 2e. That was completely wrong data entry. Essentially all the wrong keys.
     # Let's remove asset entirely and redo.
-    cmd = ['onyo', '--yes', 'rm', str(laptop), '-m', "Delete asset due to erroneous data enty"]
+    cmd = ['onyo', '--yes', 'rm', str(laptop), '-m', "Delete asset due to erroneous data entry"]
     ret = subprocess.run(cmd, capture_output=True, text=True)
     assert ret.returncode == 0
 
-    laptop = member / "laptop_lenovo_thinkpad.SN123Z"
-    cmd = ['onyo', '--yes', 'new', '-p', str(laptop), '-m', "New purchase: ThinkPad",
-           '--keys', 'RAM=8GB', 'build-date=20160310']
+    cmd = ['onyo', '--yes', 'new', '-p', str(member), '-m', "New purchase: ThinkPad",
+           '--keys', 'RAM=8GB', 'build-date=20160310', 'type=laptop', 'make=lenovo', 'model=thinkpad', 'serial=SN123Z']
     ret = subprocess.run(cmd, capture_output=True, text=True)
     assert ret.returncode == 0
 
@@ -171,7 +171,8 @@ def test_workflow_cli(repo: OnyoRepo) -> None:
     # One should remain:
     assert len(ret.stdout.splitlines()) == 1
 
-    # All assets not in "retired" location of a certain type, that match something like `"20160101 <= build-date <= 20171231"`
+    # All assets not in "retired" location of a certain type, that match something like
+    # `"20160101 <= build-date <= 20171231"`
     # Apple recall on battery of all 13" MacBook Pros built between 2016-2017
     # -> query for all matching laptops not in 'retired'.
 


### PR DESCRIPTION
Fixes remaining failures due to new interfacee of  `onyo new` and turns remaining cases of `raise RuntimeError("TODO: ...` into `pytest.skip("TODO...`. This should re-establish a "green" CI pipeline (provided #468 merged), so we can stop the hackathon related phase of merging things that don't pass. 