### PR TITLE
Rework `GitRepo` and `OnyoRepo`

### DIFF
--- a/onyo/commands/tests/test_edit.py
+++ b/onyo/commands/tests/test_edit.py
@@ -21,7 +21,7 @@ def test_get_editor_git(repo: OnyoRepo, variant: str) -> None:
     """
     Get the editor from git or onyo configs.
     """
-    repo.git.set_config('onyo.core.editor', variant, location=variant)
+    repo.set_config('onyo.core.editor', variant, location=variant)
 
     # test
     editor = repo.get_editor()
@@ -60,8 +60,8 @@ def test_get_editor_precedence(repo: OnyoRepo) -> None:
     The order of precedence should be git > onyo > $EDITOR.
     """
     # set locations
-    repo.git.set_config('onyo.core.editor', 'local', location='local')
-    repo.git.set_config('onyo.core.editor', 'onyo', location='onyo')
+    repo.set_config('onyo.core.editor', 'local', location='local')
+    repo.set_config('onyo.core.editor', 'onyo', location='onyo')
     os.environ['EDITOR'] = 'editor'
 
     # git should win

--- a/onyo/commands/tests/test_history.py
+++ b/onyo/commands/tests/test_history.py
@@ -96,8 +96,8 @@ def test_history_config_unset(repo: OnyoRepo) -> None:
     """
     # unset config for history tool
     repo.git.set_config('onyo.history.non-interactive', '')
-    repo.git.stage_and_commit(paths=repo.dot_onyo / 'config',
-                              message="Unset in .onyo/config: 'onyo.history.non-interactive'")
+    repo.git.commit(paths=repo.dot_onyo / 'config',
+                    message="Unset in .onyo/config: 'onyo.history.non-interactive'")
 
     # verify unset
     assert not repo.get_config('onyo.history.non-interactive')
@@ -119,8 +119,8 @@ def test_history_config_invalid(repo: OnyoRepo) -> None:
     """
     # set to invalid
     repo.git.set_config('onyo.history.non-interactive', 'does-not-exist-in-path')
-    repo.git.stage_and_commit(paths=repo.dot_onyo / 'config',
-                              message="Set non-existing: 'onyo.history.non-interactive'")
+    repo.git.commit(paths=repo.dot_onyo / 'config',
+                    message="Set non-existing: 'onyo.history.non-interactive'")
 
     # run history
     ret = subprocess.run(['onyo', 'history', '-I', assets[0]],
@@ -139,8 +139,8 @@ def test_history_fake_noninteractive_stdout(repo: OnyoRepo, asset: str) -> None:
     run commands different from the default options.
     """
     repo.git.set_config('onyo.history.non-interactive', '/usr/bin/env printf')
