### PR TITLE
Enforce non-empty values for required keys

### DIFF
--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -119,7 +119,7 @@ def onyo_cat(inventory: Inventory,
     from .assets import validate_yaml
     non_asset_paths = [str(p) for p in paths if not inventory.repo.is_asset_path(p)]
     if non_asset_paths:
-        raise ValueError("The following paths are not asset files:\n%s",
+        raise ValueError("The following paths are not asset files:\n%s" %
                          "\n".join(non_asset_paths))
     # TODO: "Full" asset validation. Address when fsck is reworked
     assets_valid = validate_yaml(set(paths))
@@ -857,7 +857,7 @@ def onyo_set(inventory: Inventory,
                            if not inventory.repo.is_asset_path(p) and
                            not inventory.repo.is_inventory_dir(p)]
     if non_inventory_paths:
-        raise ValueError("The following paths are neither an inventory directory nor an asset:\n%s",
+        raise ValueError("The following paths are neither an inventory directory nor an asset:\n%s" %
                          "\n".join(non_inventory_paths))
     filters = set_filters(filter_strings, repo=inventory.repo) if filter_strings else None
     # TODO: We are only interested in paths here. Factor that in for changing get_asset_by_query, when
@@ -972,7 +972,7 @@ def unset(repo: OnyoRepo,
 
     non_inventory_paths = [str(p) for p in paths if not repo.is_asset_path(p) and not repo.is_inventory_dir(p)]
     if non_inventory_paths:
-        raise ValueError("The following paths are neither an inventory directory nor an asset:\n%s",
+        raise ValueError("The following paths are neither an inventory directory nor an asset:\n%s" %
                          "\n".join(non_inventory_paths))
 
     filters = set_filters(filter_strings, repo=repo) if filter_strings else None

--- a/onyo/lib/inventory.py
+++ b/onyo/lib/inventory.py
@@ -230,6 +230,8 @@ class Inventory(object):
             raise ValueError(f"{str(path)} is not a valid asset path.")
         if name in self._get_pending_asset_names() + [p.name for p in self.repo.asset_paths]:
             raise ValueError(f"Asset name '{name}' already exists in inventory")
+        if self._required_key_empty(asset):
+            raise ValueError("Required asset keys must not have empty values.")
 
         if asset.get('is_asset_directory', False):
             if self.repo.is_inventory_dir(path):
@@ -342,6 +344,8 @@ class Inventory(object):
                 raise ValueError(f"{str(new_asset['path'])} is not a valid asset path.")
             if name in self._get_pending_asset_names() + [p.name for p in self.repo.asset_paths]:
                 raise ValueError(f"Asset name '{name}' already exists in inventory")
+        if self._required_key_empty(new_asset):
+            raise ValueError("Required asset keys must not have empty values.")
 
         if asset == new_asset:
             raise NoopError
@@ -547,3 +551,10 @@ class Inventory(object):
                 faux_serials.add(f'faux{serial}')
 
         return faux_serials
+
+    def _required_key_empty(self, asset: dict) -> bool:
+        """Whether `asset` has an empty value for a required key.
+
+        Validation helper.
+        """
+        return any(not str(v) for k, v in asset.items() if k in self.repo.get_required_asset_keys())

--- a/onyo/lib/tests/test_inventory_operations.py
+++ b/onyo/lib/tests/test_inventory_operations.py
@@ -78,6 +78,10 @@ def test_add_asset(repo: OnyoRepo) -> None:
     assert asset_from_disc == {k: v for k, v in asset.items() if k not in RESERVED_KEYS + NEW_PSEUDO_KEYS}
     # TODO: check commit message
 
+    # required keys must not be empty
+    asset.update(dict(model=""))
+    pytest.raises(ValueError, inventory.add_asset, asset)
+
     # To be added Asset requires a path:
     asset = Asset(a_key='a_value')
     pytest.raises(ValueError, inventory.add_asset, asset)
@@ -216,10 +220,15 @@ def test_modify_asset(repo: OnyoRepo) -> None:
     inventory.commit("First asset added")
 
     asset_changes = Asset(some_key="new_value",  # arbitrary content change
-                          model="CORRECTED-MODEL"  # implies rename w/ default name config
+                          model=""  # empty required key
                           )
     new_asset = asset.copy()
     new_asset.update(asset_changes)
+
+    # required keys must not be empty
+    pytest.raises(ValueError, inventory.add_asset, asset)
+
+    new_asset.update(dict(model="CORRECTED-MODEL"))  # implies rename w/ default name config
 
     # illegal to define 'path' in `new_asset`:
     pytest.raises(ValueError, inventory.modify_asset, asset, new_asset)


### PR DESCRIPTION
Asset validation for new_assets and modify_assets operations now fail,
when a required key has an empty value.

Closes #481