### PR TITLE
Fix order of asset validation/evaluation

### DIFF
--- a/onyo/commands/set.py
+++ b/onyo/commands/set.py
@@ -77,7 +77,11 @@ def set(args: argparse.Namespace) -> None:
 
     inventory = Inventory(repo=OnyoRepo(Path.cwd(), find_root=True))
     paths = [Path(p).resolve() for p in args.path] if args.path else None
-    assert len(args.keys) == 1
+    # TODO: The following check should be incorporated in the argparse Action.
+    #       IOW: This requires a variant of StoreKeyValuePairs, that does not
+    #       allow for key duplication (and can tell which keys are affected)
+    if len(args.keys) > 1:
+        raise ValueError("Keys must not be given multiple times.")
     onyo_set(inventory=inventory,
              paths=paths,
              keys=args.keys[0],

--- a/onyo/commands/tests/test_new.py
+++ b/onyo/commands/tests/test_new.py
@@ -372,7 +372,7 @@ def test_new_with_flags_edit_keys_template(repo: OnyoRepo, directory: str) -> No
                          capture_output=True, text=True)
 
     # verify output
-    assert "The following will be created:" in ret.stdout
+    assert "Effective changes:" in ret.stdout
     assert str(asset) in ret.stdout
     assert not ret.stderr
     assert ret.returncode == 0
@@ -490,7 +490,7 @@ def test_error_two_identical_assets_in_input(
 
     # verify correct error
     assert not ret.stdout
-    assert f"Multiple {asset_a}" in ret.stderr
+    assert asset_a in ret.stderr and "already exists" in ret.stderr
     assert ret.returncode == 1
 
     # verify that no new assets were created and the repository stays clean
@@ -594,7 +594,7 @@ def test_tsv_with_flags_template_keys_edit(repo: OnyoRepo) -> None:
                           '--template', template],
                          capture_output=True, text=True)
 
-    assert "The following will be created:" in ret.stdout
+    assert "Effective changes:" in ret.stdout
     assert not ret.stderr
     assert ret.returncode == 0
 
@@ -767,7 +767,7 @@ def test_tsv_error_identical_entries(repo: OnyoRepo) -> None:
 
     # verify correct error
     assert not ret.stdout
-    assert "Multiple" in ret.stderr
+    assert "already exists" in ret.stderr
     assert ret.returncode == 1
 
     # verify that no new assets were created and the repository is still clean

--- a/onyo/commands/tests/test_set.py
+++ b/onyo/commands/tests/test_set.py
@@ -588,3 +588,23 @@ def test_update_many_faux_serial_numbers(repo: OnyoRepo) -> None:
 
     # verify state of repo is clean
     assert repo.git.is_clean_worktree()
+
+
+@pytest.mark.repo_contents(assets[0])
+@pytest.mark.parametrize('asset', [asset_paths[0]])
+@pytest.mark.parametrize('set_values', values)
+def test_duplicate_keys(repo: OnyoRepo, asset: str, set_values: list[str]) -> None:
+    """
+    Test that `onyo set` fails, if the same key is given multiple times.
+    """
+
+    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', *set_values, 'dup_key=1', 'dup_key=2', '--path', asset],
+                         capture_output=True, text=True)
+
+    # verify output
+    assert ret.returncode == 1
+    assert "Keys must not be given multiple times." in ret.stderr
+    assert not ret.stdout
+
+    # verify state of repo is clean
+    assert repo.git.is_clean_worktree()

--- a/onyo/conftest.py
+++ b/onyo/conftest.py
@@ -107,7 +107,7 @@ def inventory(repo) -> Generator:
                               model="MODEL",
                               serial="SERIAL",
                               other=1,
-                              path=repo.git.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL")
+                              directory=repo.git.root / "somewhere" / "nested")
                         )
     inventory.add_directory(repo.git.root / 'empty')
     inventory.add_directory(repo.git.root / 'different' / 'place')

--- a/onyo/lib/assets.py
+++ b/onyo/lib/assets.py
@@ -3,13 +3,13 @@ import logging
 
 import re
 from pathlib import Path
