### PR TITLE
TST/DOC: add/update tests and doc-strings

### DIFF
--- a/onyo/commands/tests/test_config.py
+++ b/onyo/commands/tests/test_config.py
@@ -15,6 +15,19 @@ def test_config_set(repo: OnyoRepo) -> None:
     assert repo.git.is_clean_worktree()
 
 
+def test_config_already_set(repo: OnyoRepo) -> None:
+    """`onyo config` does not error if a legal value is
+    already set and no changes are made."""
+    assert 'onyo "history"' in Path('.onyo/config').read_text()
+    assert 'interactive = tig --follow' in Path('.onyo/config').read_text()
+    ret = subprocess.run(["onyo", "config", "onyo.history.interactive", "tig --follow"],
+                         capture_output=True, text=True)
+    assert ret.returncode == 0
+    assert "No changes to commit." in ret.stdout
+    assert not ret.stderr
+    assert repo.git.is_clean_worktree()
+
+
 def test_config_get_onyo(repo: OnyoRepo) -> None:
     # set
     ret = subprocess.run(["onyo", "config", "onyo.test.get-onyo",

--- a/onyo/commands/tests/test_set.py
+++ b/onyo/commands/tests/test_set.py
@@ -51,10 +51,10 @@ name_fields = [["type=desktop"],
 @pytest.mark.repo_contents(*assets)
 @pytest.mark.parametrize('asset', asset_paths)
 @pytest.mark.parametrize('set_values', values)
-def test_set(repo: OnyoRepo, asset: str, set_values: list[str]) -> None:
-    """
-    Test that `onyo set KEY=VALUE <asset>` updates contents of assets.
-    """
+def test_set(repo: OnyoRepo,
+             asset: str,
+             set_values: list[str]) -> None:
+    """Test that `onyo set KEY=VALUE <asset>` updates contents of assets."""
     ret = subprocess.run(['onyo', '--yes', 'set', '--keys', *set_values, '--path', asset],
                          capture_output=True, text=True)
 
@@ -71,14 +71,14 @@ def test_set(repo: OnyoRepo, asset: str, set_values: list[str]) -> None:
 
 
 @pytest.mark.repo_contents(*assets)
-@pytest.mark.parametrize('asset', asset_paths)
+@pytest.mark.parametrize('asset', [asset_paths[0]])
 @pytest.mark.parametrize('set_values', values)
-def test_set_interactive(repo: OnyoRepo, asset: str, set_values: list[str]) -> None:
-    """
-    Test that `onyo set KEY=VALUE <asset>` updates contents of assets.
-    """
-    ret = subprocess.run(['onyo', 'set', '--keys', *set_values, '--path', asset], input='y',
-                         capture_output=True, text=True)
+def test_set_interactive(repo: OnyoRepo,
+                         asset: str,
+                         set_values: list[str]) -> None:
+    """Test that `onyo set KEY=VALUE <asset>` updates contents of assets."""
+    ret = subprocess.run(['onyo', 'set', '--keys', *set_values, '--path', asset],
+                         input='y', capture_output=True, text=True)
 
     # verify output
     assert "The following assets will be changed:" in ret.stdout
@@ -95,12 +95,13 @@ def test_set_interactive(repo: OnyoRepo, asset: str, set_values: list[str]) -> N
 
 @pytest.mark.repo_contents(*assets)
 @pytest.mark.parametrize('set_values', values)
-def test_set_multiple_assets(repo: OnyoRepo, set_values: list[str]) -> None:
-    """
-    Test that `onyo set KEY=VALUE <asset>` can update the contents of multiple
+def test_set_multiple_assets(repo: OnyoRepo,
+                             set_values: list[str]) -> None:
+    """Test that `onyo set KEY=VALUE <asset>` can update the contents of multiple
     assets in a single call.
     """
-    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', *set_values, '--path', *asset_paths],
+    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', *set_values,
+                          '--path', *asset_paths],
                          capture_output=True, text=True)
 
     # verify output
@@ -120,8 +121,7 @@ def test_set_multiple_assets(repo: OnyoRepo, set_values: list[str]) -> None:
 @pytest.mark.parametrize('no_assets', non_existing_assets)
 def test_set_error_non_existing_assets(repo: OnyoRepo,
                                        no_assets: list[str]) -> None:
-    """
-    Test that `onyo set KEY=VALUE <asset>` errors correctly for:
+    """Test that `onyo set KEY=VALUE <asset>` errors correctly for:
     - non-existing assets on root
     - non-existing assets in directories
     - one non-existing asset in a list of existing ones
@@ -138,9 +138,9 @@ def test_set_error_non_existing_assets(repo: OnyoRepo,
 
 @pytest.mark.repo_contents(*assets)
 @pytest.mark.parametrize('set_values', values)
-def test_set_with_dot_recursive(repo: OnyoRepo, set_values: list[str]) -> None:
-    """
-    Test that when `onyo set KEY=VALUE .` is called from the repository root,
+def test_set_with_dot_recursive(repo: OnyoRepo,
+                                set_values: list[str]) -> None:
+    """Test that when `onyo set KEY=VALUE .` is called from the repository root,
     onyo selects all assets in the complete repo recursively.
     """
     ret = subprocess.run(['onyo', '--yes', 'set', '--keys', *set_values,
@@ -161,12 +161,13 @@ def test_set_with_dot_recursive(repo: OnyoRepo, set_values: list[str]) -> None:
 
 @pytest.mark.repo_contents(*assets)
 @pytest.mark.parametrize('set_values', values)
-def test_set_without_path(repo: OnyoRepo, set_values: list[str]) -> None:
-    """
-    Test that `onyo set KEY=VALUE` without a given path selects all assets in
+def test_set_without_path(repo: OnyoRepo,
+                          set_values: list[str]) -> None:
+    """Test that `onyo set KEY=VALUE` without a given path selects all assets in
     the repository, beginning with cwd.
     """
-    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', *set_values], capture_output=True, text=True)
+    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', *set_values],
+                         capture_output=True, text=True)
 
     # verify that output contains one line per asset
     assert "The following assets will be changed:" in ret.stdout
@@ -185,12 +186,14 @@ def test_set_without_path(repo: OnyoRepo, set_values: list[str]) -> None:
 @pytest.mark.repo_contents(*assets)
 @pytest.mark.parametrize('directory', directories)
 @pytest.mark.parametrize('set_values', values)
-def test_set_recursive_directories(repo: OnyoRepo, directory: str, set_values: list[str]) -> None:
+def test_set_recursive_directories(repo: OnyoRepo,
+                                   directory: str,
+                                   set_values: list[str]) -> None:
+    """Test that `onyo set KEY=VALUE <directory>` updates
+    contents of assets correctly.
     """
-    Test that `onyo set KEY=VALUE <directory>` updates contents of assets
-    correctly.
-    """
-    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', *set_values, '--path', directory],
+    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', *set_values,
+                          '--path', directory],
                          capture_output=True, text=True)
 
     # verify output
@@ -208,14 +211,14 @@ def test_set_recursive_directories(repo: OnyoRepo, directory: str, set_values: l
 
 
 @pytest.mark.repo_contents(*assets)
-@pytest.mark.parametrize('asset', asset_paths)
+@pytest.mark.parametrize('asset', [asset_paths[0]])
 @pytest.mark.parametrize('set_values', values)
-def test_set_discard_changes_single_assets(repo: OnyoRepo, asset: str,
+def test_set_discard_changes_single_assets(repo: OnyoRepo,
+                                           asset: str,
                                            set_values: list[str]) -> None:
-    """
-    Test that `onyo set` discards changes for assets successfully.
-    """
-    ret = subprocess.run(['onyo', 'set', '--keys', *set_values, '--path', asset], input='n',
+    """Test that `onyo set` discards changes for assets successfully."""
+    ret = subprocess.run(['onyo', 'set', '--keys', *set_values, '--path', asset],
+                         input='n',
                          capture_output=True, text=True)
 
     # verify output for just dot, should be all in onyo root, but not recursive
@@ -234,11 +237,10 @@ def test_set_discard_changes_single_assets(repo: OnyoRepo, asset: str,
 
 @pytest.mark.repo_contents(*assets)
 def test_set_discard_changes_recursive(repo: OnyoRepo) -> None:
-    """
-    Test that `onyo set` discards changes for all assets successfully.
-    """
+    """Test that `onyo set` discards changes for all assets successfully."""
     set_values = "key=discard"
-    ret = subprocess.run(['onyo', 'set', '--keys', set_values], input='n', capture_output=True, text=True)
+    ret = subprocess.run(['onyo', 'set', '--keys', set_values],
+                         input='n', capture_output=True, text=True)
 
     # verify output for just dot, should be all in onyo root, but not recursive
     assert "The following assets will be changed:" in ret.stdout
@@ -256,38 +258,14 @@ def test_set_discard_changes_recursive(repo: OnyoRepo) -> None:
 
 
 @pytest.mark.repo_contents(*assets)
-@pytest.mark.parametrize('asset', asset_paths)
-@pytest.mark.parametrize('set_values', values)
-def test_set_yes_flag(repo: OnyoRepo, asset: str, set_values: list[str]) -> None:
-    """
-    Test that `onyo set --yes KEY=VALUE <asset>` updates assets without prompt.
-    """
-    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', *set_values, '--path', asset],
-                         capture_output=True, text=True)
-
-    # verify output
-    assert "The following assets will be changed:" in ret.stdout
-    assert str(Path(asset)) in ret.stdout
-    assert not ret.stderr
-    assert ret.returncode == 0
-
-    # should not be asked with --yes flag
-    assert "Update assets? (y/n) " not in ret.stdout
-
-    # verify changes, and the repository clean
-    for value in set_values:
-        assert f"+{value.replace('=', ': ')}" in ret.stdout
-        assert value.replace("=", ": ") in Path.read_text(Path(asset))
-    assert repo.git.is_clean_worktree()
-
-
-@pytest.mark.repo_contents(*assets)
-@pytest.mark.parametrize('asset', asset_paths)
-@pytest.mark.parametrize('set_values', values)
-def test_set_message_flag(repo: OnyoRepo, asset: str, set_values: list[str]) -> None:
-    """
-    Test that `onyo set --message msg` overwrites the default commit message
-    with one specified by the user containing different special characters.
+@pytest.mark.parametrize('asset', [asset_paths[0]])
+@pytest.mark.parametrize('set_values', [values[0]])
+def test_set_message_flag(repo: OnyoRepo,
+                          asset: str,
+                          set_values: list[str]) -> None:
+    """Test that `onyo set --message msg` overwrites the
+    default commit message with one specified by the user
+    containing various special characters.
     """
     msg = "I am here to test the --message flag with spe\"cial\\char\'acteஞrs!"
     ret = subprocess.run(['onyo', '--yes', 'set', '--message', msg,
@@ -302,54 +280,13 @@ def test_set_message_flag(repo: OnyoRepo, asset: str, set_values: list[str]) -> 
     assert repo.git.is_clean_worktree()
 
 
-@pytest.mark.repo_contents(assets[2])
-def test_set_quiet_without_yes_flag(repo: OnyoRepo) -> None:
-    """
-    Test that `onyo set --quiet KEY=VALUE <asset>` errors correctly without the
-    --yes flag.
-    """
-    ret = subprocess.run(['onyo', '--quiet', 'set', '--keys', "mode=single", '--path', repo.asset_paths[0]],
-                         capture_output=True, text=True)
-
-    # verify output
-    assert not ret.stdout
-    assert "The --quiet flag requires --yes." in ret.stderr
-    assert ret.returncode == 1
-
-    # verify that the repository is in a clean state
-    assert repo.git.is_clean_worktree()
-
-
 @pytest.mark.repo_contents(*assets)
-@pytest.mark.parametrize('asset', asset_paths)
-@pytest.mark.parametrize('set_values', values)
-def test_set_quiet_flag(repo: OnyoRepo, asset: str, set_values: list[str]) -> None:
-    """
-    Test that `onyo set --quiet --yes KEY=VALUE <asset>` works correctly without
-    output and user-response.
-    """
-    ret = subprocess.run(['onyo', '--yes', '--quiet', 'set', '--keys', *set_values, '--path', asset], capture_output=True, text=True)
-
-    # verify that output is completely empty
-    assert not ret.stdout
-    assert not ret.stderr
-    assert ret.returncode == 0
-
-    # verify that asset contents are updated
-    for value in set_values:
-        assert value.replace("=", ": ") in Path.read_text(Path(asset))
-
-    # verify that the repository is in a clean state
-    assert repo.git.is_clean_worktree()
-
-
-@pytest.mark.repo_contents(*assets)
-@pytest.mark.parametrize('set_values', values)
+@pytest.mark.parametrize('set_values', [values[0]])
 @pytest.mark.parametrize('depth', ['0', '1', '3', '10'])
-def test_set_depth_flag(
-        repo: OnyoRepo, set_values: list[str], depth: str) -> None:
-    """
-    Test correct behavior for `onyo set --depth N KEY=VALUE <assets>` for
+def test_set_depth_flag(repo: OnyoRepo,
+                        set_values: list[str],
+                        depth: str) -> None:
+    """Test correct behavior for `onyo set --depth N KEY=VALUE <assets>` for
     different values for `--depth N`.
 
     The test searches through the output to find returned assets and ensures
@@ -372,15 +309,16 @@ def test_set_depth_flag(
             assert str(p) not in ret.stdout
 
 
-@pytest.mark.parametrize('set_values', values)
+@pytest.mark.parametrize('set_values', [values[0]])
 @pytest.mark.parametrize('depth,expected', [
     ('-1', "depth must be greater or equal 0, but is '-1'"),
 ])
-def test_set_depth_flag_error(
-        repo: OnyoRepo, set_values: list[str], depth: str, expected: str) -> None:
-    """
-    Test correct behavior for `onyo set --depth N KEY=VALUE <assets>` when an
-    invalid depth value is given.
+def test_set_depth_flag_error(repo: OnyoRepo,
+                              set_values: list[str],
+                              depth: str,
+                              expected: str) -> None:
+    """Test correct behavior for `onyo set --depth N KEY=VALUE <assets>`
+    when an invalid depth value is given.
     """
     cmd = ['onyo', 'set', '--depth', depth, '--keys', *set_values]
     ret = subprocess.run(cmd, capture_output=True, text=True)
@@ -390,10 +328,10 @@ def test_set_depth_flag_error(
 
 
 @pytest.mark.repo_contents(*assets)
-@pytest.mark.parametrize('asset', asset_paths)
-def test_add_new_key_to_existing_content(repo: OnyoRepo, asset: str) -> None:
-    """
-    Test that `onyo set KEY=VALUE <asset>` can be called two times with
+@pytest.mark.parametrize('asset', [asset_paths[0]])
+def test_add_new_key_to_existing_content(repo: OnyoRepo,
+                                         asset: str) -> None:
+    """Test that `onyo set KEY=VALUE <asset>` can be called two times with
     different `KEY`, and adds it without overwriting existing values.
     """
     set_1 = "change=one"
@@ -432,8 +370,9 @@ def test_add_new_key_to_existing_content(repo: OnyoRepo, asset: str) -> None:
 
 
 @pytest.mark.repo_contents(*assets)
-@pytest.mark.parametrize('asset', asset_paths)
-def test_set_overwrite_key(repo: OnyoRepo, asset: str) -> None:
+@pytest.mark.parametrize('asset', [asset_paths[0]])
+def test_set_overwrite_key(repo: OnyoRepo,
+                           asset: str) -> None:
     """
     Test that `onyo set KEY=VALUE <asset>` can be called two times with
     different VALUE for the same KEY, and overwrites existing values correctly.
@@ -471,10 +410,10 @@ def test_set_overwrite_key(repo: OnyoRepo, asset: str) -> None:
 
 
 @pytest.mark.repo_contents(*assets)
-@pytest.mark.parametrize('asset', asset_paths)
-def test_setting_new_values_if_some_values_already_set(repo: OnyoRepo, asset: str) -> None:
-    """
-    Test that `onyo set KEY=VALUE <asset>` updates contents of assets and adds
+@pytest.mark.parametrize('asset', [asset_paths[0]])
+def test_setting_new_values_if_some_values_already_set(repo: OnyoRepo,
+                                                       asset: str) -> None:
+    """Test that `onyo set KEY=VALUE <asset>` updates contents of assets and adds
     the correct output if called multiple times, and that the output is correct.
     """
     set_values = "change=one"
@@ -515,14 +454,18 @@ def test_setting_new_values_if_some_values_already_set(repo: OnyoRepo, asset: st
 @pytest.mark.repo_contents(assets[0])
 @pytest.mark.parametrize('asset', [asset_paths[0]])
 @pytest.mark.parametrize('set_values', values)
-def test_values_already_set(repo: OnyoRepo, asset: str, set_values: list[str]) -> None:
-    """
-    Test that `onyo set KEY=VALUE <asset>` updates contents of assets once, and
-    if called again with same valid values the command does display the correct
-    info message without error, and the repository stays in a clean state.
+def test_values_already_set(repo: OnyoRepo,
+                            asset: str,
+                            set_values: list[str]) -> None:
+    """Test that `onyo set KEY=VALUE <asset>` updates
+    contents of assets once, and if called again with
+    same valid values the command does display the correct
+    info message without error, and the repository stays
+    in a clean state.
     """
 
-    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', *set_values, '--path', asset],
+    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', *set_values,
+                          '--path', asset],
                          capture_output=True, text=True)
 
     # verify output
@@ -547,17 +490,18 @@ def test_values_already_set(repo: OnyoRepo, asset: str, set_values: list[str]) -
 
 
 @pytest.mark.repo_contents(*assets)
-@pytest.mark.parametrize('asset', asset_paths)
+@pytest.mark.parametrize('asset', [asset_paths[0]])
 @pytest.mark.parametrize('set_values', name_fields)
-def test_set_update_name_fields(repo: OnyoRepo, asset: str, set_values: list[str]) -> None:
+def test_set_update_name_fields(repo: OnyoRepo,
+                                asset: str,
+                                set_values: list[str]) -> None:
+    """Test that `onyo set --rename --keys KEY=VALUE <asset>` can
+    successfully change the names of assets, when KEY is
+    type, make, model or/and serial number. Test also, that
+    faux serials can be set and name fields are recognized
+    and can be updated when they are `onyo set` together
+    with a list of content fields.
     """
-    Test that `onyo set KEY=VALUE <asset>` can successfully change the names of
-    assets, when KEY is type, make, model or/and serial number. Test also, that
-    faux serials can be set and name fields are recognized and can be updated
-    when they are `onyo set` together with a list of content fields.
-    """
-    # TODO: This test is supposed to test whether we can set fields that are part of the
-    #       asset names. There are four such fields. This test function generates a whopping 168 test cases!
     ret = subprocess.run(['onyo', '--yes', 'set', '--rename', '--keys', *set_values,
                           '--path', asset], capture_output=True, text=True)
 
@@ -572,9 +516,9 @@ def test_set_update_name_fields(repo: OnyoRepo, asset: str, set_values: list[str
 
 @pytest.mark.repo_contents(*assets)
 def test_update_many_faux_serial_numbers(repo: OnyoRepo) -> None:
-    """
-    Test that `onyo set --rename serial=faux <asset>` can successfully update
-    many assets with new faux serial numbers in one call.
+    """Test that `onyo set --rename serial=faux <asset>`
+    can successfully update many assets with new faux
+    serial numbers in one call.
     """
 
     pytest.skip("TODO: faux serials not yet considered outside new. Needs to move (modify_asset)")
@@ -608,14 +552,14 @@ def test_update_many_faux_serial_numbers(repo: OnyoRepo) -> None:
 @pytest.mark.repo_contents(assets[0])
 @pytest.mark.parametrize('asset', [asset_paths[0]])
 @pytest.mark.parametrize('set_values', values)
-def test_duplicate_keys(repo: OnyoRepo, asset: str, set_values: list[str]) -> None:
-    """
-    Test that `onyo set` fails, if the same key is given multiple times.
-    """
+def test_duplicate_keys(repo: OnyoRepo,
+                        asset: str,
+                        set_values: list[str]) -> None:
+    """Test that `onyo set` fails, if the same key is given multiple times."""
 
-    ret = subprocess.run(
-        ['onyo', '--yes', 'set', '--keys', *set_values, 'dup_key=1', 'dup_key=2', '--path', asset],
-        capture_output=True, text=True)
+    ret = subprocess.run(['onyo', '--yes', 'set', '--keys',
+                          *set_values, 'dup_key=1', 'dup_key=2', '--path', asset],
+                         capture_output=True, text=True)
 
     # verify output
     assert ret.returncode == 1

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -927,11 +927,12 @@ def onyo_set(inventory: Inventory,
     paths = paths or [inventory.root]
     if not keys:
         raise ValueError("At least one key-value pair must be specified.")
-
+    if any(not k or not k.strip() for k in keys.keys()):
+        raise ValueError("Keys are not allowed to be empty or None-values.")
     if not rename and any(k in inventory.repo.get_asset_name_keys() for k in keys.keys()):
         raise ValueError("Can't change asset name keys without --rename.")
     if any(k in RESERVED_KEYS + PSEUDO_KEYS for k in keys.keys()):
-        raise ValueError(f"Can't set reserved keys ({', '.join(RESERVED_KEYS + PSEUDO_KEYS)}).")
+        raise ValueError(f"Can't set reserved or pseudo keys ({', '.join(RESERVED_KEYS + PSEUDO_KEYS)}).")
 
     non_inventory_paths = [str(p)
                            for p in paths  # pyre-ignore[16]  `paths` not Optional anymore here
@@ -1064,7 +1065,7 @@ def onyo_unset(inventory: Inventory,
     if any(k in inventory.repo.get_asset_name_keys() for k in keys):
         raise ValueError("Can't unset asset name keys.")
     if any(k in RESERVED_KEYS + PSEUDO_KEYS for k in keys):
-        raise ValueError(f"Can't unset reserved keys ({', '.join(RESERVED_KEYS + PSEUDO_KEYS)}).")
+        raise ValueError(f"Can't unset reserved or pseudo keys ({', '.join(RESERVED_KEYS + PSEUDO_KEYS)}).")
 
     asset_paths_to_unset = inventory.get_assets_by_query(paths=paths,
                                                          depth=depth,

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -1037,6 +1037,8 @@ def onyo_unset(inventory: Inventory,
         An optional string to overwrite Onyo's default commit message.
     """
     paths = paths or []
+    if not keys:
+        raise ValueError("At least one key must be specified.")
 
     non_inventory_paths = [str(p) for p in paths
                            if not inventory.repo.is_asset_path(p) and

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -5,7 +5,7 @@ import logging
 import subprocess
 import sys
 from pathlib import Path
-from typing import Callable, Dict, Optional, TypeVar, ParamSpec
+from typing import Callable, Dict, Literal, Optional, ParamSpec, TypeVar
 from functools import wraps
 
 from rich import box
@@ -386,13 +386,13 @@ def onyo_edit(inventory: Inventory,
 
 @raise_on_inventory_state
 def onyo_get(inventory: Inventory,
-             paths: Optional[list[Path]],
-             depth: int,
-             machine_readable: bool,
-             match: Optional[list[Callable[[dict], bool]]],
-             keys: Optional[list[str]],
-             sort: str = 'ascending') -> list[dict]:
-    """Query the repository for assets.
+             paths: Optional[list[Path]] = None,
+             depth: int = 0,
+             machine_readable: bool = False,
+             match: Optional[list[Callable[[dict], bool]]] = None,
+             keys: Optional[list[str]] = None,
+             sort: Literal['ascending', 'descending'] = 'ascending') -> list[dict]:
+    """Query the repository for information about assets.
 
     Parameters
     ----------
@@ -400,20 +400,22 @@ def onyo_get(inventory: Inventory,
       The inventory to query.
     paths: list of Path, optional
       Limits the query to assets underneath these paths.
+      Paths can be assets and directories.
+      If no paths are specified, the inventory root is used as default.
     depth: int
       Number of levels to descent into. Must be greater or equal 0.
       If 0, descend recursively without limit.
-    machine_readable: bool
+    machine_readable: bool, optional
       Whether to print the matching assets as TAB-separated lines,
       where the columns correspond to the `keys`. If `False`,
       print a table meant for human consumption.
-    match: list of Callable
+    match: list of Callable, optional
       Callables suited for use with builtin `filter`. They are
       passed an asset dictionary and expected to return a `bool`,
       where `True` indicates a match. The result of the query
       consists of all assets that are matched by all callables in
       this list.
-    keys: list of str
+    keys: list of str, optional
       Defines what key-value pairs of an asset a result is composed of.
       If no `keys` are given the keys then the asset name keys are
       used. The 'path' pseudo-key is always appended.
@@ -421,6 +423,7 @@ def onyo_get(inventory: Inventory,
     sort: str
       How to sort the results by `keys`. Possible values are
       'ascending' and 'descending'. Default: 'ascending'.
+      If other values are specified an error is raised.
 
     Raises
     ------
@@ -445,6 +448,10 @@ def onyo_get(inventory: Inventory,
     if invalid_paths:
         err_str = '\n'.join([str(x) for x in invalid_paths])
         raise ValueError(f"The following paths are not part of the inventory:\n{err_str}")
+
+    allowed_sorting = ['ascending', 'descending']
+    if sort not in allowed_sorting:
+        raise ValueError(f"Allowed sorting modes: {', '.join(allowed_sorting)}")
 
     selected_keys = selected_keys or inventory.repo.get_asset_name_keys()
     results = inventory.get_assets_by_query(paths=paths,
@@ -1039,8 +1046,13 @@ def onyo_unset(inventory: Inventory,
     paths = paths or []
     if not keys:
         raise ValueError("At least one key must be specified.")
+<<<<<<< Updated upstream
 
     non_inventory_paths = [str(p) for p in paths
+=======
+    
+    non_inventory_paths = [str(p) for p in paths  # pyre-ignore[16]  `paths` not Optional anymore
+>>>>>>> Stashed changes
                            if not inventory.repo.is_asset_path(p) and
                            not inventory.repo.is_inventory_dir(p)]
 

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -923,8 +923,8 @@ def onyo_set(inventory: Inventory,
 
     if not rename and any(k in inventory.repo.get_asset_name_keys() for k in keys.keys()):
         raise ValueError("Can't change asset name keys without --rename.")
-    if any(k in RESERVED_KEYS for k in keys.keys()):
-        raise ValueError(f"Can't set reserved keys ({', '.join(RESERVED_KEYS)}).")
+    if any(k in RESERVED_KEYS + PSEUDO_KEYS for k in keys.keys()):
+        raise ValueError(f"Can't set reserved keys ({', '.join(RESERVED_KEYS + PSEUDO_KEYS)}).")
 
     non_inventory_paths = [str(p)
                            for p in paths

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -1006,7 +1006,7 @@ def onyo_tree(inventory: Inventory,
 @raise_on_inventory_state
 def onyo_unset(inventory: Inventory,
                keys: list[str],
-               match: Optional[list[Callable[[dict], bool]]],
+               match: Optional[list[Callable[[dict], bool]]] = None,
                paths: Optional[list[Path]] = None,
                depth: int = 0,
                message: Optional[str] = None) -> None:

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -1048,8 +1048,8 @@ def onyo_unset(inventory: Inventory,
 
     if any(k in inventory.repo.get_asset_name_keys() for k in keys):
         raise ValueError("Can't unset asset name keys.")
-    if any(k in RESERVED_KEYS for k in keys):
-        raise ValueError(f"Can't unset reserved keys ({', '.join(RESERVED_KEYS)}).")
+    if any(k in RESERVED_KEYS + PSEUDO_KEYS for k in keys):
+        raise ValueError(f"Can't unset reserved keys ({', '.join(RESERVED_KEYS + PSEUDO_KEYS)}).")
 
     asset_paths_to_unset = inventory.get_assets_by_query(paths=paths,
                                                          depth=depth,

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -1023,16 +1023,17 @@ def onyo_unset(inventory: Inventory,
     ----------
     inventory: Inventory
         The Inventory in which to unset key/values for assets.
-    keys: list
+    keys: list of str
         The keys that will be unset in assets.
         If keys do not exist in an asset, a debug message is logged.
         If keys are specified which appear in asset names an error is raised.
+        If `keys` is empty an error is raised.
     match: list of Callable, optional
       Callables suited for use with builtin `filter`. They are
       passed an asset dictionary and expected to return a `bool`,
       where `True` indicates a match. `keys` will be removed from
       all assets that are matched by all callables in this list.
-    paths: Path or list of Path, optional
+    paths: list of Path, optional
         Paths to assets or directories for which to unset key-value pairs.
         If paths are directories, the values will be unset recursively in assets
         under the specified path.
@@ -1042,6 +1043,12 @@ def onyo_unset(inventory: Inventory,
         0 means no limit and is the default.
     message: str, optional
         An optional string to overwrite Onyo's default commit message.
+
+    Raises
+    ------
+    ValueError
+        If paths are invalid, or `keys` are empty or invalid.
+
     """
     paths = paths or []
     if not keys:

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -900,7 +900,7 @@ def onyo_set(inventory: Inventory,
         Paths to assets or directories for which to set key-value pairs.
         If paths are directories, the values will be set recursively in assets
         under the specified path.
-        If no paths are specified, CWD is used as default.
+        If no paths are specified, the inventory root is used as default.
     keys: dict
         Key-value pairs that will be set in assets. If keys already exist in an
         asset their value will be overwritten, if they do not exist the values
@@ -924,7 +924,7 @@ def onyo_set(inventory: Inventory,
         If a given path is invalid or changes are made that would result in
         renaming an asset, while `rename` is not true, or if `keys` is empty.
     """
-    paths = paths or []
+    paths = paths or [inventory.root]
     if not keys:
         raise ValueError("At least one key-value pair must be specified.")
 
@@ -934,7 +934,7 @@ def onyo_set(inventory: Inventory,
         raise ValueError(f"Can't set reserved keys ({', '.join(RESERVED_KEYS + PSEUDO_KEYS)}).")
 
     non_inventory_paths = [str(p)
-                           for p in paths
+                           for p in paths  # pyre-ignore[16]  `paths` not Optional anymore here
                            if not inventory.repo.is_asset_path(p) and
                            not inventory.repo.is_inventory_dir(p)]
     if non_inventory_paths:
@@ -1037,7 +1037,7 @@ def onyo_unset(inventory: Inventory,
         Paths to assets or directories for which to unset key-value pairs.
         If paths are directories, the values will be unset recursively in assets
         under the specified path.
-        If no paths are specified, CWD is used as default.
+        If no paths are specified, the inventory root is used as default.
     depth: int
         Depth limit of recursion if a `path` is a directory.
         0 means no limit and is the default.
@@ -1050,16 +1050,10 @@ def onyo_unset(inventory: Inventory,
         If paths are invalid, or `keys` are empty or invalid.
 
     """
-    paths = paths or []
+    paths = paths or [inventory.root]
     if not keys:
         raise ValueError("At least one key must be specified.")
-<<<<<<< Updated upstream
-
-    non_inventory_paths = [str(p) for p in paths
-=======
-    
     non_inventory_paths = [str(p) for p in paths  # pyre-ignore[16]  `paths` not Optional anymore
->>>>>>> Stashed changes
                            if not inventory.repo.is_asset_path(p) and
                            not inventory.repo.is_inventory_dir(p)]
 

--- a/onyo/lib/tests/test_commands_cat.py
+++ b/onyo/lib/tests/test_commands_cat.py
@@ -39,7 +39,7 @@ def test_onyo_cat_errors(inventory: Inventory) -> None:
                   inventory,
                   paths=[inventory.root / "untracked" / "file"])
 
-    # outside of onyo repository
+    # cat on path outside onyo repository
     pytest.raises(ValueError,
                   onyo_cat,
                   inventory,

--- a/onyo/lib/tests/test_commands_get.py
+++ b/onyo/lib/tests/test_commands_get.py
@@ -1,0 +1,398 @@
+from pathlib import Path
+
+import pytest
+
+from onyo.lib.filters import Filter
+from onyo.lib.inventory import Inventory
+from onyo.lib.onyo import OnyoRepo
+from ..commands import onyo_get
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_get_errors(inventory: Inventory) -> None:
+    """`onyo_get()` must raise the correct error in different illegal or impossible calls."""
+
+    # get on non-existing asset
+    pytest.raises(ValueError,
+                  onyo_get,
+                  inventory,
+                  paths=[inventory.root / "not-existing" / "TYPE_MAKER_MODEL.SERIAL"])
+
+    # get outside the repository
+    pytest.raises(ValueError,
+                  onyo_get,
+                  inventory,
+                  paths=[(inventory.root / "..")])
+
+    # get with negative depth value
+    pytest.raises(ValueError,
+                  onyo_get,
+                  inventory,
+                  depth=-1)
+
+    # get on ".anchor"
+    pytest.raises(ValueError,
+                  onyo_get,
+                  inventory,
+                  paths=[inventory.root / "somewhere" / OnyoRepo.ANCHOR_FILE_NAME])
+
+    # get on .git/
+    pytest.raises(ValueError,
+                  onyo_get,
+                  inventory,
+                  paths=[inventory.root / ".git"])
+
+    # get on .onyo/
+    pytest.raises(ValueError,
+                  onyo_get,
+                  inventory,
+                  paths=[inventory.root / ".onyo"])
+
+
+@pytest.mark.repo_contents(
+    ["one_that_exists.test", "type: one\nmake: that\nmodel: exists\nserial: test\nempty_key: ''"])
+@pytest.mark.ui({'yes': True})
+def test_onyo_get_empty_keys(inventory: Inventory,
+                             capsys) -> None:
+    """Verify `onyo_get()` prints values for non-existing keys as unset,
+    and values for keys that exist but have an empty value correctly."""
+    from onyo.lib.consts import UNSET_VALUE
+    asset_path1 = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    asset_path2 = inventory.root / "one_that_exists.test"
+    missing_key = "asdf"
+    empty_key = "empty_key"
+
+    # call `onyo_get()` requesting a key that does not exist
+    assert missing_key not in Path.read_text(asset_path1)
+    onyo_get(inventory,
+             paths=[asset_path1],
+             keys=[missing_key])
+
+    # verify output
+    output1 = capsys.readouterr().out
+    assert UNSET_VALUE in output1
+    assert asset_path1.name in output1
+
+    # call `onyo_get()` requesting a key that exists, but has no value set
+    assert empty_key in Path.read_text(asset_path2)
+    onyo_get(inventory,
+             paths=[asset_path2],
+             keys=[empty_key])
+
+    # verify output
+    output2 = capsys.readouterr().out
+    assert UNSET_VALUE not in output2
+    assert asset_path2.name in output2
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_get_on_empty_directory(inventory: Inventory) -> None:
+    """`onyo_get()` does not error when called on a valid but empty directory."""
+    dir_path = inventory.root / 'empty'
+
+    # `onyo_get()` on a directory without assets does not error
+    onyo_get(inventory,
+             paths=[dir_path])
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_get_reserved_keys(inventory: Inventory,
+                                capsys) -> None:
+    """`onyo_get()` allows to specify all reserved keys to query
+    and display information for."""
+    from onyo.lib.consts import RESERVED_KEYS, PSEUDO_KEYS
+    reserved = ["type", "make", "model", "serial"] + PSEUDO_KEYS + RESERVED_KEYS
+    asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+
+    # get on reserved fields
+    for reserved_key in reserved:
+        onyo_get(inventory, keys=[reserved_key])
+        # verify output
+        output = capsys.readouterr().out
+        assert asset_path.name in output
+        assert reserved_key in output
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_get_name_keys(inventory: Inventory,
+                            capsys) -> None:
+    """If no keys are specified when calling `onyo_get()`
+    the name keys are printed by default."""
+    asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    name_keys = ["type", "make", "model", "serial"]
+
+    # call `onyo_get()` without keys specified
+    onyo_get(inventory,
+             paths=[asset_path])
+
+    # verify output
+    output = capsys.readouterr().out
+    assert asset_path.name in output
+    for name_key in name_keys:
+        assert name_key in output
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_get_errors_before_get(inventory: Inventory) -> None:
+    """`onyo_get()` must raise the correct error if one of
+    the specified paths is not valid.
+    """
+    asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    non_existing_asset_path = inventory.root / "non-existing" / "TYPE_MAKER_MODEL.SERIAL"
+
+    # one of multiple paths does not exist
+    pytest.raises(ValueError,
+                  onyo_get,
+                  inventory,
+                  paths=[asset_path,
+                         non_existing_asset_path])
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_get_simple(inventory: Inventory,
+                         capsys) -> None:
+    """`onyo_get()` gets a value in an asset."""
+    asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    get_key = "some_key"
+
+    # get a value in an asset
+    onyo_get(inventory,
+             paths=[asset_path],
+             keys=[get_key])
+
+    # verify output
+    output = capsys.readouterr().out
+    assert asset_path.name in output
+    assert get_key in output
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_get_machine_readable(inventory: Inventory,
+                                   capsys) -> None:
+    """`onyo_get()` with machine_readable=True gives different
+    output that contains all requested information."""
+    asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    get_key = "some_key"
+
+    # call `onyo_get()` without machine readable mode
+    onyo_get(inventory,
+             paths=[asset_path],
+             keys=[get_key])
+
+    standard_output = capsys.readouterr().out
+
+    # call `onyo_get()` in machine readable mode
+    onyo_get(inventory,
+             paths=[asset_path],
+             keys=[get_key],
+             machine_readable=True)
+
+    # verify output contains the correct information but is different from normal mode
+    machine_readable_output = capsys.readouterr().out
+    assert machine_readable_output != standard_output
+    assert asset_path.name in machine_readable_output
+    # machine_readable does not print headers, just the values
+    assert "some_value" in machine_readable_output
+
+
+@pytest.mark.repo_contents(
+    ["one_that_exists.test", "type: one\nmake: that\nmodel: exists\nserial: test\nsome_key: value"])
+@pytest.mark.ui({'yes': True})
+def test_onyo_get_sorting(inventory: Inventory,
+                          capsys) -> None:
+    """`onyo_get()` allows different types of sorting the output,
+    but errors if illegal sorting is specified."""
+    asset_path1 = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    asset_path2 = inventory.root / "one_that_exists.test"
+    get_key = "some_key"
+
+    # call `onyo_get()` with sort=ascending
+    onyo_get(inventory,
+             sort="ascending",
+             keys=[get_key])
+    ascending_output = capsys.readouterr().out
+
+    # call `onyo_get()` with sort=descending
+    onyo_get(inventory,
+             sort="descending",
+             keys=[get_key])
+    descending_output = capsys.readouterr().out
+
+    # verify output contains the correct information but is different depending on sorting
+    assert ascending_output != descending_output
+    assert asset_path1.name in ascending_output
+    assert asset_path2.name in ascending_output
+    assert get_key in ascending_output
+    assert asset_path1.name in descending_output
+    assert asset_path2.name in descending_output
+    assert get_key in descending_output
+
+    # call `onyo_get()` with illegal sort keyword errors
+    pytest.raises(ValueError,
+                  onyo_get,
+                  inventory,
+                  sort="ILLEGAL",
+                  keys=[get_key])
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_get_on_directory(inventory: Inventory,
+                               capsys) -> None:
+    """`onyo_get()` gets a value in assets inside a directory."""
+    asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    dir_path = inventory.root / "somewhere"
+    get_key = "some_key"
+
+    # call `onyo_get()` on a directory
+    onyo_get(inventory,
+             paths=[dir_path],
+             keys=[get_key])
+
+    # verify output contains the asset inside the directory
+    output = capsys.readouterr().out
+    assert asset_path.name in output
+    assert get_key in output
+
+
+@pytest.mark.repo_contents(
+    ["one_that_exists.test", "type: one\nmake: that\nmodel: exists\nserial: test\nsome_key: value"])
+@pytest.mark.ui({'yes': True})
+def test_onyo_get_match(inventory: Inventory,
+                        capsys) -> None:
+    """`onyo_get()` lists just matching assets when `match` is used."""
+    asset_path1 = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    asset_path2 = inventory.root / "one_that_exists.test"
+    matches = [Filter("other=1").match]
+    get_key = "some_key"
+
+    # both assets have `get_key`, but just one asset matches
+    assert get_key in inventory.repo.get_asset_content(asset_path1).keys()
+    assert get_key in inventory.repo.get_asset_content(asset_path2).keys()
+
+    # get a value just in the matching asset, but specify both paths
+    onyo_get(inventory,
+             paths=[asset_path1, asset_path2],
+             match=matches,  # pyre-ignore[6]
+             keys=[get_key])
+
+    # verify output contains just information for matching assets
+    output = capsys.readouterr().out
+    assert asset_path1.name in output
+    assert output.count(get_key) == 1
+    assert asset_path2.name not in output
+
+
+@pytest.mark.repo_contents(
+    ["one_that_exists.test", "type: one\nmake: that\nmodel: exists\nserial: test\nsome_key: value"])
+@pytest.mark.ui({'yes': True})
+def test_onyo_get_no_matches(inventory: Inventory,
+                             capsys) -> None:
+    """`onyo_get()` behaves correctly when `match` matches no assets."""
+    asset_path1 = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    asset_path2 = inventory.root / "one_that_exists.test"
+    matches = [Filter("unfound=values").match]
+
+    # `onyo_get()` is called, but no assets match
+    onyo_get(inventory,
+             match=matches)  # pyre-ignore[6]
+
+    # verify output contains no assets because nothing matched
+    output = capsys.readouterr().out
+    assert "No assets matching the filter(s) were found" in output
+    assert asset_path1.name not in output
+    assert asset_path2.name not in output
+    assert "path" not in output
+
+
+@pytest.mark.repo_contents(
+    ["one_that_exists.test", "type: one\nmake: that\nmodel: exists\nserial: test"])
+@pytest.mark.ui({'yes': True})
+def test_onyo_get_multiple(inventory: Inventory,
+                           capsys) -> None:
+    """`onyo_get()` finds information about multiple assets in a single call."""
+    asset_path1 = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    asset_path2 = inventory.root / "one_that_exists.test"
+    get_key = "some_key"
+
+    # get a value in multiple assets at once
+    onyo_get(inventory,
+             paths=[asset_path1,
+                    asset_path2],
+             keys=[get_key])
+
+    # verify output contains all assets and "path" as default key
+    output = capsys.readouterr().out
+    assert asset_path1.name in output
+    assert asset_path2.name in output
+    assert "path" in output
+    assert get_key in output
+
+
+@pytest.mark.repo_contents(
+    ["one_that_exists.test", "type: one\nmake: that\nmodel: exists\nserial: test\nsome_key: value"])
+@pytest.mark.ui({'yes': True})
+def test_onyo_get_depth(inventory: Inventory,
+                        capsys) -> None:
+    """`onyo_get()` with depth selects the correct assets."""
+    asset_path1 = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    asset_path2 = inventory.root / "one_that_exists.test"
+
+    # get a value using depth
+    onyo_get(inventory,
+             paths=[inventory.root],
+             depth=1)
+
+    # verify output contains all assets and "path" as default key
+    output = capsys.readouterr().out
+    assert asset_path1.name not in output
+    assert asset_path2.name in output
+    assert "path" in output
+
+
+@pytest.mark.repo_contents(
+    ["one_that_exists.test", "type: one\nmake: that\nmodel: exists\nserial: test\nsome_key: value"])
+@pytest.mark.ui({'yes': True})
+def test_onyo_get_depth_zero(inventory: Inventory,
+                             capsys) -> None:
+    """Calling `onyo_get(depth=0)` is legal and selects all assets from all subpaths."""
+    onyo_get(inventory,
+             paths=[inventory.root],
+             depth=0)
+
+    # verify output contains all assets and "path" as default key
+    output = capsys.readouterr().out
+    for asset in inventory.repo.get_asset_paths():
+        assert asset.name in output
+    assert "path" in output
+
+
+@pytest.mark.repo_contents(
+    ["one_that_exists.test", "type: one\nmake: that\nmodel: exists\nserial: test"])
+@pytest.mark.ui({'yes': True})
+def test_onyo_get_default_inventory_root(inventory: Inventory,
+                                         capsys) -> None:
+    """Calling `onyo_get()` without path uses inventory.root as default
+    and selects all assets of the inventory."""
+    onyo_get(inventory)
+
+    # verify output contains all assets and "path" as default key
+    output = capsys.readouterr().out
+    for asset in inventory.repo.get_asset_paths():
+        assert asset.name in output
+    assert "path" in output
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_get_allows_duplicates(inventory: Inventory,
+                                    capsys) -> None:
+    """Calling `onyo_get()` with a list containing the same asset multiple
+    times does not error, but displays information just once."""
+    asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+
+    # call `onyo_get()` with `paths` containing duplicates
+    onyo_get(inventory,
+             paths=[asset_path, asset_path, asset_path])
+
+    # verify output contains all assets and "path" as default key
+    output = capsys.readouterr().out
+    assert output.count(asset_path.name) == 1

--- a/onyo/lib/tests/test_commands_mv.py
+++ b/onyo/lib/tests/test_commands_mv.py
@@ -11,6 +11,7 @@ def test_onyo_mv_errors(inventory: Inventory) -> None:
     """`onyo_mv` must raise the correct error in different illegal or impossible calls."""
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     dir_path = inventory.root / 'empty'
+    dir_path2 = inventory.root / 'different' / 'place'
 
     # move directory into itself
     pytest.raises(InvalidInventoryOperationError,
@@ -76,6 +77,14 @@ def test_onyo_mv_errors(inventory: Inventory) -> None:
                   inventory,
                   source=inventory.root / "not-existent",
                   destination=dir_path,
+                  message="some subject\n\nAnd a body")
+
+    # renaming multiple sources at once is not allowed
+    pytest.raises(ValueError,
+                  onyo_mv,
+                  inventory,
+                  source=[dir_path, dir_path2],
+                  destination=inventory.root / "new_name",
                   message="some subject\n\nAnd a body")
 
 
@@ -169,13 +178,9 @@ def test_onyo_mv_move_simple(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_mv_move_to_explicit_destination(inventory: Inventory) -> None:
-    """Allow moving a source to destination.
-
-    `destination_path` does not yet exist, which would indicate a
-    renaming if it wasn't the same name as the source. If recognized
-    as a renaming, however, it should fail because not only the name
-    but also the parent changed, which implies two operations: A move
-    and a renaming (with no order given).
+    """Allow moving a source to a destination stating the
+    destination name explicitely, e.g.:
+    inventory.root/dir1/asset -> inventory.root/dir2/asset.
     """
     dir_path = inventory.root / 'somewhere' / 'nested'
     # move by explicitly restating the source's name:
@@ -203,7 +208,7 @@ def test_onyo_mv_move_to_explicit_destination(inventory: Inventory) -> None:
 
 
 @pytest.mark.ui({'yes': True})
-def test_onyo_mv_rename(inventory: Inventory) -> None:
+def test_onyo_mv_rename_directory(inventory: Inventory) -> None:
     """`onyo_mv` must allow renaming of a directory."""
     dir_path = inventory.root / 'somewhere' / 'nested'
     destination_path = dir_path.parent / 'newname'

--- a/onyo/lib/tests/test_commands_set.py
+++ b/onyo/lib/tests/test_commands_set.py
@@ -191,6 +191,31 @@ def test_onyo_set_multiple(inventory: Inventory) -> None:
     # assert inventory.repo.git.is_clean_worktree()
 
 
+@pytest.mark.repo_contents(
+    ["one_that_exists.test", "type: one\nmake: that\nmodel: exists\nserial: test"])
+@pytest.mark.ui({'yes': True})
+def test_onyo_set_default_inventory_root(inventory: Inventory) -> None:
+    """Calling `onyo_set()` without path uses inventory.root as default
+    and selects all assets of the inventory."""
+    key = {"new_key": "new_me"}
+    old_hexsha = inventory.repo.git.get_hexsha()
+
+    # set a value without giving a path
+    onyo_set(inventory,
+             keys=key,  # pyre-ignore[6]
+             message="some subject\n\nAnd a body")
+
+    # check key was set in all assets
+    for asset in inventory.repo.get_asset_paths():
+        assert "new_key" in inventory.repo.get_asset_content(asset).keys()
+
+    # exactly one commit added
+    assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
+    # TODO: verifying cleanness of worktree does not work,
+    #       because fixture returns inventory with untracked stuff
+    # assert inventory.repo.git.is_clean_worktree()
+
+
 @pytest.mark.ui({'yes': True})
 def test_onyo_set_allows_duplicates(inventory: Inventory) -> None:
     """Calling `onyo_set()` with a list containing the same asset multiple

--- a/onyo/lib/tests/test_commands_set.py
+++ b/onyo/lib/tests/test_commands_set.py
@@ -7,7 +7,7 @@ from ..commands import onyo_set
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_set_errors(inventory: Inventory) -> None:
-    """`onyo_set` must raise the correct error in different illegal or impossible calls."""
+    """`onyo_set()` must raise the correct error in different illegal or impossible calls."""
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     key_value = {"this_key": "that_value"}
 
@@ -62,7 +62,7 @@ def test_onyo_set_errors(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_set_on_empty_directory(inventory: Inventory) -> None:
-    """`onyo_set` does not error when called on a valid but empty directory,
+    """`onyo_set()` does not error when called on a valid but empty directory,
     but no commits are added."""
     dir_path = inventory.root / 'empty'
     key_value = {"this_key": "that_value"}
@@ -80,7 +80,7 @@ def test_onyo_set_on_empty_directory(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_set_illegal_fields(inventory: Inventory) -> None:
-    """`onyo_set` must raise an error when requested to set an
+    """`onyo_set()` must raise an error when requested to set an
     illegal/reserverd field without `rename=True`."""
     from onyo.lib.consts import RESERVED_KEYS, PSEUDO_KEYS
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
@@ -110,7 +110,7 @@ def test_onyo_set_illegal_fields(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_set_errors_before_set(inventory: Inventory) -> None:
-    """`onyo_set` must raise the correct error and is not allowed to
+    """`onyo_set()` must raise the correct error and is not allowed to
     modify/commit anything, if one of the specified paths is not valid.
     """
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
@@ -139,12 +139,12 @@ def test_onyo_set_errors_before_set(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_set_simple(inventory: Inventory) -> None:
-    """Set a value in an asset."""
+    """`onyo_set()` sets a value in an asset."""
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     key_value = {"this_key": "that_value"}
     old_hexsha = inventory.repo.git.get_hexsha()
 
-    # create a new directory
+    # set a value in an asset
     onyo_set(inventory,
              paths=[asset_path],
              keys=key_value,  # pyre-ignore[6]
@@ -171,7 +171,7 @@ def test_onyo_set_multiple(inventory: Inventory) -> None:
     key_value = {"this_key": "that_value"}
     old_hexsha = inventory.repo.git.get_hexsha()
 
-    # create a new directory
+    # set a value in multiple assets at once
     onyo_set(inventory,
              paths=[asset_path1,
                     asset_path2],
@@ -199,7 +199,7 @@ def test_onyo_set_allows_duplicates(inventory: Inventory) -> None:
     key_value = {"this_key": "that_value"}
     old_hexsha = inventory.repo.git.get_hexsha()
 
-    # call `onyo_set()` with `dirs` containing duplicates
+    # call `onyo_set()` with `paths` containing duplicates
     onyo_set(inventory,
              paths=[asset_path, asset_path, asset_path],
              keys=key_value,  # pyre-ignore[6]

--- a/onyo/lib/tests/test_commands_set.py
+++ b/onyo/lib/tests/test_commands_set.py
@@ -82,8 +82,7 @@ def test_onyo_set_on_empty_directory(inventory: Inventory) -> None:
 def test_onyo_set_illegal_fields(inventory: Inventory) -> None:
     """`onyo_set` must raise an error when requested to set an
     illegal/reserverd field without `rename=True`."""
-    # TODO: add PSEUDO_KEYS after fixing BUG #527:
-    from onyo.lib.consts import RESERVED_KEYS  # PSEUDO_KEYS
+    from onyo.lib.consts import RESERVED_KEYS, PSEUDO_KEYS
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     old_hexsha = inventory.repo.git.get_hexsha()
 
@@ -92,9 +91,7 @@ def test_onyo_set_illegal_fields(inventory: Inventory) -> None:
         {"make": "new_value"},
         {"model": "new_value"},
         {"serial": "new_value"}]
-    # TODO: add PSEUDO_KEYS after fixing BUG #527:
-    # illegal_fields.extend([{k : "new_value"} for k in PSEUDO_KEYS])
-    illegal_fields.extend([{k: "new_value"} for k in RESERVED_KEYS])
+    illegal_fields.extend([{k: "new_value"} for k in PSEUDO_KEYS + RESERVED_KEYS])
 
     # set on illegal fields
     for illegal in illegal_fields:

--- a/onyo/lib/tests/test_commands_tree.py
+++ b/onyo/lib/tests/test_commands_tree.py
@@ -41,7 +41,8 @@ def test_onyo_tree_errors(inventory: Inventory) -> None:
 
 
 @pytest.mark.ui({'yes': True})
-def test_onyo_tree_single(inventory: Inventory) -> None:
+def test_onyo_tree_single(inventory: Inventory,
+                          capsys) -> None:
     """Display a tree for a directory."""
     directory_path = inventory.root / "somewhere" / "nested"
 
@@ -49,13 +50,19 @@ def test_onyo_tree_single(inventory: Inventory) -> None:
     onyo_tree(inventory,
               paths=[directory_path])
 
+    # verify assets and paths are in output
+    tree_output = capsys.readouterr().out
+    for path in inventory.repo.get_asset_paths(subtrees=[directory_path]):
+        assert all([part in tree_output for part in path.parts])
+
     # TODO: verifying cleanness of worktree does not work,
     #       because fixture returns inventory with untracked stuff
     # assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
-def test_onyo_tree_multiple_paths(inventory: Inventory) -> None:
+def test_onyo_tree_multiple_paths(inventory: Inventory,
+                                  capsys) -> None:
     """Display multiple trees with one call."""
     dir_path = inventory.root / 'somewhere' / 'nested'
 
@@ -63,16 +70,26 @@ def test_onyo_tree_multiple_paths(inventory: Inventory) -> None:
               paths=[dir_path,
                      inventory.root])
 
+    # verify assets and paths are in output
+    tree_output = capsys.readouterr().out
+    for path in inventory.repo.get_asset_paths(subtrees=[dir_path, inventory.root]):
+        assert all([part in tree_output for part in path.parts])
+
     # TODO: verifying cleanness of worktree does not work,
     #       because fixture returns inventory with untracked stuff
     # assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
-def test_onyo_tree_without_explicit_paths(inventory: Inventory) -> None:
+def test_onyo_tree_without_explicit_paths(inventory: Inventory,
+                                          capsys) -> None:
     """Display the root of the inventory, if onyo_tree() is called without paths."""
     onyo_tree(inventory)
 
+    # verify assets and paths are in output
+    tree_output = capsys.readouterr().out
+    for path in inventory.repo.get_asset_paths(subtrees=[inventory.root]):
+        assert all([part in tree_output for part in path.parts])
     # TODO: verifying cleanness of worktree does not work,
     #       because fixture returns inventory with untracked stuff
     # assert inventory.repo.git.is_clean_worktree()
@@ -99,9 +116,10 @@ def test_onyo_tree_errors_before_showing_trees(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 @pytest.mark.repo_dirs("a/b/c", "a/d/c")
-def test_onyo_tree_with_same_dir_twice(inventory: Inventory) -> None:
-    """Allow to display the tree to a directory twice when `onyo_tree()` is called with the same
-    path twice at once."""
+def test_onyo_tree_with_same_dir_twice(inventory: Inventory,
+                                       capsys) -> None:
+    """Allow to display the tree to a directory twice when
+    `onyo_tree()` is called with the same path twice at once."""
     directory_path = inventory.root / "somewhere" / "nested"
 
     # call onyo_tree() with `directory_path` twice in `paths`.
@@ -109,6 +127,12 @@ def test_onyo_tree_with_same_dir_twice(inventory: Inventory) -> None:
               paths=[directory_path,
                      inventory.root,
                      directory_path])
+
+    # verify assets and paths are in output
+    tree_output = capsys.readouterr().out
+    for path in inventory.repo.get_asset_paths(subtrees=[directory_path]):
+        assert all([part in tree_output for part in path.parts])
+    assert tree_output.count(str(directory_path)) == 2
 
     # TODO: verifying cleanness of worktree does not work,
     #       because fixture returns inventory with untracked stuff

--- a/onyo/lib/tests/test_commands_unset.py
+++ b/onyo/lib/tests/test_commands_unset.py
@@ -264,6 +264,34 @@ def test_onyo_unset_multiple(inventory: Inventory) -> None:
     # assert inventory.repo.git.is_clean_worktree()
 
 
+@pytest.mark.repo_contents(
+    ["one_that_exists.test", "type: one\nmake: that\nmodel: exists\nserial: test\nsome_key: value"])
+@pytest.mark.ui({'yes': True})
+def test_onyo_unset_default_inventory_root(inventory: Inventory) -> None:
+    """Calling `onyo_unset()` without path uses inventory.root as default."""
+    key = "some_key"
+    old_hexsha = inventory.repo.git.get_hexsha()
+
+    # check key exists
+    for asset in inventory.repo.get_asset_paths():
+        assert key in inventory.repo.get_asset_content(asset).keys()
+
+    # unset a value
+    onyo_unset(inventory,
+               keys=[key],
+               message="some subject\n\nAnd a body")
+
+    # check key was unset in all assets
+    for asset in inventory.repo.get_asset_paths():
+        assert key not in inventory.repo.get_asset_content(asset).keys()
+
+    # exactly one commit added
+    assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
+    # TODO: verifying cleanness of worktree does not work,
+    #       because fixture returns inventory with untracked stuff
+    # assert inventory.repo.git.is_clean_worktree()
+
+
 @pytest.mark.ui({'yes': True})
 def test_onyo_unset_allows_asset_duplicates(inventory: Inventory) -> None:
     """Calling `onyo_unset()` with a list containing the same asset

--- a/onyo/lib/tests/test_commands_unset.py
+++ b/onyo/lib/tests/test_commands_unset.py
@@ -1,0 +1,349 @@
+import pytest
+
+from onyo.lib.inventory import Inventory
+from onyo.lib.onyo import OnyoRepo
+from ..commands import onyo_unset
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_unset_errors(inventory: Inventory) -> None:
+    """`onyo_unset` must raise the correct error in different illegal or impossible calls."""
+    asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    key = "some_key"
+
+    # unset on non-existing asset
+    pytest.raises(ValueError,
+                  onyo_unset,
+                  inventory,
+                  paths=[inventory.root / "not-existing" / "TYPE_MAKER_MODEL.SERIAL"],
+                  keys=[key],
+                  message="some subject\n\nAnd a body")
+
+    # unset outside the repository
+    pytest.raises(ValueError,
+                  onyo_unset,
+                  inventory,
+                  paths=[(inventory.root / "..").resolve()],
+                  keys=[key],
+                  message="some subject\n\nAnd a body")
+
+    # unset without keys specified
+    pytest.raises(ValueError,
+                  onyo_unset,
+                  inventory,
+                  paths=[asset_path],
+                  keys=[],
+                  message="some subject\n\nAnd a body")
+
+    # unset on ".anchor"
+    pytest.raises(ValueError,
+                  onyo_unset,
+                  inventory,
+                  paths=[inventory.root / "somewhere" / OnyoRepo.ANCHOR_FILE_NAME],
+                  keys=[key],
+                  message="some subject\n\nAnd a body")
+
+    # unset on .git/
+    pytest.raises(ValueError,
+                  onyo_unset,
+                  inventory,
+                  paths=[inventory.root / ".git"],
+                  keys=[key],
+                  message="some subject\n\nAnd a body")
+
+    # unset on .onyo/
+    pytest.raises(ValueError,
+                  onyo_unset,
+                  inventory,
+                  paths=[inventory.root / ".onyo"],
+                  keys=[key],
+                  message="some subject\n\nAnd a body")
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_unset_on_empty_directory(inventory: Inventory) -> None:
+    """`onyo_unset` does not error when called on a valid but empty directory,
+    but no commits are added."""
+    dir_path = inventory.root / 'empty'
+    key = "some_key"
+    old_hexsha = inventory.repo.git.get_hexsha()
+
+    # unset on a directory without assets
+    onyo_unset(inventory,
+               paths=[dir_path],
+               keys=[key],
+               message="some subject\n\nAnd a body")
+
+    # no commit was added
+    assert inventory.repo.git.get_hexsha() == old_hexsha
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_unset_name_fields_error(inventory: Inventory) -> None:
+    """`onyo_unset` must raise an error when requested to unset a
+    reserved name field."""
+    asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    old_hexsha = inventory.repo.git.get_hexsha()
+    illegal_fields = ["type",
+                      "make",
+                      "model",
+                      "serial"]
+
+    # unset on illegal fields
+    for illegal in illegal_fields:
+        pytest.raises(ValueError,
+                      onyo_unset,
+                      inventory,
+                      paths=[asset_path],
+                      keys=[illegal],
+                      message="some subject\n\nAnd a body")
+        # name fields are still in the asset
+        assert illegal in asset_path.read_text()
+
+    # no commit was added
+    assert inventory.repo.git.get_hexsha() == old_hexsha
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_unset_illegal_fields(inventory: Inventory) -> None:
+    """`onyo_unset` must raise an error when requested to unset an
+    illegal/reserverd field."""
+    from onyo.lib.consts import RESERVED_KEYS, PSEUDO_KEYS
+    asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    old_hexsha = inventory.repo.git.get_hexsha()
+
+    illegal_fields = RESERVED_KEYS + PSEUDO_KEYS
+
+    # unset on illegal fields errors
+    for illegal in illegal_fields:
+        pytest.raises(ValueError,
+                      onyo_unset,
+                      inventory,
+                      paths=[asset_path],
+                      keys=[illegal],
+                      message="some subject\n\nAnd a body")
+
+    # no commit was added
+    assert inventory.repo.git.get_hexsha() == old_hexsha
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_unset_errors_before_unset(inventory: Inventory) -> None:
+    """`onyo_unset` must raise the correct error and is not allowed to
+    modify/commit anything, if one of the specified paths is not valid.
+    """
+    asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    non_existing_asset_path = inventory.root / "non-existing" / "TYPE_MAKER_MODEL.SERIAL"
+    key = "some_key"
+    old_hexsha = inventory.repo.git.get_hexsha()
+
+    # one of multiple paths does not exist
+    pytest.raises(ValueError,
+                  onyo_unset,
+                  inventory,
+                  paths=[asset_path,
+                         non_existing_asset_path],
+                  keys=[key],
+                  message="some subject\n\nAnd a body")
+
+    # no new asset was created
+    assert not non_existing_asset_path.exists()
+    assert non_existing_asset_path not in inventory.repo.git.files
+    # the valid asset was not modified either
+    assert key in asset_path.read_text()
+    # no commit was added
+    assert inventory.repo.git.get_hexsha() == old_hexsha
+    # TODO: verifying cleanness of worktree does not work,
+    #       because fixture returns inventory with untracked stuff
+    # assert inventory.repo.git.is_clean_worktree()
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_unset_simple(inventory: Inventory) -> None:
+    """Unset a key in an asset."""
+    asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    key = "some_key"
+    old_hexsha = inventory.repo.git.get_hexsha()
+
+    # check key exists
+    assert key in inventory.repo.get_asset_content(asset_path).keys()
+
+    # unset a value
+    onyo_unset(inventory,
+               paths=[asset_path],
+               keys=[key],
+               message="some subject\n\nAnd a body")
+
+    # check key was removed
+    assert key not in inventory.repo.get_asset_content(asset_path).keys()
+
+    # exactly one commit added
+    assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
+    # TODO: verifying cleanness of worktree does not work,
+    #       because fixture returns inventory with untracked stuff
+    # assert inventory.repo.git.is_clean_worktree()
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_unset_directories(inventory: Inventory) -> None:
+    """`onyo_unset()` on directories unsets keys recursively for all assets
+    in the directory."""
+    asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    directory_path = inventory.root / "somewhere"
+    key = "some_key"
+    old_hexsha = inventory.repo.git.get_hexsha()
+
+    # check key exists
+    assert key in inventory.repo.get_asset_content(asset_path).keys()
+
+    # unset a value
+    onyo_unset(inventory,
+               paths=[directory_path],
+               keys=[key],
+               message="some subject\n\nAnd a body")
+
+    # check key was removed from the asset
+    assert key not in inventory.repo.get_asset_content(asset_path).keys()
+
+    # exactly one commit added
+    assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
+    # TODO: verifying cleanness of worktree does not work,
+    #       because fixture returns inventory with untracked stuff
+    # assert inventory.repo.git.is_clean_worktree()
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_unset_empty_directory(inventory: Inventory) -> None:
+    """`onyo_unset()` on an empty directory does not error."""
+    empty_dir_path = inventory.root / 'empty'
+    key = "some_key"
+    old_hexsha = inventory.repo.git.get_hexsha()
+
+    # unset a value on an empty dir does not error
+    onyo_unset(inventory,
+               paths=[empty_dir_path],
+               keys=[key],
+               message="some subject\n\nAnd a body")
+
+    # nothing was changed, so nothing should have been committed
+    assert inventory.repo.git.get_hexsha() == old_hexsha
+    # TODO: verifying cleanness of worktree does not work,
+    #       because fixture returns inventory with untracked stuff
+    # assert inventory.repo.git.is_clean_worktree()
+
+
+@pytest.mark.repo_contents(
+    ["one_that_exists.test", "type: one\nmake: that\nmodel: exists\nserial: test\nsome_key: value"])
+@pytest.mark.ui({'yes': True})
+def test_onyo_unset_multiple(inventory: Inventory) -> None:
+    """Modify multiple assets in a single call and with one commit."""
+    asset_path1 = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    asset_path2 = inventory.root / "one_that_exists.test"
+    key = "some_key"
+    old_hexsha = inventory.repo.git.get_hexsha()
+
+    # check key exists in both assets
+    assert key in inventory.repo.get_asset_content(asset_path1).keys()
+    assert key in inventory.repo.get_asset_content(asset_path2).keys()
+
+    # create a new directory
+    onyo_unset(inventory,
+               paths=[asset_path1,
+                      asset_path2],
+               keys=[key],
+               message="some subject\n\nAnd a body")
+
+    # check key was removed in both assets
+    assert key not in inventory.repo.get_asset_content(asset_path1).keys()
+    assert key not in inventory.repo.get_asset_content(asset_path2).keys()
+
+    # exactly one commit added
+    assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
+    # TODO: verifying cleanness of worktree does not work,
+    #       because fixture returns inventory with untracked stuff
+    # assert inventory.repo.git.is_clean_worktree()
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_unset_allows_asset_duplicates(inventory: Inventory) -> None:
+    """Calling `onyo_unset()` with a list containing the same asset
+    multiple times does not error."""
+    asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    key = "some_key"
+    old_hexsha = inventory.repo.git.get_hexsha()
+
+    # call `onyo_unset()` with asset duplicates
+    onyo_unset(inventory,
+               paths=[asset_path, asset_path, asset_path],
+               keys=[key],
+               message="some subject\n\nAnd a body")
+
+    # check content
+    assert key not in inventory.repo.get_asset_content(asset_path).keys()
+
+    # exactly one commit added
+    assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
+    # TODO: verifying cleanness of worktree does not work,
+    #       because fixture returns inventory with untracked stuff
+    # assert inventory.repo.git.is_clean_worktree()
+
+
+@pytest.mark.repo_contents(
+    ["one_that_exists.test", "type: one\nmake: that\nmodel: exists\nserial: test\nother_key: value"])
+@pytest.mark.ui({'yes': True})
+def test_onyo_unset_non_existing_keys(inventory: Inventory) -> None:
+    """Calling `onyo_unset()` on a non-existing key does not error."""
+    asset_path1 = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    asset_path2 = inventory.root / "one_that_exists.test"
+    other_key = "other_key"
+    old_hexsha = inventory.repo.git.get_hexsha()
+
+    # trying to remove a non-existing key in an asset that does not exist does not error
+    assert other_key not in inventory.repo.get_asset_content(asset_path1).keys()
+    onyo_unset(inventory,
+               paths=[asset_path1],
+               keys=[other_key],
+               message="some subject\n\nAnd a body")
+
+    # no commit was added
+    assert inventory.repo.git.get_hexsha() == old_hexsha
+
+    # trying to remove a key in two assets, but just one contains the key does not error
+    assert other_key not in inventory.repo.get_asset_content(asset_path1).keys()
+    assert other_key in inventory.repo.get_asset_content(asset_path2).keys()
+    onyo_unset(inventory,
+               paths=[asset_path1,
+                      asset_path2],
+               keys=[other_key],
+               message="some subject\n\nAnd a body")
+
+    # the key was removed in asset_path2
+    assert other_key not in inventory.repo.get_asset_content(asset_path2).keys()
+
+    # exactly one commit added
+    assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
+    # TODO: verifying cleanness of worktree does not work,
+    #       because fixture returns inventory with untracked stuff
+    # assert inventory.repo.git.is_clean_worktree()
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_unset_allows_key_duplicates(inventory: Inventory) -> None:
+    """Calling `onyo_unset()` with the same key multiple times does not error."""
+    asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    key = "some_key"
+    old_hexsha = inventory.repo.git.get_hexsha()
+
+    # call `onyo_unset()` with key duplicates
+    onyo_unset(inventory,
+               paths=[asset_path],
+               keys=[key, key, key],
+               message="some subject\n\nAnd a body")
+
+    # check content
+    assert key not in inventory.repo.get_asset_content(asset_path).keys()
+    # exactly one commit added
+    assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
+    # TODO: verifying cleanness of worktree does not work,
+    #       because fixture returns inventory with untracked stuff
+    # assert inventory.repo.git.is_clean_worktree()

--- a/onyo/shared_arguments.py
+++ b/onyo/shared_arguments.py
@@ -15,7 +15,7 @@ shared_arg_match = dict(
     type=str,
     default=None,
     help=(
-        "Matching criteria for assets in teh form 'KEY=VALUE',"
+        "Matching criteria for assets in the form 'KEY=VALUE',"
         "where VALUE is a python regular expression. Special values"
         "supported are '<unset>', '<list>', and '<dict>'."
         "Pseudo-keys like 'path' can be used."))


### PR DESCRIPTION
Changes:
1. adds/updates tests/docs for the python implementations of commands
2. at least one key to unset is required
3. `match` is now actually optional for `onyo_unset()`
4. Check for illegal `path` in keys for  `onyo_set()` and `onyo_unset()`
  - close #527 
  - close #528 
5. check for illegal none values in `keys`for `onyo_set()` and `onyo_unset()`
  - close #530
6. Normalize default path for python functions of commands
  - some (e.g. `onyo_get()` and `onyo_tree()`) already used `inventory.root` when called like `onyo_<cmd>(inventory, ...)`, while `onyo_set()` and `onyo_unset()` were still using the CWD like the command line implementations do. I normalized these and added tests for this behavior
7. correct default values and optional parameters for `onyo_get()`
  - doc-strings of `get` stated this already, it was just not functionally allowed
8. `onyo_get()`requires sorting to be ascending/descending, illegal values error now instead of silently using the default