### PR TITLE
BF: replace Union with new `|`-syntax and `Optional[]`

### DIFF
--- a/onyo/argparse_helpers.py
+++ b/onyo/argparse_helpers.py
@@ -1,14 +1,14 @@
 import argparse
 import os
 
-from typing import Optional, Sequence, Union
+from typing import Optional, Sequence
 
 
 class StoreKeyValuePairs(argparse.Action):
     def __init__(self,
                  option_strings: Sequence[str],
                  dest: str,
-                 nargs: Union[None, int, str] = None,
+                 nargs: Optional[int | str] = None,
                  **kwargs) -> None:
         self._nargs = nargs
         super().__init__(option_strings, dest, nargs=nargs, **kwargs)
@@ -39,7 +39,7 @@ class StoreKeyValuePairs(argparse.Action):
                          f"Max. times a key was given: {number_of_dicts}.{os.linesep}"
                          f"But also got: {', '.join(['{} {} times'.format(k, c) for k, c in invalid_keys])}")
 
-        def cvt(v: str) -> Union[int, float, str]:
+        def cvt(v: str) -> int | float | str:
             try:
                 r = int(v)
             except ValueError:

--- a/onyo/commands/tests/test_get.py
+++ b/onyo/commands/tests/test_get.py
@@ -3,7 +3,7 @@ import subprocess
 import pytest
 
 from pathlib import Path
-from typing import Any, Generator, Union
+from typing import Any, Generator, Optional
 
 from onyo.lib.command_utils import sanitize_keys, set_filters, fill_unset, natural_sort
 from onyo.lib.assets import PSEUDO_KEYS
@@ -65,8 +65,8 @@ def test_get_defaults(repo: OnyoRepo) -> None:
 @pytest.mark.parametrize('sort', ['-s', None])
 def test_get_all(
         repo: OnyoRepo, filters: list[str], depth: str, keys: list[str],
-        paths: list[str], machine_readable: Union[str, None],
-        sort: Union[str, None]) -> None:
+        paths: list[str], machine_readable: Optional[str],
+        sort: Optional[str]) -> None:
     """
     Test `onyo get` with a combination of arguments.
     """
@@ -314,7 +314,7 @@ def test_get_depth_error(repo: OnyoRepo) -> None:
     (['./one/two/three/four', './another/dir'], None, 2),
     ([], None, 6)])
 def test_get_path_at_depth(
-        repo: OnyoRepo, paths: str, depth: Union[str, None],
+        repo: OnyoRepo, paths: str, depth: Optional[str],
         expected: int) -> None:
     """
     Test that `onyo get --path x --depth y` retrieves the expected assets by
@@ -378,8 +378,8 @@ def test_get_path_error(repo: OnyoRepo, path: str) -> None:
     (['unset', 'type'], ['a2cd', 'a13bc', 'a36ab']),
     ([], ['a2cd', 'a13bc', 'a36ab'])])
 def test_get_sort(
-        repo: OnyoRepo, sort: Union[str, None], keys: list[str],
-        expected: list[str], default: Union[int, None]) -> None:
+        repo: OnyoRepo, sort: Optional[str], keys: list[str],
+        expected: list[str], default: Optional[int]) -> None:
     """
     Test that `onyo get --keys x y z` with `-s` (ascending) or `-S`
     (descending)  retrieves assets in the expected 'natural sorted' order.
@@ -422,7 +422,7 @@ def test_get_sort_error(repo: OnyoRepo) -> None:
 @pytest.mark.parametrize('keys', [None, ['num'], ['str', 'num']])
 @pytest.mark.parametrize('reverse', [True, False])
 def test_natural_sort(
-        assets: list[tuple[Path, dict[str, str]]], keys: Union[list, None],
+        assets: list[tuple[Path, dict[str, str]]], keys: Optional[list],
         reverse: bool) -> None:
     """Test implementation of natural sorting algorithm"""
     sorted_assets = natural_sort(assets, keys=keys, reverse=reverse)

--- a/onyo/conftest.py
+++ b/onyo/conftest.py
@@ -2,7 +2,7 @@ import os
 from collections.abc import Iterable
 from itertools import chain, combinations
 from pathlib import Path