-    repo.git.stage_and_commit(paths=repo.dot_onyo / 'config',
-                              message="Update config: 'onyo.history.non-interactive'")
+    repo.git.commit(paths=repo.dot_onyo / 'config',
+                    message="Update config: 'onyo.history.non-interactive'")
 
     # test
     ret = subprocess.run(['onyo', 'history', '-I', asset],
@@ -159,8 +159,8 @@ def test_history_fake_noninteractive_stderr(repo: OnyoRepo, asset: str) -> None:
     stderr instead of stdout.
     """
     repo.git.set_config('onyo.history.non-interactive', '/usr/bin/env printf >&2')
-    repo.git.stage_and_commit(paths=repo.dot_onyo / 'config',
-                              message="Update config: 'onyo.history.non-interactive'")
+    repo.git.commit(paths=repo.dot_onyo / 'config',
+                    message="Update config: 'onyo.history.non-interactive'")
 
     # test
     ret = subprocess.run(['onyo', 'history', '-I', asset],
@@ -184,8 +184,8 @@ def test_history_fake_noninteractive_bubble_exit_code(repo: OnyoRepo, variant: d
     tools configured return.
     """
     repo.git.set_config('onyo.history.non-interactive', variant['cmd'])
-    repo.git.stage_and_commit(paths=repo.dot_onyo / 'config',
-                              message="Update config: 'onyo.history.non-interactive'")
+    repo.git.commit(paths=repo.dot_onyo / 'config',
+                    message="Update config: 'onyo.history.non-interactive'")
 
     # test
     ret = subprocess.run(['onyo', 'history', '-I', assets[0]],

--- a/onyo/commands/tests/test_history.py
+++ b/onyo/commands/tests/test_history.py
@@ -95,7 +95,7 @@ def test_history_config_unset(repo: OnyoRepo) -> None:
     Test that `onyo history` errors when no tool is configured.
     """
     # unset config for history tool
-    repo.git.set_config('onyo.history.non-interactive', '')
+    repo.set_config('onyo.history.non-interactive', '')
     repo.git.commit(paths=repo.dot_onyo / 'config',
                     message="Unset in .onyo/config: 'onyo.history.non-interactive'")
 
@@ -118,7 +118,7 @@ def test_history_config_invalid(repo: OnyoRepo) -> None:
     not exist.
     """
     # set to invalid
-    repo.git.set_config('onyo.history.non-interactive', 'does-not-exist-in-path')
+    repo.set_config('onyo.history.non-interactive', 'does-not-exist-in-path')
     repo.git.commit(paths=repo.dot_onyo / 'config',
                     message="Set non-existing: 'onyo.history.non-interactive'")
 
@@ -138,7 +138,7 @@ def test_history_fake_noninteractive_stdout(repo: OnyoRepo, asset: str) -> None:
     Test that the history tool can be reconfigured, so that `onyo history` can
     run commands different from the default options.
     """
-    repo.git.set_config('onyo.history.non-interactive', '/usr/bin/env printf')
+    repo.set_config('onyo.history.non-interactive', '/usr/bin/env printf')
     repo.git.commit(paths=repo.dot_onyo / 'config',
                     message="Update config: 'onyo.history.non-interactive'")
 
@@ -158,7 +158,7 @@ def test_history_fake_noninteractive_stderr(repo: OnyoRepo, asset: str) -> None:
     Test that the history tool can be so reconfigured, that it prints into
     stderr instead of stdout.
     """
-    repo.git.set_config('onyo.history.non-interactive', '/usr/bin/env printf >&2')
+    repo.set_config('onyo.history.non-interactive', '/usr/bin/env printf >&2')
     repo.git.commit(paths=repo.dot_onyo / 'config',
                     message="Update config: 'onyo.history.non-interactive'")
 
@@ -183,7 +183,7 @@ def test_history_fake_noninteractive_bubble_exit_code(repo: OnyoRepo, variant: d
     Test that `onyo history` does bubble up the different exit codes that the
     tools configured return.
     """
-    repo.git.set_config('onyo.history.non-interactive', variant['cmd'])
+    repo.set_config('onyo.history.non-interactive', variant['cmd'])
     repo.git.commit(paths=repo.dot_onyo / 'config',
                     message="Update config: 'onyo.history.non-interactive'")
 

--- a/onyo/commands/tests/test_history.py
+++ b/onyo/commands/tests/test_history.py
@@ -96,8 +96,8 @@ def test_history_config_unset(repo: OnyoRepo) -> None:
     """
     # unset config for history tool
     repo.set_config('onyo.history.non-interactive', '')
-    repo.git.commit(paths=repo.dot_onyo / 'config',
-                    message="Unset in .onyo/config: 'onyo.history.non-interactive'")
+    repo.commit(paths=repo.dot_onyo / 'config',
+                message="Unset in .onyo/config: 'onyo.history.non-interactive'")
 
     # verify unset
     assert not repo.get_config('onyo.history.non-interactive')
@@ -119,8 +119,8 @@ def test_history_config_invalid(repo: OnyoRepo) -> None:
     """
     # set to invalid
     repo.set_config('onyo.history.non-interactive', 'does-not-exist-in-path')
-    repo.git.commit(paths=repo.dot_onyo / 'config',
-                    message="Set non-existing: 'onyo.history.non-interactive'")
+    repo.commit(paths=repo.dot_onyo / 'config',
+                message="Set non-existing: 'onyo.history.non-interactive'")
 
     # run history
     ret = subprocess.run(['onyo', 'history', '-I', assets[0]],
@@ -139,8 +139,8 @@ def test_history_fake_noninteractive_stdout(repo: OnyoRepo, asset: str) -> None:
     run commands different from the default options.
     """
     repo.set_config('onyo.history.non-interactive', '/usr/bin/env printf')
-    repo.git.commit(paths=repo.dot_onyo / 'config',
-                    message="Update config: 'onyo.history.non-interactive'")
+    repo.commit(paths=repo.dot_onyo / 'config',
+                message="Update config: 'onyo.history.non-interactive'")
 
     # test
     ret = subprocess.run(['onyo', 'history', '-I', asset],
@@ -159,8 +159,8 @@ def test_history_fake_noninteractive_stderr(repo: OnyoRepo, asset: str) -> None:
     stderr instead of stdout.
     """
     repo.set_config('onyo.history.non-interactive', '/usr/bin/env printf >&2')
-    repo.git.commit(paths=repo.dot_onyo / 'config',
-                    message="Update config: 'onyo.history.non-interactive'")
+    repo.commit(paths=repo.dot_onyo / 'config',
+                message="Update config: 'onyo.history.non-interactive'")
 
     # test
     ret = subprocess.run(['onyo', 'history', '-I', asset],
@@ -184,8 +184,8 @@ def test_history_fake_noninteractive_bubble_exit_code(repo: OnyoRepo, variant: d
     tools configured return.
     """
     repo.set_config('onyo.history.non-interactive', variant['cmd'])
-    repo.git.commit(paths=repo.dot_onyo / 'config',
-                    message="Update config: 'onyo.history.non-interactive'")
+    repo.commit(paths=repo.dot_onyo / 'config',
+                message="Update config: 'onyo.history.non-interactive'")
 
     # test
     ret = subprocess.run(['onyo', 'history', '-I', assets[0]],

--- a/onyo/conftest.py
+++ b/onyo/conftest.py
@@ -74,8 +74,8 @@ def repo(tmp_path: Path, monkeypatch, request) -> Generator[OnyoRepo, None, None
     # populate the repo
     if dirs:
         anchors = repo_.mk_inventory_dirs([repo_path / d for d in dirs])
-        repo_.git.stage_and_commit(paths=anchors,
-                                   message="populate dirs for tests")
+        repo_.git.commit(paths=anchors,
+                         message="populate dirs for tests")
 
     for i in files:
         i.touch()
@@ -84,8 +84,8 @@ def repo(tmp_path: Path, monkeypatch, request) -> Generator[OnyoRepo, None, None
         if contents:
             for file in contents:
                 (repo_path / file[0]).write_text(file[1])
-        repo_.git.stage_and_commit(paths=files,
-                                   message="populate files for tests")
+        repo_.git.commit(paths=files,
+                         message="populate files for tests")
 
     # TODO: Do we still need/want that? CWD should only ever be relevant for CLI tests.
     #       Hence, should probably be done there.

--- a/onyo/conftest.py
+++ b/onyo/conftest.py
@@ -114,8 +114,8 @@ def repo(tmp_path: Path, monkeypatch, request) -> Generator[OnyoRepo, None, None
     # populate the repo
     if dirs:
         anchors = repo_.mk_inventory_dirs([repo_path / d for d in dirs])
-        repo_.git.commit(paths=anchors,
-                         message="populate dirs for tests")
+        repo_.commit(paths=anchors,
+                     message="populate dirs for tests")
 
     for i in files:
         i.touch()
@@ -124,8 +124,8 @@ def repo(tmp_path: Path, monkeypatch, request) -> Generator[OnyoRepo, None, None
         if contents:
             for file in contents:
                 (repo_path / file[0]).write_text(file[1])
-        repo_.git.commit(paths=files,
-                         message="populate files for tests")
+        repo_.commit(paths=files,
+                     message="populate files for tests")
 
     # TODO: Do we still need/want that? CWD should only ever be relevant for CLI tests.
     #       Hence, should probably be done there.

--- a/onyo/lib/assets.py
+++ b/onyo/lib/assets.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Iterable, Optional, Set
+from typing import Set
 
 from ruamel.yaml import YAML, scanner  # pyre-ignore[21]
 
@@ -89,33 +89,6 @@ def validate_yaml(asset_files: Set[Path]) -> bool:
         return False
 
     return True
-
-
-def get_asset_files_by_path(asset_files: list[Path],
-                            paths: Iterable[Path],
-                            depth: Optional[int]) -> list[Path]:
-    """
-    Check and normalize a list of paths. Select all assets in the
-    repository that are relative to the given `paths` descending at most
-    `depth` directories. A `depth` of 0 descends without a limit.
-    """
-    if depth and depth < 0:
-        raise ValueError(f"depth values must be positive, but is {depth}.")
-
-    paths = {Path(p) for p in paths}
-    assets = [
-        a for a in asset_files if any([
-            a.is_relative_to(p) and
-            (len(a.parents) - len(p.parents) <= depth if depth else True)
-            for p in paths])]
-
-    # Note: Why does this function need to raise instead of returning an empty list?
-    #       The query yielded no matching asset. That's a valid response. What to do with that should be up to the
-    #       caller.
-    if not assets:
-        raise ValueError('No assets selected.')
-
-    return assets
 
 
 # The idea of an Asset class is currently abandoned. If not re-introduced, can go entirely.

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -158,8 +158,8 @@ def onyo_config(inventory: Inventory,
         # It's a write operation, and we'd want to commit
         # if there were any changes.
         try:
-            inventory.repo.git.commit(inventory.repo.ONYO_CONFIG,
-                                      'config: modify repository config')
+            inventory.repo.commit(inventory.repo.ONYO_CONFIG,
+                                  'config: modify repository config')
         except subprocess.CalledProcessError as e:
             if "no changes added to commit" in e.stdout or "nothing to commit" in e.stdout:
                 ui.print("No changes to commit.")

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -64,6 +64,8 @@ def fsck(repo: OnyoRepo,
     from .assets import has_unique_names, validate_yaml, validate_assets, contains_no_name_keys
 
     all_tests = {
+        # TODO: fsck would probably want to relay or analyze `git-status` output, rather
+        # than just get a bool for clean worktree:
         "clean-tree": repo.git.is_clean_worktree,
         "anchors": repo.validate_anchors,
         "asset-unique": partial(has_unique_names, repo.asset_paths),
@@ -156,8 +158,8 @@ def onyo_config(inventory: Inventory,
         # It's a write operation, and we'd want to commit
         # if there were any changes.
         try:
-            inventory.repo.git.stage_and_commit(inventory.repo.ONYO_CONFIG,
-                                                'config: modify repository config')
+            inventory.repo.git.commit(inventory.repo.ONYO_CONFIG,
+                                      'config: modify repository config')
         except subprocess.CalledProcessError as e:
             if "no changes added to commit" in e.stdout or "nothing to commit" in e.stdout:
                 ui.print("No changes to commit.")

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -128,7 +128,7 @@ def onyo_cat(inventory: Inventory,
         #       `dict_to_yaml(inventory.repo.get_asset_content(path))` - no need to
         #       distinguish asset and asset dir at this level. However, need to
         #       make sure to not print pointless empty lines.
-        f = path / OnyoRepo.ASSET_DIR_FILE if inventory.repo.is_asset_dir(path) else path
+        f = path / OnyoRepo.ASSET_DIR_FILE_NAME if inventory.repo.is_asset_dir(path) else path
         ui.print(f.read_text(), end='')
     if not assets_valid:
         raise OnyoInvalidRepoError("Invalid assets")

--- a/onyo/lib/executors.py
+++ b/onyo/lib/executors.py
@@ -48,9 +48,9 @@ def exec_remove_assets(repo: OnyoRepo, operands: tuple) -> tuple[list[Path], lis
     p = operands[0] if isinstance(operands[0], Path) else operands[0].get('path')
     paths = []
     if p.is_dir():
-        paths.append(p / OnyoRepo.ANCHOR_FILE)
+        paths.append(p / OnyoRepo.ANCHOR_FILE_NAME)
         # we were told p is an asset. It's also a dir, ergo an asset dir
-        paths.append(p / OnyoRepo.ASSET_DIR_FILE)
+        paths.append(p / OnyoRepo.ASSET_DIR_FILE_NAME)
     else:
         paths = [p]
     for p in paths:
@@ -64,12 +64,12 @@ def exec_remove_directories(repo: OnyoRepo, operands: tuple) -> tuple[list[Path]
     p = operands[0]
     is_asset_dir = repo.is_asset_dir(p)  # required after dir was removed, therefore store
     asset = dict()
-    anchor = p / repo.ANCHOR_FILE
+    anchor = p / repo.ANCHOR_FILE_NAME
     anchor.unlink()
     paths.append(anchor)
     if is_asset_dir:
         asset = repo.get_asset_content(p)
-        asset_dir_file = p / repo.ASSET_DIR_FILE
+        asset_dir_file = p / repo.ASSET_DIR_FILE_NAME
         asset_dir_file.unlink()
         paths.append(asset_dir_file)
     p.rmdir()

--- a/onyo/lib/executors.py
+++ b/onyo/lib/executors.py
@@ -48,7 +48,6 @@ def exec_remove_assets(repo: OnyoRepo, operands: tuple) -> tuple[list[Path], lis
     p = operands[0] if isinstance(operands[0], Path) else operands[0].get('path')
     paths = []
     if p.is_dir():
-        paths.append(p / OnyoRepo.ANCHOR_FILE_NAME)
         # we were told p is an asset. It's also a dir, ergo an asset dir
         paths.append(p / OnyoRepo.ASSET_DIR_FILE_NAME)
     else:

--- a/onyo/lib/git.py
+++ b/onyo/lib/git.py
@@ -10,18 +10,19 @@ log: logging.Logger = logging.getLogger('onyo.git')
 
 
 class GitRepo(object):
-    """
-    An object to get and set git information, and to call git functions with.
+    """Representation of a git repository.
+
+    This relies on subprocesses running on a git worktree.
+    Does not currently support bare repositories.
 
     Attributes
     ----------
     root: Path
-        The absolute path to the directory of the git worktree root.
+      The absolute path to the root of the git worktree.
     files: list of Path
-        A property containing the absolute Path to all files saved in git.
-        This property is cached and consistent when only the public functions of
-        GitRepo are called. Usage of private or external functions might
-        require a manual reset of the cache with `GitRepo.clear_caches()`.
+      A property containing the absolute paths to all files tracked by git.
+      This property is cached. Usage of private or external functions might
+      require a manual reset via `GitRepo.get_subtree.cache_clear()`.
     """
 
     def __init__(self,
@@ -32,14 +33,12 @@ class GitRepo(object):
         Parameters
         ----------
         path: Path
-            An absolute path to the root of a git repository.
-
+          An absolute path to the root of a git repository.
         find_root: bool
-            `find_root=True` allows to search the root of a git worktree from a
-            sub-directory, beginning at `path`, instead of requiring the root.
+          `find_root=True` allows to search the root of a git worktree from a
+          subdirectory, beginning at `path`, instead of requiring the root.
         """
         self.root = GitRepo.find_root(path) if find_root else path.resolve()
-
         self._files: Optional[list[Path]] = None
 
     @staticmethod
@@ -49,21 +48,19 @@ class GitRepo(object):
         Parameters
         ----------
         path: Path
-            The path to identify the git worktree root for. This can be any
-            sub-directory of the repository, or the root directory itself.
+          The path to identify the git worktree root for. This can be any
+          subdirectory of the repository, or the root directory itself.
 
         Returns
         -------
         Path
-            An absolute path to the root of the git worktree where `.git/` is
-            located.
+          An absolute path to the root of the git worktree.
 
         Raises
         ------
         OnyoInvalidRepoError
             If `path` is not inside a git repository at all.
         """
-        root = None
         try:
             ret = subprocess.run(["git", "rev-parse", "--show-toplevel"],
                                  cwd=path, check=True,
@@ -77,30 +74,26 @@ class GitRepo(object):
              args: list[str], *,
              cwd: Optional[Path] = None,
              raise_error: bool = True) -> str:
-        """A wrapper function for git calls that runs commands from the root
-        directory and returns the output of commands.
+        """A wrapper function for git calls, returning the output of commands.
 
         Parameters
         ----------
         args: list of str
-            Arguments to specify the git call to run, e.g. args=['add', <file>]
-            leads to a system call `git add <file>` from the root of git.
-
+          Arguments to specify the git call to run, e.g. args=['add', <file>]
+          leads to a system call `git add <file>`.
         cwd: Path, optional
-            Run git commands from `cwd` instead of the root of the repository.
-
+          Run git commands from `cwd`. Default: `self.root`.
         raise_error: bool
-            Specify if `subprocess.run()` is allowed to raise errors.
+          Whether to raise `subprocess.CalledProcessError` if the command
+          returned with non-zero exitcode.
 
         Returns
         -------
         str
-            Return the standard output from running the git command.
+          Standard output of the git command.
         """
-        if cwd is None:
-            cwd = self.root
-
-        ui.log_debug(f"Running 'git {args}'")
+        cwd = cwd or self.root
+        ui.log_debug(f"Running 'git {' '.join(args)}'")
         ret = subprocess.run(["git"] + args,
                              cwd=cwd, check=raise_error,
                              capture_output=True, text=True)
@@ -110,41 +103,36 @@ class GitRepo(object):
     def files(self) -> list[Path]:
         """Get the absolute `Path`s of all tracked files.
 
-        This property is cached, and the cache is consistent with the state of
-        the repository when only `Repo`s public functions are used. Use of
-        private functions might require a manual reset of the caches, see
-        `GitRepo.clear_caches()`.
+        This property is cached. The cache is reset on `GitRepo.commit()`.
+        If changes are made by different means, `GitRepo.clear_caches()`
+        is available to reset the cache.
         """
         if not self._files:
             self._files = self.get_subtrees()
         return self._files
 
-    def clear_caches(self,
-                     files: bool = True) -> None:
-        """Clear caches of the instance of the GitRepo object.
+    def clear_cache(self) -> None:
+        """Clear the `files` cache of this instance of GitRepo.
 
-        Paths to files in git are cached, and can become stale when the
-        repository contents are modified. By default, this function clears the
-        cache of all properties of the GitRepo.
-
-        If the repository is exclusively modified via public API functions, the
-        caches of the `GitRepo` object are consistent. If the repository is
-        modified otherwise, this function clears the caches to ensure that the
-        caches do not contain stale information.
-
-        Parameters
-        ----------
-        files: bool
-            Whether to reset the file cache.
+        Needed if changes to the repository are made by other means
+        than `GitRepo.commit()`
         """
-        if files:
-            self._files = None
+        self._files = None
 
     def get_subtrees(self,
                      paths: Optional[Iterable[Path]] = None) -> list[Path]:
-        """"""
-        # TODO: - We might want to consider untracked files as well. Would need `--others` in addition.
-        #       - turn into issue
+        """Get tracked files in the subtrees rooted at `paths`.
+
+        Parameters
+        ----------
+        paths: Iterable of Path
+          Roots of subtrees to consider. The entire worktree by default.
+
+        Returns
+        -------
+        list of Path
+          Absolute paths to all tracked files within the given subtrees.
+        """
         ui.log_debug("Looking up tracked files%s",
                      f" underneath {', '.join([str(p) for p in paths])}" if paths else "")
         git_cmd = ['ls-files', '-z']
@@ -159,31 +147,25 @@ class GitRepo(object):
         Returns
         -------
         bool
-            True if the git worktree is clean, otherwise False.
+          True if the git worktree is clean, otherwise False.
         """
         return not bool(self._git(['status', '--porcelain']))
 
-    def maybe_init(self,
-                   target_dir: Path) -> None:
-        """Initialize a directory as a git repository if it is not already one.
-
-        Parameters
-        ----------
-        target_dir: Path
-            A path to initialize as a git repository.
+    def maybe_init(self) -> None:
+        """Initialize `self.root` as a git repository
+        if it is not already one.
         """
         # Note: Why? git-init would do that
         # create target if it doesn't already exist
-        target_dir.mkdir(exist_ok=True)
+        self.root.mkdir(exist_ok=True)
 
         # git init (if needed)
-        if (target_dir / '.git').exists():
-            log.info(f"'{target_dir}' is already a git repository.")
+        if (self.root / '.git').exists():
+            log.info(f"'{self.root}' is already a git repository.")
         else:
-            ret = self._git(['init'], cwd=target_dir)
+            ret = self._git(['init'])
             # Note: What is it about capturing output everywhere only to spit it out again?
             ui.log_debug(ret.strip())
-        self.root = target_dir
 
     def commit(self,
                paths: Iterable[Path] | Path,
@@ -193,32 +175,36 @@ class GitRepo(object):
         Parameters
         ----------
         paths: Path or Iterable of Path
-            List of paths to files or directories for which to commit changes to
-            git.
-
+          List of paths to commit.
         message: str
-            Specify the git commit message.
+          The git commit message.
         """
         if isinstance(paths, Path):
             paths = [paths]
         self._git(['add'] + [str(p) for p in paths])
         self._git(['commit', '-m', message])
-        self.clear_caches()
+        self.clear_cache()
 
     @staticmethod
     def is_git_path(path: Path) -> bool:
-        """Identifies if a path is a git file or directory, e.g.
-        `.git/*`, `.gitignore`, `.gitattributes`, `.gitmodules`, etc.
+        """Whether `path` is a git file or directory.
+
+        A 'git path' is considered a path that is used by git
+        itself (tracked or not) and therefore not valid for use
+        by onyo, e.g. `.git/*`, `.gitignore`, `gitattributes`,
+        `.gitmodules`, etc.
+        Any path underneath a directory called `.git` and any
+        basename starting with `.git` returns False.
 
         Parameters
         ----------
         path: Path
-            The path to identify if it is a git file or directory, or if not.
+          The path to check.
 
         Returns
         -------
         bool
-            True if path is a git file or directory, otherwise False.
+          True if path is a git file or directory, otherwise False.
         """
         return '.git' in path.parts or path.name.startswith('.git')
 
@@ -227,8 +213,8 @@ class GitRepo(object):
                    file_: Optional[Path] = None) -> Optional[str]:
         """Get the value for a configuration option specified by `name`.
 
-        By default, git-config is checked following its order of precedence (worktree,
-        local, global, system). If a `file_` is given, this is checked instead.
+        By default, git-config is read following its order of precedence (worktree,
+        local, global, system). If a `file_` is given, this is read instead.
 
         Parameters:
         -----------
@@ -243,7 +229,7 @@ class GitRepo(object):
         Returns
         -------
         str or None
-          the config value on success. None otherwise.
+          The config value if it exists. None otherwise.
         """
         # TODO: lru_cache?
         # TODO: Not sure whether to stick with `file_` being alternative rather than fallback.
@@ -268,70 +254,62 @@ class GitRepo(object):
     def set_config(self,
                    name: str,
                    value: str,
-                   location: str = 'onyo') -> bool:
+                   location: Optional[str | Path] = None) -> None:
         """Set the configuration option `name` to `value`.
 
         Parameters
         ----------
         name: str
-            The name of the configuration option to set.
-
+          The name of the configuration option to set.
         value: str
-            The value to set for the configuration option.
-
-        location: str
-            The location of the configuration for which the value should be set.
-            Defaults to `onyo`. Other git config locations are: `system`,
-            `global`, `local`, and `worktree`.
-
-        Returns
-        -------
-        bool
-            True on success, otherwise raises an exception.
+          The value to set for the configuration option.
+        location: Path or str, optional
+          The location of the configuration for which the value should
+          be set. If a `Path`: config file to read, otherwise standard
+          Git config locations: 'system', 'global', 'local',
+          and 'worktree'. `None` means ``git-config``
+          default behavior ('local'). Default: `None`.
 
         Raises
         ------
         ValueError
-            If the config file was not found to set the value in.
+          If `location` is unknown.
         """
         location_options = {
-            'onyo': ['--file', str(self.root / '.onyo/config')],
             'system': ['--system'],
             'global': ['--global'],
             'local': ['--local'],
-            'worktree': ['--worktree']
+            'worktree': ['--worktree'],
+            None: []  # Just go with Git's default behavior
         }
-        location_arg = []
-
         try:
-            location_arg = location_options[location]
+            location_arg = ['--file', str(location)] if isinstance(location, Path) \
+                else location_options[location]
         except KeyError as e:
             raise ValueError("Invalid config location requested. Valid options are: {}"
-                             "".format(', '.join(location_options.keys()))) from e
+                             "".format(', '.join(str(location_options.keys())))) from e
 
-        # git-config (with its full stack of locations to check)
-        self._git(['config'] + location_arg + [name, value]).strip()
+        self._git(['config'] + location_arg + [name, value])
         ui.log_debug(f"'config for '{location}' set '{name}': '{value}'")
-
-        return True
 
     # Credit: Datalad
     def get_hexsha(self,
                    commitish: Optional[str] = None,
                    short: bool = False) -> Optional[str]:
-        """Return a hexsha for a given commit-ish.
+        """Return the hexsha of a given commit-ish.
 
         Parameters
         ----------
         commitish: str, optional
-            Any identifier that refers to a commit (defaults to "HEAD").
+          Any identifier that refers to a commit (defaults to "HEAD").
         short: bool
-            Whether to return the abbreviated form of the hexsha.
+          Whether to return the abbreviated form of the hexsha.
 
         Returns
         -------
         str or None
-            Returns string if no commitish was given and there are no commits yet, None.
+          Hexsha of commitish. None, if querying the mother of all commits,
+          i.e. 'HEAD' of an empty repository.
 
         Raises
         ------
@@ -367,3 +345,40 @@ class GitRepo(object):
             the commit message including the subject line.
         """
         return self._git(['log', commitish or 'HEAD', '-n1', '--pretty=%B'])
+
+    def check_ignore(self, ignore: Path, paths: list[Path]) -> list[Path]:
+        """Get the `paths` that are matched by patterns defined in `ignore`.
+
+        This is utilizing ``git-check-ignore`` to evaluate `paths` against
+        a file `ignore`, that defines exclude patterns the gitignore-way.
+
+        Parameters
+        ----------
+        ignore: Path
+          Path to a file containing exclude patterns to evaluate.
+        paths: list of Path
+          Paths to check against the patterns in `ignore`.
+
+        Returns
+        -------
+        list of Path
+          Paths in `paths` that are excluded by the patterns in `ignore`.
+        """
+        try:
+            output = self._git(['-c', f'core.excludesFile={str(ignore)}', 'check-ignore', '--no-index', '--verbose'] +
+                               [str(p) for p in paths])
+        except subprocess.CalledProcessError as e:
+            if e.returncode == 1:
+                # None of `paths` was ignored. That's fine.
+                return []
+            raise  # reraise on unexpected error
+        excluded = []
+        for line in output.splitlines():
+            parts = line.split('\t')
+            src_file = Path(parts[0].split(':')[0])
+            if src_file == ignore:
+                excluded.append(Path(parts[1]))
+        return excluded
+
+    # TODO: git check-ignore --no-index --stdin (or via command call)  ->  lazy, check GitRepo.files once. (Same invalidation)
+    #       -> OnyoRepo would use it to maintain a ignore list from a (top-level .onyoignore)? .onyo/ignore ? Both?

--- a/onyo/lib/inventory.py
+++ b/onyo/lib/inventory.py
@@ -150,7 +150,7 @@ class Inventory(object):
                 sorted(line for line in deduplicate(snippets)))  # pyre-ignore[16]
 
         # TODO: Actually: staging (only new) should be done in execute. committing is then unified
-        self.repo.git.stage_and_commit(set(paths_to_commit + paths_to_stage), commit_msg)
+        self.repo.git.commit(set(paths_to_commit + paths_to_stage), commit_msg)
         self.reset()
 
     def diff(self) -> Generator[str, None, None]:

--- a/onyo/lib/inventory.py
+++ b/onyo/lib/inventory.py
@@ -150,7 +150,7 @@ class Inventory(object):
                 sorted(line for line in deduplicate(snippets)))  # pyre-ignore[16]
 
         # TODO: Actually: staging (only new) should be done in execute. committing is then unified
-        self.repo.git.commit(set(paths_to_commit + paths_to_stage), commit_msg)
+        self.repo.commit(set(paths_to_commit + paths_to_stage), commit_msg)
         self.reset()
 
     def diff(self) -> Generator[str, None, None]:

--- a/onyo/lib/inventory.py
+++ b/onyo/lib/inventory.py
@@ -382,7 +382,7 @@ class Inventory(object):
                 is_asset = False
             if self.repo.is_inventory_dir(p):
                 operations.extend(self.remove_directory(p))
-            elif not is_asset and p.name not in [self.repo.ANCHOR_FILE, self.repo.ASSET_DIR_FILE]:
+            elif not is_asset and p.name not in [self.repo.ANCHOR_FILE_NAME, self.repo.ASSET_DIR_FILE_NAME]:
                 # not an asset and not an inventory dir
                 # (hence also not an asset dir) implies
                 # we have a non-inventory file.

--- a/onyo/lib/inventory.py
+++ b/onyo/lib/inventory.py
@@ -434,10 +434,7 @@ class Inventory(object):
 
     def get_asset(self, path: Path):
         # read and return Asset
-        if self.repo.is_asset_path(path):
-            return self.repo.get_asset_content(path)
-        else:
-            raise ValueError(f"{path} is not an asset.")
+        return self.repo.get_asset_content(path)
 
     def get_assets(self,
                    paths: Optional[list[Path]] = None,

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -323,8 +323,8 @@ class OnyoRepo(object):
         shutil.copytree(skel_dir, self.dot_onyo)
 
         # add and commit
-        self.git.stage_and_commit(self.dot_onyo,
-                                  message='Initialize as an Onyo repository')
+        self.git.commit(self.dot_onyo,
+                        message='Initialize as an Onyo repository')
         ui.print(f'Initialized empty Onyo repository in {self.dot_onyo}/')
 
     def is_onyo_path(self,

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -215,8 +215,8 @@ class OnyoRepo(object):
             self._asset_paths = None
             self.git.clear_cache()
 
-    def generate_commit_message(self,
-                                format_string: str,
+    @staticmethod
+    def generate_commit_message(format_string: str,
                                 max_length: int = 80,
                                 **kwargs) -> str:
         """Generate a commit message subject.

--- a/onyo/lib/tests/test_commands_mv.py
+++ b/onyo/lib/tests/test_commands_mv.py
@@ -84,14 +84,12 @@ def test_onyo_mv_move_simple(inventory: Inventory) -> None:
 
     # asset was moved
     assert inventory.repo.is_asset_path(destination_path / asset_path.name)
-    assert (destination_path / asset_path.name) not in inventory.repo.git.files_untracked
-    assert (destination_path / asset_path.name) not in inventory.repo.git.files_staged
+    assert (destination_path / asset_path.name) in inventory.repo.git.files
     assert not asset_path.exists()
     # dir was moved
     assert inventory.repo.is_inventory_dir(destination_path / dir_path.name)
     assert (destination_path / dir_path.name / OnyoRepo.ANCHOR_FILE).is_file()
-    assert (destination_path / dir_path.name / OnyoRepo.ANCHOR_FILE) not in inventory.repo.git.files_untracked
-    assert (destination_path / dir_path.name / OnyoRepo.ANCHOR_FILE) not in inventory.repo.git.files_staged
+    assert (destination_path / dir_path.name / OnyoRepo.ANCHOR_FILE) in inventory.repo.git.files
     assert not dir_path.exists()
 
 
@@ -110,8 +108,7 @@ def test_onyo_mv_move_explicit(inventory: Inventory) -> None:
             message="some subject\n\nAnd a body")
 
     assert inventory.repo.is_inventory_dir(dst)
-    assert (dst / OnyoRepo.ANCHOR_FILE) not in inventory.repo.git.files_untracked
-    assert (dst / OnyoRepo.ANCHOR_FILE) not in inventory.repo.git.files_staged
+    assert (dst / OnyoRepo.ANCHOR_FILE) in inventory.repo.git.files
     assert not src.exists()
 
 
@@ -126,6 +123,5 @@ def test_onyo_mv_rename(inventory: Inventory) -> None:
             message="some subject\n\nAnd a body")
 
     assert inventory.repo.is_inventory_dir(new_name)
-    assert (new_name / OnyoRepo.ANCHOR_FILE) not in inventory.repo.git.files_untracked
-    assert (new_name / OnyoRepo.ANCHOR_FILE) not in inventory.repo.git.files_staged
+    assert (new_name / OnyoRepo.ANCHOR_FILE) in inventory.repo.git.files
     assert not dir_path.exists()

--- a/onyo/lib/tests/test_commands_mv.py
+++ b/onyo/lib/tests/test_commands_mv.py
@@ -88,8 +88,8 @@ def test_onyo_mv_move_simple(inventory: Inventory) -> None:
     assert not asset_path.exists()
     # dir was moved
     assert inventory.repo.is_inventory_dir(destination_path / dir_path.name)
-    assert (destination_path / dir_path.name / OnyoRepo.ANCHOR_FILE).is_file()
-    assert (destination_path / dir_path.name / OnyoRepo.ANCHOR_FILE) in inventory.repo.git.files
+    assert (destination_path / dir_path.name / OnyoRepo.ANCHOR_FILE_NAME).is_file()
+    assert (destination_path / dir_path.name / OnyoRepo.ANCHOR_FILE_NAME) in inventory.repo.git.files
     assert not dir_path.exists()
 
 
@@ -108,7 +108,7 @@ def test_onyo_mv_move_explicit(inventory: Inventory) -> None:
             message="some subject\n\nAnd a body")
 
     assert inventory.repo.is_inventory_dir(dst)
-    assert (dst / OnyoRepo.ANCHOR_FILE) in inventory.repo.git.files
+    assert (dst / OnyoRepo.ANCHOR_FILE_NAME) in inventory.repo.git.files
     assert not src.exists()
 
 
@@ -123,5 +123,5 @@ def test_onyo_mv_rename(inventory: Inventory) -> None:
             message="some subject\n\nAnd a body")
 
     assert inventory.repo.is_inventory_dir(new_name)
-    assert (new_name / OnyoRepo.ANCHOR_FILE) in inventory.repo.git.files
+    assert (new_name / OnyoRepo.ANCHOR_FILE_NAME) in inventory.repo.git.files
     assert not dir_path.exists()

--- a/onyo/lib/tests/test_commands_new.py
+++ b/onyo/lib/tests/test_commands_new.py
@@ -57,7 +57,7 @@ def test_onyo_new_keys(inventory: Inventory) -> None:
     for s in specs:
         p = inventory.root / "empty" / f"{s['type']}_{s['make']}_{s['model']}.{s['serial']}"
         assert inventory.repo.is_asset_path(p)
-        assert p not in inventory.repo.git.files_untracked
+        assert p in inventory.repo.git.files
         new_asset = inventory.get_asset(p)
         assert new_asset.get("path") == p
         assert all(new_asset[k] == s[k] for k in s.keys())
@@ -91,7 +91,7 @@ def test_onyo_new_keys(inventory: Inventory) -> None:
         # expected filename (except serial):
         assert files[0].name.startswith(f"{s['type']}_{s['make']}_{s['model']}.")
         assert inventory.repo.is_asset_path(files[0])
-        assert files[0] not in inventory.repo.git.files_untracked
+        assert files[0] in inventory.repo.git.files
         new_asset = inventory.get_asset(files[0])
         assert new_asset.get("path") == files[0]
         # reserved key 'directory' is not part of the asset's content
@@ -136,7 +136,7 @@ def test_onyo_new_edit(inventory: Inventory, monkeypatch) -> None:
     onyo_new(inventory, keys=specs, path=directory, edit=True)
     expected_path = directory / "TYPE_MAKER_MODEL.totally_random"
     assert inventory.repo.is_asset_path(expected_path)
-    assert expected_path not in inventory.repo.git.files_untracked
+    assert expected_path in inventory.repo.git.files
     asset_content = inventory.repo.get_asset_content(expected_path)
     assert asset_content['key'] == 'value'
 

--- a/onyo/lib/tests/test_commands_new.py
+++ b/onyo/lib/tests/test_commands_new.py
@@ -85,7 +85,7 @@ def test_onyo_new_keys(inventory: Inventory) -> None:
     for s in specs:
         files = [p
                  for p in (inventory.root / f"{s['directory']}").iterdir()
-                 if p.name != OnyoRepo.ANCHOR_FILE
+                 if p.name != OnyoRepo.ANCHOR_FILE_NAME
                  ]
         assert len(files) == 1
         # expected filename (except serial):

--- a/onyo/lib/tests/test_git.py
+++ b/onyo/lib/tests/test_git.py
@@ -1,6 +1,5 @@
 import subprocess
 from pathlib import Path
-from subprocess import CalledProcessError
 
 import pytest
 
@@ -13,7 +12,7 @@ def test_GitRepo_instantiation(tmp_path: Path) -> None:
     The `GitRepo` class must instantiate and set the root correctly for paths
     to existing repositories.
     """
-    # initialize the temp_path as an git repository
+    # initialize the temp_path as a git repository
     subprocess.run(['git', 'init', tmp_path])
 
     # test that `GitRepo()` instantiates (and sets the root to) the object
@@ -24,7 +23,7 @@ def test_GitRepo_instantiation(tmp_path: Path) -> None:
     # create a sub-directory to test the find-root behavior
     subprocess.run(['mkdir', '-p', tmp_path / "sub-directory"])
 
-    # with `find_root=False` it excepts other existing paths e.g. sub-dirs
+    # with `find_root=False` it accepts other existing paths e.g. sub-dirs
     new_repo = GitRepo(tmp_path / "sub-directory", find_root=False)
     assert new_repo.root.samefile(tmp_path / "sub-directory")
 
@@ -67,95 +66,6 @@ def test_GitRepo_find_root(tmp_path: Path) -> None:
         GitRepo.find_root(tmp_path / 'non-existing/directory')
 
 
-def test_GitRepo_restore_staged(tmp_path: Path) -> None:
-    """
-    `GitRepo.restore_staged()` must restore all staged files in the repository.
-    If no files are staged, it should not raise an error.
-    If there are modified or untracked files, they should not be changed.
-    """
-    subprocess.run(['git', 'init', tmp_path])
-    new_git = GitRepo(tmp_path)
-    test_file = new_git.root / 'asset_for_test.0'
-    test_file.touch()
-    new_git.stage_and_commit(test_file, message="Create file for test")
-
-    # test that no error is raised, when called on a clean repository
-    new_git.restore_staged()
-    assert new_git.is_clean_worktree()
-
-    # have an untracked, a changed and a staged file
-    untracked_file = new_git.root / 'asset_for_test.1'
-    untracked_file.touch()
-
-    changed_file = new_git.root / 'asset_for_test.2'
-    changed_file.touch()
-    new_git.stage_and_commit(changed_file, message="Create file to change")
-    changed_file.open('w').write('Test: content')
-
-    test_file.open('w').write('Test: content')
-    new_git.add(test_file)
-    assert untracked_file in new_git.files_untracked
-    assert changed_file in new_git.files_changed
-    assert test_file in new_git.files_staged
-
-    # call restore_staged() and verify that the changes on test_file are not
-    # staged anymore, but that modified and untracked files are unchanged
-    new_git.restore_staged()
-    assert test_file not in new_git.files_staged
-    assert untracked_file in new_git.files_untracked
-    assert changed_file in new_git.files_changed
-
-
-def test_GitRepo_restore(tmp_path: Path) -> None:
-    """
-    `GitRepo.restore()` receives a list of paths and must restore changes for
-    them.
-
-    This does restore files which contain changes, but it does not restore
-    changes that are already staged.
-    When called on an untracked file, it must raise an error (like `git restore
-    <untracked>`).
-    """
-    subprocess.run(['git', 'init', tmp_path])
-    new_git = GitRepo(tmp_path)
-    test_file = new_git.root / 'asset_for_test.0'
-    test_file.touch()
-    new_git.stage_and_commit([test_file], message="Test File")
-
-    # Test that no error is raised, when called on a clean file
-    new_git.restore(test_file)
-    assert new_git.is_clean_worktree()
-
-    # Test that calling `GitRepo.restore()` on a file with already staged
-    # changes does not effect the file
-    test_file.open('w').write('Test: content')
-    new_git.add(test_file)
-    assert test_file in new_git.files_staged
-    new_git.restore(test_file)
-    assert test_file in new_git.files_staged
-
-    # Test that calling `GitRepo.restore()` on an untracked file must raise an
-    # error (like `git restore` does)
-    untracked_file = new_git.root / 'asset_for_test.untracked'
-    untracked_file.touch()
-    assert untracked_file in new_git.files_untracked
-    with pytest.raises(CalledProcessError):
-        new_git.restore(untracked_file)
-    assert untracked_file in new_git.files_untracked
-
-    # Test that calling `GitRepo.restore()` on a file with unstaged changes
-    # restores the file
-    changed_file = new_git.root / 'asset_for_test.changed'
-    changed_file.touch()
-    new_git.stage_and_commit([changed_file], message="Test File")
-    changed_file.open('w').write('Test: content')
-    assert changed_file in new_git.files_changed
-    new_git.restore(changed_file)
-    assert changed_file not in new_git.files_changed
-    assert changed_file not in new_git.files_untracked
-    assert changed_file not in new_git.files_staged
-
-
 def test_GitRepo_clear_caches(tmp_path: Path) -> None:
     """
     The function `GitRepo.clear_caches()` must allow to empty the cache of the
@@ -168,13 +78,14 @@ def test_GitRepo_clear_caches(tmp_path: Path) -> None:
     new_git = GitRepo(tmp_path)
     file = new_git.root / 'asset_for_test.0'
     file.touch()
-    new_git.stage_and_commit(file, message="Create file for test")
+    new_git.commit(file, message="Create file for test")
     assert file in new_git.files
 
     # delete the file (with a non-onyo function to invalid the cache) and then
     # verify that the file stays in the cache after the deletion
     Path.unlink(file)
-    new_git.stage_and_commit(file, message="Delete file for test")
+    subprocess.run(['git', 'add', str(file)], check=True, cwd=new_git.root)
+    subprocess.run(['git', 'commit', '-m', "Delete file for test"], check=True, cwd=new_git.root)
     assert file in new_git.files
     assert not file.exists()
 
@@ -197,26 +108,23 @@ def test_GitRepo_is_clean_worktree(tmp_path: Path) -> None:
 
     # a file created but not added (i.e. untracked) must lead to return False
     test_file.touch()
-    assert test_file in new_git.files_untracked
     assert not new_git.is_clean_worktree()
 
     # a file added but not commit-ed (i.e. staged) must lead to return False
-    new_git.add(test_file)
-    assert test_file in new_git.files_staged
+    subprocess.run(['git', 'add', str(test_file)], check=True, cwd=new_git.root)
     assert not new_git.is_clean_worktree()
 
     # when commit-ed, the function must return True again
-    new_git.commit(test_file, 'commit-ed!')
+    subprocess.run(['git', 'commit', '-m', 'commit-ed!'], check=True, cwd=new_git.root)
     assert new_git.is_clean_worktree()
 
     # a file modified but not commit-ed (i.e. changed) must lead to return False
     test_file.open('w').write('Test: content')
-    new_git.add(test_file)
-    assert test_file in new_git.files_staged
+    subprocess.run(['git', 'add', str(test_file)], check=True, cwd=new_git.root)
     assert not new_git.is_clean_worktree()
 
     # when commit-ed, the function must return True again
-    new_git.commit(test_file, 'commit-ed again!')
+    subprocess.run(['git', 'commit', '-m', 'commit-ed again!'], check=True, cwd=new_git.root)
     assert new_git.is_clean_worktree()
 
 
@@ -249,49 +157,6 @@ def test_GitRepo_is_git_path(tmp_path: Path) -> None:
                                    "test_file.txt")
 
 
-def test_GitRepo_add(tmp_path: Path) -> None:
-    """
-    `GitRepo.add()` must allow to add files which are either new or contain
-    changes. If called on files without changes, it does not raise an error.
-    """
-    # setup the repo and GitRepo object
-    subprocess.run(['git', 'init', tmp_path])
-    new_git = GitRepo(tmp_path)
-
-    # create a file for the test and add it to git
-    existing_file = new_git.root / 'test_file.txt'
-    existing_file.touch()
-    new_git.stage_and_commit(existing_file, message="Create file for test")
-
-    # create a Path to a file that does not yet exist
-    new_file = new_git.root / 'new_file.txt'
-
-    # test that GitRepo.add() does not raise an error on files that exist and
-    # have no changes
-    new_git.add(existing_file)
-    assert new_git.is_clean_worktree()
-
-    # test that GitRepo.add() raises a FileNotFoundError for `new_file`, an
-    # absolute path to a file that do not yet exist
-    with pytest.raises(FileNotFoundError):
-        new_git.add(new_file)
-
-    # modify an existing file, and create a new file
-    existing_file.open('w').write('Test: content')
-    assert existing_file in new_git.files_changed
-    new_file.touch()
-    assert new_file in new_git.files_untracked
-
-    new_git.add([existing_file, new_file])
-    assert existing_file in new_git.files_staged
-    assert new_file in new_git.files_staged
-
-    # after files are `GitRepo.add()`ed they should not be cached in the
-    # properties GitRepo.files_changed and GitRepo.files_untracked
-    assert existing_file not in new_git.files_changed
-    assert new_file not in new_git.files_untracked
-
-
 def test_GitRepo_commit(tmp_path: Path) -> None:
     """
     `GitRepo.commit()` must commit all staged changes.
@@ -302,48 +167,19 @@ def test_GitRepo_commit(tmp_path: Path) -> None:
     new_git = GitRepo(tmp_path)
     test_file = new_git.root / 'test_file.txt'
     test_file.touch()
-    new_git.stage_and_commit(test_file, message="Create file for test")
-
-    # test that GitRepo.commit() raises a ValueError if no commit message is
-    # provided
-    with pytest.raises(ValueError):
-        new_git.commit()
+    assert test_file not in new_git.files
+    # fresh repo w/ no commit
+    assert new_git.get_hexsha() is None
+    new_git.commit(test_file, message="Create file for test")
+    hexsha = new_git.get_hexsha()
+    # created a commit:
+    assert hexsha is not None
+    # only one commit (HEAD~1 does not exist):
+    pytest.raises(ValueError, new_git.get_hexsha, 'HEAD~1')
+    assert test_file in new_git.files
 
     # modify an existing file, and add it
     test_file.open('w').write('Test: content')
-    new_git.add(test_file)
-    assert test_file in new_git.files_staged
-
-    # commit staged changes
-    new_git.commit("Test commit message")
+    new_git.commit(test_file, "Test commit message")
+    assert hexsha == new_git.get_hexsha('HEAD~1')
     assert test_file in new_git.files
-
-    # after files are `GitRepo.commit()`ed they should not be cached in the
-    # properties GitRepo.files_changed or GitRepo.files_staged anymore
-    assert test_file not in new_git.files_changed
-    assert test_file not in new_git.files_staged
-
-
-def test_GitRepo_stage_and_commit(tmp_path: Path) -> None:
-    """
-    `GitRepo.stage_and_commit()` must allow to add+commit changed files.
-
-    This test follows the scheme of `test_GitRepo_add()`.
-    """
-    subprocess.run(['git', 'init', tmp_path])
-    new_git = GitRepo(tmp_path)
-    test_file = new_git.root / 'test_file.txt'
-
-    # add a file
-    test_file.open('w').write('Test: content')
-    assert test_file in new_git.files_untracked
-
-    # add+commit a changed file
-    new_git.stage_and_commit(test_file, "Test commit message")
-    assert test_file in new_git.files
-
-    # after files are `GitRepo.stage_and_commit()`ed they should not be cached
-    # in the properties GitRepo.files_changed or GitRepo.files_staged
-    assert test_file not in new_git.files_untracked
-    assert test_file not in new_git.files_changed
-    assert test_file not in new_git.files_staged

--- a/onyo/lib/tests/test_inventory_operations.py
+++ b/onyo/lib/tests/test_inventory_operations.py
@@ -672,9 +672,9 @@ def test_rename_asset_dir(repo: OnyoRepo) -> None:
     pytest.raises(ValueError, inventory.rename_directory, asset_dir_path, "newname")
 
     # renaming as an asset by changing the naming config
-    inventory.repo.git.set_config("onyo.assets.filename", "{serial}_{other}", "onyo")
-    inventory.repo.git.commit(inventory.root / OnyoRepo.ONYO_CONFIG,
-                              "Change asset name config")
+    inventory.repo.set_config("onyo.assets.filename", "{serial}_{other}", "onyo")
+    inventory.repo.commit(inventory.root / OnyoRepo.ONYO_CONFIG,
+                          "Change asset name config")
     new_asset_dir_path = asset_dir_path.parent / "SERIAL_1"
 
     inventory.rename_asset(asset_dir_path)

--- a/onyo/lib/tests/test_inventory_operations.py
+++ b/onyo/lib/tests/test_inventory_operations.py
@@ -297,7 +297,7 @@ def test_add_directory(repo: OnyoRepo) -> None:
     # now commit
     inventory.commit("Add new directory")
     assert repo.is_inventory_dir(new_dir)
-    assert (new_dir / repo.ANCHOR_FILE).is_file()
+    assert (new_dir / repo.ANCHOR_FILE_NAME).is_file()
 
 
 def test_remove_directory(repo: OnyoRepo) -> None:
@@ -462,7 +462,7 @@ def test_add_asset_dir(repo: OnyoRepo) -> None:
     assert inventory.repo.git.is_clean_worktree()
     # dir and yaml file are created:
     assert asset_dir_path.is_dir()
-    assert (asset_dir_path / OnyoRepo.ASSET_DIR_FILE).is_file()
+    assert (asset_dir_path / OnyoRepo.ASSET_DIR_FILE_NAME).is_file()
     # an asset dir is both - an inventory directory and an asset:
     assert inventory.repo.is_asset_path(asset_dir_path)
     assert inventory.repo.is_inventory_dir(asset_dir_path)
@@ -585,7 +585,7 @@ def test_remove_asset_dir_asset(repo: OnyoRepo) -> None:
     assert inventory.repo.is_inventory_dir(asset_dir_path)
     # but not an asset anymore:
     assert not inventory.repo.is_asset_path(asset_dir_path)
-    assert not (asset_dir_path / OnyoRepo.ASSET_DIR_FILE).exists()
+    assert not (asset_dir_path / OnyoRepo.ASSET_DIR_FILE_NAME).exists()
     assert inventory.repo.git.is_clean_worktree()
 
 

--- a/onyo/lib/tests/test_inventory_operations.py
+++ b/onyo/lib/tests/test_inventory_operations.py
@@ -673,8 +673,8 @@ def test_rename_asset_dir(repo: OnyoRepo) -> None:
 
     # renaming as an asset by changing the naming config
     inventory.repo.git.set_config("onyo.assets.filename", "{serial}_{other}", "onyo")
-    inventory.repo.git.stage_and_commit(inventory.root / OnyoRepo.ONYO_CONFIG,
-                                        "Change asset name config")
+    inventory.repo.git.commit(inventory.root / OnyoRepo.ONYO_CONFIG,
+                              "Change asset name config")
     new_asset_dir_path = asset_dir_path.parent / "SERIAL_1"
 
     inventory.rename_asset(asset_dir_path)

--- a/onyo/lib/tests/test_onyo.py
+++ b/onyo/lib/tests/test_onyo.py
@@ -171,7 +171,7 @@ def test_Repo_validate_anchors(repo: OnyoRepo) -> None:
 
     # Delete an .anchor, commit changes, reload object
     Path.unlink(repo.git.root / "a" / "test" / ".anchor")
-    repo.git.stage_and_commit(repo.git.root / "a" / "test" / ".anchor", "TEST")
+    repo.git.commit(repo.git.root / "a" / "test" / ".anchor", "TEST")
     repo = OnyoRepo(repo.git.root)
 
     # Must return False, because an .anchor is missing

--- a/onyo/lib/tests/test_onyo.py
+++ b/onyo/lib/tests/test_onyo.py
@@ -54,16 +54,20 @@ def test_clear_caches(repo: OnyoRepo) -> None:
     The function `clear_caches()` must allow to empty the cache of the OnyoRepo,
     so that an invalid cache can be re-loaded by a newly call of the property.
     """
-    # make sure the asset is in the cache
+    # make sure the asset is in the cache:
     asset = Path('a/test/asset_for_test.0').resolve()
     assert asset in repo.asset_paths
 
-    # delete the asset (with a non-onyo function to invalid the cache) and then
-    # verify that the asset stays in the cache after the deletion
+    # only committed state is considered:
     Path.unlink(asset)
     assert asset in repo.asset_paths
 
-    # test clear_caches() fixes the cache
+    # committing while circumventing `OnyoRepo.commit` would
+    # make the cache out-of-sync:
+    repo.git.commit(asset, "asset deleted")
+    assert asset in repo.asset_paths
+
+    # clear_caches() fixes the cache:
     repo.clear_caches(assets=True)
     assert asset not in repo.asset_paths
 
@@ -171,7 +175,7 @@ def test_Repo_validate_anchors(repo: OnyoRepo) -> None:
 
     # Delete an .anchor, commit changes, reload object
     Path.unlink(repo.git.root / "a" / "test" / ".anchor")
-    repo.git.commit(repo.git.root / "a" / "test" / ".anchor", "TEST")
+    repo.commit(repo.git.root / "a" / "test" / ".anchor", "TEST")
     repo = OnyoRepo(repo.git.root)
 
     # Must return False, because an .anchor is missing

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,5 +5,8 @@ markers =
     repo_contents: populate files of a repo with content; for use with the "repo" fixture
     ui: set properties of the UI object to use; dictionary {'yes': bool, 'quiet': bool, 'debug': bool}
     gitrepo_contents: Tuples (`Path`, `str`) of files to be committed in the "gitrepo" fixture
+    inventory_assets: dicts specifying assets to create; for use with the "onyorepo" fixture
+    inventory_dirs: paths specifying (empty) inventory dirs; for use with the "onyorepo" fixture
+
 addopts =
     --strict-markers

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,5 +4,6 @@ markers =
     repo_files: populate a repo with files (parent dirs are automatically created); for use with the "repo" fixture
     repo_contents: populate files of a repo with content; for use with the "repo" fixture
     ui: set properties of the UI object to use; dictionary {'yes': bool, 'quiet': bool, 'debug': bool}
+    gitrepo_contents: Tuples (`Path`, `str`) of files to be committed in the "gitrepo" fixture
 addopts =
     --strict-markers


### PR DESCRIPTION
This is largely focusing on ironing out the base layer(s) in `GitRepo` and `OnyoRepo`.

- For almost everything, only the committed state of the repository is considered, making most functionality rely on `git ls-files` via the `GitRepo.files` property and the `GitRepo.get_subtrees` method.
- The above involves a clean up of caching. With this patch, only `GitRepo.files` and `OnyoRepo.asset_paths` are cached and the only place to invalidate the cache is consequently the respective `commit` method.
- Introduces new `gitrepo` and `onyorepo` fixtures that are taking a step towards more generic tests, that query the object they get to formulate assertions rather than hardcoding assumptions about it. This should lead to significantly reducing the effort of future adjustments to these tests.
- Adds a couple tests for `GitRepo` + `OnyoRepo`.
- Implements support for `.onyoignore` files. They work exactly like `.gitignore` files, except that they define what is tracked by git but not considered an inventory item by onyo.
- Removes a bunch of by now unused code.


Note, that while tests were in fact enhanced, not everything is properly tested yet. However, I consider enhancing unit tests for `GitRepo` and `OnyoRepo` and refining the above mentioned fixtures to be a separate effort and out of scope here.

Closes #502
Closes #89 