### PR TITLE
Poor-ify: remove unneeded rich print

### DIFF
--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -492,7 +492,7 @@ def onyo_get(inventory: Inventory,
 
         ui.rich_print(table)
     else:
-        ui.rich_print('No assets matching the filter(s) were found')
+        ui.print('No assets matching the filter(s) were found')
     return results
 
 


### PR DESCRIPTION
@aqw found an error that appears in one of the tests for `onyo_get()`:

```
❱ pytest -vv
[...]
=================================================================================== FAILURES ===================================================================================
___________________________________________________________________________ test_onyo_get_no_matches ___________________________________________________________________________

inventory = <onyo.lib.inventory.Inventory object at 0x7fbf7aedb9d0>, capsys = <_pytest.capture.CaptureFixture object at 0x7fbf7ae094d0>

    @pytest.mark.repo_contents(
        ["one_that_exists.test", "type: one\nmake: that\nmodel: exists\nserial: test\nsome_key: value"])
    @pytest.mark.ui({'yes': True})
    def test_onyo_get_no_matches(inventory: Inventory,
                                 capsys) -> None:
        """`onyo_get()` behaves correctly when `match` matches no assets."""
        asset_path1 = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
        asset_path2 = inventory.root / "one_that_exists.test"
        matches = [Filter("unfound=values").match]
    
        # `onyo_get()` is called, but no assets match
        onyo_get(inventory,
                 match=matches)  # pyre-ignore[6]
    
        # verify output contains no assets because nothing matched
        output = capsys.readouterr().out
>       assert "No assets matching the filter(s) were found" in output
E       AssertionError: assert 'No assets matching the filter(s) were found' in 'No assets matching the \x1b[1;35mfilter\x1b[0m\x1b[1m(\x1b[0ms\x1b[1m)\x1b[0m were found\n'
```

I can reproduce this error exclusively when I run all tests, if I just run the one for the file with the error (`REPO_ROOT=$PWD pytest onyo/lib/tests/test_commands_get.py -vv`) the test is not raised.
There should be some investigation into this.

However, the error is created just at one place in the code, which uses `ui.rich_print()` for a normal (not rich) string.
This is not onyo-breaking behavior, but because of the way we "assert" for a specific string (and rich printing special characters), this errors. For now this problem can be removed through using a normal `ui.print()` for the string.