### PR TITLE
TST: check clean-ness of git worktrees for python command functions

### DIFF
--- a/onyo/lib/tests/test_commands_mkdir.py
+++ b/onyo/lib/tests/test_commands_mkdir.py
@@ -74,6 +74,9 @@ def test_onyo_mkdir_errors(inventory: Inventory) -> None:
                   dirs=[dir_path / ".onyo"],
                   message="some subject\n\nAnd a body")
 
+    # no error scenario leaves the inventory unclean
+    assert inventory.repo.git.is_clean_worktree()
+
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_mkdir_errors_before_mkdir(inventory: Inventory) -> None:
@@ -98,9 +101,7 @@ def test_onyo_mkdir_errors_before_mkdir(inventory: Inventory) -> None:
     assert not (dir_path_new / OnyoRepo.ANCHOR_FILE_NAME) in inventory.repo.git.files
     # no commit was added
     assert inventory.repo.git.get_hexsha() == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -121,9 +122,7 @@ def test_onyo_mkdir_simple(inventory: Inventory) -> None:
     assert (dir_path_new / OnyoRepo.ANCHOR_FILE_NAME) in inventory.repo.git.files
     # exactly one commit added
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -158,9 +157,7 @@ def test_onyo_mkdir_multiple(inventory: Inventory) -> None:
     assert (dir_path_new3 / OnyoRepo.ANCHOR_FILE_NAME) in inventory.repo.git.files
     # exactly one commit added
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -194,9 +191,7 @@ def test_onyo_mkdir_create_multiple_subdirectories(inventory: Inventory) -> None
     assert (dir_z / OnyoRepo.ANCHOR_FILE_NAME) in inventory.repo.git.files
     # exactly one commit added
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -217,6 +212,4 @@ def test_onyo_mkdir_allows_duplicates(inventory: Inventory) -> None:
     assert (dir_path_new / OnyoRepo.ANCHOR_FILE_NAME) in inventory.repo.git.files
     # exactly one commit added
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()

--- a/onyo/lib/tests/test_commands_mv.py
+++ b/onyo/lib/tests/test_commands_mv.py
@@ -78,6 +78,9 @@ def test_onyo_mv_errors(inventory: Inventory) -> None:
                   destination=inventory.root / "new_name",
                   message="some subject\n\nAnd a body")
 
+    # no error scenario leaves the inventory unclean
+    assert inventory.repo.git.is_clean_worktree()
+
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_mv_errors_before_mv(inventory: Inventory) -> None:
@@ -101,9 +104,7 @@ def test_onyo_mv_errors_before_mv(inventory: Inventory) -> None:
     assert not (destination_path / asset_path.name).is_file()
     # no commit was added
     assert inventory.repo.git.get_hexsha() == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -130,9 +131,7 @@ def test_onyo_mv_src_to_dest_with_same_name(inventory: Inventory) -> None:
     assert (destination_path / source_path.name / OnyoRepo.ANCHOR_FILE_NAME) in inventory.repo.git.files
     # exactly one commit added
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -161,9 +160,7 @@ def test_onyo_mv_move_simple(inventory: Inventory) -> None:
     assert (destination_path / dir_path.name / OnyoRepo.ANCHOR_FILE_NAME) in inventory.repo.git.files
     # exactly one commit added
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -192,9 +189,7 @@ def test_onyo_mv_move_to_explicit_destination(inventory: Inventory) -> None:
     assert (destination_path / OnyoRepo.ANCHOR_FILE_NAME).is_file()
     # exactly one commit added
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -219,9 +214,7 @@ def test_onyo_mv_rename_directory(inventory: Inventory) -> None:
     assert inventory.repo.is_inventory_dir(destination_path)
     # exactly one commit added
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -239,3 +232,4 @@ def test_onyo_mv_and_rename(inventory: Inventory) -> None:
     assert inventory.repo.git.is_clean_worktree()
     assert not inventory.repo.is_inventory_dir(source)
     assert inventory.repo.is_inventory_dir(destination)
+    assert inventory.repo.git.is_clean_worktree()

