### PR TITLE
DOC/BF: update a bunch more help text

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ cd onyo
 #### (3) Create then activate a virtual environment
 
 ```bash
-python -m venv ~/.venvs/onyo
+python3 -m venv ~/.venvs/onyo
 source ~/.venvs/onyo/bin/activate
 ```
 
@@ -33,7 +33,7 @@ source ~/.venvs/onyo/bin/activate
 
 Debian/Ubuntu:
 ```bash
-apt-get install git tig tree
+apt-get install git tig tree python3-pip
 ```
 
 macOS ([Homebrew](https://brew.sh):
@@ -44,7 +44,7 @@ brew install git tig tree
 #### (5) Install Onyo and test dependencies
 
 ```bash
-pip install -e ".[tests, docs]"
+pip3 install -e ".[tests, docs]"
 ```
 
 ### Running tests

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Onyo requires Python >= 3.11 and a few system utilities.
 
 Debian/Ubuntu:
 ```
-apt-get install git tig tree
+apt-get install git tig tree python3-pip
 ```
 
 macOS:
@@ -31,7 +31,7 @@ brew install git tig tree
 
 #### Setup and activate virtual environment:
 ```
-python -m venv ~/.venvs/onyo
+python3 -m venv ~/.venvs/onyo
 source ~/.venvs/onyo/bin/activate
 ```
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -11,7 +11,7 @@ system utilities.
 
 .. code:: shell
 
-   apt-get install git tig tree
+   apt-get install git tig tree python3-pip
 
 **macOS**:
 
@@ -27,7 +27,7 @@ To install Onyo, run the following from your command line:
 
 .. code::
 
-   pip install git+https://github.com/psyinfra/onyo.git
+   pip3 install git+https://github.com/psyinfra/onyo.git
 
 Enabling tab-completion is also recommended:
 .. code::

--- a/onyo/commands/config.py
+++ b/onyo/commands/config.py
@@ -38,19 +38,19 @@ def config(args: argparse.Namespace) -> None:
 
     Onyo configuration options:
 
-        * ``onyo.assets.filename``: The format for asset names on the
-          filesystem. (default: "{type}_{make}_{model}.{serial}")
-        * ``onyo.core.editor``: The editor to use for commands such as ``edit``
-          and ``new``. If unset, it will fallback to the environmental variable
-          ``EDITOR`` and lastly ``nano``. (default: unset)
-        * ``onyo.history.interactive``: The interactive command to use for
-          ``onyo history``. (default: "tig --follow")
-        * ``onyo.history.non-interactive``: The non-interactive command for
-          running ``onyo history --non-interactive``.
-          (default: "git --no-pager log --follow")
-        * ``onyo.new.template``: The default template to use with ``onyo new``.
-          (default: "empty")
-        * ``onyo.repo.version``: The Onyo repository version.
+      * ``onyo.assets.filename``: The format for asset names on the
+        filesystem. (default: "{type}_{make}_{model}.{serial}")
+      * ``onyo.core.editor``: The editor to use for commands such as ``edit``
+        and ``new``. If unset, it will fallback to the environmental variable
+        ``EDITOR`` and lastly ``nano``. (default: unset)
+      * ``onyo.history.interactive``: The interactive command to use for
+        ``onyo history``. (default: "tig --follow")
+      * ``onyo.history.non-interactive``: The non-interactive command for
+        running ``onyo history --non-interactive``.
+        (default: "git --no-pager log --follow")
+      * ``onyo.new.template``: The default template to use with ``onyo new``.
+        (default: "empty")
+      * ``onyo.repo.version``: The Onyo repository version.
     """
 
     # TODO: Wouldn't we want to commit (implying message parameter)?

--- a/onyo/commands/config.py
+++ b/onyo/commands/config.py
@@ -16,15 +16,17 @@ args_config = {
         metavar='ARGS',
         nargs='+',
         type=git_config,
-        help='Config options to set in .onyo/config'),
+        help='Config options to set in .onyo/config'
+    ),
 }
 
 
 def config(args: argparse.Namespace) -> None:
     """
-    Set, query, and unset Onyo repository configuration options. These options
-    are stored in ``.onyo/config``. This file is tracked by git and are shared
-    with all other consumers of an Onyo repository.
+    Set, query, and unset Onyo repository configuration options.
+
+    These options are stored in ``.onyo/config``, which is tracked by git and
+    shared with all other users of the Onyo repository.
 
     To set configuration options locally (and not commit them to the Onyo
     repository), use ``git config`` instead.
@@ -36,16 +38,19 @@ def config(args: argparse.Namespace) -> None:
 
     Onyo configuration options:
 
-    - ``onyo.core.editor``: The editor to use for commands such as ``edit`` and
-      ``new``. If unset, it will fallback to the environmental variable
-      ``EDITOR`` and lastly ``nano``. (default: unset)
-    - ``onyo.history.interactive``: The command used to display history when
-      running ``onyo history``. (default: "tig --follow")
-    - ``onyo.history.non-interactive``: The command used to print history when
-      running ``onyo history`` with ``--non-interactive``.
-      (default: "git --no-pager log --follow")
-    - ``onyo.new.template``: The default template to use with ``onyo new``.
-      (default: "empty")
+        * ``onyo.assets.filename``: The format for asset names on the
+          filesystem. (default: "{type}_{make}_{model}.{serial}")
+        * ``onyo.core.editor``: The editor to use for commands such as ``edit``
+          and ``new``. If unset, it will fallback to the environmental variable
+          ``EDITOR`` and lastly ``nano``. (default: unset)
+        * ``onyo.history.interactive``: The interactive command to use for
+          ``onyo history``. (default: "tig --follow")
+        * ``onyo.history.non-interactive``: The non-interactive command for
+          running ``onyo history --non-interactive``.
+          (default: "git --no-pager log --follow")
+        * ``onyo.new.template``: The default template to use with ``onyo new``.
+          (default: "empty")
+        * ``onyo.repo.version``: The Onyo repository version.
     """
 
     # TODO: Wouldn't we want to commit (implying message parameter)?

--- a/onyo/commands/edit.py
+++ b/onyo/commands/edit.py
@@ -32,9 +32,9 @@ def edit(args: argparse.Namespace) -> None:
 
     The editor is selected by (in order):
 
-        * configuration option `onyo.core.editor`
-        * ``EDITOR`` environment variable
-        * ``nano`` (as a final fallback)
+      * configuration option `onyo.core.editor`
+      * ``EDITOR`` environment variable
+      * ``nano`` (as a final fallback)
 
     The contents of all edited ASSETs are checked for validity before
     committing. If problems are found, a prompt is offered to either reopen the

--- a/onyo/commands/edit.py
+++ b/onyo/commands/edit.py
@@ -17,7 +17,8 @@ args_edit = {
         metavar='ASSET',
         nargs='+',
         type=file,
-        help='Paths of asset(s) to edit'),
+        help='Paths of ASSETs to edit.'
+    ),
 
     'message': shared_arg_message,
 }
@@ -25,14 +26,19 @@ args_edit = {
 
 def edit(args: argparse.Namespace) -> None:
     """
-    Open the ``ASSET``\(s) using the editor specified by "onyo.core.editor",
-    the environment variable ``EDITOR``, or ``nano`` (as a final fallback).
+    Open ``ASSET``\s using an editor.
 
-    When multiple ``ASSET``\(s) are given, Onyo will open them in sequence.
+    When multiple ASSETs are given, they are opened sequentially.
 
-    After editing an ``ASSET``, the contents will be checked for valid YAML.
-    If problems are found, the choice will be offered to reopen the editor to
-    fix them, or discard the invalid changes made.
+    The editor is selected by (in order):
+
+        * configuration option `onyo.core.editor`
+        * ``EDITOR`` environment variable
+        * ``nano`` (as a final fallback)
+
+    The contents of all edited ASSETs are checked for validity before
+    committing. If problems are found, a prompt is offered to either reopen the
+    editor or discard the changes.
     """
 
     paths = [Path(p).resolve() for p in args.asset]

--- a/onyo/commands/history.py
+++ b/onyo/commands/history.py
@@ -46,8 +46,8 @@ def history(args: argparse.Namespace) -> None:
 
     The commands to display history are configurable using ``onyo config``:
 
-        * ``onyo.history.interactive``
-        * ``onyo.history.non-interactive``
+      * ``onyo.history.interactive``
+      * ``onyo.history.non-interactive``
     """
 
     # Note: Currently exceptional command in that it's not a function in lib/commands, because of exit code handling.

--- a/onyo/commands/history.py
+++ b/onyo/commands/history.py
@@ -20,30 +20,34 @@ args_history = {
         required=False,
         default=True,
         action='store_false',
-        help=(
-            "Use the interactive history tool (specified in '.onyo/config' "
-            "under 'onyo.history.interactive') to display the history of the "
-            "repository, an asset or a directory")),
+        help="""
+            Use the non-interactive tool to display history.
+        """
+    ),
 
     'path': dict(
         metavar='PATH',
         nargs='?',
         type=path,
-        help='Specify an asset or a directory to show the history of'),
+        help="""
+            PATH of an asset or directory to display the history of.
+        """
+    ),
 }
 
 
 def history(args: argparse.Namespace) -> None:
     """
-    Display the history of an ``ASSET`` or ``DIRECTORY``.
+    Display the history of ``PATH``.
 
-    Onyo detects whether an interactive TTY is in use, and will either use
-    the interactive display tool (specified in ``.onyo/config`` under
-    ``onyo.history.interactive``; default ``tig –-follow``) or the
-    non-interactive one (``onyo.history.non-interactive``; default ``git log``)
-    accordingly.
+    Onyo makes an effort to detect if the TTY is interactive in order to
+    automatically select whether to use the interactive or non-interactive
+    history tool.
 
-    The commands to display history are configurable using ``onyo config``.
+    The commands to display history are configurable using ``onyo config``:
+
+        * ``onyo.history.interactive``
+        * ``onyo.history.non-interactive``
     """
 
     # Note: Currently exceptional command in that it's not a function in lib/commands, because of exit code handling.

