### PR TITLE
BF/DOC: even more help-text fixes

### DIFF
--- a/onyo/commands/fsck.py
+++ b/onyo/commands/fsck.py
@@ -12,19 +12,19 @@ if TYPE_CHECKING:
 
 def fsck(args: argparse.Namespace) -> None:
     """
-    Run a suite of checks to verify the integrity and validity of an Onyo
-    repository and its contents.
+    Run a suite of integrity checks on the Onyo repository and its contents.
 
-    By default, the following tests will be performed:
+    By default, the following tests are performed:
 
-    - "clean-tree": verifies that the git tree is clean ---that there are
-      no changed (staged or unstaged) nor untracked files.
-    - "anchors": verifies that all directories (outside of .onyo) have an
+    * ``clean-tree``: verify that git has no changed (staged or unstaged) or
+      untracked files
+    * ``anchors``: verify that all directories (outside of .onyo) have an
       .anchor file
-    - "asset-unique": verifies that all asset names are unique
-    - "asset-yaml": loads each assets and checks if it's valid YAML
-    - "asset-validity": loads each asset and validates the contents against
-      the validation rulesets defined in ``.onyo/validation/``.
+    * ``asset-unique``: verify that all asset names are unique
+    * ``asset-yaml``: verify that all asset contents are valid YAML
+    * ``asset-validity``: verify that all assets pass the validation rulesets
+      defined in ``.onyo/validation/``
+    * ``pseudo-keys``: verify that asset contents do not contain pseudo-key names
     """
     # TODO: Pass args and have a test; Actually - no args defined?
     repo = OnyoRepo(Path.cwd(), find_root=True)

