### PR TITLE
BF: improve help text for `onyo new`

### DIFF
--- a/onyo/shared_arguments.py
+++ b/onyo/shared_arguments.py
@@ -4,9 +4,11 @@ shared_arg_depth = dict(
     type=int,
     required=False,
     default=0,
-    help=(
-        'Descend up to DEPTH levels into directories specified. DEPTH=0 '
-        'descends recursively without limit'))
+    help="""
+        Descend up to DEPTH levels into the directories specified. DEPTH=0
+        descends recursively without limit.
+    """
+)
 
 shared_arg_match = dict(
     args=('-M', '--match'),
@@ -14,18 +16,24 @@ shared_arg_match = dict(
     nargs='+',
     type=str,
     default=None,
-    help=(
-        "Matching criteria for assets in the form 'KEY=VALUE', "
-        "where VALUE is a python regular expression. Special values "
-        "supported are '<unset>', '<list>', and '<dict>'. "
-        "Pseudo-keys like 'path' can be used."))
+    help="""
+        Matching criteria for assets in the form ``KEY=VALUE``, where VALUE is a
+        python regular expression. Pseudo-keys such as ``path`` can also be
+        used. Special values supported are:
+        - ``<dict>``
+        - ``<list>``
+        - ``<unset>``
+    """
+)
 
 shared_arg_message = dict(
     args=('-m', '--message'),
     metavar='MESSAGE',
     action='append',
     type=str,
-    help=(
-        'Use the given MESSAGE as the commit message (rather than the '
-        'default). If multiple -m options are given, their values are '
-        'concatenated as separate paragraphs'))
+    help="""
+        Use the given MESSAGE as the commit message (rather than the default).
+        If multiple ``-m`` options are given, their values are concatenated as
+        separate paragraphs.
+    """
+)

--- a/onyo/shell_completion/zsh/_onyo
+++ b/onyo/shell_completion/zsh/_onyo
@@ -34,7 +34,7 @@ _onyo() {
         'init:initialize a new Onyo repository'
         'mkdir:create DIRECTORYs'
         'mv:move SOURCEs (assets or directories) to the DEST directory, or rename a SOURCE directory to DEST'
-        'new:create new ASSETs'
+        'new:create new ASSETs and populate with KEY-VALUE pairs'
         'rm:delete ASSETs and DIRECTORYs'
         'set:set the VALUE of KEYs for matching assets'
         'shell-completion:display a tab-completion script for Onyo'


### PR DESCRIPTION
This rewrites and reformats much of the help text for `onyo new`, and also the shared arguments.

Fixes: #395