--- a/onyo/commands/init.py
+++ b/onyo/commands/init.py
@@ -31,9 +31,9 @@ def init(args: argparse.Namespace) -> None:
 
     Initialization steps are:
 
-        * create the target directory (if it does not exist)
-        * initialize as a git repository (if it is not one already)
-        * create the ``.onyo/`` directory, populate its contents, and commit
+      * create the target directory (if it does not exist)
+      * initialize as a git repository (if it is not one already)
+      * create the ``.onyo/`` directory, populate its contents, and commit
 
     Running ``onyo init`` on non-empty directories and git repositories is
     allowed. Only the ``.onyo`` directory will be committed. All other contents

--- a/onyo/commands/init.py
+++ b/onyo/commands/init.py
@@ -14,22 +14,33 @@ args_init = {
         metavar='DIR',
         nargs='?',
         type=directory,
-        help='Initialize DIR as an onyo repository')
+        help="""
+            Initialize DIR as an Onyo repository.
+        """
+    )
 }
 
 
 def init(args: argparse.Namespace) -> None:
     """
-    Initialize an Onyo repository. The directory will be initialized as a git
-    repository (if it is not one already), the ``.onyo/`` directory created and
-    populated with config files, templates, etc. If the directory specified does
-    not exist, it will be created. Everything will be committed.
+    Initialize an Onyo repository.
 
-    The current working directory will be initialized if neither ``directory``
-    nor the ``onyo -C DIR`` option are specified.
+    The current working directory will be initialized if neither ``DIR`` nor the
+    ``onyo -C DIR`` flag are specified. If the target directory does not exist,
+    it will be created.
 
-    Running ``onyo init`` on an existing repository is safe. It will not
-    overwrite anything.
+    Initialization steps are:
+
+        * create the target directory (if it does not exist)
+        * initialize as a git repository (if it is not one already)
+        * create the ``.onyo/`` directory, populate its contents, and commit
+
+    Running ``onyo init`` on non-empty directories and git repositories is
+    allowed. Only the ``.onyo`` directory will be committed. All other contents
+    will be left in their state.
+
+    Running ``onyo init`` repeatedly on a repository will not alter the
+    contents, and will exit with an error.
     """
     target_dir = Path(args.directory).resolve() if args.directory else Path.cwd()
     OnyoRepo(target_dir, init=True)

