### PR TITLE
BF: Fix rename operation records 

### DIFF
--- a/onyo/lib/differs.py
+++ b/onyo/lib/differs.py
@@ -59,7 +59,6 @@ def differ_move_assets(repo: OnyoRepo, operands: tuple) -> Generator[str, None, 
 
 def differ_move_directories(repo: OnyoRepo, operands: tuple) -> Generator[str, None, None]:
     yield from diff_path_change(operands[0], operands[1])
-    # TODO: Fuse w/ differ_move_asset
 
 
 def differ_rename_directories(repo: OnyoRepo, operands: tuple) -> Generator[str, None, None]:

--- a/onyo/lib/executors.py
+++ b/onyo/lib/executors.py
@@ -95,7 +95,6 @@ def exec_move_directories(repo: OnyoRepo, operands: tuple) -> tuple[list[Path], 
 
 def renamer(src: Path, dst: Path) -> list[Path]:
     # expected: full path as dst
-    # TODO: Fuse w/ mover() - distinction superfluous by now
     src.rename(dst)
     return [src, dst]
 

--- a/onyo/lib/recorders.py
+++ b/onyo/lib/recorders.py
@@ -19,7 +19,9 @@ from onyo.lib.onyo import OnyoRepo
 # While a recorder currently only ever returns a single snippet (line) for an operation,
 # the dict assumes a list in order to provide the option to deliver several.
 
-# TODO: Double-check we always report posix paths!
+# TODO: Most functions here account for asset being given as dict or Path.
+#       This is probably superfluous. Re-evaluate, when the `Inventory` class
+#       is reasonably stable.
 
 
 def record_item(repo: OnyoRepo, item: Path | dict) -> str:
@@ -28,11 +30,19 @@ def record_item(repo: OnyoRepo, item: Path | dict) -> str:
 
 
 def record_move(repo: OnyoRepo, src: Path | dict, dst: Path) -> str:
-    # Attention: This currently expects `dst` to be the dir to move src into,
-    # rather than already containing src' name at the destination. This may not be consistent yet.
+    # This currently expects `dst` to be the dir to move src into,
+    # rather than already containing src' name at the destination.
     src_path = src if isinstance(src, Path) else src['path']
     dst_path = (dst / src_path.name).relative_to(repo.git.root).as_posix()
     src_path = src_path.relative_to(repo.git.root).as_posix()
+    return f"- {src_path} -> {dst_path}{linesep}"
+
+
+def record_rename(repo: OnyoRepo, src: Path | dict, dst: Path) -> str:
+    # In opposition to record_move, this expects the full target path in `dst`
+    src_path = src if isinstance(src, Path) else src['path']
+    src_path = src_path.relative_to(repo.git.root).as_posix()
+    dst_path = dst.relative_to(repo.git.root).as_posix()
     return f"- {src_path} -> {dst_path}{linesep}"
 
 
@@ -61,7 +71,7 @@ def record_move_directories(repo: OnyoRepo, operands: tuple) -> dict[str, list[s
 
 
 def record_rename_directories(repo: OnyoRepo, operands: tuple) -> dict[str, list[str]]:
-    return {f"Renamed directories:{linesep}": [record_move(repo, operands[0], operands[1])]}
+    return {f"Renamed directories:{linesep}": [record_rename(repo, operands[0], operands[1])]}
 
 
 def record_rename_assets(repo: OnyoRepo, operands: tuple) -> dict[str, list[str]]:
@@ -71,7 +81,7 @@ def record_rename_assets(repo: OnyoRepo, operands: tuple) -> dict[str, list[str]
     # of asset depends on content and config. (Plus: We can't actually rename the same thing twice)
     #
     # This type of double recording may need to be done for other operations on asset dirs - double-check!
-    return {f"Renamed assets:{linesep}": [record_move(repo, operands[0], operands[1])]}
+    return {f"Renamed assets:{linesep}": [record_rename(repo, operands[0], operands[1])]}
 
 
 def record_modify_assets(repo: OnyoRepo, operands: tuple) -> dict[str, list[str]]:


### PR DESCRIPTION
Inventory operation records used wrong target path when a rename
operation was recorded. The basename of the target was repeated,
indicating a directory with the same name containing the target.
Reason was that the respective recorders used the same helper function
as move recorders. The latter did, however, expect the dir to move into
as argument.
Fixed by providing a dedicated helper for rename records.

Also fixed another bug, where only the basename was treated as target
path when renaming a directory. This behavior was changed for assets
already, but directories were missing that fix.

Closes #414