### PR TITLE
DOCS: correct changes in syntax, remove out-of-date information

### DIFF
--- a/docs/source/cmd_cat.rst
+++ b/docs/source/cmd_cat.rst
@@ -17,6 +17,10 @@ Example Usage
 
     onyo cat accounting/Bingo\ Bob/laptop_lenovo_T490s.abc123
 
+    type: laptop
+    make: lenovo
+    model: T490s
+    serial: abc123
     RAM: 16GB
     display_size: '14.6'
     touch: yes

--- a/docs/source/cmd_config.rst
+++ b/docs/source/cmd_config.rst
@@ -29,3 +29,9 @@ Example Usage
 .. code:: shell
 
     onyo config onyo.core.editor vim
+
+**Change scheme for filenames of assets**
+
+.. code:: shell
+
+    onyo config onyo.assets.filename "{type}_{make}_{model}.{serial}"

--- a/docs/source/cmd_edit.rst
+++ b/docs/source/cmd_edit.rst
@@ -16,4 +16,4 @@ Example Usage
 .. code:: shell
 
    onyo edit accounting/Bingo\ Bob/laptop_lenovo_T490s.abc123
-   <spawns $EDITOR; user edits RAM field>
+   <spawns $EDITOR; user can edit the asset>

--- a/docs/source/cmd_mkdir.rst
+++ b/docs/source/cmd_mkdir.rst
@@ -16,7 +16,9 @@ Example Usage
 
     onyo mkdir accounting/Bingo\ Bob/
 
+
 **Create a new group with some users**
+
 .. code:: shell
 
-    onyo mkdir --message "the marketing group joined!" marketing/Alice\ Wonder/ marketing/Karl\ Krebs
+    onyo mkdir --message "the marketing group joined\!" marketing/Alice\ Wonder/ marketing/Karl\ Krebs

--- a/docs/source/cmd_mv.rst
+++ b/docs/source/cmd_mv.rst
@@ -26,7 +26,7 @@ Example Usage
 
 .. code:: shell
 
-   onyo mv --message "Bob is now an admin!" accounting/Bingo\ Bob/ admin/
+   onyo mv --message "Bob works now as an admin" accounting/Bingo\ Bob/ admin/
 
 **Rename a group**
 

--- a/docs/source/cmd_new.rst
+++ b/docs/source/cmd_new.rst
@@ -17,7 +17,7 @@ Use ``onyo new`` to add a new asset and add some content to it:
 
 .. code:: shell
 
-   onyo new --keys RAM=8GB display=14.6 --path shelf/laptop_lenovo_T490s.abc123
+   onyo new --keys RAM=8GB display=14.6 type=laptop make=lenovo model=T490s serial=abc123 --path shelf/
 
 This command writes a YAML file to ``shelf/laptop_lenovo_T490s.abc123``:
 
@@ -25,6 +25,10 @@ This command writes a YAML file to ``shelf/laptop_lenovo_T490s.abc123``:
 
    RAM: 8GB
    display: 14.6
+   type: laptop
+   make: lenovo
+   model: T490s
+   serial: abc123
 
 Create multiple new assets with content, and overwrite the default message
 with a more helpful one describing the action:
@@ -32,9 +36,11 @@ with a more helpful one describing the action:
 .. code:: shell
 
    onyo new --keys RAM=16GB display_size=14.6 touch=yes
+   type=laptop make=lenovo model=T490s serial=abc123
+   type=laptop make=apple model=macbookpro serial=abc456
+   type=laptop make=apple model=macbookpro serial=17
    --message "devices for the new group are delivered"
-   --path shelf/laptop_lenovo_T490s.abc123 shelf/laptop_lenovo_T490s.abc456
-   admin/Karl/laptop_apple_macbookpro.222 admin/Theo/laptop_apple_macbookpro.17
+   --path shelf/
 
 
 **Add inventory with a table**
@@ -72,6 +78,10 @@ will be written into the asset file
 
 .. code:: shell
 
+    type: laptop
+    make: apple
+    model: macbookpro
+    serial: 0io4ff
     display: 13.3
     usb_ports: 2
 
@@ -81,17 +91,19 @@ will be written into the asset file
 To facilitate the creation of many similar devices, add templates under
 ``.onyo/templates/`` and use them with ``onyo new --template <template>``.
 
-``onyo new --edit --template laptop_lenovo
---path shelf/laptop_apple_macbookpro.0io4ff`` adds a new macbook to the
-inventory with the template ``.onyo/templates/laptop_lenovo``:
+``onyo new --edit --template laptop_lenovo --path shelf/`` adds a new laptop to
+the inventory, using ``.onyo/templates/laptop_lenovo`` as a pre-filled template:
 
 .. code:: yaml
 
    ---