--- a/onyo/commands/new.py
+++ b/onyo/commands/new.py
@@ -112,10 +112,10 @@ def new(args: argparse.Namespace) -> None:
     Asset contents are populated in a waterfall pattern and can overwrite
     values from previous steps:
 
-        1) ``--template`` or ``--clone``
-        2) ``--tsv``
-        3) ``--keys``
-        4) ``--edit`` (i.e. manual user input)
+      1) ``--template`` or ``--clone``
+      2) ``--tsv``
+      3) ``--keys``
+      4) ``--edit`` (i.e. manual user input)
 
     The keys that comprise the asset filename are required (configured by
     `onyo.assets.filename`).
@@ -126,12 +126,12 @@ def new(args: argparse.Namespace) -> None:
 
     Some key names are reserved, and are not stored as keys in asset contents:
 
-        * ``directory``: directory to create the asset in relative to the root
-          of the repository. This key cannot be used with the ``--path`` flag.
-        * ``is_asset_directory``: whether to create the asset as an Asset
-          Directory.  Default is ``false``.
-        * ``template``: which template to use for the asset. This key cannot be
-          used with the ``--clone`` or ``--template`` flags.
+      * ``directory``: directory to create the asset in relative to the root of
+        the repository. This key cannot be used with the ``--path`` flag.
+      * ``is_asset_directory``: whether to create the asset as an Asset
+        Directory.  Default is ``false``.
+      * ``template``: which template to use for the asset. This key cannot be
+        used with the ``--clone`` or ``--template`` flags.
     """
     inventory = Inventory(repo=OnyoRepo(Path.cwd(), find_root=True))
     onyo_new(inventory=inventory,

--- a/onyo/commands/shell_completion.py
+++ b/onyo/commands/shell_completion.py
@@ -13,20 +13,25 @@ args_shell_completion = {
         required=False,
         default='zsh',
         choices=['zsh'],
-        help='Specify the shell for which to generate tab completion for')
+        help="""
+            The shell to generate a tab-completion script for.
+        """
+    )
 }
 
 
 def shell_completion(args: argparse.Namespace) -> None:
     """