--- a/onyo/lib/tests/test_commands_new.py
+++ b/onyo/lib/tests/test_commands_new.py
@@ -32,6 +32,7 @@ def test_onyo_new_invalid(inventory: Inventory) -> None:
                   keys=[{'serial': 'faux'}],
                   clone=inventory.root / "somewhere" / "nested" / "TYPE_MAKE_MODEL.SERIAL",
                   template='laptop.example')
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -44,6 +45,7 @@ def test_onyo_new_tsv(inventory: Inventory, tsv: Path) -> None:
         # TODO: Same here; just ensures those tables still don't crash
         onyo_new(inventory, tsv=tsv)
         inventory.repo.git._git(['reset', '--hard', 'HEAD~1'])
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -140,6 +142,7 @@ def test_onyo_new_keys(inventory: Inventory) -> None:
     # (Note: key must be there - no `KeyError`; but content is `None`)
     for k in ['RAM', 'Size', 'USB']:
         assert asset_content[k] is None
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -178,6 +181,7 @@ def test_onyo_new_creates_directories(inventory: Inventory) -> None:
         new_asset = inventory.get_asset(p)
         assert new_asset.get("path") == p
         assert all(new_asset[k] == s[k] for k in s.keys())
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -220,6 +224,7 @@ def test_onyo_new_edit(inventory: Inventory, monkeypatch) -> None:
     monkeypatch.setenv('EDITOR', f"printf '{edit_str}' >>")
     specs = [{'template': 'empty'}]
     pytest.raises(ValueError, onyo_new, inventory, keys=specs, path=directory, edit=True)
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -255,3 +260,4 @@ def test_onyo_new_clones(inventory: Inventory) -> None:
     # equals existing asset except for path and serial:
     assert all(v == new_asset[k] for k, v in existing_asset.items() if k not in ['serial', 'path'])
     assert new_asset['serial'] == 'whatever'
+    assert inventory.repo.git.is_clean_worktree()

--- a/onyo/lib/tests/test_commands_rm.py
+++ b/onyo/lib/tests/test_commands_rm.py
@@ -52,6 +52,9 @@ def test_onyo_rm_errors(inventory: Inventory) -> None:
                   paths=inventory.root,
                   message="some subject\n\nAnd a body")
 
+    # no error scenario leaves the git tree unclean
+    assert inventory.repo.git.is_clean_worktree()
+
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_rm_errors_before_rm(inventory: Inventory) -> None:
@@ -74,9 +77,7 @@ def test_onyo_rm_errors_before_rm(inventory: Inventory) -> None:
     assert destination_path.is_dir()
     # no commit was added
     assert inventory.repo.git.get_hexsha() == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -130,9 +131,7 @@ def test_onyo_rm_move_single(inventory: Inventory) -> None:
     assert asset_path not in inventory.repo.git.files
     # exactly one commit added
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -151,9 +150,7 @@ def test_onyo_rm_delete_directory(inventory: Inventory) -> None:
     assert dir_path / OnyoRepo.ANCHOR_FILE_NAME not in inventory.repo.git.files
     # exactly one commit added
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -176,9 +173,7 @@ def test_onyo_rm_list(inventory: Inventory) -> None:
     assert dir_path / OnyoRepo.ANCHOR_FILE_NAME not in inventory.repo.git.files
     # exactly one commit added
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -203,6 +198,4 @@ def test_onyo_rm_subpath_and_contents(inventory: Inventory) -> None:
     assert asset_path not in inventory.repo.git.files
     # exactly one commit added
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()

--- a/onyo/lib/tests/test_commands_set.py
+++ b/onyo/lib/tests/test_commands_set.py
@@ -71,6 +71,9 @@ def test_onyo_set_errors(inventory: Inventory) -> None:
                   keys=key_value,
                   message="some subject\n\nAnd a body")
 