+   type: laptop
+   make: lenovo
+   model:
+   serial:
    RAM: 16GB
    Size: 14.6
    USB: 3
 
-The command copies the contents of the template file into the asset
-``shelf/laptop_apple_macbookpro.0io4ff``, and then the ``--edit`` flag opens the
-editor to add or adjust missing information.
+The command copies the contents of the template file into the new asset, and
+then the ``--edit`` flag opens the editor to add or adjust missing information.

--- a/docs/source/cmd_rm.rst
+++ b/docs/source/cmd_rm.rst
@@ -21,4 +21,4 @@ Example Usage
 
 .. code:: shell
 
-    onyo rm --message "Bob retired!" admin/Bingo\ Bob/
+    onyo rm --message "Bob retired" admin/Bingo\ Bob/

--- a/docs/source/concepts.rst
+++ b/docs/source/concepts.rst
@@ -8,8 +8,7 @@ Everything is based on text files and folders. This simplicity makes Onyo
 adaptable to alternate layouts and workflows beyond what was imagined when
 designing it.
 
-Every asset is a file, and there is only one asset per file. Folders denote
-assignment: *where* something is or *who* has it.
+Folders denote assignment: *where* something is or *who* has it.
 
 Inventory Concepts
 ******************
@@ -26,15 +25,10 @@ MacBook Pro with the inventory number ``ABC123``).
 
 The identify of assets is tracked via its **serial** (see "Asset Name Scheme").
 
-**Counting** is for assets that are neither tracked nor identified. A typical
-example is counting the number of USB cables or mice available in inventory, but
-who receives these items is *not tracked*. Onyo does *not* address this use
-case, and has no mechanism to count or tally without tracking.
-
 Asset Name Scheme
 *****************
 
-Onyo asset names use the following pattern:
+Onyo asset names use by default the following pattern:
 
 .. code::
 
@@ -63,15 +57,6 @@ Each filename is unique within the repository. The **serial** alone *should* be
 unique, but cross-manufacturer conflicts is theoretically possible. In practice,
 the combination of type, make, model, and serial is sufficient to avoid all
 (reasonable) chance of conflicts.
-
-Reserved Characters
-*******************
-
-The ``type``, ``make``, or ``model`` fields reserve the ``_`` and ``.``
-characters. The ``serial`` field has no restrictions.
-
-Values for the ``type``, ``make``, and ``model`` name fields are checked against
-a list of reserved characters.
 
 File Contents
 *************
@@ -104,8 +89,6 @@ repository.
 
   - the templates for the ``onyo new --template <template>`` command (see
     "Template Files")
-
- .. _templates:
 
 Template Files
 **************

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -39,6 +39,14 @@ Options
 ``onyo.new.template``
     The default template to use with ``onyo new``. (default: "empty")
 
+``onyo.assets.filename``
+    The name scheme for asset files and asset directories in the repository.
+    (default: "{type}_{make}_{model}.{serial}")
+
+``onyo.repo.version``
+	The version of the onyo repository.
+
+.. _templates:
 
 Templates
 *********
@@ -46,14 +54,12 @@ Templates
 This section describes some of the templates provided with ``onyo init`` in the
 directory ``.onyo/templates/``.
 
-``onyo new --path <asset>`` (equivalent to
-``onyo new --template empty --path <asset>``) as defined
-by ``.onyo/templates/empty`` is an empty YAML file.
+``onyo new --keys <keys> --path <directory>`` (equivalent to
+``onyo new --keys <keys> --template empty --path <directory>``) as defined
+by ``.onyo/templates/empty`` is an empty YAML file, and ``keys`` must
+additionally specify the keys used for asset names.
 
-This template passes the YAML syntax check when onyo is called while the editor
-is suppressed with ``onyo new --non-interactive --path <asset>``.
-
-``onyo new --template laptop.example --path <asset>`` as defined by
+``onyo new --edit --template laptop.example --path <directory>`` as defined by
 ``.onyo/templates/laptop.example`` contains a simple example for a laptop asset
 which already contains some fields, which are relevant for all assets of that
 device type.
@@ -61,6 +67,10 @@ device type.
 .. code:: yaml
 
    ---
+   type:
+   make:
+   model:
+   serial:
    RAM:
    Size:
    USB:


### PR DESCRIPTION
This PR is not meant to add anything new or to make the docs more complete; Instead it brings everything up to date, corrects the docs in regards to changes in onyo (e.g. `onyo new --path` gets a directory, not an asset name) or removes information that is simply out of date (e.g. "_" is not a reserved character anymore and can be used in keys of asset names).

This should allow other people to focus later on adding new information and help during the hackathon to either use the documentation or see that information is just not given yet, instead of wondering permanently if the user does something wrong or if the docs might just be incorrect.