-from typing import Generator, List, Type, Union
+from typing import Generator, List, Type
 import pytest
 from _pytest.mark.structures import MarkDecorator
 
@@ -141,7 +141,7 @@ class Helpers:
                 yield x
 
     @staticmethod
-    def onyo_flags() -> List[Union[List[List[str]], List[str]]]:
+    def onyo_flags() -> List[List[List[str]] | List[str]]:
         return [['-d', '--debug'],
                 [['-C', '/tmp'], ['--onyopath', '/tmp']],
                 ]

--- a/onyo/lib/assets.py
+++ b/onyo/lib/assets.py
@@ -3,7 +3,7 @@ import logging
 
 import re
 from pathlib import Path
-from typing import Dict, Union, Iterable, Set, Generator, Optional
+from typing import Dict, Generator, Iterable, Optional, Set
 
 from ruamel.yaml import YAML, scanner  # pyre-ignore[21]
 
@@ -115,7 +115,7 @@ def valid_asset_name(asset_file: Path) -> bool:
 
 def get_asset_files_by_path(asset_files: list[Path],
                             paths: Iterable[Path],
-                            depth: Union[int, None]) -> list[Path]:
+                            depth: Optional[int]) -> list[Path]:
     """
     Check and normalize a list of paths. Select all assets in the
     repository that are relative to the given `paths` descending at most
@@ -141,7 +141,7 @@ def get_asset_files_by_path(asset_files: list[Path],
 
 
 def write_asset_file(asset_path: Path,
-                     asset_content: Dict[str, Union[float, int, str]]) -> None:
+                     asset_content: Dict[str, float | int | str]) -> None:
     if asset_content == {}:
         asset_path.open('w').write("")
     else:
@@ -149,7 +149,7 @@ def write_asset_file(asset_path: Path,
         yaml.dump(asset_content, asset_path)
 
 
-def get_asset_content(asset_file: Path) -> Dict[str, Union[float, int, str]]:
+def get_asset_content(asset_file: Path) -> Dict[str, float | int | str]:
     yaml = YAML(typ='rt', pure=True)
     contents = dict()
     try:
@@ -164,8 +164,8 @@ def get_asset_content(asset_file: Path) -> Dict[str, Union[float, int, str]]:
 def get_assets_by_query(asset_files: list[Path],
                         keys: Optional[Set[str]],
                         paths: Iterable[Path],
-                        depth: Union[int, None] = None,
-                        filters: Union[list[Filter], None] = None) -> Generator:
+                        depth: Optional[int] = None,
+                        filters: Optional[list[Filter]] = None) -> Generator:
     """
     Get keys from assets matching paths and filters.
     """

--- a/onyo/lib/command_utils.py
+++ b/onyo/lib/command_utils.py
@@ -6,7 +6,7 @@ import shutil
 import sys
 from collections import Counter
 from pathlib import Path
-from typing import Dict, Union, Generator, Iterable, Optional, Tuple
+from typing import Dict, Generator, Iterable, Optional, Tuple
 
 from rich.console import Console
 
@@ -119,7 +119,7 @@ def fill_unset(
 
 def natural_sort(
         assets: list[tuple[Path, dict[str, str]]],
-        keys: Union[list, None] = None, reverse: bool = False) -> list:
+        keys: Optional[list] = None, reverse: bool = False) -> list:
     """
     Sort the output of `Repo.get()` by a given list of `keys` or by the path
     of the `assets` if no `keys` are provided.
@@ -173,7 +173,7 @@ def get_history_cmd(interactive: bool, repo: OnyoRepo) -> str:
 def unset(repo: OnyoRepo,
           paths: Iterable[Path],
           keys: list[str],
-          depth: Union[int, None]) -> list[Tuple[Path, Dict, Iterable]]:
+          depth: Optional[int]) -> list[Tuple[Path, Dict, Iterable]]:
 
     from .assets import get_asset_files_by_path, PSEUDO_KEYS, get_asset_content
     from .onyo import dict_to_yaml

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import subprocess
 import sys
 import logging
-from typing import Optional, Union, Iterable, Dict
+from typing import Dict, Iterable, Optional
 from pathlib import Path
 
 from rich.console import Console
