### PR TITLE
TST: add tests for `onyo_mv()`

### DIFF
--- a/onyo/commands/tests/test_mv.py
+++ b/onyo/commands/tests/test_mv.py
@@ -5,9 +5,6 @@ import pytest
 
 from onyo.lib import OnyoRepo
 
-# These tests focus on functionality specific to the CLI for `onyo mv`.
-# Tests located in this file should not duplicate those testing `OnyoRepo.mv()`
-# directly.
 
 assets = ['laptop_apple_macbookpro.0',
           'simple/laptop_apple_macbookpro.1',
@@ -16,14 +13,9 @@ assets = ['laptop_apple_macbookpro.0',
           ]
 
 
-#
-# FLAGS
-#
 @pytest.mark.repo_files('subdir/laptop_apple_macbook.abc123')
 def test_mv_interactive_missing_y(repo: OnyoRepo) -> None:
-    """
-    Default mode is interactive. It requires a "y" to approve.
-    """
+    """Default mode is interactive. It requires a "y" to approve."""
     ret = subprocess.run(['onyo', 'mv', 'subdir/laptop_apple_macbook.abc123', './'],
                          capture_output=True, text=True)
     assert ret.returncode == 1
@@ -63,10 +55,9 @@ def test_mv_errors_non_existing_destination(repo: OnyoRepo) -> None:
 
 @pytest.mark.repo_files('subdir/laptop_apple_macbook.abc123')
 def test_mv_interactive_abort(repo: OnyoRepo) -> None:
-    """
-    Default mode is interactive. Provide the "n" to abort.
-    """
-    ret = subprocess.run(['onyo', 'mv', 'subdir/laptop_apple_macbook.abc123', './'], input='n', capture_output=True, text=True)
+    """Default mode is interactive. Provide the "n" to abort."""
+    ret = subprocess.run(['onyo', 'mv', 'subdir/laptop_apple_macbook.abc123', './'],
+                         input='n', capture_output=True, text=True)
     assert ret.returncode == 0
     assert "Save changes? No discards all changes. (y/n) " in ret.stdout
     assert not ret.stderr
@@ -78,61 +69,11 @@ def test_mv_interactive_abort(repo: OnyoRepo) -> None:
 
 @pytest.mark.repo_files('subdir/laptop_apple_macbook.abc123')
 def test_mv_interactive(repo: OnyoRepo) -> None:
-    """
-    Default mode is interactive. Provide the "y" to approve.
-    """
-    ret = subprocess.run(['onyo', 'mv', 'subdir/laptop_apple_macbook.abc123', './'], input='y', capture_output=True, text=True)
+    """Default mode is interactive. Provide the "y" to approve."""
+    ret = subprocess.run(['onyo', 'mv', 'subdir/laptop_apple_macbook.abc123', './'],
+                         input='y', capture_output=True, text=True)
     assert ret.returncode == 0
     assert "Save changes? No discards all changes. (y/n) " in ret.stdout
-    assert not ret.stderr
-
-    assert not Path('subdir/laptop_apple_macbook.abc123').exists()
-    assert Path('laptop_apple_macbook.abc123').exists()
-    assert repo.git.is_clean_worktree()
-
-
-@pytest.mark.repo_files('subdir/laptop_apple_macbook.abc123')
-def test_mv_quiet_missing_yes(repo: OnyoRepo) -> None:
-    """
-    ``--quiet`` requires ``--yes``
-    """
-    ret = subprocess.run(['onyo', '--quiet', 'mv', 'subdir/laptop_apple_macbook.abc123', './'], capture_output=True, text=True)
-    assert ret.returncode == 1
-    assert not ret.stdout
-    assert ret.stderr
-
-    assert Path('subdir/laptop_apple_macbook.abc123').exists()
-    assert not Path('laptop_apple_macbook.abc123').exists()
-    assert repo.git.is_clean_worktree()
-
-
-@pytest.mark.repo_files('subdir/laptop_apple_macbook.abc123')
-def test_mv_quiet(repo: OnyoRepo) -> None:
-    """
-    ``--quiet`` requires ``--yes``
-    """
-    ret = subprocess.run(
-        ['onyo', '--yes', '--quiet', 'mv', 'subdir/laptop_apple_macbook.abc123', './'],
-        capture_output=True, text=True)
-    assert ret.returncode == 0
-    assert not ret.stdout
-    assert not ret.stderr
-
-    assert not Path('subdir/laptop_apple_macbook.abc123').exists()
-    assert Path('laptop_apple_macbook.abc123').exists()
-    assert repo.git.is_clean_worktree()
-
-
-@pytest.mark.repo_files('subdir/laptop_apple_macbook.abc123')
-def test_mv_yes(repo: OnyoRepo) -> None:
-    """
-    --yes removes any prompts and auto-approves the move.
-    """
-    ret = subprocess.run(['onyo', '--yes', 'mv', 'subdir/laptop_apple_macbook.abc123', './'],
-                         capture_output=True, text=True)
-    assert ret.returncode == 0
-    assert "The following will be moved:" in ret.stdout
-    assert "Save changes? No discards all changes. (y/n) " not in ret.stdout
     assert not ret.stderr
 
     assert not Path('subdir/laptop_apple_macbook.abc123').exists()
@@ -144,9 +85,8 @@ def test_mv_yes(repo: OnyoRepo) -> None:
 @pytest.mark.repo_dirs("destination/")
 @pytest.mark.parametrize('asset', assets)
 def test_mv_message_flag(repo: OnyoRepo, asset: str) -> None:
-    """
-    Test that `onyo mv --message msg` overwrites the default commit message
-    with one specified by the user containing different special characters.
+    """Test that `onyo mv --message msg` overwrites the default commit message with one specified by
+    the user containing different special characters.
     """
     msg = "I am here to test the --message flag with spe\"cial\\char\'acteஞrs!"
     ret = subprocess.run(['onyo', '--yes', 'mv', '--message', msg, asset,
@@ -155,7 +95,5 @@ def test_mv_message_flag(repo: OnyoRepo, asset: str) -> None:
     assert not ret.stderr
 
     # test that the onyo history does contain the user-defined message
-    ret = subprocess.run(['onyo', 'history', '-I', Path("destination") / Path(asset).name],
-                         capture_output=True, text=True)
-    assert msg in ret.stdout
+    assert msg in repo.git.get_commit_msg()
     assert repo.git.is_clean_worktree()

--- a/onyo/lib/tests/test_commands_mv.py
+++ b/onyo/lib/tests/test_commands_mv.py
@@ -7,11 +7,12 @@ from ..commands import onyo_mv
 
 
 @pytest.mark.ui({'yes': True})
-def test_onyo_mv_into_self(inventory: Inventory) -> None:
+def test_onyo_mv_errors(inventory: Inventory) -> None:
+    """`onyo_mv` must raise the correct error in different illegal or impossible calls."""
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     dir_path = inventory.root / 'empty'
 
-    # move into itself:
+    # move directory into itself
     pytest.raises(InvalidInventoryOperation,
                   onyo_mv,
                   inventory,
@@ -19,7 +20,7 @@ def test_onyo_mv_into_self(inventory: Inventory) -> None:
                   destination=dir_path,
                   message="some subject\n\nAnd a body")
 
-    # move asset into non-existing
+    # move asset into non-existing directory
     pytest.raises(ValueError,
                   onyo_mv,
                   inventory,
@@ -27,7 +28,7 @@ def test_onyo_mv_into_self(inventory: Inventory) -> None:
                   destination=dir_path / "doesnotexist",
                   message="some subject\n\nAnd a body")
 
-    # move dir into non-existing
+    # move dir into non-existing directory
     pytest.raises(ValueError,
                   onyo_mv,
                   inventory,
@@ -35,7 +36,7 @@ def test_onyo_mv_into_self(inventory: Inventory) -> None:
                   destination=dir_path / "doesnotexist" / "somewhere",
                   message="some subject\n\nAnd a body")
 
-    # rename including a move
+    # rename and move of a directory in one call
     pytest.raises(InvalidInventoryOperation,
                   onyo_mv,
                   inventory,
@@ -43,7 +44,7 @@ def test_onyo_mv_into_self(inventory: Inventory) -> None:
                   destination=dir_path / "newname",
                   message="some subject\n\nAnd a body")
 
-    # move to existing file
+    # move directory to existing file
     pytest.raises(ValueError,
                   onyo_mv,
                   inventory,
@@ -69,12 +70,79 @@ def test_onyo_mv_into_self(inventory: Inventory) -> None:
                   destination=asset_path.parent,
                   message="some subject\n\nAnd a body")
 
+    # source does not exist
+    pytest.raises(ValueError,
+                  onyo_mv,
+                  inventory,
+                  source=inventory.root / "not-existent",
+                  destination=dir_path,
+                  message="some subject\n\nAnd a body")
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_mv_errors_before_mv(inventory: Inventory) -> None:
+    """`onyo_mv` must raise the correct error and is not allowed to move/commit anything, if one of
+    the sources does not exist.
+    """
+    asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    destination_path = inventory.root / 'empty'
+    old_hexsha = inventory.repo.git.get_hexsha()
+
+    # one of multiple sources does not exist
+    pytest.raises(ValueError,
+                  onyo_mv,
+                  inventory,
+                  source=[asset_path, inventory.root / "not-existent"],
+                  destination=destination_path,
+                  message="some subject\n\nAnd a body")
+
+    # nothing was moved and no new commit was created
+    assert asset_path.is_file()
+    assert not (destination_path / asset_path.name).is_file()
+    # no commit was added
+    assert inventory.repo.git.get_hexsha() == old_hexsha
+    # TODO: verifying cleanness of worktree does not work,
+    #       because fixture returns inventory with untracked stuff
+    # assert inventory.repo.git.is_clean_worktree()
+
+
+@pytest.mark.skip(reason="still a BUG: #516")
+@pytest.mark.ui({'yes': True})
+@pytest.mark.repo_dirs("a/b/c", "a/d/c")
+def test_onyo_mv_src_to_dest_with_same_name(inventory: Inventory) -> None:
+    """Allow to move a directory into another one with the same name."""
+    source_path = inventory.root / "a" / "b" / "c"
+    destination_path = inventory.root / "a" / "d" / "c"
+    old_hexsha = inventory.repo.git.get_hexsha()
+
+    # move a source dir into a destination dir with the same name
+    onyo_mv(inventory,
+            source=source_path,
+            destination=destination_path,
+            message="some subject\n\nAnd a body")
+
+    # source
+    assert not source_path.exists()
+    assert (source_path / OnyoRepo.ANCHOR_FILE_NAME) not in inventory.repo.git.files
+    # directory was moved
+    assert (destination_path / source_path.name).is_dir()
+    assert (destination_path / source_path.name / OnyoRepo.ANCHOR_FILE_NAME).is_file()
+    assert inventory.repo.is_inventory_dir(destination_path / source_path.name)
+    assert (destination_path / source_path.name / OnyoRepo.ANCHOR_FILE_NAME) in inventory.repo.git.files
+    # exactly one commit added
+    assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
+    # TODO: verifying cleanness of worktree does not work,
+    #       because fixture returns inventory with untracked stuff
+    # assert inventory.repo.git.is_clean_worktree()
+
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_mv_move_simple(inventory: Inventory) -> None:
+    """Move an asset and a directory in one commit into a destination."""
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     dir_path = inventory.root / 'empty'
     destination_path = inventory.root / 'different' / 'place'
+    old_hexsha = inventory.repo.git.get_hexsha()
 
     # move an asset and a dir to the same destination
     onyo_mv(inventory,
@@ -86,42 +154,76 @@ def test_onyo_mv_move_simple(inventory: Inventory) -> None:
     assert inventory.repo.is_asset_path(destination_path / asset_path.name)
     assert (destination_path / asset_path.name) in inventory.repo.git.files
     assert not asset_path.exists()
+    assert asset_path not in inventory.repo.git.files
     # dir was moved
     assert inventory.repo.is_inventory_dir(destination_path / dir_path.name)
     assert (destination_path / dir_path.name / OnyoRepo.ANCHOR_FILE_NAME).is_file()
-    assert (destination_path / dir_path.name / OnyoRepo.ANCHOR_FILE_NAME) in inventory.repo.git.files
     assert not dir_path.exists()
+    assert (destination_path / dir_path.name / OnyoRepo.ANCHOR_FILE_NAME) in inventory.repo.git.files
+    # exactly one commit added
+    assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
+    # TODO: verifying cleanness of worktree does not work,
+    #       because fixture returns inventory with untracked stuff
+    # assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
-def test_onyo_mv_move_explicit(inventory: Inventory) -> None:
+def test_onyo_mv_move_to_explicit_destination(inventory: Inventory) -> None:
+    """Allow moving a source to destination.
+
+    `destination_path` does not yet exist, which would indicate a
+    renaming if it wasn't the same name as the source. If recognized
+    as a renaming, however, it should fail because not only the name
+    but also the parent changed, which implies two operations: A move
+    and a renaming (with no order given).
+    """
     dir_path = inventory.root / 'somewhere' / 'nested'
     # move by explicitly restating the source's name:
     src = dir_path
-    # `dst` does not yet exist, which would indicate a renaming if it wasn't the same name as the source.
-    # If recognized as a renaming, however, it should fail because not only the name but also the parent changed, which
-    # implies two operations: A move and a renaming (with no order given).
-    dst = inventory.root / src.name
+    destination_path = inventory.root / src.name
+    old_hexsha = inventory.repo.git.get_hexsha()
+
     onyo_mv(inventory,
             source=src,
-            destination=dst,
+            destination=destination_path,
             message="some subject\n\nAnd a body")
 
-    assert inventory.repo.is_inventory_dir(dst)
-    assert (dst / OnyoRepo.ANCHOR_FILE_NAME) in inventory.repo.git.files
+    # source is moved
+    assert (src / OnyoRepo.ANCHOR_FILE_NAME) not in inventory.repo.git.files
     assert not src.exists()
+    # destination is correct
+    assert inventory.repo.is_inventory_dir(destination_path)
+    assert (destination_path / OnyoRepo.ANCHOR_FILE_NAME) in inventory.repo.git.files
+    assert (destination_path / OnyoRepo.ANCHOR_FILE_NAME).is_file()
+    # exactly one commit added
+    assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
+    # TODO: verifying cleanness of worktree does not work,
+    #       because fixture returns inventory with untracked stuff
+    # assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_mv_rename(inventory: Inventory) -> None:
+    """`onyo_mv` must allow renaming of a directory."""
     dir_path = inventory.root / 'somewhere' / 'nested'
-    new_name = dir_path.parent / 'newname'
+    destination_path = dir_path.parent / 'newname'
+    old_hexsha = inventory.repo.git.get_hexsha()
 
     onyo_mv(inventory,
             source=dir_path,
-            destination=new_name,
+            destination=destination_path,
             message="some subject\n\nAnd a body")
 
-    assert inventory.repo.is_inventory_dir(new_name)
-    assert (new_name / OnyoRepo.ANCHOR_FILE_NAME) in inventory.repo.git.files
+    # source
     assert not dir_path.exists()
+    assert (dir_path / OnyoRepo.ANCHOR_FILE_NAME) not in inventory.repo.git.files
+    assert not inventory.repo.is_inventory_dir(dir_path)
+    # destination is correct
+    assert destination_path.is_dir()
+    assert (destination_path / OnyoRepo.ANCHOR_FILE_NAME) in inventory.repo.git.files
+    assert inventory.repo.is_inventory_dir(destination_path)
+    # exactly one commit added
+    assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
+    # TODO: verifying cleanness of worktree does not work,
+    #       because fixture returns inventory with untracked stuff
+    # assert inventory.repo.git.is_clean_worktree()


### PR DESCRIPTION
This adds tests for `commands.onyo_mv()`, and cleans up the CLI tests for `onyo mv`.

There might be some cases missing that should be tested, and during review it should be checked that I did not remove CLI tests that are wanted after all. I also did not test yet for specific commit message contents.

PS: The missing coverage is because of the temporary test for issue #516. I skip the test, because it is not yet working and we have to decide on how to handle this.