### PR TITLE
BF: Don't commit what onyo hasn't staged itself

### DIFF
--- a/onyo/lib/git.py
+++ b/onyo/lib/git.py
@@ -190,8 +190,9 @@ class GitRepo(object):
         """
         if isinstance(paths, Path):
             paths = [paths]
-        self._git(['add'] + [str(p) for p in paths])
-        self._git(['commit', '-m', message])
+        pathspecs = [str(p) for p in paths]
+        self._git(['add'] + pathspecs)
+        self._git(['commit', '-m', message, '--'] + pathspecs)
         self.clear_cache()
 
     @staticmethod


### PR DESCRIPTION
This limits git-commit calls to the paths that were requested to be
committed. Long standing issue, that I somehow keep forgetting about. Thanks, @aqw for making an issue about it ;-)

Closes #571