--- a/onyo/commands/get.py
+++ b/onyo/commands/get.py
@@ -14,63 +14,71 @@ if TYPE_CHECKING:
     import argparse
 
 args_get = {
-    'machine_readable': dict(
-        args=('-H', '--machine-readable'),
-        action='store_true',
-        help=(
-            'Display asset(s) separated by new lines, and keys by tabs instead '
-            'of printing a formatted table')),
 
     'keys': dict(
         args=('-k', '--keys'),
-        metavar='KEYS',
+        metavar='KEY',
         nargs='+',
-        help=(
-            'Key value(s) to return. Pseudo-keys (information not stored in '
-            'the asset file) are also available for queries')),
+        help="""
+            KEY values to print. Pseudo-keys (information not stored in the
+            asset file) are also available for queries.
+        """
+    ),
+
+    'machine_readable': dict(
+        args=('-H', '--machine-readable'),
+        action='store_true',
+        help="""
+            Useful for scripting. Do not print headers and separate values with
+            a single tab instead of variable white space.
+        """
+    ),
 
     'path': dict(
         args=('-p', '--path'),
         metavar='PATH',
         type=path,
         nargs='+',
-        help='Asset(s) or directory(s) to search through'),
+        help="""
+            PATHs to assets or directories to query.
+        """
+    ),
 
     'sort_ascending': dict(
         args=('-s', '--sort-ascending'),
         action='store_true',
         default=False,
-        help='Sort output in ascending order (excludes --sort-descending)'),
+        help="""
+            Sort output in ascending order (excludes --sort-descending).
+        """
+    ),
 
     'sort_descending': dict(
         args=('-S', '--sort-descending'),
         action='store_true',
         default=False,
-        help='Sort output in descending order (excludes --sort-ascending)'),
-
-    'depth': shared_arg_depth,
-    'match': shared_arg_match
+        help="""
+            Sort output in descending order (excludes --sort-ascending).
+        """
+    ),
 }
 
 
 def get(args: argparse.Namespace) -> None:
     """
-    Return matching ``ASSET``\(s) and values corresponding to the requested
-    ``KEY``\(s).
+    Return values of the requested KEYs for matching assets.
 
-    If no key(s) are given, the keys used in asset names are returned.
-    If no ``asset`` or ``directory`` is specified, the current working
+    If no KEYs are given, all keys in the asset name are used (see
+    ``onyo.assets.filename``). If no PATHs are given, the current working
     directory is used.
 
-    Filters can make use of pseudo-keys (i.e., properties of assets, that are
-    provided by onyo rather than the asset file, like 'path'). Values of the
-    dictionary or list type, as well as assets missing a value can be referenced
-    as '<dict>', '<list>', or '<unset>' instead of their contents, respectively.
-    If a requested key does not exist, its output is displayed as '<unset>'.
+    In addition to keys in asset contents, PSEUDO-KEYS can be queried and
+    matched.
 
-    The ``value`` of filters can be a string or a Python regular expression.
+      * ``is_asset_directory``: is the asset an Asset Directory
+      * ``path``: path of the asset from repo root
 
-    By default, the returned assets are sorted by their paths.
+    By default, the results are sorted by ``path``.
     """
     if args.sort_ascending and args.sort_descending:
         raise ValueError('--sort-ascending (-s) and --sort-descending (-S) cannot be '

--- a/onyo/commands/get.py
+++ b/onyo/commands/get.py
@@ -8,12 +8,22 @@ from onyo.argparse_helpers import path
 from onyo.lib.commands import onyo_get
 from onyo.lib.filters import Filter
 from onyo.lib.inventory import Inventory
-from onyo.shared_arguments import shared_arg_depth, shared_arg_match
 
 if TYPE_CHECKING:
     import argparse
 
 args_get = {
+    'depth': dict(
+        args=('-d', '--depth'),
+        metavar='DEPTH',
+        type=int,
+        required=False,
+        default=0,
+        help="""
+            Descend up to DEPTH levels into the directories specified. DEPTH=0
+            descends recursively without limit.
+        """
+    ),
 
     'keys': dict(
         args=('-k', '--keys'),
@@ -31,6 +41,22 @@ args_get = {
         help="""
             Useful for scripting. Do not print headers and separate values with
             a single tab instead of variable white space.
+        """
+    ),
+
+    'match': dict(
+        args=('-M', '--match'),
+        metavar='MATCH',
+        nargs='+',
+        type=str,
+        default=None,
+        help="""
+            Criteria to match assets in the form ``KEY=VALUE``, where VALUE is a
+            python regular expression. Pseudo-keys such as ``path`` can also be
+            used. Special values supported are:
+              * ``<dict>``
+              * ``<list>``
+              * ``<unset>``
         """
     ),
 

--- a/onyo/commands/mkdir.py
+++ b/onyo/commands/mkdir.py
@@ -17,7 +17,10 @@ args_mkdir = {
         metavar='DIR',
         nargs='+',
         type=path,
-        help='Directory(s) to create'),
+        help="""
+            DIRECTORYs to create; or assets to convert into an Asset Directory.
+        """
+    ),
 
     'message': shared_arg_message,
 }
@@ -25,17 +28,17 @@ args_mkdir = {
 
 def mkdir(args: argparse.Namespace) -> None:
     """
-    Create ``directory``\\(s). Intermediate directories will be created as
-    needed (i.e. parent and child directories can be created in one call).
+    Create DIRECTORYs or convert Asset Files into an Asset Directory.
+
+    Intermediate directories are created as needed (i.e. parent and child
+    directories can be created in one call).
 
     An empty ``.anchor`` file is added to each directory, to ensure that git
     tracks them even when empty.
 
-    If a given path is an existing asset file, that asset will be turned into
-    an asset dir instead.
-
-    If the directory already exists, or the path is protected, Onyo will throw
-    an error. All checks are performed before creating directories.
+    If the DIRECTORY already exists, the path is protected, or the asset is
+    already an Asset Directory, then Onyo will error and leave everything
+    unmodified.
     """
     dirs = [Path(d).resolve() for d in args.directory]
     inventory = Inventory(repo=OnyoRepo(Path.cwd(), find_root=True))

--- a/onyo/commands/mv.py
+++ b/onyo/commands/mv.py
@@ -17,12 +17,18 @@ args_mv = {
         metavar='SOURCE',
         nargs='+',
         type=path,
-        help='Asset(s) and/or directory(s) to move into DEST'),
+        help="""
+            Assets and/or directories to move into DEST.
+        """
+    ),
 
     'destination': dict(
         metavar='DEST',
         type=path,
-        help='Destination to move SOURCE(s) into'),
+        help="""
+            Destination to move SOURCEs into.
+        """
+    ),
 
     'message': shared_arg_message,
 }