+    # no error scenario leaves the git tree unclean
+    assert inventory.repo.git.is_clean_worktree()
+
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_set_empty_keys_or_values(inventory: Inventory) -> None:
@@ -106,9 +109,7 @@ def test_onyo_set_empty_keys_or_values(inventory: Inventory) -> None:
     assert "key: ''" in asset_path.read_text()
     # exactly one commit added
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -131,9 +132,7 @@ def test_onyo_set_directory(inventory: Inventory) -> None:
 
     # exactly one commit added
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -152,6 +151,7 @@ def test_onyo_set_on_empty_directory(inventory: Inventory) -> None:
 
     # no commit was added
     assert inventory.repo.git.get_hexsha() == old_hexsha
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -182,6 +182,7 @@ def test_onyo_set_illegal_fields(inventory: Inventory) -> None:
     assert "new_value" not in asset_path.read_text()
     # no commit was added
     assert inventory.repo.git.get_hexsha() == old_hexsha
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -208,9 +209,7 @@ def test_onyo_set_errors_before_set(inventory: Inventory) -> None:
     assert non_existing_asset_path not in inventory.repo.git.files
     # no commit was added
     assert inventory.repo.git.get_hexsha() == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -232,9 +231,7 @@ def test_onyo_set_simple(inventory: Inventory) -> None:
 
     # exactly one commit added
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -261,9 +258,7 @@ def test_onyo_set_already_set(inventory: Inventory) -> None:
 
     # no commit added
     assert inventory.repo.git.get_hexsha() == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -292,9 +287,7 @@ def test_onyo_set_overwrite_existing_value(inventory: Inventory) -> None:
 
     # exactly one commit added
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -328,9 +321,7 @@ def test_onyo_set_some_values_already_set(inventory: Inventory) -> None:
 
     # exactly one commit added
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.repo_contents(
@@ -364,9 +355,7 @@ def test_onyo_set_match(inventory: Inventory) -> None:
 
     # exactly one commit added
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.repo_contents(
@@ -399,9 +388,7 @@ def test_onyo_set_no_matches(inventory: Inventory) -> None:
 
     # no commit was added because nothing matched
     assert inventory.repo.git.get_hexsha() == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.repo_contents(
@@ -429,9 +416,7 @@ def test_onyo_set_multiple(inventory: Inventory) -> None:
 
     # exactly one commit added
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.repo_contents(
@@ -461,9 +446,7 @@ def test_onyo_set_depth(inventory: Inventory) -> None:
 
     # exactly one commit added
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.repo_contents(
@@ -492,9 +475,7 @@ def test_onyo_set_depth_zero(inventory: Inventory) -> None:
 
     # exactly one commit added
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.repo_contents(
@@ -517,9 +498,7 @@ def test_onyo_set_default_inventory_root(inventory: Inventory) -> None:
 
     # exactly one commit added
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -542,6 +521,4 @@ def test_onyo_set_allows_duplicates(inventory: Inventory) -> None:
 
     # exactly one commit added
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()

--- a/onyo/lib/tests/test_commands_tree.py
+++ b/onyo/lib/tests/test_commands_tree.py
@@ -39,6 +39,9 @@ def test_onyo_tree_errors(inventory: Inventory) -> None:
                          inventory.root / "doesnotexist",
                          dir_path])
 
+    # no error scenario leaves the git worktree unclean
+    assert inventory.repo.git.is_clean_worktree()
+
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_tree_single(inventory: Inventory,
@@ -54,10 +57,7 @@ def test_onyo_tree_single(inventory: Inventory,
     tree_output = capsys.readouterr().out
     for path in inventory.repo.get_asset_paths(subtrees=[directory_path]):
         assert all([part in tree_output for part in path.parts])
-
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -74,10 +74,7 @@ def test_onyo_tree_multiple_paths(inventory: Inventory,
     tree_output = capsys.readouterr().out
     for path in inventory.repo.get_asset_paths(subtrees=[dir_path, inventory.root]):
         assert all([part in tree_output for part in path.parts])
-
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -90,9 +87,7 @@ def test_onyo_tree_without_explicit_paths(inventory: Inventory,
     tree_output = capsys.readouterr().out
     for path in inventory.repo.get_asset_paths(subtrees=[inventory.root]):
         assert all([part in tree_output for part in path.parts])
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -108,10 +103,7 @@ def test_onyo_tree_errors_before_showing_trees(inventory: Inventory) -> None:
                   paths=[directory_path,
                          non_existing_path,
                          inventory.root])
-
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -133,7 +125,4 @@ def test_onyo_tree_with_same_dir_twice(inventory: Inventory,
     for path in inventory.repo.get_asset_paths(subtrees=[directory_path]):
         assert all([part in tree_output for part in path.parts])
     assert tree_output.count(str(directory_path)) == 2
-
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()

--- a/onyo/lib/tests/test_commands_unset.py
+++ b/onyo/lib/tests/test_commands_unset.py
@@ -69,6 +69,9 @@ def test_onyo_unset_errors(inventory: Inventory) -> None:
                   keys=[key],
                   message="some subject\n\nAnd a body")
 
+    # no error scenario leaves the git worktree unclean
+    assert inventory.repo.git.is_clean_worktree()
+
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_unset_on_empty_directory(inventory: Inventory) -> None:
@@ -86,6 +89,7 @@ def test_onyo_unset_on_empty_directory(inventory: Inventory) -> None:
 
     # no commit was added
     assert inventory.repo.git.get_hexsha() == old_hexsha
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -112,6 +116,7 @@ def test_onyo_unset_name_fields_error(inventory: Inventory) -> None:
 
     # no commit was added
     assert inventory.repo.git.get_hexsha() == old_hexsha
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -135,6 +140,7 @@ def test_onyo_unset_illegal_fields(inventory: Inventory) -> None:
 
     # no commit was added
     assert inventory.repo.git.get_hexsha() == old_hexsha
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -163,9 +169,7 @@ def test_onyo_unset_errors_before_unset(inventory: Inventory) -> None:
     assert key in asset_path.read_text()
     # no commit was added
     assert inventory.repo.git.get_hexsha() == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -189,9 +193,7 @@ def test_onyo_unset_simple(inventory: Inventory) -> None:
 
     # exactly one commit added
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.repo_contents(
@@ -225,9 +227,7 @@ def test_onyo_unset_match(inventory: Inventory) -> None:
 
     # exactly one commit added
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.repo_contents(
@@ -260,9 +260,7 @@ def test_onyo_unset_no_matches(inventory: Inventory) -> None:
 
     # no commits added because nothing changed
     assert inventory.repo.git.get_hexsha() == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.repo_contents(
@@ -292,9 +290,7 @@ def test_onyo_unset_depth(inventory: Inventory) -> None:
 
     # exactly one commit added
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.repo_contents(
@@ -323,9 +319,7 @@ def test_onyo_unset_depth_zero(inventory: Inventory) -> None:
 
     # exactly one commit added
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -351,9 +345,7 @@ def test_onyo_unset_directories(inventory: Inventory) -> None:
 
     # exactly one commit added
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -371,9 +363,7 @@ def test_onyo_unset_empty_directory(inventory: Inventory) -> None:
 
     # nothing was changed, so nothing should have been committed
     assert inventory.repo.git.get_hexsha() == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.repo_contents(
@@ -403,9 +393,7 @@ def test_onyo_unset_multiple(inventory: Inventory) -> None:
 
     # exactly one commit added
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.repo_contents(
@@ -431,9 +419,7 @@ def test_onyo_unset_default_inventory_root(inventory: Inventory) -> None:
 
     # exactly one commit added
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -455,9 +441,7 @@ def test_onyo_unset_allows_asset_duplicates(inventory: Inventory) -> None:
 
     # exactly one commit added
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.repo_contents(
@@ -494,9 +478,7 @@ def test_onyo_unset_non_existing_keys(inventory: Inventory) -> None:
 
     # exactly one commit added
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()
 
 
 @pytest.mark.ui({'yes': True})
@@ -516,6 +498,4 @@ def test_onyo_unset_allows_key_duplicates(inventory: Inventory) -> None:
     assert key not in inventory.repo.get_asset_content(asset_path).keys()
     # exactly one commit added
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
-    # TODO: verifying cleanness of worktree does not work,
-    #       because fixture returns inventory with untracked stuff
-    # assert inventory.repo.git.is_clean_worktree()
+    assert inventory.repo.git.is_clean_worktree()


### PR DESCRIPTION
This could not be tested before, because the `inventory` fixture constructed an inventory which contained un-saved files.
Since that behavior was changed, commands that might change the worktree can check it again, especially when they do some changes, or to verify that nothing was left unclean after errors where triggered.

There is no issue as such for this, instead it removes the TODOs in the code describing the necessity of this.