### PR TITLE
`new`: --clone from existing asset

### DIFF
--- a/onyo/commands/new.py
+++ b/onyo/commands/new.py
@@ -21,6 +21,13 @@ args_new = {
         type=template,
         help='Name of the template to seed the new asset(s)'),
 
+    'clone': dict(
+        args=('-c', '--clone'),
+        metavar='CLONE',
+        required=False,
+        type=path,
+        help='Path to an asset to clone from'),
+
     'edit': dict(
         args=('-e', '--edit'),
         required=False,
@@ -71,6 +78,7 @@ def new(args: argparse.Namespace) -> None:
     onyo_new(inventory=inventory,
              path=Path(args.path).resolve() if args.path else None,
              template=args.template,
+             clone=Path(args.clone).resolve() if args.clone else None,
              tsv=Path(args.tsv).resolve() if args.tsv else None,
              keys=args.keys,
              edit=args.edit,

--- a/onyo/shell_completion/zsh/_onyo
+++ b/onyo/shell_completion/zsh/_onyo
@@ -120,7 +120,8 @@ _onyo() {
             new)
                 args+=(
                     '(- : *)'{-h,--help}'[show this help message and exit]'
-                    '(-t --template)'{-t,--template}'[template to seed the new assets]:TEMPLATE:_path_files -W "$(_template_dir)" -g "*(.)"'
+                    '(-t --template -c --clone)'{-t,--template}'[template to seed the new assets]:TEMPLATE:_path_files -W "$(_template_dir)" -g "*(.)"'
+                    '(-c --clone -t --template)'{-c,--clone}'[asset path to clone from]:CLONE:_files -W "$(_onyo_dir)"'
                     '(-e --edit)'{-e,--edit}'[open new assets in an editor before creation]'
                     '(-k --keys)'{-k,--keys}'[key-value pairs to set in the new assets]:*-*:KEYS: '
                     '(-p --path)'{-p,--path}'[directory to create new assets in]:PATH:_files -W "$(_onyo_dir)"'


### PR DESCRIPTION
Allow to clone new asset(s) from an existing one as an ad-hoc template.

- Closes #461

@aqw: shell completion doesn't seem to work yet. I get:
```
_arguments:comparguments:327: invalid argument: (-c --clone){-c,
```

when trying to complete. Can you have a look please?