### PR TITLE
Fix help on unrecognized arguments

### DIFF
--- a/onyo/main.py
+++ b/onyo/main.py
@@ -68,6 +68,9 @@ def build_parser(parser, args: dict) -> None:
             parser.add_argument(**args[cmd])
 
 
+subcmds = None
+
+
 def setup_parser() -> argparse.ArgumentParser:
     from onyo.onyo_arguments import args_onyo
     from onyo.commands.cat import args_cat
@@ -85,6 +88,8 @@ def setup_parser() -> argparse.ArgumentParser:
     from onyo.commands.tree import args_tree
     from onyo.commands.unset import args_unset
 
+    global subcmds
+
     parser = argparse.ArgumentParser(
         description='A text-based inventory system backed by git.',
         formatter_class=SubcommandHelpFormatter
@@ -93,7 +98,8 @@ def setup_parser() -> argparse.ArgumentParser:
 
     # subcommands
     subcmds = parser.add_subparsers(
-        title='commands'
+        title='commands',
+        dest='cmd'
     )
     subcmds.metavar = '<command>'
     #
@@ -301,9 +307,14 @@ def main() -> None:
         if not any(x in sys.argv for x in ['-h', '--help']):
             sys.argv.insert(subcmd_index + 1, '--')
 
+    global subcmds
     # parse the arguments
     parser = setup_parser()
-    args = parser.parse_args()
+    args, extras = parser.parse_known_args()
+    if extras:
+        if args.cmd:
+            subcmds._name_parser_map[args.cmd].print_usage(file=sys.stderr)
+        parser.error("unrecognized arguments: %s" % " ".join(extras))
 
     # configure user interface
     ui.set_debug(args.debug)


### PR DESCRIPTION
This patch tries to workaround an issue with `argparse`, where an error on unrecognized arguments, is not associated with the selected subparser.
See https://bugs.python.org/issue34479

Solution here is, to rely on `parse_known_args` instead of `parse_args`, returning unrecognized arguments in a dedicated list and call the subparsers `print_usage` in addition to reproducing the toplevel parsers' error.

The reason for doing both, is because we can't distinguish `onyo -x new` from `onyo new -x` via argparse (we'd need to reparse `argv` ourselves). Hence, it's not clear in all cases, whether the usage for `new` or `onyo` would be relevant to the user.

So, in the above example this path ends up with:
```
❱ onyo -x new                                                                                                                                                                   1 !
usage: onyo new [-h] [-t TEMPLATE] [-c CLONE] [-e] [-k KEYS [KEYS ...]] [-p PATH] [-tsv TSV] [-m MESSAGE]
usage: onyo [-h] [-C DIR] [-d] [-v] [-q] [-y] <command> ...
onyo: error: unrecognized arguments: -x
```

(exact same for `onyo new -x`)

Still: A lot better than before, I think.

(Closes #356)
(Closes #408)