@@ -281,7 +281,7 @@ def move_asset_or_dir(inventory: Inventory, src: Path, dst: Path) -> None:
 
 
 def onyo_mv(inventory: Inventory,
-            source: Union[list[Path], Path],
+            source: list[Path] | Path,
             destination: Path,
             message: Optional[str] = None) -> None:
     """
@@ -558,7 +558,7 @@ def onyo_new(inventory: Inventory,
 
 
 def onyo_rm(inventory: Inventory,
-            path: Union[Iterable[Path], Path],
+            path: Iterable[Path] | Path,
             message: Optional[str]) -> None:
 
     paths = [path] if not isinstance(path, (list, set, tuple)) else path
@@ -593,11 +593,11 @@ def onyo_rm(inventory: Inventory,
 
 def onyo_set(inventory: Inventory,
              paths: Optional[Iterable[Path]],
-             keys: Dict[str, Union[str, int, float]],
+             keys: Dict[str, str | int | float],
              filter_strings: list[str],
              rename: bool,
              depth: int,
-             message: Optional[str] = None) -> Union[str, None]:
+             message: Optional[str] = None) -> Optional[str]:
 
     if not paths:
         paths = [Path.cwd()]
@@ -665,7 +665,7 @@ def unset(repo: OnyoRepo,
           keys: list[str],
           filter_strings: list[str],
           dryrun: bool,
-          depth: Union[int, None],
+          depth: Optional[int],
           message: Optional[str]) -> None:
     from onyo.lib.command_utils import unset as ut_unset
     from .assets import write_asset_file

--- a/onyo/lib/differs.py
+++ b/onyo/lib/differs.py
@@ -1,7 +1,7 @@
 from functools import partial
 from pathlib import Path
 from difflib import unified_diff
-from typing import Union, Generator
+from typing import Generator
 
 from onyo.lib.onyo import dict_to_yaml, OnyoRepo
 
@@ -29,7 +29,7 @@ diff_modified_asset = diff_assets
 diff_renamed_asset = diff_assets  # This is the same, because a rename requires a change in keys composing the name (or change in config).
 
 
-def diff_moved_asset(asset_old: Union[dict, Path], asset_new: Path):
+def diff_moved_asset(asset_old: dict | Path, asset_new: Path):
     # could be same. Just check isinstance?
     yield from diff_path_change(asset_old if isinstance(asset_old, Path) else asset_old.get('path'),
                                 asset_new)

--- a/onyo/lib/git.py
+++ b/onyo/lib/git.py
@@ -4,7 +4,7 @@ import logging
 
 from onyo.lib.ui import ui
 from onyo.lib.exceptions import OnyoInvalidRepoError
-from typing import Union, Iterable, Optional
+from typing import Iterable, Optional
 
 log: logging.Logger = logging.getLogger('onyo.git')
 
@@ -166,7 +166,7 @@ class GitRepo(object):
         self.clear_caches()
 
     def restore(self,
-                paths: Union[list[Path], Path]) -> None:
+                paths: list[Path] | Path) -> None:
         """
         Call git-restore on `paths`.
 
@@ -300,7 +300,7 @@ class GitRepo(object):
         self.root = target_dir
 
     def stage_and_commit(self,
-                         paths: Union[Iterable[Path], Path],
+                         paths: Iterable[Path] | Path,
                          message: str) -> None:
         """
         Stage and commit changes in git.
@@ -338,7 +338,7 @@ class GitRepo(object):
         return '.git' in path.parts or path.name.startswith('.git')
 
     def add(self,
-            targets: Union[Iterable[Path], Path]) -> None:
+            targets: Iterable[Path] | Path) -> None:
         """
         Perform ``git add`` to stage files.
 
@@ -405,7 +405,7 @@ class GitRepo(object):
 
     def get_config(self,
                    name: str,
-                   file_: Optional[Path] = None) -> Union[str, None]:
+                   file_: Optional[Path] = None) -> Optional[str]:
         """
         Get the value for a configuration option specified by `name`.
 
@@ -516,7 +516,7 @@ class GitRepo(object):
         return "\n".join(diff).strip()
 
     def mv(self,
-           source: Union[Path, Iterable[Path]],
+           source: Path | Iterable[Path],
            destination: Path,
            dryrun: bool = False) -> str:
         """