@@ -30,23 +36,14 @@ args_mv = {
 
 def mv(args: argparse.Namespace) -> None:
     """
-    Move ``SOURCE``\\(s) (assets or directories) to the ``DEST`` directory, or
-    rename a ``SOURCE`` directory to ``DEST``.
+    Move SOURCEs (assets or directories) into the DEST directory, or rename a
+    SOURCE directory to DEST.
 
-    Files cannot be renamed using ``onyo mv``, since their names are generated from their contents.
-    To rename a file, use ``onyo set``, or use ``onyo edit`` and change the keys used for the
-    asset's name.
-    To rename a directory, call ``onyo mv`` with a single ``SOURCE`` to rename, and a different and
-    non-existing ``DEST`` name in the same directory.
+    If DEST is an asset file, it will be converted into an Asset Directory and
+    then the SOURCEs will be moved into it.
 
-    Otherwise, when called on one or multiple assets or directories, the command will move
-    ``SOURCE``\\(s) into ``DEST``.
-
-    Special case: If ``DEST`` is an asset file, it will be turned into an asset dir first.
-
-    A list of all files and directories to modify will be presented, and the user prompted for
-    confirmation.
-
+    Assets cannot be renamed using ``onyo mv``. Their names are generated from
+    keys in their contents. To rename a file, use ``onyo set`` or ``onyo edit``.
     """
     inventory = Inventory(repo=OnyoRepo(Path.cwd(), find_root=True))
 

--- a/onyo/commands/new.py
+++ b/onyo/commands/new.py
@@ -57,13 +57,13 @@ args_new = {
         args=('-k', '--keys'),
         required=False,
         action=StoreKeyValuePairs,
-        metavar="KEYS",
+        metavar="KEY",
         nargs='+',
         help="""
-            Key-value pairs to populate content of new assets.
+            KEY-VALUE pairs to populate content of new assets.
 
-            Each key can be defined either 1 or N times (where N is the number
-            of assets to be created). A key that is declared once will apply
+            Each KEY can be defined either 1 or N times (where N is the number
+            of assets to be created). A KEY that is declared once will apply
             to all new assets, otherwise each will be applied to each new asset
             in the order they were declared.
 
@@ -106,18 +106,18 @@ args_new = {
 
 def new(args: argparse.Namespace) -> None:
     """
-    Create new ``ASSET``\s and populate with key-value pairs. Destination
+    Create new ``ASSET``\s and populate with KEY-VALUE pairs. Destination
     directories are created if they are missing.
 
     Asset contents are populated in a waterfall pattern and can overwrite
     values from previous steps:
 
-      1) ``--template`` or ``--clone``
+      1) ``--clone`` or ``--template``
       2) ``--tsv``
       3) ``--keys``
       4) ``--edit`` (i.e. manual user input)
 
