### PR TITLE
BF: more help improvements

### DIFF
--- a/onyo/commands/cat.py
+++ b/onyo/commands/cat.py
@@ -16,15 +16,16 @@ args_cat = {
         metavar='ASSET',
         nargs='+',
         type=file,
-        help='Paths of asset(s) to print'),
+        help='path of ``ASSET`` to print'),
 }
 
 
 def cat(args: argparse.Namespace) -> None:
-    """Print the contents of ``ASSET`` file(s) to the terminal.
+    """
+    Print the contents of ``ASSET``\s to the terminal.
 
-    At least one valid asset path is required. Assets can be given multiple times.
-    If any path specified is invalid, no contents are printed and an error is raised.
+    If any of the paths are invalid, then no contents are printed and an error
+    is returned.
     """
     paths = [Path(p).resolve() for p in args.asset]
 

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -21,7 +21,18 @@ class SubcommandHelpFormatter(argparse.RawTextHelpFormatter):
         return parts
 
     def _split_lines(self, text, width):
+        """
+        This is a very, very naive approach to stripping rst syntax from
+        docstrings. Sadly, docutils does not have a plain-text writer. That
+        would be the ideal solution.
+        """
         text = textwrap.dedent(text).strip()
+
+        # `` -> `
+        text = text.replace('``', '`')
+        # remove escapes of characters; everything is literal here
+        text = text.replace('\\', '')
+
         text = super()._split_lines(text, width)
 
         return text

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -21,7 +21,7 @@ class SubcommandHelpFormatter(argparse.RawTextHelpFormatter):
         return parts
 
     def _split_lines(self, text, width):
-        text = textwrap.dedent(text)
+        text = textwrap.dedent(text).strip()
         text = super()._split_lines(text, width)
 
         return text
@@ -32,7 +32,7 @@ class SubcommandHelpFormatter(argparse.RawTextHelpFormatter):
         docstrings. Sadly, docutils does not have a plain-text writer. That
         would be the ideal solution.
         """
-        text = textwrap.dedent(text)
+        text = textwrap.dedent(text).strip()
         text = super()._fill_text(text, width, indent)
 
         # `` -> `

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -103,7 +103,7 @@ def setup_parser() -> argparse.ArgumentParser:
         'cat',
         description=commands.cat.__doc__,
         formatter_class=SubcommandHelpFormatter,
-        help=commands.cat.__doc__
+        help='Print the contents of assets to the terminal.'
     )
     cmd_cat.set_defaults(run=commands.cat)
     build_parser(cmd_cat, args_cat)
@@ -114,7 +114,7 @@ def setup_parser() -> argparse.ArgumentParser:
         'config',
         description=commands.config.__doc__,
         formatter_class=SubcommandHelpFormatter,
-        help=commands.config.__doc__
+        help='Set, query, and unset Onyo repository configuration options.'
     )
     cmd_config.set_defaults(run=commands.config)
     build_parser(cmd_config, args_config)
@@ -125,7 +125,7 @@ def setup_parser() -> argparse.ArgumentParser:
         'edit',
         description=commands.edit.__doc__,
         formatter_class=SubcommandHelpFormatter,
-        help=commands.edit.__doc__
+        help='Open assets using an editor.'
     )
     cmd_edit.set_defaults(run=commands.edit)
     build_parser(cmd_edit, args_edit)
@@ -136,7 +136,7 @@ def setup_parser() -> argparse.ArgumentParser:
         'fsck',
         description=commands.fsck.__doc__,
         formatter_class=SubcommandHelpFormatter,
-        help=commands.fsck.__doc__
+        help='Run a suite of integrity checks on the Onyo repository and its contents.'
     )
     cmd_fsck.set_defaults(run=commands.fsck)
     #
@@ -146,7 +146,7 @@ def setup_parser() -> argparse.ArgumentParser:
         'get',
         description=commands.get.__doc__,
         formatter_class=SubcommandHelpFormatter,
-        help=commands.get.__doc__
+        help='Return and sort asset values matching query patterns.'
     )
     cmd_get.set_defaults(run=commands.get)
     build_parser(cmd_get, args_get)
@@ -157,7 +157,7 @@ def setup_parser() -> argparse.ArgumentParser:
         'history',
         description=commands.history.__doc__,
         formatter_class=SubcommandHelpFormatter,
-        help=commands.history.__doc__
+        help='Display the history of an asset or directory.'
     )
     cmd_history.set_defaults(run=commands.history)
     build_parser(cmd_history, args_history)
@@ -168,7 +168,7 @@ def setup_parser() -> argparse.ArgumentParser:
         'init',
         description=commands.init.__doc__,
         formatter_class=SubcommandHelpFormatter,
-        help=commands.init.__doc__
+        help='Initialize a new Onyo repository.'
     )
     cmd_init.set_defaults(run=commands.init)
     build_parser(cmd_init, args_init)
@@ -179,7 +179,7 @@ def setup_parser() -> argparse.ArgumentParser:
         'mkdir',
         description=commands.mkdir.__doc__,
         formatter_class=SubcommandHelpFormatter,
-        help=commands.mkdir.__doc__
+        help='Create directories.'
     )
     cmd_mkdir.set_defaults(run=commands.mkdir)
     build_parser(cmd_mkdir, args_mkdir)