-    Display a shell script for tab completion for Onyo.
+    Display a tab-completion shell script for Onyo.
 
     The output of this command should be "sourced" to enable tab completion.
 
-    example:
+    Example:
 
-        $ source <(onyo shell-completion)
-        $ onyo --<PRESS TAB to display available options>
+        ```
+        source <(onyo shell-completion)
+        onyo --<PRESS TAB to display available options>
+        ```
     """
     content = ''
     shell_completion_dir = Path(__file__).resolve().parent.parent / 'shell_completion'
@@ -35,6 +40,7 @@ def shell_completion(args: argparse.Namespace) -> None:
         shell_completion_file = shell_completion_dir / 'zsh' / '_onyo'
 
     # TODO: add bash
+    # bash: ~/.local/share/bash-completion/completions
 
     content = shell_completion_file.read_text()
     print(content)

--- a/onyo/commands/shell_completion.py
+++ b/onyo/commands/shell_completion.py
@@ -28,10 +28,10 @@ def shell_completion(args: argparse.Namespace) -> None:
 
     Example:
 
-        ```
-        source <(onyo shell-completion)
-        onyo --<PRESS TAB to display available options>
-        ```
+      ```
+      source <(onyo shell-completion)
+      onyo --<PRESS TAB to display available options>
+      ```
     """
     content = ''
     shell_completion_dir = Path(__file__).resolve().parent.parent / 'shell_completion'

--- a/onyo/commands/tree.py
+++ b/onyo/commands/tree.py
@@ -16,17 +16,19 @@ args_tree = {
         metavar='DIR',
         nargs='*',
         type=directory,
-        help='Directory(s) to print tree of')
+        help='DIRECTORYs to list'
+    )
 }
 
 
 def tree(args: argparse.Namespace) -> None:
-    """List the assets and directories in ``DIRECTORY`` in the ``tree`` format.
+    """
+    List the assets and directories of ``DIRECTORY``\s in a tree-like format.
 
-    All given paths must be existing directories inside the onyo repository.
-    They are tested for their validity in the beginning and only displayed if all paths are valid.
+    If no directory is provided, the tree for CWD is listed.
 