-from typing import Dict, Generator, Iterable, Optional, Set
+from typing import Generator, Iterable, Optional, Set
 
 from ruamel.yaml import YAML, scanner  # pyre-ignore[21]
 
 from onyo.lib.ui import ui
 from onyo.lib.filters import Filter
-
+from onyo.lib.utils import get_asset_content
 
 log: logging.Logger = logging.getLogger('onyo.assets')
 
@@ -138,27 +138,6 @@ def get_asset_files_by_path(asset_files: list[Path],
         raise ValueError('No assets selected.')
 
     return assets
-
-
-def write_asset_file(asset_path: Path,
-                     asset_content: Dict[str, float | int | str]) -> None:
-    if asset_content == {}:
-        asset_path.open('w').write("")
-    else:
-        yaml = YAML(typ='rt')
-        yaml.dump(asset_content, asset_path)
-
-
-def get_asset_content(asset_file: Path) -> Dict[str, float | int | str]:
-    yaml = YAML(typ='rt', pure=True)
-    contents = dict()
-    try:
-        contents = yaml.load(asset_file)
-    except scanner.ScannerError as e:
-        ui.print(e)
-    if contents is None:
-        return dict()
-    return contents
 
 
 def get_assets_by_query(asset_files: list[Path],

--- a/onyo/lib/command_utils.py
+++ b/onyo/lib/command_utils.py
@@ -177,7 +177,7 @@ def unset(repo: OnyoRepo,
 
     from .assets import get_asset_files_by_path, PSEUDO_KEYS
     from .utils import get_asset_content
-    from .onyo import dict_to_yaml
+    from .utils import dict_to_yaml
     # set and unset should select assets exactly the same way
     assets_to_unset = get_asset_files_by_path(repo.asset_paths, paths, depth)
 

--- a/onyo/lib/command_utils.py
+++ b/onyo/lib/command_utils.py
@@ -175,7 +175,8 @@ def unset(repo: OnyoRepo,
           keys: list[str],
           depth: Optional[int]) -> list[Tuple[Path, Dict, Iterable]]:
 
-    from .assets import get_asset_files_by_path, PSEUDO_KEYS, get_asset_content
+    from .assets import get_asset_files_by_path, PSEUDO_KEYS
+    from .utils import get_asset_content
     from .onyo import dict_to_yaml
     # set and unset should select assets exactly the same way
     assets_to_unset = get_asset_files_by_path(repo.asset_paths, paths, depth)

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -862,8 +862,10 @@ def onyo_set(inventory: Inventory,
     filters = set_filters(filter_strings, repo=inventory.repo) if filter_strings else None
     # TODO: We are only interested in paths here. Factor that in for changing get_asset_by_query, when
     #       rewriting `onyo get`.
-    asset_paths_to_set = [p for p, _ in get_assets_by_query(
-        inventory.repo.asset_paths, keys=None, paths=paths, depth=depth, filters=filters)]
+    asset_paths_to_set = [p for p, _ in inventory.get_assets_by_query(keys=None,
+                                                                      paths=paths,
+                                                                      depth=depth,
+                                                                      filters=filters)]
 
     for path in asset_paths_to_set:
         asset = inventory.get_asset(path)

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -17,7 +17,7 @@ from onyo.lib.command_utils import sanitize_keys, set_filters, \
 from onyo.lib.exceptions import OnyoInvalidRepoError, NotAnAssetError, NoopError
 from onyo.lib.filters import UNSET_VALUE
 from onyo.lib.onyo import OnyoRepo
-from onyo.lib.utils import edit_asset, deduplicate
+from onyo.lib.utils import edit_asset, deduplicate, write_asset_file
 
 log: logging.Logger = logging.getLogger('onyo.commands')
 
@@ -898,7 +898,6 @@ def unset(repo: OnyoRepo,
         TODO
     """
     from onyo.lib.command_utils import unset as ut_unset
-    from .assets import write_asset_file
 
     if not paths:
         paths = [Path.cwd()]

--- a/onyo/lib/differs.py
+++ b/onyo/lib/differs.py
@@ -3,7 +3,9 @@ from pathlib import Path
 from difflib import unified_diff
 from typing import Generator
 
-from onyo.lib.onyo import dict_to_yaml, OnyoRepo
+from onyo.lib.onyo import OnyoRepo
+from onyo.lib.utils import dict_to_yaml
+
 
 # Differs signature: (repo: OnyoRepo, operands: tuple) -> Generator[str, None, None]:
 # yielded strings are supposed to be lines of a diff for a given operation

--- a/onyo/lib/filters.py
+++ b/onyo/lib/filters.py
@@ -75,7 +75,7 @@ class Filter:
                 return True
             return False
 
-        from onyo.lib.assets import get_asset_content
+        from onyo.lib.utils import get_asset_content
         data = get_asset_content(asset)
 
         # Check if filter is <unset> and there is no data

--- a/onyo/lib/inventory.py
+++ b/onyo/lib/inventory.py
@@ -443,7 +443,6 @@ class Inventory(object):
                             depth: Optional[int] = None,
                             filters: Optional[list[Filter]] = None) -> Generator:
         # filters + path/depth limit (TODO: turn into filters as well)
-        # self.repo.get_asset_paths(subtrees=, depth=)
 
         # Note: This is interested in the key-value pairs of assets, not their paths exactly.
         #       But tries to not read a file when pseudo keys are considered only.
@@ -452,10 +451,6 @@ class Inventory(object):
         """
         Get keys from assets matching paths and filters.
         """
-        # TODO: This won't be necessary anymore
-        from .filters import asset_name_to_keys
-        from .assets import PSEUDO_KEYS
-
         # filter assets by path and depth relative to paths
         asset_paths = self.repo.get_asset_paths(subtrees=paths, depth=depth)
 
@@ -471,12 +466,10 @@ class Inventory(object):
         if keys:
             assets = ((a, {
                 k: v
-                for k, v in (get_asset_content(a) | asset_name_to_keys(a, PSEUDO_KEYS)).items()
+                for k, v in self.get_asset(a).items()
                 if k in keys}) for a in asset_paths)
         else:
-            assets = ((a, {
-                k: v
-                for k, v in (get_asset_content(a) | asset_name_to_keys(a, PSEUDO_KEYS)).items()}) for a in asset_paths)
+            assets = ((a, self.get_asset(a)) for a in asset_paths)
 
         return assets
 

--- a/onyo/lib/inventory.py
+++ b/onyo/lib/inventory.py
@@ -371,7 +371,7 @@ class Inventory(object):
 
     def get_asset_from_template(self, template: str) -> Asset:
         # TODO: Possibly join with get_asset (path optional)
-        return Asset(self.repo.get_template(template))
+        return self.repo.get_template(template)
 
     def get_assets_by_query(self,
                             keys: Optional[Set[str]],

--- a/onyo/lib/inventory.py
+++ b/onyo/lib/inventory.py
@@ -49,7 +49,7 @@ from onyo.lib.exceptions import (
     NoopError,
     InvalidInventoryOperation,
 )
-from onyo.lib.utils import deduplicate, get_asset_content
+from onyo.lib.utils import deduplicate
 
 
 @dataclass

--- a/onyo/lib/inventory.py
+++ b/onyo/lib/inventory.py
@@ -48,7 +48,7 @@ from onyo.lib.exceptions import (
     NoopError,
     InvalidInventoryOperation,
 )
-from onyo.lib.utils import deduplicate
+from onyo.lib.utils import deduplicate, get_asset_content
 
 
 @dataclass
@@ -390,7 +390,7 @@ class Inventory(object):
         """
         # TODO: This won't be necessary anymore
         from .filters import asset_name_to_keys
-        from .assets import PSEUDO_KEYS, get_asset_content
+        from .assets import PSEUDO_KEYS
 
         # filter assets by path and depth relative to paths
         asset_paths = self.repo.get_asset_paths(subtrees=paths, depth=depth)

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -10,7 +10,7 @@ from typing import Iterable, List, Optional
 from .ui import ui
 from .git import GitRepo
 from .exceptions import OnyoInvalidRepoError, OnyoProtectedPathError
-from .utils import dict_to_yaml, yaml_to_dict, write_asset_file
+from .utils import yaml_to_dict, write_asset_file
 
 log: logging.Logger = logging.getLogger('onyo.onyo')
 
@@ -359,7 +359,6 @@ class OnyoRepo(object):
     def is_asset_path(self,
                       path: Path) -> bool:
         # TODO: check for .onyoignore
-        # TODO: possibly nested assets; hence "asset path", not "asset file"
         # TODO: We are currently ignoring .gitignore w/ underlying globbing
         # TODO: Only account for tracked files!
         return self.is_inventory_path(path) and \

--- a/onyo/lib/tests/test_Filter.py
+++ b/onyo/lib/tests/test_Filter.py
@@ -24,7 +24,7 @@ def test_filter(filt: str) -> None:
         elif asset.name == 'wheelchair_make_model.4':
             return {'foo': ''}
 
-    with mock.patch("onyo.lib.assets.get_asset_content", read_asset_mock):
+    with mock.patch("onyo.lib.utils.get_asset_content", read_asset_mock):
         f = Filter(filt)
         assert f.key == filt.split('=', 1)[0]
         assert f.value == filt.split('=', 1)[1]
@@ -52,7 +52,7 @@ def test_filter_match_type(filt: str) -> None:
         elif asset.name == 'type_make_model.2':
             return {'key': {'a': 'b', 'c': 'd'}}
 
-    with mock.patch("onyo.lib.assets.get_asset_content", read_asset_mock):
+    with mock.patch("onyo.lib.utils.get_asset_content", read_asset_mock):
         string_type = filt.split('=', 1)[1]
         f = Filter(filt)
         if string_type == '<list>':
@@ -77,7 +77,7 @@ def test_filter_invalid(filter_arg: str) -> None:
 
     def read_asset_mock(asset: Path):
         return {'foo': 'bar', 'key': 'value and more'}
-    with mock.patch("onyo.lib.assets.get_asset_content", read_asset_mock), \
+    with mock.patch("onyo.lib.utils.get_asset_content", read_asset_mock), \
             pytest.raises(OnyoInvalidFilterError) as exc:
         _ = Filter('key')
 

--- a/onyo/lib/tests/test_commands_new.py
+++ b/onyo/lib/tests/test_commands_new.py
@@ -136,7 +136,6 @@ def test_onyo_new_edit(inventory: Inventory, monkeypatch) -> None:
               'type': 'TYPE',
               'serial': 'totally_random'}]
     onyo_new(inventory, keys=specs, path=directory, edit=True)
-
     expected_path = directory / "TYPE_MAKER_MODEL.totally_random"
     assert inventory.repo.is_asset_path(expected_path)
     assert expected_path not in inventory.repo.git.files_untracked
@@ -145,6 +144,12 @@ def test_onyo_new_edit(inventory: Inventory, monkeypatch) -> None:
 
     # missing required fields:
     specs = [{'template': 'empty'}]
+
+    # Note, that when starting from an empty template, appending a
+    # "key: value" to the file doesn't work, b/c the empty YAML
+    # document is "{}" not "". Hence, appending would lead to a
+    # YAML parser error.
+    monkeypatch.setenv('EDITOR', "printf 'key: value' >")
     pytest.raises(ValueError, onyo_new, inventory, keys=specs, path=directory, edit=True)
 
     # file already exists:

--- a/onyo/lib/utils.py
+++ b/onyo/lib/utils.py
@@ -109,7 +109,7 @@ def get_temp_file() -> Path:
 
 def write_asset_file(path: Path,
                      asset: Dict[str, float | int | str | Path]) -> None:
-    content = None
+    content = dict()
     if path.exists():
         # For comment roundtrip mode, first read existing file content
         # to get ruamel.yaml's CommentedMap object and edit this rather


### PR DESCRIPTION
This is primarily addressing the order and places in which the generation of values in assets (like 'faux' serials and its actual name) and the validation of the resulting assets is happening.
For more details please check the commit messages.


Closes #457
Closes #455
Closes #443
Closes #437
Closes #435
Closes #424
Closes #417
Closes #413
Closes #412
Closes #411