-    The keys that comprise the asset filename are required (configured by
+    The KEYs that comprise the asset filename are required (configured by
     `onyo.assets.filename`).
 
     The contents of all new assets are checked for validity before committing.

--- a/onyo/commands/new.py
+++ b/onyo/commands/new.py
@@ -14,19 +14,6 @@ if TYPE_CHECKING:
 
 args_new = {
 
-    'template': dict(
-        args=('-t', '--template'),
-        metavar='TEMPLATE',
-        required=False,
-        type=template,
-        help="""
-            Name of a template to populate the contents of new assets.
-
-            This cannot be used with the ``--clone`` flag nor the ``template``
-            Reserved Key.
-        """
-    ),
-
     'clone': dict(
         args=('-c', '--clone'),
         metavar='CLONE',
@@ -40,13 +27,29 @@ args_new = {
         """
     ),
 
-    'edit': dict(
-        args=('-e', '--edit'),
+    'template': dict(
+        args=('-t', '--template'),
+        metavar='TEMPLATE',
         required=False,
-        default=False,
-        action='store_true',
+        type=template,
         help="""
-            Open new assets in an editor.
+            Name of a template to populate the contents of new assets.
+
+            This cannot be used with the ``--clone`` flag nor the ``template``
+            Reserved Key.
+        """
+    ),
+
+    'tsv': dict(
+        args=('-tsv', '--tsv'),
+        metavar='TSV',
+        required=False,
+        type=path,
+        help="""
+            Path to a TSV file describing new assets.
+
+            The header declares the key names to be populated. The values to
+            populate assets are declared with one line per asset.
         """
     ),
 
@@ -76,6 +79,16 @@ args_new = {
         """
     ),
 
+    'edit': dict(
+        args=('-e', '--edit'),
+        required=False,
+        default=False,
+        action='store_true',
+        help="""
+            Open new assets in an editor.
+        """
+    ),
+
     'path': dict(
         args=('-p', '--path'),
         metavar='PATH',
@@ -84,19 +97,6 @@ args_new = {
             Directory to create new assets in.
 
             This cannot be used with the ``directory`` Reserved Key.
-        """
-    ),
-
-    'tsv': dict(
-        args=('-tsv', '--tsv'),
-        metavar='TSV',
-        required=False,
-        type=path,
-        help="""
-            Path to a TSV file describing new assets.
-
-            The header declares the key names to be populated. The values to
-            populate assets are declared with one line per asset.
         """
     ),
 

--- a/onyo/commands/rm.py
+++ b/onyo/commands/rm.py
@@ -17,34 +17,52 @@ args_rm = {
         metavar='PATH',
         nargs='+',
         type=path,
-        help='Asset(s) and/or directory(s) to delete'),
+        help="""
+            Assets and/or directories to delete.
+        """
+    ),
+
     'assets': dict(
         args=('-a', '--asset'),
         required=False,
         default=False,
         action='store_true',
-        help='Only remove assets. Turns asset dirs into plain dirs.'
-             'Mutually exclusive with ``--dir``.'),
+        help="""
+            Operate only on assets. Asset Files are removed. Asset Directories
+            are converted into normal directories.
+
+            This cannot be used with the ``--dir`` flag.
+        """
+    ),
+
     'dirs': dict(
         args=('-d', '--dir'),
         required=False,
         default=False,
         action='store_true',
-        help='Only remove dirs. Turns asset dirs into plain asset files.'
-             'Mutually exclusive with ``--asset``.'),
+        help="""
+            Operate only on directories. Directories are removed. Asset
+            Directories are converted into Asset Files.
+
+            This cannot be used with the ``--asset`` flag.
+        """
+    ),
+
     'message': shared_arg_message,
 }
 
 
 def rm(args: argparse.Namespace) -> None:
     """
-    Delete ``ASSET``\\(s) and ``DIRECTORY``\\(s).
+    Delete ASSETs and/or DIRECTORYs.
 
-    Directories and asset directories are deleted together with their contents.
-    If any of the specified paths is invalid, Onyo will error and delete none of them.
+    Directories and asset directories are deleted along with their contents.
 
-    A list of all files and directories to delete will be presented, and the
-    user prompted for confirmation.
+    The ``--asset`` and ``--dir` flags can be used to constrain actions to
+    either assets or directories (respectively).
+
+    If any of the given paths are invalid, Onyo will error and delete none of
+    them.
     """
     inventory = Inventory(repo=OnyoRepo(Path.cwd(), find_root=True))
     paths = [Path(p).resolve() for p in args.path]

--- a/onyo/commands/set.py
+++ b/onyo/commands/set.py
@@ -20,19 +20,28 @@ args_set = {
         required=False,
         default=False,
         action='store_true',
-        help=(
-            'Permit assigning values to keys that would result in the '
-            'asset(s) being renamed.')),
+        help="""
+            Allow setting KEYs that are part of the asset name.
+            (see the `onyo.assets.filename` configuration option)
+        """
+    ),
 
     'keys': dict(
         args=('-k', '--keys'),
         required=True,
         action=StoreKeyValuePairs,
-        metavar="KEYS",
+        metavar="KEY",
         nargs='+',
-        help=(
-            'Specify key-value pairs to set in asset(s). Multiple pairs can '
-            'be specified (e.g. key=value key2=value2)')),
+        help="""
+            KEY-VALUE pairs to set in assets. Multiple pairs can be given
+            (e.g. key1=value1 key2=value2 key3=value3).
+
+            Quotes are necessary when using spaces or shell command characters:
+            ```
+            onyo set --keys title='Bob Bozniffiq: Saint of the Awkward' --path ...
+            ```
+        """
+    ),
 
     'path': dict(
         args=('-p', '--path'),
@@ -40,7 +49,10 @@ args_set = {
         metavar='PATH',
         nargs='+',
         type=path,
-        help='Asset(s) to set KEY=VALUE in'),
+        help="""
+            Assets to set KEY=VALUEs in.
+        """
+    ),
 
     'message': shared_arg_message,
 }
@@ -48,28 +60,22 @@ args_set = {
 
 def set(args: argparse.Namespace) -> None:
     """
-    Set the ``value`` of ``key`` for given assets. If a key does not exist,
-    it is added and set appropriately.
+    Set ``KEY``\s to ``VALUE`` for assets.
 
-    Key names can be any valid YAML key name.
+    KEY names can be any valid YAML key-name. If a KEY does not exist, it is
+    added and set appropriately.
 
-    Multiple ``key=value`` pairs can be declared and divided by spaces. Quotes
-    can be used around ``value``, which is necessary when it contains a comma,
-    whitespace, etc.
+    Setting KEYs used in the asset name require the ``--rename`` flag, and will
+    result in the asset being renamed on the filesystem.
 
-    Note, that the key ``is_asset_directory`` takes a bool and determines whether
-    an asset is in fact an asset dir. Changing that value with this command turns
-    an asset file into an asset dir (or vice versa).
-    Required keys as defined by the 'onyo.assets.filename' config (by default
-    ``type``, ``make``, ``model``, and ``serial``) can only be set when the
-    `--rename` flag is used. It will result in the file(s) being
-    renamed.
+    In addition to keys in asset contents, some PSEUDO-KEYS can be set:
 
-    Changes are printed to the terminal in the style of ``diff``.
+      * ``is_asset_directory``: boolean to control whether the asset is an
+        Asset Directory.
 
-    Errors reading or parsing files print to STDERR, but do not halt Onyo. Any
-    error encountered while writing a file will cause Onyo to error and exit
-    immediately.
+    The contents of all modified assets are checked for validity before
+    committing. If problems are found, Onyo will error and leave the assets
+    unmodified.
     """
 
     inventory = Inventory(repo=OnyoRepo(Path.cwd(), find_root=True))

--- a/onyo/commands/unset.py
+++ b/onyo/commands/unset.py
@@ -16,12 +16,14 @@ args_unset = {
     'keys': dict(
         args=('-k', '--keys'),
         required=True,
-        metavar="KEYS",
+        metavar="KEY",
         nargs='+',
         type=str,
-        help=(
-            'Specify keys to unset in assets. Multiple keys can be given '
-            '(e.g. key key2 key3)')),
+        help="""
+            KEYs to unset in assets. Multiple keys can be given
+            (e.g. key1 key2 key3).
+        """
+    ),
 
     'path': dict(
         args=('-p', '--path'),
@@ -29,7 +31,10 @@ args_unset = {
         metavar="PATH",
         nargs='+',
         type=path,
-        help='Asset(s) and/or directory(s) for which to unset values in'),
+        help="""
+            Assets unset KEYs in.
+        """
+    ),
 
     'message': shared_arg_message,
 }
@@ -37,21 +42,14 @@ args_unset = {
 
 def unset(args: argparse.Namespace) -> None:
     """
-    Remove the ``value`` of ``key`` for ``ASSET``\s.
+    Remove ``KEY``\s from assets.
 
-    Multiple ``key=value`` pairs can be declared and divided by spaces. Quotes
-    can be used around ``value``, which is necessary when it contains a comma,
-    whitespace, etc.
+    Keys that are used in asset names (see the ``onyo.assets.filename``
+    configuration option) cannot be unset.
 
-    Keys that are used in asset names as specified in the
-    ``onyo.assets.filename`` configuration cannot be unset.
-    To rename a file(s) use ``onyo set --rename``.
-
-    Changes are printed to the terminal in the style of ``diff``.
-
-    Errors reading or parsing files print to STDERR, but do not halt Onyo. Any
-    error encountered while writing a file will cause Onyo to error and exit
-    immediately.
+    The contents of all modified assets are checked for validity before
+    committing. If problems are found, Onyo will error and leave the assets
+    unmodified.
     """
 
     inventory = Inventory(repo=OnyoRepo(Path.cwd(), find_root=True))

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -75,15 +75,15 @@ def fsck(repo: OnyoRepo,
 
     By default, the following tests will be performed:
 
-    - "clean-tree": verifies that the git tree is clean ---that there are
-      no changed (staged or unstaged) nor untracked files.
-    - "anchors": verifies that all folders (outside of .onyo) have an
+    * ``clean-tree``: verify that git has no changed (staged or unstaged) or
+      untracked files
+    * ``anchors``: verify that all directories (outside of .onyo) have an
       .anchor file
-    - "asset-unique": verifies that all asset names are unique
-    - "asset-yaml": loads each assets and checks if it's valid YAML
-    - "asset-validity": loads each asset and validates the contents against
-      the validation rulesets defined in ``.onyo/validation/``.
-    - "pseudo-keys": verifies that assets do not contain pseudo-key names
+    * ``asset-unique``: verify that all asset names are unique
+    * ``asset-yaml``: verify that all asset contents are valid YAML
+    * ``asset-validity``: verify that all assets pass the validation rulesets
+      defined in ``.onyo/validation/``
+    * ``pseudo-keys``: verify that asset contents do not contain pseudo-key names
 
     Parameters
     ----------

--- a/onyo/shared_arguments.py
+++ b/onyo/shared_arguments.py
@@ -1,31 +1,3 @@
-shared_arg_depth = dict(
-    args=('-d', '--depth'),
-    metavar='DEPTH',
-    type=int,
-    required=False,
-    default=0,
-    help="""
-        Descend up to DEPTH levels into the directories specified. DEPTH=0
-        descends recursively without limit.
-    """
-)
-
-shared_arg_match = dict(
-    args=('-M', '--match'),
-    metavar='MATCH',
-    nargs='+',
-    type=str,
-    default=None,
-    help="""
-        Matching criteria for assets in the form ``KEY=VALUE``, where VALUE is a
-        python regular expression. Pseudo-keys such as ``path`` can also be
-        used. Special values supported are:
-        - ``<dict>``
-        - ``<list>``
-        - ``<unset>``
-    """
-)
-
 shared_arg_message = dict(
     args=('-m', '--message'),
     metavar='MESSAGE',


### PR DESCRIPTION
This PR finishes the tour of updating and reformatting the help text of the commands.

- `fsck`
- `get`
- `mkdir`
- `mv`
- `unset`
- `rm`
- `set`

This PR also:
- makes `new` match help conventions used in other commands
- fixes #396 
- fixes #449 

