### PR TITLE
Docs and Tests

### DIFF
--- a/onyo/commands/cat.py
+++ b/onyo/commands/cat.py
@@ -21,8 +21,10 @@ args_cat = {
 
 
 def cat(args: argparse.Namespace) -> None:
-    """
-    Print the contents of ``ASSET``\\(s) to the terminal without parsing.
+    """Print the contents of ``ASSET`` file(s) to the terminal.
+
+    At least one valid asset path is required. Assets can be given multiple times.
+    If any path specified is invalid, no contents are printed and an error is raised.
     """
     paths = [Path(p).resolve() for p in args.asset]
 

--- a/onyo/commands/mv.py
+++ b/onyo/commands/mv.py
@@ -34,7 +34,17 @@ def mv(args: argparse.Namespace) -> None:
     rename a ``SOURCE`` directory to ``DEST``.
 
     Files cannot be renamed using ``onyo mv``, since their names are generated from their contents.
-    To rename a file, use ``onyo set``.
+    To rename a file, use ``onyo set``, or use ``onyo edit`` and change the keys used for the
+    asset's name.
+    To rename a directory, call ``onyo mv`` with a single ``SOURCE`` to rename, and a different and
+    non-existing ``DEST`` name in the same directory.
+
+    Otherwise, when called on one or multiple assets or directories, the command will move
+    ``SOURCE``\\(s) into ``DEST``.
+
+    A list of all files and directories to modify will be presented, and the user prompted for
+    confirmation.
+
     """
     inventory = Inventory(repo=OnyoRepo(Path.cwd(), find_root=True))
 

--- a/onyo/commands/new.py
+++ b/onyo/commands/new.py
@@ -36,7 +36,10 @@ args_new = {
         nargs='+',
         help=(
             'Key-value pairs to set in the new asset(s). Multiple pairs can be '
-            'specified (e.g. key=value key2=value2)')),
+            'specified (e.g. key=value key2=value2). All fields that are part of '
+            'asset filenames (defined in .onyo/config under `onyo.assets.filename`) '
+            'are required. If the value `faux` is assigned to the key `serial`, '
+            'a random, repository-unique string will be filled in instead.')),
 
     'path': dict(
         args=('-p', '--path'),

--- a/onyo/commands/rm.py
+++ b/onyo/commands/rm.py
@@ -27,6 +27,9 @@ def rm(args: argparse.Namespace) -> None:
     """
     Delete ``ASSET``\\(s) and ``DIRECTORY``\\(s).
 
+    Directories and asset directories are deleted together with their contents.
+    If any of the specified paths is invalid, Onyo will error and delete none of them.
+
     A list of all files and directories to delete will be presented, and the
     user prompted for confirmation.
     """

--- a/onyo/commands/tests/test_rm.py
+++ b/onyo/commands/tests/test_rm.py
@@ -162,41 +162,6 @@ def test_rm_interactive(repo: OnyoRepo, asset: str) -> None:
 
 
 @pytest.mark.repo_files(*assets)
-def test_rm_quiet_missing_yes(repo: OnyoRepo) -> None:
-    """
-    Test that `onyo rm --quiet` errors correctly, when the required flag
-    `--yes` is missing.
-    """
-    ret = subprocess.run(['onyo', '--quiet', 'rm', *assets], capture_output=True, text=True)
-    assert ret.returncode == 1
-    assert not ret.stdout
-    assert ret.stderr
-
-    # verify no changes were made and the repository is in a clean state
-    for asset in assets:
-        assert Path(asset).exists()
-    assert repo.git.is_clean_worktree()
-
-
-@pytest.mark.repo_files(*assets)
-def test_rm_quiet_flag(repo: OnyoRepo) -> None:
-    """
-    Test that `onyo rm --quiet --yes` deletes a list of assets successfully
-    without printing any output or error.
-    """
-    ret = subprocess.run(['onyo', '--yes', '--quiet', 'rm', *assets], capture_output=True,
-                         text=True)
-    assert ret.returncode == 0
-    assert not ret.stdout
-    assert not ret.stderr
-
-    # verify deleting was successful and the repository is in a clean state
-    for asset in assets:
-        assert not Path(asset).exists()
-    assert repo.git.is_clean_worktree()
-
-
-@pytest.mark.repo_files(*assets)
 @pytest.mark.parametrize('asset', assets)
 def test_rm_message_flag(repo: OnyoRepo, asset: str) -> None:
     """

--- a/onyo/commands/tree.py
+++ b/onyo/commands/tree.py
@@ -21,8 +21,12 @@ args_tree = {
 
 
 def tree(args: argparse.Namespace) -> None:
-    """
-    List the assets and directories in ``DIRECTORY`` in the ``tree`` format.
+    """List the assets and directories in ``DIRECTORY`` in the ``tree`` format.
+
+    All given paths must be existing directories inside the onyo repository.
+    They are tested for their validity in the beginning and only displayed if all paths are valid.
+
+    If no path is specified, `onyo tree` prints the directory tree for CWD.
     """
 
     inventory = Inventory(repo=OnyoRepo(Path.cwd(), find_root=True))

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -98,18 +98,22 @@ def onyo_cat(inventory: Inventory,
              paths: list[Path]) -> None:
     """Print the contents of assets.
 
+    At least one valid asset path is required.
+    The same paths can be given multiple times.
+    If any path specified is invalid, no contents are printed and an error is raised.
+
     Parameters
     ----------
     inventory: Inventory
         The inventory containing the assets to print.
-
-    paths: Path or list of Path
+    paths: list of Path
         Path(s) to assets for which to print the contents.
 
     Raises
     ------
     ValueError
-        If paths point to a location which is not an asset.
+        If paths point to a location which is not an asset, or `paths`
+        is empty.
 
     OnyoInvalidRepoError
         If paths are not valid assets, e.g. because their content is not valid

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -846,6 +846,8 @@ def onyo_set(inventory: Inventory,
         renaming an asset, while `rename` is not true.
     """
     paths = paths or []
+    if not keys:
+        raise ValueError("At least one key-value pair must be specified.")
 
     if not rename and any(k in inventory.repo.get_asset_name_keys() for k in keys.keys()):
         raise ValueError("Can't change asset name keys without --rename.")

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -455,6 +455,8 @@ def onyo_mkdir(inventory: Inventory,
     message: str, optional
         An optional string to overwrite Onyo's default commit message.
     """
+    if not dirs:
+        raise ValueError("At least one directory path must be specified.")
     for d in deduplicate(dirs):  # pyre-ignore[16]  deduplicate would return None only of `dirs` was None.
         # explicit duplicates would make auto-generating message subject more complicated ATM
         inventory.add_directory(d)

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -116,6 +116,8 @@ def onyo_cat(inventory: Inventory,
         YAML format.
     """
     from .assets import validate_yaml
+    if not paths:
+        raise ValueError("At least one asset path must be specified.")
     non_asset_paths = [str(p) for p in paths if not inventory.repo.is_asset_path(p)]
     if non_asset_paths:
         raise ValueError("The following paths are not asset files:\n%s" %

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -448,16 +448,33 @@ def onyo_mkdir(inventory: Inventory,
                message: Optional[str]) -> None:
     """Create new directories in the inventory.
 
+    Intermediate directories will be created as needed (i.e. parent and
+    child directories can be created in one call).
+
+    An empty `.anchor` file is added to each directory, to ensure that git
+    tracks them even when empty.
+    If `dirs` contains duplicates, onyo will create just one new directory and
+    ignore the duplicates.
+
+    All paths in `dirs` must be new and valid directory paths inside the
+    inventory.
+    At least one valid path is required.
+    If any path specified is invalid no new directories are created, and an
+    error is raised.
+
     Parameters
     ----------
     inventory: Inventory
         The inventory in which to create new directories.
-
     dirs: list of Path
         Paths to directories which to create.
-
     message: str, optional
         An optional string to overwrite Onyo's default commit message.
+
+    Raises
+    ------
+    ValueError
+        If `dirs` is empty.
     """
     if not dirs:
         raise ValueError("At least one directory path must be specified.")

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -838,7 +838,7 @@ def onyo_set(inventory: Inventory,
     ----------
     inventory: Inventory
         The Inventory in which to set key/values for assets.
-    paths: Path or list of Path, optional
+    paths: list of Path, optional
         Paths to assets or directories for which to set key-value pairs.
         If paths are directories, the values will be set recursively in assets
         under the specified path.
@@ -864,7 +864,7 @@ def onyo_set(inventory: Inventory,
     ------
     ValueError
         If a given path is invalid or changes are made that would result in
-        renaming an asset, while `rename` is not true.
+        renaming an asset, while `rename` is not true, or if `keys` is empty.
     """
     paths = paths or []
     if not keys:

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -892,7 +892,7 @@ def onyo_set(inventory: Inventory,
 
 
 def onyo_tree(inventory: Inventory,
-              paths: list[Path]) -> None:
+              paths: list[Path] = []) -> None:
     """Print the directory tree of paths.
 
     Parameters
@@ -902,7 +902,8 @@ def onyo_tree(inventory: Inventory,
 
     paths: list of Path
         The paths to directories for which to print the directory tree.
-        If no path is specified, prints the directory tree for CWD.
+        If no path is specified, `onyo_tree(inventory)` prints the
+        directory tree for the root of the inventory.
 
     Raises
     ------
@@ -910,6 +911,7 @@ def onyo_tree(inventory: Inventory,
         If paths are invalid.
     """
     # sanitize the paths
+    paths = paths if paths else [inventory.root]
     non_inventory_dirs = [str(p) for p in paths if not inventory.repo.is_inventory_dir(p)]
     if non_inventory_dirs:
         raise ValueError("The following paths are not inventory directories: %s" %

--- a/onyo/lib/tests/test_commands_cat.py
+++ b/onyo/lib/tests/test_commands_cat.py
@@ -1,0 +1,134 @@
+from pathlib import Path
+
+import pytest
+
+from onyo.lib.inventory import Inventory
+from onyo.lib.onyo import OnyoRepo
+from ..assets import Asset
+from ..commands import onyo_cat
+from ... import OnyoInvalidRepoError
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_cat_errors(inventory: Inventory) -> None:
+    """`onyo_cat` must raise the correct error in different illegal or impossible calls."""
+    asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    dir_path = inventory.root / 'empty'
+
+    # cat with no file
+    pytest.raises(ValueError,
+                  onyo_cat,
+                  inventory,
+                  paths=[])
+
+    # cat on dir
+    pytest.raises(ValueError,
+                  onyo_cat,
+                  inventory,
+                  paths=[dir_path])
+
+    # cat on non-existing file
+    pytest.raises(ValueError,
+                  onyo_cat,
+                  inventory,
+                  paths=[dir_path / "does_not_exi.st"])
+
+    # cat on untracked file
+    pytest.raises(ValueError,
+                  onyo_cat,
+                  inventory,
+                  paths=[inventory.root / "untracked" / "file"])
+
+    # outside of onyo repository
+    pytest.raises(ValueError,
+                  onyo_cat,
+                  inventory,
+                  paths=[inventory.root / ".."])
+
+    # one of multiple is non-existing
+    pytest.raises(ValueError,
+                  onyo_cat,
+                  inventory,
+                  paths=[asset_path,
+                         inventory.root / "doesnotexist",
+                         asset_path])
+
+    # cat on .anchor
+    pytest.raises(ValueError,
+                  onyo_cat,
+                  inventory,
+                  paths=[dir_path / OnyoRepo.ANCHOR_FILE_NAME])
+
+    # cat on a template file
+    pytest.raises(ValueError,
+                  onyo_cat,
+                  inventory,
+                  paths=[inventory.repo.dot_onyo / "templates" / "laptop.example"])
+
+    # cat on a file that is in the inventory, but has invalid YAML contents
+    invalid_path = inventory.root / "in_va_l.id"
+    invalid_path.touch()
+    invalid_path.write_text("key: value\ninvalid")
+    inventory.repo.git._git(["add", str(invalid_path)])
+    inventory.commit("Invalid file added")
+    pytest.raises(OnyoInvalidRepoError,
+                  onyo_cat,
+                  inventory,
+                  paths=[invalid_path])
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_cat_single(inventory: Inventory,
+                         capsys) -> None:
+    """`onyo_cat()` a single valid asset."""
+    asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+
+    # cat single asset
+    onyo_cat(inventory,
+             paths=[asset_path])
+
+    # verify asset contents are in output
+    assert Path.read_text(asset_path) in capsys.readouterr().out
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_cat_multiple(inventory: Inventory,
+                           capsys) -> None:
+    """`onyo_cat()` on multiple valid assets."""
+    asset_path1 = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    # TODO: simplify with new fixtures
+    # add a different second asset to the inventory
+    inventory.add_asset(Asset(some_key="some_value",
+                              type="TYPE",
+                              make="MAKER",
+                              model="MODEL",
+                              serial="SERIAL2",
+                              other=1,
+                              directory=inventory.root)
+                        )
+    asset_path2 = inventory.root / "TYPE_MAKER_MODEL.SERIAL2"
+    inventory.commit("Second asset added")
+
+    # cat multiple assets at once
+    onyo_cat(inventory,
+             paths=[asset_path1,
+                    asset_path2])
+
+    # verify the output contains both assets
+    out = capsys.readouterr().out
+    assert Path.read_text(asset_path1) in out
+    assert Path.read_text(asset_path2) in out
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_cat_with_duplicate_path(inventory: Inventory,
+                                      capsys) -> None:
+    """`onyo_cat()` Multiple times on the same asset succeeds."""
+    asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+
+    # cat single asset
+    onyo_cat(inventory,
+             paths=[asset_path, asset_path, asset_path])
+
+    # verify output contains the asset contents once for each time the asset is in `paths`
+    assert capsys.readouterr().out.count(Path.read_text(asset_path)) == 3

--- a/onyo/lib/tests/test_commands_mkdir.py
+++ b/onyo/lib/tests/test_commands_mkdir.py
@@ -1,0 +1,222 @@
+import pytest
+
+from onyo.lib.inventory import Inventory
+from onyo.lib.onyo import OnyoRepo
+from ..commands import onyo_mkdir
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_mkdir_errors(inventory: Inventory) -> None:
+    """`onyo_mkdir` must raise the correct error in different illegal or impossible calls."""
+    asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    dir_path = inventory.root / 'empty'
+
+    # mkdir on existing directory path
+    pytest.raises(ValueError,
+                  onyo_mkdir,
+                  inventory,
+                  dirs=[dir_path],
+                  message="some subject\n\nAnd a body")
+
+    # mkdir on existing asset path
+    pytest.raises(ValueError,
+                  onyo_mkdir,
+                  inventory,
+                  dirs=[asset_path],
+                  message="some subject\n\nAnd a body")
+
+    # mkdir outside the repository
+    pytest.raises(ValueError,
+                  onyo_mkdir,
+                  inventory,
+                  dirs=[(inventory.root / ".." / "outside").resolve()],
+                  message="some subject\n\nAnd a body")
+
+    # mkdir with empty list
+    pytest.raises(ValueError,
+                  onyo_mkdir,
+                  inventory,
+                  dirs=[],
+                  message="some subject\n\nAnd a body")
+
+    # mkdir on illegal but non-existing name ".anchor"
+    pytest.raises(ValueError,
+                  onyo_mkdir,
+                  inventory,
+                  dirs=[inventory.root / "subdir" / ".anchor"],
+                  message="some subject\n\nAnd a body")
+
+    # mkdir on illegal but non-existing directory in .git/
+    pytest.raises(ValueError,
+                  onyo_mkdir,
+                  inventory,
+                  dirs=[inventory.root / ".git" / "new-dir"],
+                  message="some subject\n\nAnd a body")
+
+    # mkdir is not allowed to create a new .git/ in a subdirectory
+    pytest.raises(ValueError,
+                  onyo_mkdir,
+                  inventory,
+                  dirs=[dir_path / ".git"],
+                  message="some subject\n\nAnd a body")
+
+    # mkdir on illegal but non-existing directory in .onyo/
+    pytest.raises(ValueError,
+                  onyo_mkdir,
+                  inventory,
+                  dirs=[inventory.root / ".onyo" / "new-dir"],
+                  message="some subject\n\nAnd a body")
+
+    # mkdir is not allowed to create a new .onyo/ in a subdirectory
+    pytest.raises(ValueError,
+                  onyo_mkdir,
+                  inventory,
+                  dirs=[dir_path / ".onyo"],
+                  message="some subject\n\nAnd a body")
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_mkdir_errors_before_mkdir(inventory: Inventory) -> None:
+    """`onyo_mkdir` must raise the correct error and is not allowed to create/commit anything, if
+    one of the specified paths is not valid.
+    """
+    dir_path_new = inventory.root / 'new_dir'
+    dir_path_existing = inventory.root / 'empty'
+    old_hexsha = inventory.repo.git.get_hexsha()
+
+    # one of multiple sources does already exist
+    pytest.raises(ValueError,
+                  onyo_mkdir,
+                  inventory,
+                  dirs=[dir_path_new,
+                        dir_path_existing],
+                  message="some subject\n\nAnd a body")
+
+    # no new directory/anchor was created
+    assert not dir_path_new.is_dir()
+    assert not (dir_path_new / OnyoRepo.ANCHOR_FILE_NAME).is_file()
+    assert not (dir_path_new / OnyoRepo.ANCHOR_FILE_NAME) in inventory.repo.git.files
+    # no commit was added
+    assert inventory.repo.git.get_hexsha() == old_hexsha
+    # TODO: verifying cleanness of worktree does not work,
+    #       because fixture returns inventory with untracked stuff
+    # assert inventory.repo.git.is_clean_worktree()
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_mkdir_simple(inventory: Inventory) -> None:
+    """Create a single new directory."""
+    dir_path_new = inventory.root / 'new_dir'
+    old_hexsha = inventory.repo.git.get_hexsha()
+
+    # create a new directory
+    onyo_mkdir(inventory,
+               dirs=[dir_path_new],
+               message="some subject\n\nAnd a body")
+
+    # directory was created and anchor exists
+    assert dir_path_new.is_dir()
+    assert inventory.repo.is_inventory_dir(dir_path_new)
+    assert (dir_path_new / OnyoRepo.ANCHOR_FILE_NAME).is_file()
+    assert (dir_path_new / OnyoRepo.ANCHOR_FILE_NAME) in inventory.repo.git.files
+    # exactly one commit added
+    assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
+    # TODO: verifying cleanness of worktree does not work,
+    #       because fixture returns inventory with untracked stuff
+    # assert inventory.repo.git.is_clean_worktree()
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_mkdir_multiple(inventory: Inventory) -> None:
+    """Create multiple new directories in a single call and with one commit."""
+    dir_path_new1 = inventory.root / 'new_dir1'
+    dir_path_new2 = inventory.root / 'new_dir2'
+    dir_path_new3 = inventory.root / 'new_dir3'
+    old_hexsha = inventory.repo.git.get_hexsha()
+
+    # create a new directory
+    onyo_mkdir(inventory,
+               dirs=[dir_path_new1,
+                     dir_path_new2,
+                     dir_path_new3],
+               message="some subject\n\nAnd a body")
+
+    # directories were created and anchor exists for 1.
+    assert dir_path_new1.is_dir()
+    assert inventory.repo.is_inventory_dir(dir_path_new1)
+    assert (dir_path_new1 / OnyoRepo.ANCHOR_FILE_NAME).is_file()
+    assert (dir_path_new1 / OnyoRepo.ANCHOR_FILE_NAME) in inventory.repo.git.files
+    # directories were created and anchor exists for 2.
+    assert dir_path_new2.is_dir()
+    assert inventory.repo.is_inventory_dir(dir_path_new2)
+    assert (dir_path_new2 / OnyoRepo.ANCHOR_FILE_NAME).is_file()
+    assert (dir_path_new2 / OnyoRepo.ANCHOR_FILE_NAME) in inventory.repo.git.files
+    # directories were created and anchor exists for 3.
+    assert dir_path_new3.is_dir()
+    assert inventory.repo.is_inventory_dir(dir_path_new3)
+    assert (dir_path_new3 / OnyoRepo.ANCHOR_FILE_NAME).is_file()
+    assert (dir_path_new3 / OnyoRepo.ANCHOR_FILE_NAME) in inventory.repo.git.files
+    # exactly one commit added
+    assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
+    # TODO: verifying cleanness of worktree does not work,
+    #       because fixture returns inventory with untracked stuff
+    # assert inventory.repo.git.is_clean_worktree()
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_mkdir_create_multiple_subdirectories(inventory: Inventory) -> None:
+    """Create multiple not-yet-existing subdirectories at once."""
+    dir_x = inventory.root / 'x'
+    dir_y = inventory.root / 'x' / 'y'
+    dir_z = inventory.root / 'x' / 'y' / 'z'
+
+    old_hexsha = inventory.repo.git.get_hexsha()
+
+    # call onyo_mkdir with the deepest new directory, and create the other dirs implicitely
+    onyo_mkdir(inventory,
+               dirs=[dir_z],
+               message="some subject\n\nAnd a body")
+
+    # directory x was created and anchor exists
+    assert dir_x.is_dir()
+    assert inventory.repo.is_inventory_dir(dir_x)
+    assert (dir_x / OnyoRepo.ANCHOR_FILE_NAME).is_file()
+    assert (dir_x / OnyoRepo.ANCHOR_FILE_NAME) in inventory.repo.git.files
+    # directory x was created and anchor exists
+    assert dir_y.is_dir()
+    assert inventory.repo.is_inventory_dir(dir_y)
+    assert (dir_y / OnyoRepo.ANCHOR_FILE_NAME).is_file()
+    assert (dir_y / OnyoRepo.ANCHOR_FILE_NAME) in inventory.repo.git.files
+    # directory x was created and anchor exists
+    assert dir_z.is_dir()
+    assert inventory.repo.is_inventory_dir(dir_z)
+    assert (dir_z / OnyoRepo.ANCHOR_FILE_NAME).is_file()
+    assert (dir_z / OnyoRepo.ANCHOR_FILE_NAME) in inventory.repo.git.files
+    # exactly one commit added
+    assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
+    # TODO: verifying cleanness of worktree does not work,
+    #       because fixture returns inventory with untracked stuff
+    # assert inventory.repo.git.is_clean_worktree()
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_mkdir_allows_duplicates(inventory: Inventory) -> None:
+    """Calling `onyo_mkdir()` with a list containing the same path multiple times does not error."""
+    dir_path_new = inventory.root / 'new_dir'
+    old_hexsha = inventory.repo.git.get_hexsha()
+
+    # call `onyo_mkdir()` with `dirs` containing duplicates
+    onyo_mkdir(inventory,
+               dirs=[dir_path_new, dir_path_new, dir_path_new],
+               message="some subject\n\nAnd a body")
+
+    # the new directory was created and anchor exists
+    assert dir_path_new.is_dir()
+    assert inventory.repo.is_inventory_dir(dir_path_new)
+    assert (dir_path_new / OnyoRepo.ANCHOR_FILE_NAME).is_file()
+    assert (dir_path_new / OnyoRepo.ANCHOR_FILE_NAME) in inventory.repo.git.files
+    # exactly one commit added
+    assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
+    # TODO: verifying cleanness of worktree does not work,
+    #       because fixture returns inventory with untracked stuff
+    # assert inventory.repo.git.is_clean_worktree()

--- a/onyo/lib/tests/test_commands_rm.py
+++ b/onyo/lib/tests/test_commands_rm.py
@@ -1,0 +1,169 @@
+import pytest
+
+from onyo.lib.exceptions import InvalidInventoryOperation
+from onyo.lib.inventory import Inventory
+from onyo.lib.onyo import OnyoRepo
+from ..commands import onyo_rm
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_rm_errors(inventory: Inventory) -> None:
+    """`onyo_rm` must raise the correct error in different illegal or impossible calls."""
+    # delete non-existing asset
+    pytest.raises(InvalidInventoryOperation,
+                  onyo_rm,
+                  inventory,
+                  paths=inventory.root / "TYPE_MAKER_MODEL.SERIAL",
+                  message="some subject\n\nAnd a body")
+
+    # delete non-existing directory
+    pytest.raises(InvalidInventoryOperation,
+                  onyo_rm,
+                  inventory,
+                  paths=inventory.root / "somewhere" / "non-existing",
+                  message="some subject\n\nAnd a body")
+
+    # delete .anchor
+    pytest.raises(InvalidInventoryOperation,
+                  onyo_rm,
+                  inventory,
+                  paths=inventory.root / OnyoRepo.ANCHOR_FILE_NAME,
+                  message="some subject\n\nAnd a body")
+
+    # delete outside of onyo repository
+    pytest.raises(InvalidInventoryOperation,
+                  onyo_rm,
+                  inventory,
+                  paths=inventory.root / "..",
+                  message="some subject\n\nAnd a body")
+
+    # deleting an existing file which is neither an asset nor a directory is illegal
+    assert (inventory.root / ".onyo" / "templates" / "laptop.example").is_file()
+    pytest.raises(InvalidInventoryOperation,
+                  onyo_rm,
+                  inventory,
+                  paths=inventory.root / ".onyo" / "templates" / "laptop.example",
+                  message="some subject\n\nAnd a body")
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_rm_errors_before_rm(inventory: Inventory) -> None:
+    """`onyo_rm` must raise the correct error and is not allowed to delete anything if one of
+    the paths does not exist.
+    """
+    asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    destination_path = inventory.root / 'empty'
+    old_hexsha = inventory.repo.git.get_hexsha()
+
+    # one of multiple paths to delete does not exist
+    pytest.raises(InvalidInventoryOperation,
+                  onyo_rm,
+                  inventory,
+                  paths=[asset_path, inventory.root / "not-existent", destination_path],
+                  message="some subject\n\nAnd a body")
+
+    # nothing was deleted and no new commit was created
+    assert asset_path.is_file()
+    assert destination_path.is_dir()
+    # no commit was added
+    assert inventory.repo.git.get_hexsha() == old_hexsha
+    # TODO: verifying cleanness of worktree does not work,
+    #       because fixture returns inventory with untracked stuff
+    # assert inventory.repo.git.is_clean_worktree()
+
+
+# TODO: after #309, add a test for a call for deleting multiple times the same path
+@pytest.mark.skip(reason="still a BUG: #309")
+@pytest.mark.ui({'yes': True})
+@pytest.mark.repo_dirs("a/b/c", "a/d/c")
+def test_onyo_rm_with_same_input_path_twice(inventory: Inventory) -> None:
+    """FIX BUG FIRST. `onyo rm dir dir` for same dir twice?"""
+    asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    old_hexsha = inventory.repo.git.get_hexsha()
+
+    # delete a path through giving it twice with the same name to onyo_rm()
+    onyo_rm(inventory,
+            paths=[asset_path, asset_path],
+            message="some subject\n\nAnd a body")
+
+    # asset file
+    assert not asset_path.exists()
+    assert asset_path not in inventory.repo.git.files
+    # exactly one commit added
+    assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
+    # TODO: verifying cleanness of worktree does not work,
+    #       because fixture returns inventory with untracked stuff
+    # assert inventory.repo.git.is_clean_worktree()
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_rm_move_single(inventory: Inventory) -> None:
+    """Delete a single asset path."""
+    asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    old_hexsha = inventory.repo.git.get_hexsha()
+
+    # delete a single asset as path
+    onyo_rm(inventory,
+            paths=asset_path,
+            message="some subject\n\nAnd a body")
+
+    # asset was deleted
+    assert not asset_path.exists()
+    assert asset_path not in inventory.repo.git.files
+    # exactly one commit added
+    assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
+    # TODO: verifying cleanness of worktree does not work,
+    #       because fixture returns inventory with untracked stuff
+    # assert inventory.repo.git.is_clean_worktree()
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_rm_list(inventory: Inventory) -> None:
+    """Delete a directory and an asset together as a list in one commit."""
+    asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    dir_path = inventory.root / 'empty'
+    old_hexsha = inventory.repo.git.get_hexsha()
+
+    # delete an asset and a dir together in the same call
+    onyo_rm(inventory,
+            paths=[asset_path, dir_path],
+            message="some subject\n\nAnd a body")
+
+    # asset was deleted
+    assert not asset_path.exists()
+    assert asset_path not in inventory.repo.git.files
+    # dir was deleted
+    assert not dir_path.exists()
+    assert dir_path / OnyoRepo.ANCHOR_FILE_NAME not in inventory.repo.git.files
+    # exactly one commit added
+    assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
+    # TODO: verifying cleanness of worktree does not work,
+    #       because fixture returns inventory with untracked stuff
+    # assert inventory.repo.git.is_clean_worktree()
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_rm_subpath_and_contents(inventory: Inventory) -> None:
+    """Delete a directory with contents."""
+    asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    nested = inventory.root / "somewhere" / "nested"
+    old_hexsha = inventory.repo.git.get_hexsha()
+
+    # delete a path
+    onyo_rm(inventory,
+            paths=nested,
+            message="some subject\n\nAnd a body")
+
+    # "somewhere" NOT deleted
+    assert (inventory.root / "somewhere").is_dir
+    assert (inventory.root / "somewhere" / OnyoRepo.ANCHOR_FILE_NAME) in inventory.repo.git.files
+    # dir "nested" was deleted, and it's contents, too
+    assert not nested.exists()
+    assert (nested / OnyoRepo.ANCHOR_FILE_NAME) not in inventory.repo.git.files
+    assert not asset_path.exists()
+    assert asset_path not in inventory.repo.git.files
+    # exactly one commit added
+    assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
+    # TODO: verifying cleanness of worktree does not work,
+    #       because fixture returns inventory with untracked stuff
+    # assert inventory.repo.git.is_clean_worktree()

--- a/onyo/lib/tests/test_commands_set.py
+++ b/onyo/lib/tests/test_commands_set.py
@@ -1,0 +1,219 @@
+import pytest
+
+from onyo.lib.inventory import Inventory
+from onyo.lib.onyo import OnyoRepo
+from ..commands import onyo_set
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_set_errors(inventory: Inventory) -> None:
+    """`onyo_set` must raise the correct error in different illegal or impossible calls."""
+    asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    key_value = {"this_key": "that_value"}
+
+    # set on non-existing asset
+    pytest.raises(ValueError,
+                  onyo_set,
+                  inventory,
+                  paths=[inventory.root / "not-existing" / "TYPE_MAKER_MODEL.SERIAL"],
+                  keys=key_value,
+                  message="some subject\n\nAnd a body")
+
+    # set outside the repository
+    pytest.raises(ValueError,
+                  onyo_set,
+                  inventory,
+                  paths=[(inventory.root / "..").resolve()],
+                  keys=key_value,
+                  message="some subject\n\nAnd a body")
+
+    # set without keys specified
+    pytest.raises(ValueError,
+                  onyo_set,
+                  inventory,
+                  paths=[asset_path],
+                  keys=[],
+                  message="some subject\n\nAnd a body")
+
+    # set on ".anchor"
+    pytest.raises(ValueError,
+                  onyo_set,
+                  inventory,
+                  paths=[inventory.root / "somewhere" / OnyoRepo.ANCHOR_FILE_NAME],
+                  keys=key_value,
+                  message="some subject\n\nAnd a body")
+
+    # set on .git/
+    pytest.raises(ValueError,
+                  onyo_set,
+                  inventory,
+                  paths=[inventory.root / ".git"],
+                  keys=key_value,
+                  message="some subject\n\nAnd a body")
+
+    # set on .onyo/
+    pytest.raises(ValueError,
+                  onyo_set,
+                  inventory,
+                  paths=[inventory.root / ".onyo"],
+                  keys=key_value,
+                  message="some subject\n\nAnd a body")
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_set_on_empty_directory(inventory: Inventory) -> None:
+    """`onyo_set` does not error when called on a valid but empty directory,
+    but no commits are added."""
+    dir_path = inventory.root / 'empty'
+    key_value = {"this_key": "that_value"}
+    old_hexsha = inventory.repo.git.get_hexsha()
+
+    # set on a directory without assets
+    onyo_set(inventory,
+             paths=[dir_path],
+             keys=key_value,  # pyre-ignore[6]
+             message="some subject\n\nAnd a body")
+
+    # no commit was added
+    assert inventory.repo.git.get_hexsha() == old_hexsha
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_set_illegal_fields(inventory: Inventory) -> None:
+    """`onyo_set` must raise an error when requested to set an
+    illegal/reserverd field without `rename=True`."""
+    # TODO: add PSEUDO_KEYS after fixing BUG #527:
+    from onyo.lib.consts import RESERVED_KEYS  # PSEUDO_KEYS
+    asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    old_hexsha = inventory.repo.git.get_hexsha()
+
+    illegal_fields = [
+        {"type": "new_value"},
+        {"make": "new_value"},
+        {"model": "new_value"},
+        {"serial": "new_value"}]
+    # TODO: add PSEUDO_KEYS after fixing BUG #527:
+    # illegal_fields.extend([{k : "new_value"} for k in PSEUDO_KEYS])
+    illegal_fields.extend([{k: "new_value"} for k in RESERVED_KEYS])
+
+    # set on illegal fields
+    for illegal in illegal_fields:
+        pytest.raises(ValueError,
+                      onyo_set,
+                      inventory,
+                      paths=[asset_path],
+                      keys=illegal,
+                      message="some subject\n\nAnd a body")
+
+    # no illegal field was written
+    assert "new_value" not in asset_path.read_text()
+    # no commit was added
+    assert inventory.repo.git.get_hexsha() == old_hexsha
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_set_errors_before_set(inventory: Inventory) -> None:
+    """`onyo_set` must raise the correct error and is not allowed to
+    modify/commit anything, if one of the specified paths is not valid.
+    """
+    asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    non_existing_asset_path = inventory.root / "non-existing" / "TYPE_MAKER_MODEL.SERIAL"
+    key_value = {"this_key": "that_value"}
+    old_hexsha = inventory.repo.git.get_hexsha()
+
+    # one of multiple paths does not exist
+    pytest.raises(ValueError,
+                  onyo_set,
+                  inventory,
+                  paths=[asset_path,
+                         non_existing_asset_path],
+                  keys=key_value,
+                  message="some subject\n\nAnd a body")
+
+    # no new asset was created
+    assert not non_existing_asset_path.exists()
+    assert non_existing_asset_path not in inventory.repo.git.files
+    # no commit was added
+    assert inventory.repo.git.get_hexsha() == old_hexsha
+    # TODO: verifying cleanness of worktree does not work,
+    #       because fixture returns inventory with untracked stuff
+    # assert inventory.repo.git.is_clean_worktree()
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_set_simple(inventory: Inventory) -> None:
+    """Set a value in an asset."""
+    asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    key_value = {"this_key": "that_value"}
+    old_hexsha = inventory.repo.git.get_hexsha()
+
+    # create a new directory
+    onyo_set(inventory,
+             paths=[asset_path],
+             keys=key_value,  # pyre-ignore[6]
+             message="some subject\n\nAnd a body")
+
+    # check content
+    assert "this_key" in inventory.repo.get_asset_content(asset_path).keys()
+    assert "that_value" in inventory.repo.get_asset_content(asset_path).values()
+
+    # exactly one commit added
+    assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
+    # TODO: verifying cleanness of worktree does not work,
+    #       because fixture returns inventory with untracked stuff
+    # assert inventory.repo.git.is_clean_worktree()
+
+
+@pytest.mark.repo_contents(
+    ["one_that_exists.test", "type: one\nmake: that\nmodel: exists\nserial: test"])
+@pytest.mark.ui({'yes': True})
+def test_onyo_set_multiple(inventory: Inventory) -> None:
+    """Modify multiple assets in a single call and with one commit."""
+    asset_path1 = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    asset_path2 = inventory.root / "one_that_exists.test"
+    key_value = {"this_key": "that_value"}
+    old_hexsha = inventory.repo.git.get_hexsha()
+
+    # create a new directory
+    onyo_set(inventory,
+             paths=[asset_path1,
+                    asset_path2],
+             keys=key_value,  # pyre-ignore[6]
+             message="some subject\n\nAnd a body")
+
+    # check contents
+    assert "this_key" in inventory.repo.get_asset_content(asset_path1).keys()
+    assert "that_value" in inventory.repo.get_asset_content(asset_path1).values()
+    assert "this_key" in inventory.repo.get_asset_content(asset_path2).keys()
+    assert "that_value" in inventory.repo.get_asset_content(asset_path2).values()
+
+    # exactly one commit added
+    assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
+    # TODO: verifying cleanness of worktree does not work,
+    #       because fixture returns inventory with untracked stuff
+    # assert inventory.repo.git.is_clean_worktree()
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_set_allows_duplicates(inventory: Inventory) -> None:
+    """Calling `onyo_set()` with a list containing the same asset multiple
+    times does not error."""
+    asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    key_value = {"this_key": "that_value"}
+    old_hexsha = inventory.repo.git.get_hexsha()
+
+    # call `onyo_set()` with `dirs` containing duplicates
+    onyo_set(inventory,
+             paths=[asset_path, asset_path, asset_path],
+             keys=key_value,  # pyre-ignore[6]
+             message="some subject\n\nAnd a body")
+
+    # check content
+    assert "this_key" in inventory.repo.get_asset_content(asset_path).keys()
+    assert "that_value" in inventory.repo.get_asset_content(asset_path).values()
+
+    # exactly one commit added
+    assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
+    # TODO: verifying cleanness of worktree does not work,
+    #       because fixture returns inventory with untracked stuff
+    # assert inventory.repo.git.is_clean_worktree()

--- a/onyo/lib/tests/test_commands_tree.py
+++ b/onyo/lib/tests/test_commands_tree.py
@@ -1,0 +1,115 @@
+import pytest
+
+from onyo.lib.inventory import Inventory
+from ..commands import onyo_tree
+
+# TODO: test with relativ paths?
+# TODO: test output?
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_tree_errors(inventory: Inventory) -> None:
+    """`onyo_tree` must raise the correct error in different illegal or impossible calls."""
+    asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    dir_path = inventory.root / 'empty'
+
+    # no tree for files
+    pytest.raises(ValueError,
+                  onyo_tree,
+                  inventory,
+                  paths=[asset_path])
+
+    # non-existing dir
+    pytest.raises(ValueError,
+                  onyo_tree,
+                  inventory,
+                  paths=[dir_path / "doesnotexist"])
+
+    # existing dir, but outside of onyo repository
+    pytest.raises(ValueError,
+                  onyo_tree,
+                  inventory,
+                  paths=[inventory.root / ".."])
+
+    # one of many paths invalid
+    pytest.raises(ValueError,
+                  onyo_tree,
+                  inventory,
+                  paths=[inventory.root / "somewhere" / "nested",
+                         inventory.root / "doesnotexist",
+                         dir_path])
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_tree_single(inventory: Inventory) -> None:
+    """Display a tree for a directory."""
+    directory_path = inventory.root / "somewhere" / "nested"
+
+    # move an asset and a dir to the same destination
+    onyo_tree(inventory,
+              paths=[directory_path])
+
+    # TODO: verifying cleanness of worktree does not work,
+    #       because fixture returns inventory with untracked stuff
+    # assert inventory.repo.git.is_clean_worktree()
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_tree_multiple_paths(inventory: Inventory) -> None:
+    """Display multiple trees with one call."""
+    dir_path = inventory.root / 'somewhere' / 'nested'
+
+    onyo_tree(inventory,
+              paths=[dir_path,
+                     inventory.root])
+
+    # TODO: verifying cleanness of worktree does not work,
+    #       because fixture returns inventory with untracked stuff
+    # assert inventory.repo.git.is_clean_worktree()
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_tree_without_explicit_paths(inventory: Inventory) -> None:
+    """Display the root of the inventory, if onyo_tree() is called without paths."""
+    onyo_tree(inventory)
+
+    # TODO: verifying cleanness of worktree does not work,
+    #       because fixture returns inventory with untracked stuff
+    # assert inventory.repo.git.is_clean_worktree()
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_tree_errors_before_showing_trees(inventory: Inventory) -> None:
+    """`onyo_tree` must raise the correct error if one of the paths does not exist."""
+    directory_path = inventory.root / "somewhere" / "nested"
+    non_existing_path = inventory.root / "doesnotexist"
+
+    # one of multiple paths does not exist
+    pytest.raises(ValueError,
+                  onyo_tree,
+                  inventory,
+                  paths=[directory_path,
+                         non_existing_path,
+                         inventory.root])
+
+    # TODO: verifying cleanness of worktree does not work,
+    #       because fixture returns inventory with untracked stuff
+    # assert inventory.repo.git.is_clean_worktree()
+
+
+@pytest.mark.ui({'yes': True})
+@pytest.mark.repo_dirs("a/b/c", "a/d/c")
+def test_onyo_tree_with_same_dir_twice(inventory: Inventory) -> None:
+    """Allow to display the tree to a directory twice when `onyo_tree()` is called with the same
+    path twice at once."""
+    directory_path = inventory.root / "somewhere" / "nested"
+
+    # call onyo_tree() with `directory_path` twice in `paths`.
+    onyo_tree(inventory,
+              paths=[directory_path,
+                     inventory.root,
+                     directory_path])
+
+    # TODO: verifying cleanness of worktree does not work,
+    #       because fixture returns inventory with untracked stuff
+    # assert inventory.repo.git.is_clean_worktree()


### PR DESCRIPTION
Works towards:
- #487
- #491
- #495
  - closes #522 -> here I chose as a solution to display the inventory.root if the python function `onyo_tree(inventory)` is called without paths. This needs probably feedback/discussion!
  - I am not verifying the correctness of the output of `onyo_tree()`
- #493
  - closes #523 -> at least one valid asset path is required by `onyo_cat()`
- #488
  - closes #524 -> at least one valid directory path is required by `onyo_mkdir()`
- does not finish but works towards #490 
  -  closes #526
- Updates tests and doc-strings for `onyo_new()`, but will not close the issue
- Tests for `onyo init` are contained in `onyo/lib/tests/test_onyo.py` and were updated, too