### PR TITLE
BF: small shell-completion fixes

### DIFF
--- a/onyo/shell_completion/zsh/_onyo
+++ b/onyo/shell_completion/zsh/_onyo
@@ -124,7 +124,7 @@ _onyo() {
                     '(-c --clone -t --template)'{-c,--clone}'[asset path to clone from]:CLONE:_files -W "$(_onyo_dir)"'
                     '(-e --edit)'{-e,--edit}'[open new assets in an editor before creation]'
                     '(-k --keys)'{-k,--keys}'[key-value pairs to set in the new assets]:*-*:KEYS: '
-                    '(-p --path)'{-p,--path}'[directory to create new assets in]:PATH:_files -W "$(_onyo_dir)"'
+                    '(-p --path)'{-p,--path}'[directory to create new assets in]:PATH:_files -W "$(_onyo_dir)" -/'
                     '(-tsv --tsv)'{-tsv,--tsv}'[path to a TSV file describing the new assets]:TSV:_files -W "$(_onyo_dir)"'
                     '(-m --message)'{-m,--message}'[use the given MESSAGE as the commit message]:MESSAGE: '
                 )

--- a/onyo/shell_completion/zsh/_onyo
+++ b/onyo/shell_completion/zsh/_onyo
@@ -99,14 +99,14 @@ _onyo() {
             init)
                 args+=(
                     '(- : *)'{-h,--help}'[show this help message and exit]'
-                    '::DIR:_path_files -W "$(_onyo_dir)" -/'
+                    '::DIR:_files -W "$(_onyo_dir)" -/'
                 )
                 ;;
             mkdir)
                 args+=(
                     '(- : *)'{-h,--help}'[show this help message and exit]'
                     '(-m --message)'{-m,--message}'[use the given MESSAGE as the commit message]:MESSAGE: '
-                    '*:DIR:_path_files -W "$(_onyo_dir)" -/'
+                    '*:DIR:_files -W "$(_onyo_dir)" -/'
                 )
                 ;;
             mv)
@@ -120,7 +120,7 @@ _onyo() {
             new)
                 args+=(
                     '(- : *)'{-h,--help}'[show this help message and exit]'
-                    '(-t --template -c --clone)'{-t,--template}'[template to seed the new assets]:TEMPLATE:_path_files -W "$(_template_dir)" -g "*(.)"'
+                    '(-t --template -c --clone)'{-t,--template}'[template to seed the new assets]:TEMPLATE:_files -W "$(_template_dir)" -g "*(.)"'
                     '(-c --clone -t --template)'{-c,--clone}'[asset path to clone from]:CLONE:_files -W "$(_onyo_dir)"'
                     '(-e --edit)'{-e,--edit}'[open new assets in an editor before creation]'
                     '(-k --keys)'{-k,--keys}'[key-value pairs to set in the new assets]:*-*:KEYS: '
@@ -156,7 +156,7 @@ _onyo() {
             tree)
                 args+=(
                     '(- : *)'{-h,--help}'[show this help message and exit]'
-                    '*::DIR:_path_files -W "$(_onyo_dir)" -/'
+                    '*::DIR:_files -W "$(_onyo_dir)" -/'
                 )
                 ;;
             unset)


### PR DESCRIPTION
Standardizing on `_files` should be a no-op. It just unifies the syntax for the sake of consistency.

The misbehavior of `onyo new --path` was caught by @bpoldrack :-)