@@ -550,7 +550,7 @@ class GitRepo(object):
         return self._git(mv_cmd)
 
     def rm(self,
-           paths: Union[list[Path], Path],
+           paths: list[Path] | Path,
            force: bool = False,
            dryrun: bool = False) -> str:
         """

--- a/onyo/lib/inventory.py
+++ b/onyo/lib/inventory.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Union, Iterable, Optional, Set, Generator
+from typing import Generator, Iterable, Optional, Set
 from dataclasses import dataclass
 from typing import Callable
 from functools import partial
@@ -217,13 +217,13 @@ class Inventory(object):
         self._add_operation('new_directories', (path,))
         [self._add_operation('new_directories', (p,)) for p in path.parents if not p.exists()]
 
-    def remove_asset(self, asset: Union[Asset, Path]) -> None:
+    def remove_asset(self, asset: Asset | Path) -> None:
         path = asset if isinstance(asset, Path) else asset.get('path')
         if not self.repo.is_asset_path(path):
             raise NotAnAssetError(f"No such asset: {path}")
         self._add_operation('remove_assets', (asset,))
 
-    def move_asset(self, src: Union[Path, Asset], dst: Path) -> None:
+    def move_asset(self, src: Path | Asset, dst: Path) -> None:
         if isinstance(src, Asset):
             src = Path(src.get('path'))
         if not self.repo.is_asset_path(src):
@@ -236,7 +236,7 @@ class Inventory(object):
 
         self._add_operation('move_assets', (src, dst))
 
-    def rename_asset(self, asset: Union[Asset, Path], name: Optional[str] = None) -> None:
+    def rename_asset(self, asset: Asset | Path, name: Optional[str] = None) -> None:
         # ??? Do we need that? On the command level it's only accessible via modify_asset.
         # But: A config change is sufficient to make it not actually an asset modification.
         # Also: If we later on want to allow it under some circumstances, it would be good have it as a formally
@@ -269,7 +269,7 @@ class Inventory(object):
         # TODO: Do we need to update asset['path'] here? See also modify_asset!
         self._add_operation('rename_assets', (path, destination))
 
-    def modify_asset(self, asset: Union[Asset, Path], content: Asset) -> None:
+    def modify_asset(self, asset: Asset | Path, content: Asset) -> None:
         path = Path(asset.get('path')) if isinstance(asset, Asset) else asset
         if not self.repo.is_asset_path(path):
             raise ValueError(f"No such asset: {path}")
@@ -323,7 +323,7 @@ class Inventory(object):
             raise InvalidInventoryOperation(f"Cannot move {src} -> {dst}. Consider renaming instead.")
         self._add_operation('move_directories', (src, dst))
 
-    def rename_directory(self, src: Path, dst: Union[str, Path]) -> None:
+    def rename_directory(self, src: Path, dst: str | Path) -> None:
         if not self.repo.is_inventory_dir(src):
             raise ValueError(f"Not an inventory directory: {src}")
         if self.repo.is_asset_dir(src):
@@ -364,8 +364,8 @@ class Inventory(object):
     def get_assets_by_query(self,
                             keys: Optional[Set[str]],
                             paths: Iterable[Path],
-                            depth: Union[int, None] = None,
-                            filters: Union[list[Filter], None] = None) -> Generator:
+                            depth: Optional[int] = None,
+                            filters: Optional[list[Filter]] = None) -> Generator:
         # filters + path/depth limit (TODO: turn into filters as well)
         # self.repo.get_asset_paths(subtrees=, depth=)
 
@@ -404,7 +404,7 @@ class Inventory(object):
 
         return assets
 
-    def asset_paths_available(self, assets: Union[Asset, list[Asset]]) -> None:
+    def asset_paths_available(self, assets: Asset | list[Asset]) -> None:
         """Test whether path(s) used by `assets` are available in the inventory.
 
         Availability not only requires the path to not yet exist, but also the filename to be unique.

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -5,7 +5,7 @@ import shutil
 import subprocess
 import os
 from pathlib import Path
