### PR TITLE
onyo: remove dry-run

### DIFF
--- a/docs/source/cmd_unset.rst
+++ b/docs/source/cmd_unset.rst
@@ -15,10 +15,3 @@ Example Usage
 .. code:: shell
 
     onyo unset --keys display touch --path accounting/Karl\ Krebs/laptop_apple_macbookpro.222
-
-
-**Show which values would be removed, but do not change the files yet**
-
-.. code:: shell
-
-     onyo unset --dry-run --keys touch --path accounting/

--- a/onyo/commands/tests/test_unset.py
+++ b/onyo/commands/tests/test_unset.py
@@ -378,37 +378,6 @@ def test_unset_message_flag(repo: OnyoRepo, asset: str) -> None:
     fsck(repo)
 
 
-@pytest.mark.repo_contents(*contents)
-def test_unset_dryrun_flag(repo: OnyoRepo) -> None:
-    """
-    Test that `onyo unset --dry-run --keys KEY --path ASSET` displays correct
-    diff-output without actually changing any assets.
-    """
-    key = list(content_dict.keys())[0]
-    # do a dry-run with unset, to check if the diff is correct without actually
-    # changing an asset
-    ret = subprocess.run(['onyo', 'unset', '--dry-run', '--keys', key,
-                          '--path', *assets], capture_output=True, text=True)
-
-    # verify output
-    assert "The following assets will be changed:" in ret.stdout
-    assert not ret.stderr
-    assert ret.returncode == 0
-
-    # should not be asked if no real changes are made
-    assert "Update assets? (y/n) " not in ret.stdout
-
-    # verify that all assets and changes are in diff output, but no changes in
-    # the asset files are made
-    for asset in assets:
-        assert str(Path(asset)) in ret.stdout
-        assert f"-{key}: {content_dict.get(key)}" in ret.stdout
-        assert f"{key}: {content_dict.get(key)}" in Path(asset).read_text()
-
-    # check that the repository is still clean
-    fsck(repo)
-
-
 depth_assets = ["laptop_macbook_pro.0",
                 "dir1/laptop_macbook_pro.1",
                 "dir1/dir2/laptop_macbook_pro.2",

--- a/onyo/commands/unset.py
+++ b/onyo/commands/unset.py
@@ -7,7 +7,6 @@ from onyo.lib.commands import unset as unset_cmd
 from onyo.argparse_helpers import path
 from onyo.shared_arguments import (
     shared_arg_depth,
-    shared_arg_dry_run,
     shared_arg_filter,
     shared_arg_message,
 )
@@ -34,7 +33,6 @@ args_unset = {
         help='Asset(s) and/or directory(s) for which to unset values in'),
 
     'depth': shared_arg_depth,
-    'dry-run': shared_arg_dry_run,
     'filter': shared_arg_filter,
     'message': shared_arg_message,
 }
@@ -67,6 +65,5 @@ def unset(args: argparse.Namespace) -> None:
               paths,
               args.keys,
               args.filter,
-              args.dry_run,
               args.depth,
               message='\n\n'.join(m for m in args.message) if args.message else None)

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -860,7 +860,6 @@ def unset(repo: OnyoRepo,
           paths: Optional[Iterable[Path]],
           keys: list[str],
           filter_strings: list[str],
-          dryrun: bool,
           depth: Optional[int],
           message: Optional[str]) -> None:
     """Remove keys from assets.
@@ -879,9 +878,6 @@ def unset(repo: OnyoRepo,
 
     filter_strings: list of str
         TODO
-
-    dryrun: bool
-        TODO: will be removed
 
     depth: int
         TODO
@@ -924,7 +920,7 @@ def unset(repo: OnyoRepo,
         ui.print("No assets containing the specified key(s) could be found. No assets updated.")
         return
 
-    if diffs and not dryrun:
+    if diffs:
         if ui.request_user_response("Update assets? (y/n) "):
             to_commit = []
             for m in modifications:

--- a/onyo/lib/git.py
+++ b/onyo/lib/git.py
@@ -496,8 +496,7 @@ class GitRepo(object):
 
     def mv(self,
            source: Path | Iterable[Path],
-           destination: Path,
-           dryrun: bool = False) -> str:
+           destination: Path) -> str:
         """Call git-mv on paths provided by `source` and `destination`.
 
         Parameters
@@ -508,10 +507,6 @@ class GitRepo(object):
         destination: Path
             The absolute path of the destination to move `source` to.
 
-        dryrun: bool
-            To perform an interactive dry-run of the `git mv` without modifying
-            the repository.
-
         Returns
         -------
         str
@@ -521,16 +516,13 @@ class GitRepo(object):
             source = [source]
 
         mv_cmd = ['mv']
-        if dryrun:
-            mv_cmd.append('--dry-run')
         mv_cmd.extend([str(p) for p in source])
         mv_cmd.append(str(destination))
         return self._git(mv_cmd)
 
     def rm(self,
            paths: list[Path] | Path,
-           force: bool = False,
-           dryrun: bool = False) -> str:
+           force: bool = False) -> str:
         """Call `git rm` on `paths`.
 
         Parameters
@@ -541,10 +533,6 @@ class GitRepo(object):
         force: bool
             Run `git rm` with option `--force`.
 
-        dryrun: bool
-            To perform an interactive dry-run of the `git rm` without modifying
-            the repository.
-
         Returns
         -------
         str
@@ -553,8 +541,6 @@ class GitRepo(object):
         if not isinstance(paths, list):
             paths = [paths]
         rm_cmd = ["rm", "-r" + ('f' if force else '')]
-        if dryrun:
-            rm_cmd.append("--dry-run")
         rm_cmd.extend([str(p) for p in paths])
         return self._git(rm_cmd)
 

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -41,8 +41,7 @@ def build_parser(parser, args: dict):
     Add arguments to a parser.
     """
     for cmd in args:
-        # note: `--dry-run` must lead to args.dry_run, the underscore is needed
-        args[cmd]['dest'] = cmd if cmd != "dry-run" else cmd.replace("-", "_")
+        args[cmd]['dest'] = cmd
         try:
             parser.add_argument(
                 *args[cmd]['args'],

--- a/onyo/shared_arguments.py
+++ b/onyo/shared_arguments.py
@@ -8,13 +8,6 @@ shared_arg_depth = dict(
         'Descent up to DEPTH levels into directories specified. DEPTH=0 '
         'descends recursively without limit'))
 
-shared_arg_dry_run = dict(
-    args=('-n', '--dry-run'),
-    required=False,
-    default=False,
-    action='store_true',
-    help='Perform a non-interactive trial-run without making any changes')
-
 shared_arg_filter = dict(
     args=('-f', '--filter'),
     metavar='FILTER',


### PR DESCRIPTION
Removes `--dry-run` everywhere, including commands, main/shared_arguments, tests and docs.

The flag is out of date and mostly removed anyways -- this PR just removes the last references to it.