### PR TITLE
commands: normalize parameter types and names, normalize docstrings 

### DIFF
--- a/onyo/commands/cat.py
+++ b/onyo/commands/cat.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from onyo.lib.onyo import OnyoRepo
+from onyo.lib.inventory import Inventory
 from onyo.lib.commands import onyo_cat
 from onyo.argparse_helpers import file
 
@@ -24,5 +25,6 @@ def cat(args: argparse.Namespace) -> None:
     """
     paths = [Path(p).resolve() for p in args.asset]
 
-    repo = OnyoRepo(Path.cwd(), find_root=True)
-    onyo_cat(repo, paths)
+    inventory = Inventory(repo=OnyoRepo(Path.cwd(), find_root=True))
+    onyo_cat(inventory,
+             paths)

--- a/onyo/commands/config.py
+++ b/onyo/commands/config.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from onyo import OnyoRepo
+from onyo.lib.inventory import Inventory
 from onyo.lib.commands import onyo_config
 from onyo.argparse_helpers import git_config
 
@@ -48,5 +49,6 @@ def config(args: argparse.Namespace) -> None:
 
     # TODO: Wouldn't we want to commit (implying message parameter)?
 
-    repo = OnyoRepo(Path.cwd(), find_root=True)
-    onyo_config(repo, args.git_config_args)
+    inventory = Inventory(repo=OnyoRepo(Path.cwd(), find_root=True))
+    onyo_config(inventory,
+                args.git_config_args)

--- a/onyo/commands/edit.py
+++ b/onyo/commands/edit.py
@@ -37,5 +37,5 @@ def edit(args: argparse.Namespace) -> None:
     paths = [Path(p).resolve() for p in args.asset]
     inventory = Inventory(repo=OnyoRepo(Path.cwd(), find_root=True))
     onyo_edit(inventory=inventory,
-              asset_paths=paths,
+              paths=paths,
               message='\n\n'.join(m for m in args.message) if args.message else None)

--- a/onyo/commands/get.py
+++ b/onyo/commands/get.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 from pathlib import Path
 
 from onyo import OnyoRepo
+from onyo.lib.inventory import Inventory
 from onyo.lib.commands import get as get_cmd
 from onyo.argparse_helpers import path
 from onyo.shared_arguments import shared_arg_depth, shared_arg_filter
@@ -70,10 +71,10 @@ def get(args: argparse.Namespace) -> None:
     By default, the returned assets are sorted by their paths.
     """
 
-    repo = OnyoRepo(Path.cwd(), find_root=True)
+    inventory = Inventory(repo=OnyoRepo(Path.cwd(), find_root=True))
 
     paths = [Path(p).resolve() for p in args.path] if args.path else None