-from typing import Iterable, Optional, Union, List, Dict
+from typing import Dict, Iterable, List, Optional
 
 from ruamel.yaml import YAML  # pyre-ignore[21]
 
@@ -17,7 +17,7 @@ from .exceptions import OnyoInvalidRepoError, OnyoProtectedPathError
 log: logging.Logger = logging.getLogger('onyo.onyo')
 
 
-def dict_to_yaml(d: Dict[str, Union[float, int, str]]) -> str:
+def dict_to_yaml(d: Dict[str, float | int | str]) -> str:
     content = {k: v for k, v in d.items() if k not in NEW_PSEUDO_KEYS}  # RESERVED_KEYS
     if not content:
         return ""
@@ -118,7 +118,7 @@ class OnyoRepo(object):
         # caches
         self._asset_paths: Optional[list[Path]] = None
 
-    def get_config(self, name: str) -> Union[str, None]:
+    def get_config(self, name: str) -> Optional[str]:
         """
         """
         # TODO: lru_cache?
@@ -639,7 +639,7 @@ class OnyoRepo(object):
         return asset
 
     def mk_inventory_dirs(self,
-                          dirs: Union[Iterable[Path], Path]) -> list[Path]:
+                          dirs: Iterable[Path] | Path) -> list[Path]:
         """Create inventory directories `dirs`
 
         Creates `dirs` including anchor files.

--- a/onyo/lib/recorders.py
+++ b/onyo/lib/recorders.py
@@ -1,6 +1,5 @@
 from os import linesep
 from pathlib import Path
-from typing import Union
 
 from onyo.lib.onyo import OnyoRepo
 
@@ -23,12 +22,12 @@ from onyo.lib.onyo import OnyoRepo
 # TODO: Double-check we always report posix paths!
 
 
-def record_item(repo: OnyoRepo, item: Union[Path, dict]) -> str:
+def record_item(repo: OnyoRepo, item: Path | dict) -> str:
     path = item if isinstance(item, Path) else item['path']
     return f"- {path.relative_to(repo.git.root).as_posix()}{linesep}"
 
 
-def record_move(repo: OnyoRepo, src: Union[Path, dict], dst: Path) -> str:
+def record_move(repo: OnyoRepo, src: Path | dict, dst: Path) -> str:
     # Attention: This currently expects `dst` to be the dir to move src into,
     # rather than already containing src' name at the destination. This may not be consistent yet.
     src_path = src if isinstance(src, Path) else src['path']

--- a/onyo/lib/ui.py
+++ b/onyo/lib/ui.py
@@ -2,7 +2,6 @@ import logging
 import os
 import sys
 import traceback
-from typing import Union
 
 
 logging.basicConfig()
@@ -111,7 +110,7 @@ class UI(object):
         self.yes = yes
 
     def error(self,
-              error: Union[str, Exception],
+              error: str | Exception,
               end: str = os.linesep) -> None:
         """
         Print an error message, if the UI is not set to `quiet`.

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -6,7 +6,7 @@ import textwrap
 from onyo import commands
 from onyo.lib.ui import ui
 from pathlib import Path
-from typing import Union
+from typing import Optional
 
 
 # credit: https://stackoverflow.com/a/13429281
@@ -248,7 +248,7 @@ def setup_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def get_subcmd_index(arglist, start: int = 1) -> Union[int, None]:
+def get_subcmd_index(arglist, start: int = 1) -> Optional[int]:
     """
     Get the index of the subcommand from a provided list of arguments (usually sys.argv).
 


### PR DESCRIPTION
This is purely a syntax uplift thing that just took me a few minutes. If it's not desired, I'm happy to walk away from it.

Now that the Python baseline is 3.11, we can use the new, more terse syntax introduced in Python 3.10.

- https://docs.python.org/3/library/stdtypes.html#types-union
- https://docs.python.org/3/library/typing.html#typing.Optional

The one controversial thing I see is the use of `Optional` (which some feel is poorly named) in place of `something | None`. This can feel odd when defining what a function returns:
```
def yope(Optional[str]) -> Optional[int]
    ...
```

If people bump on that, we can simply avoid `Optional`.