-    If no path is specified, `onyo tree` prints the directory tree for CWD.
+    If any of the directories do not exist, then no tree is printed and an error
+    is returned.
     """
 
     inventory = Inventory(repo=OnyoRepo(Path.cwd(), find_root=True))

--- a/onyo/shell_completion/zsh/_onyo
+++ b/onyo/shell_completion/zsh/_onyo
@@ -36,10 +36,10 @@ _onyo() {
         'mv:move SOURCEs (assets or directories) to the DEST directory, or rename a SOURCE directory to DEST'
         'new:create new ASSETs and populate with KEY-VALUE pairs'
         'rm:delete ASSETs and DIRECTORYs'
-        'set:set the VALUE of KEYs for matching assets'
+        'set:set the VALUE of KEYs for ASSETs'
         'shell-completion:display a tab-completion script for Onyo'
         'tree:list the assets and directories of DIRECTORY in `tree` format'
-        'unset:remove the VALUE of KEY for matching ASSETs'
+        'unset:remove KEY from ASSETs'
     )
 
     _arguments -C $args $toplevel_flags ':subcommand:->subcommand' '*::options:->options' && ret=0
@@ -144,8 +144,6 @@ _onyo() {
                     '(-r --rename)'{-r,--rename}'[allow assigning values to keys that would result in renaming asset filenames]'
                     '(-k --keys)'{-k,--keys}'[key-value pairs to set in assets; multiple pairs can be given (key=value key2=value2)]:*-*:KEYS: '
                     '(-p --path)'{-p,--path}'[assets and/or directories to set KEY=VALUE in]:*-*::PATH:_files -W "$(_onyo_dir)"'
-                    '(-d --depth)'{-d,--depth}'[descend up to DEPTH levels into directories]:DEPTH: '
-                    '(-M --match)'{-M,--match}'[criteria to match assets in the form '\''KEY=VALUE'\'', where VALUE is a python regular expression]:*-*:MATCH: '
                     '(-m --message)'{-m,--message}'[use the given MESSAGE as the commit message]:MESSAGE: '
                 )
                 ;;
@@ -166,8 +164,6 @@ _onyo() {
                     '(- : *)'{-h,--help}'[show this help message and exit]'
                     '(-k --keys)'{-k,--keys}'[keys to unset in assets; multiple keys can be given (key key2 key3)]:*-*:KEYS: '
                     '(-p --path)'{-p,--path}'[assets and/or directories to unset values in]:*-*::PATH:_files -W "$(_onyo_dir)"'
-                    '(-d --depth)'{-d,--depth}'[descend up to DEPTH levels into directories]:DEPTH: '
-                    '(-M --match)'{-M,--match}'[criteria to match assets in the form '\''KEY=VALUE'\'', where VALUE is a python regular expression]:*-*:MATCH: '
                     '(-m --message)'{-m,--message}'[use the given MESSAGE as the commit message]:MESSAGE: '
                 )
                 ;;

--- a/onyo/shell_completion/zsh/_onyo
+++ b/onyo/shell_completion/zsh/_onyo
@@ -92,7 +92,7 @@ _onyo() {
             history)
                 args+=(
                     '(- : *)'{-h,--help}'[show this help message and exit]'
-                    '(-I --non-interactive)'{-I,--non-interactive}'[use the interactive history tool]'
+                    '(-I --non-interactive)'{-I,--non-interactive}'[use the non-interactive history tool]'
                     '::PATH:_files -W "$(_onyo_dir)"'
                 )
                 ;;

--- a/onyo/shell_completion/zsh/_onyo
+++ b/onyo/shell_completion/zsh/_onyo
@@ -38,7 +38,7 @@ _onyo() {
         'rm:delete ASSETs and DIRECTORYs'
         'set:set the VALUE of KEYs for ASSETs'
         'shell-completion:display a tab-completion script for Onyo'
-        'tree:list the assets and directories of DIRECTORY in `tree` format'
+        'tree:list the assets and directories of DIRECTORYs in a tree-like format'
         'unset:remove KEY from ASSETs'
     )
 


### PR DESCRIPTION
This PR is almost entirely improvements to the contents and formatting of help text. Lots was simply improved, and quite a few wrongs were righted. :-)

- `config`
- `edit`
- `history`
- `init`
- `shell-completion`
- `tree`

This PR also:
- removes the tab completion for the recently removed match options for `set` and `unset` (#557)
- fixes #569 
- fixes #456 