@@ -190,7 +190,7 @@ def setup_parser() -> argparse.ArgumentParser:
         'mv',
         description=commands.mv.__doc__,
         formatter_class=SubcommandHelpFormatter,
-        help=commands.mv.__doc__
+        help='Move assets or directories into a destination directory; or rename a directory.'
     )
     cmd_mv.set_defaults(run=commands.mv)
     build_parser(cmd_mv, args_mv)
@@ -201,7 +201,7 @@ def setup_parser() -> argparse.ArgumentParser:
         'new',
         description=commands.new.__doc__,
         formatter_class=SubcommandHelpFormatter,
-        help=commands.new.__doc__
+        help='Create new assets and populate with key-value pairs.'
     )
     cmd_new.set_defaults(run=commands.new)
     build_parser(cmd_new, args_new)
@@ -212,7 +212,7 @@ def setup_parser() -> argparse.ArgumentParser:
         'rm',
         description=commands.rm.__doc__,
         formatter_class=SubcommandHelpFormatter,
-        help=commands.rm.__doc__
+        help='Delete assets and directories.'
     )
     cmd_rm.set_defaults(run=commands.rm)
     build_parser(cmd_rm, args_rm)
@@ -223,7 +223,7 @@ def setup_parser() -> argparse.ArgumentParser:
         'set',
         description=commands.set.__doc__,
         formatter_class=SubcommandHelpFormatter,
-        help=commands.set.__doc__
+        help='Set the value of keys for assets.'
     )
     cmd_set.set_defaults(run=commands.set)
     build_parser(cmd_set, args_set)
@@ -234,7 +234,7 @@ def setup_parser() -> argparse.ArgumentParser:
         'shell-completion',
         description=commands.shell_completion.__doc__,
         formatter_class=SubcommandHelpFormatter,
-        help=commands.shell_completion.__doc__
+        help='Display a tab-completion script for Onyo.'
     )
     cmd_shell_completion.set_defaults(run=commands.shell_completion)
     build_parser(cmd_shell_completion, args_shell_completion)
@@ -245,7 +245,7 @@ def setup_parser() -> argparse.ArgumentParser:
         'tree',
         description=commands.tree.__doc__,
         formatter_class=SubcommandHelpFormatter,
-        help=commands.tree.__doc__
+        help='List the assets and directories of a directory in ``tree`` format.'
     )
     cmd_tree.set_defaults(run=commands.tree)
     build_parser(cmd_tree, args_tree)
@@ -256,7 +256,7 @@ def setup_parser() -> argparse.ArgumentParser:
         'unset',
         description=commands.unset.__doc__,
         formatter_class=SubcommandHelpFormatter,
-        help=commands.unset.__doc__
+        help='Remove keys from assets.'
     )
     cmd_unset.set_defaults(run=commands.unset)
     build_parser(cmd_unset, args_unset)

--- a/onyo/onyo_arguments.py
+++ b/onyo/onyo_arguments.py
@@ -10,36 +10,48 @@ args_onyo = {
         required=False,
         default=Path.cwd(),
         type=directory,
-        help='Run Onyo commands from inside of DIR'),
+        help="""
+            Run Onyo from DIR instead of the current working directory.
+        """
+    ),
 
     'debug': dict(
         args=('-d', '--debug'),
         required=False,
         default=False,
         action='store_true',
-        help='Enable debug logging'),
+        help="""
+            Enable debug logging.
+        """
+    ),
 
     'version': dict(
         args=('-v', '--version'),
         action='version',
         version='%(prog)s {version}'.format(version=__version__),
-        help="Print onyo's version and exit"),
+        help="""
+            Print Onyo's version and exit.
+        """
+    ),
 
     'quiet': dict(
         args=('-q', '--quiet'),
         required=False,
         default=False,
         action='store_true',
-        help=(
-            'Silence messages printed to stdout. Does not suppress interactive '
-            'editors. Requires the --yes flag')),
+        help="""
+            Silence messages printed to stdout; does not suppress interactive
+            editors. Requires the ``--yes`` flag.
+        """
+    ),
 
     'yes': dict(
         args=('-y', '--yes'),
         required=False,
         default=False,
         action='store_true',
-        help=(
-            'Respond "yes" to any prompts. The --yes flag is required to use '
-            '--quiet')),
+        help="""
+            Respond "yes" to any prompts.
+        """
+    ),
 }

--- a/onyo/shell_completion/zsh/_onyo
+++ b/onyo/shell_completion/zsh/_onyo
@@ -17,7 +17,7 @@ _onyo() {
     args=( )
     toplevel_flags=(
         '(- : *)'{-h,--help}'[show this help message and exit]'
-        '(-C --onyopath)'{-C,--onyopath}'[run as if Onyo were started in DIR]:DIR:_files -/'
+        '(-C --onyopath)'{-C,--onyopath}'[run Onyo from DIR instead of the current working directory]:DIR:_files -/'
         '(-d --debug)'{-d,--debug}'[enable debug logging]'
         '(- : *)'{-v,--version}'[print onyo'\''s version and exit]'
         '(-q --quiet)'{-q,--quiet}'[silence messages printed to stdout; does not suppress interactive editors]'


### PR DESCRIPTION
This improves the help text primarily for the top-level `onyo --help` and `onyo cat --help`.

It also includes two fixes for formatting help text broadly:
- strip leading and trailing newlines (allowing `"""` syntax)
- make de-rst-ifying consistent across description and arguments