-    get_cmd(repo,
+    get_cmd(inventory,
             args.sort_ascending,
             args.sort_descending,
             paths,

--- a/onyo/commands/rm.py
+++ b/onyo/commands/rm.py
@@ -32,5 +32,5 @@ def rm(args: argparse.Namespace) -> None:
     inventory = Inventory(repo=OnyoRepo(Path.cwd(), find_root=True))
     paths = [Path(p).resolve() for p in args.path]
     onyo_rm(inventory,
-            path=paths,
+            paths=paths,
             message='\n\n'.join(m for m in args.message) if args.message else None)

--- a/onyo/commands/tree.py
+++ b/onyo/commands/tree.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from onyo import OnyoRepo
+from onyo.lib.inventory import Inventory
 from onyo.lib.commands import onyo_tree
 from onyo.argparse_helpers import directory
 
@@ -23,6 +24,7 @@ def tree(args: argparse.Namespace) -> None:
     List the assets and directories in ``DIRECTORY`` in the ``tree`` format.
     """
 
-    repo = OnyoRepo(Path.cwd(), find_root=True)
+    inventory = Inventory(repo=OnyoRepo(Path.cwd(), find_root=True))
     paths = [Path(p).resolve() for p in args.directory]
-    onyo_tree(repo, paths)
+    onyo_tree(inventory,
+              paths)

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -5,7 +5,6 @@ import sys
 import logging
 from typing import Dict, Iterable, Optional
 from pathlib import Path
-
 from rich.console import Console
 from rich import box
 from rich.table import Table
@@ -95,7 +94,7 @@ def fsck(repo: OnyoRepo,
 
 
 def onyo_cat(repo: OnyoRepo,
-             paths: Iterable[Path]) -> None:
+             paths: list[Path]) -> None:
     """Print the contents of assets.
 
     Parameters
@@ -103,7 +102,7 @@ def onyo_cat(repo: OnyoRepo,
     repo: OnyoRepo
         The Onyo Repository containing the assets to print.
 
-    paths: Path or Iterable of Path
+    paths: Path or list of Path
         Path(s) to assets for which to print the contents.
 
     Raises
@@ -173,7 +172,7 @@ def onyo_config(repo: OnyoRepo,
 
 
 def onyo_edit(inventory: Inventory,
-              asset_paths: Iterable[Path],
+              paths: list[Path],
               message: Optional[str]) -> None:
     """Edit the content of assets.
 
@@ -182,7 +181,7 @@ def onyo_edit(inventory: Inventory,
     inventory: Inventory
         The inventory in which to edit assets.
 
-    asset_paths: Path or Iterable of Path
+    paths: Path or list of Path
         The assets to modify.
 
     message: str, optional
@@ -199,11 +198,11 @@ def onyo_edit(inventory: Inventory,
     # Note: This command is an exception. It skips the invalid paths and
     #       proceeds to act upon the valid ones!
     valid_asset_paths = []
-    for a in asset_paths:
-        if not inventory.repo.is_asset_path(a):
-            ui.print(f"\n{a} is not an asset.", file=sys.stderr)
+    for p in paths:
+        if not inventory.repo.is_asset_path(p):
+            ui.print(f"\n{p} is not an asset.", file=sys.stderr)
         else:
-            valid_asset_paths.append(a)
+            valid_asset_paths.append(p)
     if not valid_asset_paths:
         raise RuntimeError("No asset updated.")
 
@@ -366,22 +365,23 @@ def onyo_mkdir(inventory: Inventory,
 
 
 def move_asset_or_dir(inventory: Inventory,
-                      src: Path,
-                      dst: Path) -> None:
+                      source: Path,
+                      destination: Path) -> None:
     """Move a source asset or directory to a destination.
 
-    Parameters:
-    src: Path
+    Parameters
+    ----------
+    source: Path
         Path object to an asset or directory which to move to the destination.
 
-    dst: Path
+    destination: Path
         Path object to an asset or directory to which to move source.
     """
     # TODO: method of Inventory?
     try:
-        inventory.move_asset(src, dst)
+        inventory.move_asset(source, destination)
     except NotAnAssetError:
-        inventory.move_directory(src, dst)
+        inventory.move_directory(source, destination)
 
 
 def onyo_mv(inventory: Inventory,
@@ -685,7 +685,7 @@ def onyo_new(inventory: Inventory,
 
 
 def onyo_rm(inventory: Inventory,
-            path: Iterable[Path] | Path,
+            paths: list[Path] | Path,
             message: Optional[str]) -> None:
     """Delete assets and/or directories from the inventory.
 
@@ -694,14 +694,14 @@ def onyo_rm(inventory: Inventory,
     inventory: Inventory
         The inventory in which assets and/or directories will be deleted.
 
-    path: Path or Iterable of Path
+    paths: Path or list of Path
         List of paths to assets and/or directories to delete from the Inventory.
         If any path given is not valid, none of them gets deleted.
 
     message: str, optional
         An optional string to overwrite Onyo's default commit message.
     """
-    paths = [path] if not isinstance(path, (list, set, tuple)) else path
+    paths = [paths] if not isinstance(paths, list) else paths
 
     for p in paths:
         try:
@@ -732,7 +732,7 @@ def onyo_rm(inventory: Inventory,
 
 
 def onyo_set(inventory: Inventory,
-             paths: Optional[Iterable[Path]],
+             paths: Optional[list[Path]],
              keys: Dict[str, str | int | float],
              filter_strings: list[str],
              rename: bool,
@@ -745,7 +745,7 @@ def onyo_set(inventory: Inventory,
     inventory: Inventory
         The Inventory in which to set key/values for assets.
 
-    paths: Path or Iterable of Path, optional
+    paths: Path or list of Path, optional
         Paths to assets or directories for which to set key-value pairs.
         If paths are directories, the values will be set recursively in assets
         under the specified path.

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -49,7 +49,7 @@ def fsck(repo: OnyoRepo,
     repo: OnyoRepo
         The Repository on which to perform the fsck on.
 
-    tests: list of str
+    tests: list of str, optional
         A list with the names of tests to perform. By default, all tests are
         performed on the repository.
 
@@ -185,7 +185,7 @@ def onyo_edit(inventory: Inventory,
     asset_paths: Path or Iterable of Path
         The assets to modify.
 
-    message: str
+    message: str, optional
         An optional string to overwrite Onyo's default commit message.
 
     Raises
@@ -342,7 +342,7 @@ def onyo_mkdir(inventory: Inventory,
     dirs: list of Path
         Paths to directories which to create.
 
-    message: str
+    message: str, optional
         An optional string to overwrite Onyo's default commit message.
     """
     for d in deduplicate(dirs):  # explicit duplicates would make auto-generating message subject more complicated ATM
@@ -404,7 +404,7 @@ def onyo_mv(inventory: Inventory,
         The path to which the source(s) will be moved, or a single
         source directory will be renamed.
 
-    message: str
+    message: str, optional
         An optional string to overwrite Onyo's default commit message.
 
     Raises
@@ -492,21 +492,21 @@ def onyo_new(inventory: Inventory,
     inventory: Inventory
         The Inventory in which to create new assets.
 
-    path: Path
+    path: Path, optional
         The directory to create new asset(s) in. Defaults to CWD.
         Note, that it technically is not a default (as per signature of this
         function), because we need to be able to tell whether a path was given
         in order to check for conflict with a possible 'directory' key or
         table column.
 
-    template: str
+    template: str, optional
         The name of a template file in ``.onyo/templates/`` that is copied as a
         base for the new assets to be created.
 
-    tsv: Path
+    tsv: Path, optional
         A path to a tsv table that describes new assets to be created.
 
-    keys: list of dict of str
+    keys: list of dict of str, optional
         List of dictionaries with key/value pairs that will be set in the newly
         created assets. The keys used in the ``onyo.assets.filename`` config
         ``.onyo/config`` (e.g. ``filename = "{type}_{make}_{model}.{serial}"``)
@@ -516,7 +516,7 @@ def onyo_new(inventory: Inventory,
         If True, newly created assets are opened in the editor before the
         changes are saved.
 
-    message: str
+    message: str, optional
         An optional string to overwrite Onyo's default commit message.
 
     Raises
@@ -698,7 +698,7 @@ def onyo_rm(inventory: Inventory,
         List of paths to assets and/or directories to delete from the Inventory.
         If any path given is not valid, none of them gets deleted.
 
-    message: str
+    message: str, optional
         An optional string to overwrite Onyo's default commit message.
     """
     paths = [path] if not isinstance(path, (list, set, tuple)) else path
@@ -745,7 +745,7 @@ def onyo_set(inventory: Inventory,
     inventory: Inventory
         The Inventory in which to set key/values for assets.
 
-    paths: Path or Iterable of Path
+    paths: Path or Iterable of Path, optional
         Paths to assets or directories for which to set key-value pairs.
         If paths are directories, the values will be set recursively in assets
         under the specified path.
@@ -769,7 +769,7 @@ def onyo_set(inventory: Inventory,
         Depth limit of recursion if a `path` is a directory.
         0 means no limit and is the default.
 
-    message: str
+    message: str, optional
         An optional string to overwrite Onyo's default commit message.
 
     Raises
@@ -870,7 +870,7 @@ def unset(repo: OnyoRepo,
     repo: OnyoRepo
         TODO
 
-    paths: Path or Iterable of Path
+    paths: Path or Iterable of Path, optional
         TODO
 
     keys: list of str
@@ -879,10 +879,10 @@ def unset(repo: OnyoRepo,
     filter_strings: list of str
         TODO
 
-    depth: int
+    depth: int, optional
         TODO
 
-    message: str
+    message: str, optional
         An optional string to overwrite Onyo's default commit message.
 
     Raises

--- a/onyo/lib/git.py
+++ b/onyo/lib/git.py
@@ -400,7 +400,7 @@ class GitRepo(object):
           "SECTION.NAME.KEY" to address a key in a git config file:
             [SECTION "NAME"]
               KEY = VALUE
-        file_: Path
+        file_: Path, optional
           path to a config file to read instead of Git's default locations.
 
         Returns

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -214,7 +214,7 @@ class OnyoRepo(object):
 
         Parameters
         ----------
-        message: list of str
+        message: list of str, optional
             If `message` is given, the function uses the first element of it to
             generate a message subject, and the following ones are joined for
             the message body.
@@ -230,11 +230,11 @@ class OnyoRepo(object):
         cmd: str
             Defines the beginning of a commit message subject.
 
-        keys: list of str
+        keys: list of str, optional
             Allow listing of e.g. changed keys in message subject.
             If given, they are listed at the beginning after `cmd`.
 
-        destination: Path
+        destination: Path, optional
             A string that can specify a destination for the message subject for
             moved assets and directories.
 
@@ -242,7 +242,7 @@ class OnyoRepo(object):
             An integer specifying the maximal length for generated commit
             message subjects.
 
-        modified: Iterable of Path
+        modified: Iterable of Path, optional
             A list of Paths to assets/directories modified in the commit, used
             to generate the commit message subject and body.
 
@@ -310,7 +310,7 @@ class OnyoRepo(object):
             The list of paths modified which should be mentioned in the commit
             message subject.
 
-        destination: Path
+        destination: Path, optional
             Destination for assets/directories when the commit contains `mv`s.
 
         max_length: int
@@ -510,7 +510,7 @@ class OnyoRepo(object):
 
         Parameters
         ----------
-        name: str
+        name: str, optional
             The name of the template to look for. If no name is given, the
             template defined in the config file `.onyo/config` is returned.
 


### PR DESCRIPTION
In commands:
- changes in command functions the type from `OnyoRepository` ->`Inventory` (#467) 
  - to make the API more intutive, we pass now always the same variable type (except for unset and fsck, which need to be refactored still)
  - updates variable names and types/typehints in command functions in `commands.py`

This PR also adds keyword "optional" to doc-strings to follow numpydocs.

Close #467
Close #341