### PR TITLE
BF: print correct error when calling mv to non-existing destination directory

### DIFF
--- a/onyo/commands/tests/test_mv.py
+++ b/onyo/commands/tests/test_mv.py
@@ -36,6 +36,32 @@ def test_mv_interactive_missing_y(repo: OnyoRepo) -> None:
 
 
 @pytest.mark.repo_files('subdir/laptop_apple_macbook.abc123')
+def test_mv_errors_non_existing_destination(repo: OnyoRepo) -> None:
+    """Moving an existing asset or directory into a non-existing destination must error."""
+    # Verify error for asset:
+    ret = subprocess.run(
+        ['onyo', 'mv', 'subdir/laptop_apple_macbook.abc123', 'non/existing/directory'],
+        capture_output=True, text=True)
+    assert not ret.stdout
+    assert "Can only" in ret.stderr
+
+    assert Path('subdir/laptop_apple_macbook.abc123').exists()
+    assert not Path('non/existing/directory/laptop_apple_macbook.abc123').exists()
+    assert repo.git.is_clean_worktree()
+
+    # Verify error for directory:
+    ret = subprocess.run(
+        ['onyo', 'mv', 'subdir/', 'non/existing/directory'],
+        capture_output=True, text=True)
+    assert not ret.stdout
+    assert "Can only" in ret.stderr
+
+    assert Path('subdir/').exists()
+    assert not Path('non/existing/directory/subdir/').exists()
+    assert repo.git.is_clean_worktree()
+
+
+@pytest.mark.repo_files('subdir/laptop_apple_macbook.abc123')
 def test_mv_interactive_abort(repo: OnyoRepo) -> None:
     """
     Default mode is interactive. Provide the "n" to abort.

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -537,13 +537,12 @@ def onyo_mv(inventory: Inventory,
         subject = "mv"
         for s in sources:
             move_asset_or_dir(inventory, s, destination)
-    else:
-        # RENAME
+    elif len(sources) == 1 and sources[0].is_dir() and destination.parent.is_dir():
+        # RENAME directory
         subject = "ren"
-        if len(sources) != 1:
-            raise ValueError("Cannot rename multiple sources.")
-        else:
-            inventory.rename_directory(sources[0], destination)
+        inventory.rename_directory(sources[0], destination)
+    else:
+        raise ValueError("Can only move into an existing directory or rename a single directory.")
 
     if inventory.operations_pending():
         ui.print("The following will be {}:".format("moved" if subject == "mv" else "renamed"))


### PR DESCRIPTION
close #420
close #421

The command did fail (which is the correct behavior), but printed the wrong error messages.