### PR TITLE
Command decorator for ensuring suitable inventory/repo state

### DIFF
--- a/onyo/commands/tests/test_edit.py
+++ b/onyo/commands/tests/test_edit.py
@@ -61,7 +61,8 @@ def test_get_editor_precedence(repo: OnyoRepo) -> None:
     """
     # set locations
     repo.set_config('onyo.core.editor', 'local', location='local')
-    repo.set_config('onyo.core.editor', 'onyo', location='onyo')
+    # Use onyo-config to also commit and not end up with a modified worktree here:
+    subprocess.run(["onyo", "config", '--add', "onyo.core.editor", "onyo"])
     os.environ['EDITOR'] = 'editor'
 
     # git should win

--- a/onyo/conftest.py
+++ b/onyo/conftest.py
@@ -197,11 +197,6 @@ def inventory(repo) -> Generator:
     inventory.add_directory(repo.git.root / 'empty')
     inventory.add_directory(repo.git.root / 'different' / 'place')
     inventory.commit("First asset added")
-
-    # Add some untracked stuff
-    (repo.git.root / "untracked" / "dir").mkdir(parents=True, exist_ok=True)
-    (repo.git.root / "untracked" / "file").touch(exist_ok=True)
-
     yield inventory
 
 

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -12,7 +12,13 @@ from rich.table import Table
 
 from onyo.lib.command_utils import fill_unset, natural_sort
 from onyo.lib.consts import PSEUDO_KEYS, RESERVED_KEYS
-from onyo.lib.exceptions import OnyoInvalidRepoError, NotAnAssetError, NoopError
+from onyo.lib.exceptions import (
+    OnyoRepoError,
+    OnyoInvalidRepoError,
+    PendingInventoryOperationError,
+    NotAnAssetError,
+    NoopError,
+)
 from onyo.lib.inventory import Inventory, OPERATIONS_MAPPING
 from onyo.lib.onyo import OnyoRepo
 from onyo.lib.ui import ui

--- a/onyo/lib/exceptions.py
+++ b/onyo/lib/exceptions.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 
-class OnyoInvalidRepoError(Exception):
+class OnyoRepoError(Exception):
+    """Thrown if something is wrong with an onyo repository."""
+
+
+class OnyoInvalidRepoError(OnyoRepoError):
     """Thrown if the repository is invalid."""
 
 
@@ -13,11 +17,21 @@ class OnyoInvalidFilterError(Exception):
     """Raise if filters are invalidly defined"""
 
 
-class InvalidInventoryOperation(Exception):
-    """TODO  -> enhance message w/ hint to Inventory.reset/commit"""
+class InventoryOperationError(Exception):
+    """Thrown if an inventory operation cannot be executed."""
 
 
-class NoopError(Exception):
+class InvalidInventoryOperationError(InventoryOperationError):
+    """Thrown if an invalid inventory operation is requested."""
+
+
+class PendingInventoryOperationError(InventoryOperationError):
+    """Thrown if there are unexpected pending operations."""
+    # TODO  -> enhance message w/ hint to Inventory.reset/commit?
+    #          would be useful in python context only
+
+
+class NoopError(InventoryOperationError):
     """Thrown if a requested operation is a Noop."""
     # This is intended to signal that an inventory operation would not result in any change, so that callers can decide
     # on their failure paradigm:

--- a/onyo/lib/inventory.py
+++ b/onyo/lib/inventory.py
@@ -22,7 +22,7 @@ from onyo.lib.differs import (
 from onyo.lib.exceptions import (
     NotAnAssetError,
     NoopError,
-    InvalidInventoryOperation,
+    InvalidInventoryOperationError,
 )
 from onyo.lib.executors import (
     exec_new_assets,
@@ -202,7 +202,7 @@ class Inventory(object):
 
     def add_asset(self, asset: Asset) -> list[InventoryOperation]:
         # TODO: what if I call this with a modified (possibly moved) asset?
-        # -> check for conflicts and raise InvalidInventoryOperation("something about either commit first or rest")
+        # -> check for conflicts and raise InvalidInventoryOperationError("something about either commit first or rest")
         operations = []
         path = None
 
@@ -373,7 +373,7 @@ class Inventory(object):
     def remove_directory(self, directory: Path) -> list[InventoryOperation]:
         operations = []
         if not self.repo.is_inventory_dir(directory):
-            raise InvalidInventoryOperation(f"Not an inventory directory: {directory}")
+            raise InvalidInventoryOperationError(f"Not an inventory directory: {directory}")
         for p in directory.iterdir():
             try:
                 operations.extend(self.remove_asset(p))
@@ -404,7 +404,7 @@ class Inventory(object):
         if not self.repo.is_inventory_dir(dst):
             raise ValueError(f"Destination is not an inventory directory: {dst}")
         if src.parent == dst:
-            raise InvalidInventoryOperation(f"Cannot move {src} -> {dst}. Consider renaming instead.")
+            raise InvalidInventoryOperationError(f"Cannot move {src} -> {dst}. Consider renaming instead.")
         if (dst / src.name).exists():
             raise ValueError(f"Target {dst / src.name} already exists.")
         return [self._add_operation('move_directories', (src, dst))]
@@ -417,7 +417,7 @@ class Inventory(object):
         if isinstance(dst, str):
             dst = src.parent / dst
         if src.parent != dst.parent:
-            raise InvalidInventoryOperation(f"Cannot rename {src} -> {dst}. Consider moving instead.")
+            raise InvalidInventoryOperationError(f"Cannot rename {src} -> {dst}. Consider moving instead.")
         if not self.repo.is_inventory_path(dst):
             raise ValueError(f"{dst} is not a valid inventory directory.")
         if dst.exists():

--- a/onyo/lib/tests/test_commands_mv.py
+++ b/onyo/lib/tests/test_commands_mv.py
@@ -1,6 +1,6 @@
 import pytest
 
-from onyo.lib.exceptions import InvalidInventoryOperation
+from onyo.lib.exceptions import InvalidInventoryOperationError
 from onyo.lib.inventory import Inventory
 from onyo.lib.onyo import OnyoRepo
 from ..commands import onyo_mv
@@ -13,7 +13,7 @@ def test_onyo_mv_errors(inventory: Inventory) -> None:
     dir_path = inventory.root / 'empty'
 
     # move directory into itself
-    pytest.raises(InvalidInventoryOperation,
+    pytest.raises(InvalidInventoryOperationError,
                   onyo_mv,
                   inventory,
                   source=dir_path,
@@ -37,7 +37,7 @@ def test_onyo_mv_errors(inventory: Inventory) -> None:
                   message="some subject\n\nAnd a body")
 
     # rename and move of a directory in one call
-    pytest.raises(InvalidInventoryOperation,
+    pytest.raises(InvalidInventoryOperationError,
                   onyo_mv,
                   inventory,
                   source=inventory.root / "somewhere",

--- a/onyo/lib/tests/test_commands_rm.py
+++ b/onyo/lib/tests/test_commands_rm.py
@@ -1,6 +1,6 @@
 import pytest
 
-from onyo.lib.exceptions import InvalidInventoryOperation
+from onyo.lib.exceptions import InvalidInventoryOperationError
 from onyo.lib.inventory import Inventory
 from onyo.lib.onyo import OnyoRepo
 from ..commands import onyo_rm
@@ -10,28 +10,28 @@ from ..commands import onyo_rm
 def test_onyo_rm_errors(inventory: Inventory) -> None:
     """`onyo_rm` must raise the correct error in different illegal or impossible calls."""
     # delete non-existing asset
-    pytest.raises(InvalidInventoryOperation,
+    pytest.raises(InvalidInventoryOperationError,
                   onyo_rm,
                   inventory,
                   paths=inventory.root / "TYPE_MAKER_MODEL.SERIAL",
                   message="some subject\n\nAnd a body")
 
     # delete non-existing directory
-    pytest.raises(InvalidInventoryOperation,
+    pytest.raises(InvalidInventoryOperationError,
                   onyo_rm,
                   inventory,
                   paths=inventory.root / "somewhere" / "non-existing",
                   message="some subject\n\nAnd a body")
 
     # delete .anchor
-    pytest.raises(InvalidInventoryOperation,
+    pytest.raises(InvalidInventoryOperationError,
                   onyo_rm,
                   inventory,
                   paths=inventory.root / OnyoRepo.ANCHOR_FILE_NAME,
                   message="some subject\n\nAnd a body")
 
     # delete outside of onyo repository
-    pytest.raises(InvalidInventoryOperation,
+    pytest.raises(InvalidInventoryOperationError,
                   onyo_rm,
                   inventory,
                   paths=inventory.root / "..",
@@ -39,7 +39,7 @@ def test_onyo_rm_errors(inventory: Inventory) -> None:
 
     # deleting an existing file which is neither an asset nor a directory is illegal
     assert (inventory.root / ".onyo" / "templates" / "laptop.example").is_file()
-    pytest.raises(InvalidInventoryOperation,
+    pytest.raises(InvalidInventoryOperationError,
                   onyo_rm,
                   inventory,
                   paths=inventory.root / ".onyo" / "templates" / "laptop.example",
@@ -56,7 +56,7 @@ def test_onyo_rm_errors_before_rm(inventory: Inventory) -> None:
     old_hexsha = inventory.repo.git.get_hexsha()
 
     # one of multiple paths to delete does not exist
-    pytest.raises(InvalidInventoryOperation,
+    pytest.raises(InvalidInventoryOperationError,
                   onyo_rm,
                   inventory,
                   paths=[asset_path, inventory.root / "not-existent", destination_path],

--- a/onyo/lib/tests/test_inventory_operations.py
+++ b/onyo/lib/tests/test_inventory_operations.py
@@ -2,7 +2,7 @@ import pytest
 
 from onyo.lib.assets import Asset
 from onyo.lib.consts import RESERVED_KEYS, PSEUDO_KEYS
-from onyo.lib.exceptions import InvalidInventoryOperation, NoopError, NotAnAssetError
+from onyo.lib.exceptions import InvalidInventoryOperationError, NoopError, NotAnAssetError
 from onyo.lib.inventory import Inventory, OPERATIONS_MAPPING
 from onyo.lib.onyo import OnyoRepo
 
@@ -319,7 +319,7 @@ def test_remove_directory(repo: OnyoRepo) -> None:
     inventory.commit("First asset added")
 
     # raise on non-dir
-    pytest.raises(InvalidInventoryOperation, inventory.remove_directory, asset_file)
+    pytest.raises(InvalidInventoryOperationError, inventory.remove_directory, asset_file)
 
     inventory.remove_directory(emptydir)
     assert num_operations(inventory, 'remove_directories') == 1
@@ -368,7 +368,7 @@ def test_move_directory(repo: OnyoRepo) -> None:
     pytest.raises(ValueError, inventory.move_directory, asset_file, repo.git.root / "doesnotexist")
     pytest.raises(ValueError, inventory.move_directory, asset_file, (repo.git.root / "isafile").touch())
     # raise on rename:
-    pytest.raises(InvalidInventoryOperation, inventory.move_directory, newdir2, newdir1)
+    pytest.raises(InvalidInventoryOperationError, inventory.move_directory, newdir2, newdir1)
 
     inventory.move_directory(newdir2, emptydir)
     assert num_operations(inventory, 'move_directories') == 1
@@ -408,9 +408,9 @@ def test_rename_directory(repo: OnyoRepo) -> None:
     # raise on non-dir:
     pytest.raises(ValueError, inventory.rename_directory, asset_file, new_place)
     # raise on existing destination:
-    pytest.raises(InvalidInventoryOperation, inventory.rename_directory, newdir1, emptydir)
+    pytest.raises(InvalidInventoryOperationError, inventory.rename_directory, newdir1, emptydir)
     # raise on move:
-    pytest.raises(InvalidInventoryOperation, inventory.rename_directory, newdir2, new_place)
+    pytest.raises(InvalidInventoryOperationError, inventory.rename_directory, newdir2, new_place)
 
     new_name = newdir1 / "new_name"
     inventory.rename_directory(newdir2, new_name)


### PR DESCRIPTION
This introduces a decorator for command implementations in order to have commands fail right away if there a running either on a dirty worktree or - in python context - on an `Inventory` object that still has pending operations.

A more command-tailored assessment of what's a valid state for a command to run on is imaginable, but we don't really have  a usecase for that so far and furthermore this introduces how to do it. We could still break theat down into several, different decorators anytime we encounter an actual need for this.