### PR TITLE
DOC/BF: stylize help output with `rich`

### DIFF
--- a/onyo/commands/cat.py
+++ b/onyo/commands/cat.py
@@ -16,13 +16,14 @@ args_cat = {
         metavar='ASSET',
         nargs='+',
         type=file,
-        help='path of ``ASSET`` to print'),
+        help='Paths of assets to print'
+    ),
 }
 
 
 def cat(args: argparse.Namespace) -> None:
     """
-    Print the contents of ``ASSET``\s to the terminal.
+    Print the contents of **ASSET**\s to the terminal.
 
     If any of the paths are invalid, then no contents are printed and an error
     is returned.

--- a/onyo/commands/config.py
+++ b/onyo/commands/config.py
@@ -16,7 +16,7 @@ args_config = {
         metavar='ARGS',
         nargs='+',
         type=git_config,
-        help='Config options to set in .onyo/config'
+        help='Config options to set in ``.onyo/config``.'
     ),
 }
 
@@ -31,9 +31,9 @@ def config(args: argparse.Namespace) -> None:
     To set configuration options locally (and not commit them to the Onyo
     repository), use ``git config`` instead.
 
-    ``onyo config`` is a wrapper around ``git config``. All of its options and
+    This command is a wrapper around ``git config``. All of its options and
     capabilities are available with the exception of ``--system``, ``--global``,
-    ``--local``, ``--worktree``, and ``--file``. Please see the git-config
+    ``--local``, ``--worktree``, and ``--file``. Please see the **git-config**
     manpage for more information about usage.
 
     Onyo configuration options:

--- a/onyo/commands/config.py
+++ b/onyo/commands/config.py
@@ -40,7 +40,7 @@ def config(args: argparse.Namespace) -> None:
 
       * ``onyo.assets.filename``: The format for asset names on the
         filesystem. (default: "{type}_{make}_{model}.{serial}")
-      * ``onyo.core.editor``: The editor to use for commands such as ``edit``
+      * ``onyo.core.editor``: The editor to use for subcommands such as ``edit``
         and ``new``. If unset, it will fallback to the environmental variable
         ``EDITOR`` and lastly ``nano``. (default: unset)
       * ``onyo.history.interactive``: The interactive command to use for

--- a/onyo/commands/edit.py
+++ b/onyo/commands/edit.py
@@ -17,7 +17,7 @@ args_edit = {
         metavar='ASSET',
         nargs='+',
         type=file,
-        help='Paths of ASSETs to edit.'
+        help='Paths of assets to edit.'
     ),
 
     'message': shared_arg_message,
@@ -26,17 +26,17 @@ args_edit = {
 
 def edit(args: argparse.Namespace) -> None:
     """
-    Open ``ASSET``\s using an editor.
+    Open **ASSET**\s using an editor.
 
-    When multiple ASSETs are given, they are opened sequentially.
+    When multiple **ASSET**\s are given, they are opened sequentially.
 
     The editor is selected by (in order):
 
-      * configuration option `onyo.core.editor`
+      * ``onyo.core.editor`` configuration option
       * ``EDITOR`` environment variable
       * ``nano`` (as a final fallback)
 
-    The contents of all edited ASSETs are checked for validity before
+    The contents of all edited **ASSET**\s are checked for validity before
     committing. If problems are found, a prompt is offered to either reopen the
     editor or discard the changes.
     """

--- a/onyo/commands/fsck.py
+++ b/onyo/commands/fsck.py
@@ -16,15 +16,15 @@ def fsck(args: argparse.Namespace) -> None:
 
     By default, the following tests are performed:
 
-    * ``clean-tree``: verify that git has no changed (staged or unstaged) or
-      untracked files
-    * ``anchors``: verify that all directories (outside of .onyo) have an
-      .anchor file
-    * ``asset-unique``: verify that all asset names are unique
-    * ``asset-yaml``: verify that all asset contents are valid YAML
-    * ``asset-validity``: verify that all assets pass the validation rulesets
-      defined in ``.onyo/validation/``
-    * ``pseudo-keys``: verify that asset contents do not contain pseudo-key names
+      * ``clean-tree``: verify that git has no changed (staged or unstaged) or
+        untracked files
+      * ``anchors``: verify that all directories (outside of .onyo) have an
+        .anchor file
+      * ``asset-unique``: verify that all asset names are unique
+      * ``asset-yaml``: verify that all asset contents are valid YAML
+      * ``asset-validity``: verify that all assets pass the validation rulesets
+        defined in ``.onyo/validation/``
+      * ``pseudo-keys``: verify that asset contents do not contain pseudo-key names
     """
     # TODO: Pass args and have a test; Actually - no args defined?
     repo = OnyoRepo(Path.cwd(), find_root=True)

--- a/onyo/commands/get.py
+++ b/onyo/commands/get.py
@@ -20,8 +20,8 @@ args_get = {
         required=False,
         default=0,
         help="""
-            Descend up to DEPTH levels into the directories specified. DEPTH=0
-            descends recursively without limit.
+            Descend up to **DEPTH** levels into the directories specified. A
+            depth of **0** descends recursively without limit.
         """
     ),
 
@@ -30,7 +30,7 @@ args_get = {
         metavar='KEY',
         nargs='+',
         help="""
-            KEY values to print. Pseudo-keys (information not stored in the
+            **KEY** values to print. Pseudo-keys (information not stored in the
             asset file) are also available for queries.
         """
     ),
@@ -51,9 +51,10 @@ args_get = {
         type=str,
         default=None,
         help="""
-            Criteria to match assets in the form ``KEY=VALUE``, where VALUE is a
-            python regular expression. Pseudo-keys such as ``path`` can also be
-            used. Special values supported are:
+            Criteria to match assets in the form ``KEY=VALUE``, where **VALUE**
+            is a python regular expression. Pseudo-keys such as ``path`` can
+            also be used. Special values supported are:
+
               * ``<dict>``
               * ``<list>``
               * ``<unset>``
@@ -66,7 +67,7 @@ args_get = {
         type=path,
         nargs='+',
         help="""
-            PATHs to assets or directories to query.
+            **PATH**\s to assets or directories to query.
         """
     ),
 
@@ -75,7 +76,7 @@ args_get = {
         action='store_true',
         default=False,
         help="""
-            Sort output in ascending order (excludes --sort-descending).
+            Sort output in ascending order (excludes ``--sort-descending``).
         """
     ),
 
@@ -84,7 +85,7 @@ args_get = {
         action='store_true',
         default=False,
         help="""
-            Sort output in descending order (excludes --sort-ascending).
+            Sort output in descending order (excludes ``--sort-ascending``).
         """
     ),
 }
@@ -92,13 +93,13 @@ args_get = {
 
 def get(args: argparse.Namespace) -> None:
     """
-    Return values of the requested KEYs for matching assets.
+    Return values of the requested **KEY**\s for matching assets.
 
-    If no KEYs are given, all keys in the asset name are used (see
-    ``onyo.assets.filename``). If no PATHs are given, the current working
+    If no **KEY**\s are given, all keys in the asset name are printed (see
+    ``onyo.assets.filename``). If no **PATH**\s are given, the current working
     directory is used.
 
-    In addition to keys in asset contents, PSEUDO-KEYS can be queried and
+    In addition to keys in asset contents, **PSEUDO-KEYS** can be queried and
     matched.
 
       * ``is_asset_directory``: is the asset an Asset Directory

--- a/onyo/commands/get.py
+++ b/onyo/commands/get.py
@@ -30,8 +30,8 @@ args_get = {
         metavar='KEY',
         nargs='+',
         help="""
-            **KEY** values to print. Pseudo-keys (information not stored in the
-            asset file) are also available for queries.
+            **KEY**s to print the values of. Pseudo-keys (information not stored
+            in the asset file) are also available for queries.
         """
     ),
 
@@ -67,7 +67,7 @@ args_get = {
         type=path,
         nargs='+',
         help="""
-            **PATH**\s to assets or directories to query.
+            Assets or directories to query.
         """
     ),
 

--- a/onyo/commands/history.py
+++ b/onyo/commands/history.py
@@ -30,7 +30,7 @@ args_history = {
         nargs='?',
         type=path,
         help="""
-            PATH of an asset or directory to display the history of.
+            Path of an asset or directory to display the history of.
         """
     ),
 }
@@ -38,7 +38,7 @@ args_history = {
 
 def history(args: argparse.Namespace) -> None:
     """
-    Display the history of ``PATH``.
+    Display the history of **PATH**.
 
     Onyo makes an effort to detect if the TTY is interactive in order to
     automatically select whether to use the interactive or non-interactive

--- a/onyo/commands/init.py
+++ b/onyo/commands/init.py
@@ -15,7 +15,7 @@ args_init = {
         nargs='?',
         type=directory,
         help="""
-            Initialize DIR as an Onyo repository.
+            Directory to initialize as an Onyo repository.
         """
     )
 }
@@ -35,12 +35,12 @@ def init(args: argparse.Namespace) -> None:
       * initialize as a git repository (if it is not one already)
       * create the ``.onyo/`` directory, populate its contents, and commit
 
-    Running ``onyo init`` on non-empty directories and git repositories is
-    allowed. Only the ``.onyo`` directory will be committed. All other contents
-    will be left in their state.
+    Init-ing non-empty directories and git repositories is allowed. Only the
+    ``.onyo`` directory will be committed. All other contents will be left in
+    their state.
 
-    Running ``onyo init`` repeatedly on a repository will not alter the
-    contents, and will exit with an error.
+    Repeatedly init-ing a repository will not alter the contents, and will exit
+    with an error.
     """
     target_dir = Path(args.directory).resolve() if args.directory else Path.cwd()
     OnyoRepo(target_dir, init=True)

--- a/onyo/commands/init.py
+++ b/onyo/commands/init.py
@@ -25,7 +25,7 @@ def init(args: argparse.Namespace) -> None:
     """
     Initialize an Onyo repository.
 
-    The current working directory will be initialized if neither ``DIR`` nor the
+    The current working directory will be initialized if neither **DIR** nor the
     ``onyo -C DIR`` flag are specified. If the target directory does not exist,
     it will be created.
 

--- a/onyo/commands/mkdir.py
+++ b/onyo/commands/mkdir.py
@@ -18,7 +18,7 @@ args_mkdir = {
         nargs='+',
         type=path,
         help="""
-            DIRECTORYs to create; or assets to convert into an Asset Directory.
+            Directories to create; or assets to convert into an Asset Directory.
         """
     ),
 
@@ -28,7 +28,7 @@ args_mkdir = {
 
 def mkdir(args: argparse.Namespace) -> None:
     """
-    Create DIRECTORYs or convert Asset Files into an Asset Directory.
+    Create **DIRECTORY**\s or convert Asset Files into an Asset Directory.
 
     Intermediate directories are created as needed (i.e. parent and child
     directories can be created in one call).
@@ -36,7 +36,7 @@ def mkdir(args: argparse.Namespace) -> None:
     An empty ``.anchor`` file is added to each directory, to ensure that git
     tracks them even when empty.
 
-    If the DIRECTORY already exists, the path is protected, or the asset is
+    If the **DIRECTORY** already exists, the path is protected, or the asset is
     already an Asset Directory, then Onyo will error and leave everything
     unmodified.
     """

--- a/onyo/commands/mv.py
+++ b/onyo/commands/mv.py
@@ -18,7 +18,7 @@ args_mv = {
         nargs='+',
         type=path,
         help="""
-            Assets and/or directories to move into DEST.
+            Assets and/or directories to move into **DEST**.
         """
     ),
 
@@ -26,7 +26,7 @@ args_mv = {
         metavar='DEST',
         type=path,
         help="""
-            Destination to move SOURCEs into.
+            Destination to move **SOURCE**\s into.
         """
     ),
 
@@ -36,11 +36,11 @@ args_mv = {
 
 def mv(args: argparse.Namespace) -> None:
     """
-    Move SOURCEs (assets or directories) into the DEST directory, or rename a
-    SOURCE directory to DEST.
+    Move **SOURCE**\s (assets or directories) into the **DEST** directory, or
+    rename a **SOURCE** directory to **DEST**.
 
-    If DEST is an asset file, it will be converted into an Asset Directory and
-    then the SOURCEs will be moved into it.
+    If **DEST** is an asset file, it will be converted into an Asset Directory and
+    then the **SOURCE**\s will be moved into it.
 
     Assets cannot be renamed using ``onyo mv``. Their names are generated from
     keys in their contents. To rename a file, use ``onyo set`` or ``onyo edit``.

--- a/onyo/commands/new.py
+++ b/onyo/commands/new.py
@@ -69,12 +69,12 @@ args_new = {
 
             For example, create three new laptops with different serials:
             ```
-            onyo new --keys type=laptop make=apple model=macbookpro serial=1 serial=2 serial=3 --path shelf/
+            $ onyo new --keys type=laptop make=apple model=macbookpro serial=1 serial=2 serial=3 --path shelf/
             ```
 
             Shell brace-expansion makes this even more succinct:
             ```
-            onyo new --keys type=laptop make=apple model=macbookpro serial={1,2,3} --path shelf/
+            $ onyo new --keys type=laptop make=apple model=macbookpro serial={1,2,3} --path shelf/
             ```
         """
     ),

--- a/onyo/commands/new.py
+++ b/onyo/commands/new.py
@@ -46,7 +46,7 @@ args_new = {
         required=False,
         type=path,
         help="""
-            Path to a TSV file describing new assets.
+            Path to a **TSV** file describing new assets.
 
             The header declares the key names to be populated. The values to
             populate assets are declared with one line per asset.
@@ -60,10 +60,10 @@ args_new = {
         metavar="KEY",
         nargs='+',
         help="""
-            KEY-VALUE pairs to populate content of new assets.
+            **KEY-VALUE** pairs to populate content of new assets.
 
-            Each KEY can be defined either 1 or N times (where N is the number
-            of assets to be created). A KEY that is declared once will apply
+            Each **KEY** can be defined either 1 or N times (where N is the number
+            of assets to be created). A **KEY** that is declared once will apply
             to all new assets, otherwise each will be applied to each new asset
             in the order they were declared.
 
@@ -106,7 +106,7 @@ args_new = {
 
 def new(args: argparse.Namespace) -> None:
     """
-    Create new ``ASSET``\s and populate with KEY-VALUE pairs. Destination
+    Create new **ASSET**\s and populate with **KEY-VALUE** pairs. Destination
     directories are created if they are missing.
 
     Asset contents are populated in a waterfall pattern and can overwrite
@@ -117,8 +117,8 @@ def new(args: argparse.Namespace) -> None:
       3) ``--keys``
       4) ``--edit`` (i.e. manual user input)
 
-    The KEYs that comprise the asset filename are required (configured by
-    `onyo.assets.filename`).
+    The **KEY**\s that comprise the asset filename are required (configured by
+    ``onyo.assets.filename``).
 
     The contents of all new assets are checked for validity before committing.
 

--- a/onyo/commands/rm.py
+++ b/onyo/commands/rm.py
@@ -54,7 +54,7 @@ args_rm = {
 
 def rm(args: argparse.Namespace) -> None:
     """
-    Delete ASSETs and/or DIRECTORYs.
+    Delete **ASSET**\s and/or **DIRECTORY**\s.
 
     Directories and asset directories are deleted along with their contents.
 

--- a/onyo/commands/set.py
+++ b/onyo/commands/set.py
@@ -66,7 +66,7 @@ def set(args: argparse.Namespace) -> None:
     asset, it is added and set appropriately.
 
     Setting **KEY**\s that are used in the asset name requires the ``--rename``
-    flag, and will result in the asset being renamed on the filesystem.
+    flag.
 
     In addition to keys in asset contents, some PSEUDO-KEYS can be set:
 

--- a/onyo/commands/set.py
+++ b/onyo/commands/set.py
@@ -21,8 +21,8 @@ args_set = {
         default=False,
         action='store_true',
         help="""
-            Allow setting KEYs that are part of the asset name.
-            (see the `onyo.assets.filename` configuration option)
+            Allow setting **KEY**\s that are part of the asset name.
+            (see the ``onyo.assets.filename`` configuration option)
         """
     ),
 
@@ -33,8 +33,8 @@ args_set = {
         metavar="KEY",
         nargs='+',
         help="""
-            KEY-VALUE pairs to set in assets. Multiple pairs can be given
-            (e.g. key1=value1 key2=value2 key3=value3).
+            **KEY-VALUE** pairs to set in assets. Multiple pairs can be given
+            (e.g. ``key1=value1 key2=value2 key3=value3``).
 
             Quotes are necessary when using spaces or shell command characters:
             ```
@@ -50,7 +50,7 @@ args_set = {
         nargs='+',
         type=path,
         help="""
-            Assets to set KEY=VALUEs in.
+            Assets to set **KEY-VALUE**\s in.
         """
     ),
 
@@ -60,13 +60,13 @@ args_set = {
 
 def set(args: argparse.Namespace) -> None:
     """
-    Set ``KEY``\s to ``VALUE`` for assets.
+    Set **KEY**\s to **VALUE**\s for assets.
 
-    KEY names can be any valid YAML key-name. If a KEY does not exist, it is
-    added and set appropriately.
+    **KEY** names can be any valid YAML key-name. If a key is not present in an
+    asset, it is added and set appropriately.
 
-    Setting KEYs used in the asset name require the ``--rename`` flag, and will
-    result in the asset being renamed on the filesystem.
+    Setting **KEY**\s that are used in the asset name requires the ``--rename``
+    flag, and will result in the asset being renamed on the filesystem.
 
     In addition to keys in asset contents, some PSEUDO-KEYS can be set:
 

--- a/onyo/commands/set.py
+++ b/onyo/commands/set.py
@@ -38,7 +38,7 @@ args_set = {
 
             Quotes are necessary when using spaces or shell command characters:
             ```
-            onyo set --keys title='Bob Bozniffiq: Saint of the Awkward' --path ...
+            $ onyo set --keys title='Bob Bozniffiq: Saint of the Awkward' --path ...
             ```
         """
     ),

--- a/onyo/commands/shell_completion.py
+++ b/onyo/commands/shell_completion.py
@@ -29,8 +29,8 @@ def shell_completion(args: argparse.Namespace) -> None:
     Example:
 
       ```
-      source <(onyo shell-completion)
-      onyo --<PRESS TAB to display available options>
+      $ source <(onyo shell-completion)
+      $ onyo --<PRESS TAB to display available options>
       ```
     """
     content = ''

--- a/onyo/commands/tests/test_onyo.py
+++ b/onyo/commands/tests/test_onyo.py
@@ -20,7 +20,7 @@ def test_onyo_debug(repo: OnyoRepo, variant: str) -> None:
 def test_onyo_help(repo: OnyoRepo, variant: str) -> None:
     ret = subprocess.run(['onyo', variant], capture_output=True, text=True)
     assert ret.returncode == 0
-    assert 'usage: onyo [-h]' in ret.stdout
+    assert 'Usage: onyo [-h]' in ret.stdout
     assert not ret.stderr
     assert repo.git.is_clean_worktree()
 
@@ -37,6 +37,6 @@ def test_onyo_without_subcommand(repo: OnyoRepo, helpers) -> None:
 
             ret = subprocess.run(full_cmd, capture_output=True, text=True)
             assert ret.returncode == 1
-            assert 'usage: onyo [-h]' in ret.stdout
+            assert 'Usage: onyo [-h]' in ret.stdout
             assert not ret.stderr
     assert repo.git.is_clean_worktree()

--- a/onyo/commands/tests/test_set.py
+++ b/onyo/commands/tests/test_set.py
@@ -146,7 +146,7 @@ def test_set_without_path(repo: OnyoRepo,
                          capture_output=True, text=True)
 
     assert ret.returncode != 0
-    assert "usage:" in ret.stderr  # argparse should already complain
+    assert "Usage:" in ret.stderr  # argparse should already complain
     assert repo.git.is_clean_worktree()
 
 

--- a/onyo/commands/tests/test_unset.py
+++ b/onyo/commands/tests/test_unset.py
@@ -224,7 +224,7 @@ def test_unset_without_path(repo: OnyoRepo,
     # verify the output
     assert ret.returncode != 0
     assert repo.git.is_clean_worktree()
-    assert "usage:" in ret.stderr
+    assert "Usage:" in ret.stderr
 
 
 @pytest.mark.repo_contents(*convert_contents([t for t in asset_contents if "num" in t[1]]))

--- a/onyo/commands/tree.py
+++ b/onyo/commands/tree.py
@@ -16,14 +16,14 @@ args_tree = {
         metavar='DIR',
         nargs='*',
         type=directory,
-        help='DIRECTORYs to list'
+        help='Directories to list'
     )
 }
 
 
 def tree(args: argparse.Namespace) -> None:
     """
-    List the assets and directories of ``DIRECTORY``\s in a tree-like format.
+    List the assets and directories of **DIRECTORY**\s in a tree-like format.
 
     If no directory is provided, the tree for CWD is listed.
 

--- a/onyo/commands/tree.py
+++ b/onyo/commands/tree.py
@@ -25,7 +25,8 @@ def tree(args: argparse.Namespace) -> None:
     """
     List the assets and directories of **DIRECTORY**\s in a tree-like format.
 
-    If no directory is provided, the tree for CWD is listed.
+    If no directory is provided, the tree for the current working directory is
+    listed.
 
     If any of the directories do not exist, then no tree is printed and an error
     is returned.

--- a/onyo/commands/unset.py
+++ b/onyo/commands/unset.py
@@ -21,7 +21,7 @@ args_unset = {
         type=str,
         help="""
             Keys to unset in assets. Multiple keys can be given
-            (e.g. key1 key2 key3).
+            (e.g. **key1 key2 key3**).
         """
     ),
 
@@ -32,7 +32,7 @@ args_unset = {
         nargs='+',
         type=path,
         help="""
-            Assets unset **KEY**s in.
+            Assets to unset **KEY**s in.
         """
     ),
 

--- a/onyo/commands/unset.py
+++ b/onyo/commands/unset.py
@@ -20,7 +20,7 @@ args_unset = {
         nargs='+',
         type=str,
         help="""
-            KEYs to unset in assets. Multiple keys can be given
+            Keys to unset in assets. Multiple keys can be given
             (e.g. key1 key2 key3).
         """
     ),
@@ -32,7 +32,7 @@ args_unset = {
         nargs='+',
         type=path,
         help="""
-            Assets unset KEYs in.
+            Assets unset **KEY**s in.
         """
     ),
 
@@ -42,7 +42,7 @@ args_unset = {
 
 def unset(args: argparse.Namespace) -> None:
     """
-    Remove ``KEY``\s from assets.
+    Remove **KEY**\s from assets.
 
     Keys that are used in asset names (see the ``onyo.assets.filename``
     configuration option) cannot be unset.

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -1,57 +1,67 @@
-import argparse
+from __future__ import annotations
+
 import os
 import sys
 import textwrap
+from argparse import ArgumentParser, PARSER
+from itertools import islice
 from pathlib import Path
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
+
+from rich.containers import Lines
+from rich.text import Text
+from rich_argparse import RichHelpFormatter
 
 from onyo import commands
 from onyo.lib.ui import ui
 
+if TYPE_CHECKING:
+    from argparse import Action
+    from collections.abc import Iterator
 
-# credit: https://stackoverflow.com/a/13429281
-class SubcommandHelpFormatter(argparse.RawTextHelpFormatter):
-    def _format_action(self, action: argparse.Action) -> str:
-        parts = super()._format_action(action)
 
-        # strip the first line (metavar) of the subcommands section
-        if action.nargs == argparse.PARSER:
-            parts = parts.split("\n", 1)[1]
+class WrappedTextRichHelpFormatter(RichHelpFormatter):
+    def _rich_format_action(self, action: Action) -> Iterator[tuple[Text, Text | None]]:
+        parts = super()._rich_format_action(action)
+        # remove the superfluous first line (<COMMANDS>) of the subcommands section
+        if action.nargs == PARSER:
+            parts = islice(parts, 1, None)
 
         return parts
 
-    def _split_lines(self, text, width):
-        """
-        This is a very, very naive approach to stripping rst syntax from
-        docstrings. Sadly, docutils does not have a plain-text writer. That
-        would be the ideal solution.
-        """
-        text = textwrap.dedent(text).strip()
+    def _rich_split_lines(self, text: Text, width: int) -> Lines:
+        lines = Lines()
+        for line in text.split():
+            lines.extend(line.wrap(self.console, width))
+        return lines
 
-        # `` -> `
-        text = text.replace('``', '`')
-        # remove escapes of characters; everything is literal here
-        text = text.replace('\\', '')
+    def _rich_fill_text(self, text: Text, width: int, indent: Text) -> Text:
+        lines = self._rich_split_lines(text, width)
+        return Text("\n").join(indent + line for line in lines) + "\n"
 
-        text = super()._split_lines(text, width)
+    def _rich_format_text(self, text: str) -> Text:
+        text = prepare_rst_for_rich(text)
 
-        return text
+        return super()._rich_format_text(text)
 
-    def _fill_text(self, text: str, width: int, indent: str) -> str:
-        """
-        This is a very, very naive approach to stripping rst syntax from
-        docstrings. Sadly, docutils does not have a plain-text writer. That
-        would be the ideal solution.
-        """
-        text = textwrap.dedent(text).strip()
-        text = super()._fill_text(text, width, indent)
 
-        # `` -> `
-        text = text.replace('``', '`')
-        # remove escapes of characters; everything is literal here
-        text = text.replace('\\', '')
+def prepare_rst_for_rich(text: str) -> str:
+    """
+    This is a very naive approach to cleanup docstrings and help text in
+    preparation to print to the terminal.
 
-        return text
+    Some effort is made to stylize RST markup.
+    """
+    # de-indent text
+    text = textwrap.dedent(text).strip()
+
+    # strip `` (inline code blocks)
+    text = text.replace('``', '')
+
+    # remove escaping
+    text = text.replace('\\', '')
+
+    return text
 
 
 def build_parser(parser, args: dict) -> None:
@@ -63,15 +73,15 @@ def build_parser(parser, args: dict) -> None:
         try:
             parser.add_argument(
                 *args[cmd]['args'],
-                **{k: v for k, v in args[cmd].items() if k != 'args'})
+                **{k: v for k, v in args[cmd].items() if k != 'args'} | {'help': prepare_rst_for_rich(args[cmd]['help'])})
         except KeyError:
-            parser.add_argument(**args[cmd])
+            parser.add_argument(**{k: v for k, v in args[cmd].items()} | {'help': prepare_rst_for_rich(args[cmd]['help'])})
 
 
 subcmds = None
 
 
-def setup_parser() -> argparse.ArgumentParser:
+def setup_parser() -> ArgumentParser:
     from onyo.onyo_arguments import args_onyo
     from onyo.commands.cat import args_cat
     from onyo.commands.config import args_config
@@ -90,9 +100,9 @@ def setup_parser() -> argparse.ArgumentParser:
 
     global subcmds
 
-    parser = argparse.ArgumentParser(
+    parser = ArgumentParser(
         description='A text-based inventory system backed by git.',
-        formatter_class=SubcommandHelpFormatter
+        formatter_class=WrappedTextRichHelpFormatter
     )
     build_parser(parser, args_onyo)
 
@@ -108,7 +118,7 @@ def setup_parser() -> argparse.ArgumentParser:
     cmd_cat = subcmds.add_parser(
         'cat',
         description=commands.cat.__doc__,
-        formatter_class=SubcommandHelpFormatter,
+        formatter_class=parser.formatter_class,
         help='Print the contents of assets to the terminal.'
     )
     cmd_cat.set_defaults(run=commands.cat)
@@ -119,7 +129,7 @@ def setup_parser() -> argparse.ArgumentParser:
     cmd_config = subcmds.add_parser(
         'config',
         description=commands.config.__doc__,
-        formatter_class=SubcommandHelpFormatter,
+        formatter_class=parser.formatter_class,
         help='Set, query, and unset Onyo repository configuration options.'
     )
     cmd_config.set_defaults(run=commands.config)
@@ -130,7 +140,7 @@ def setup_parser() -> argparse.ArgumentParser:
     cmd_edit = subcmds.add_parser(
         'edit',
         description=commands.edit.__doc__,
-        formatter_class=SubcommandHelpFormatter,
+        formatter_class=parser.formatter_class,
         help='Open assets using an editor.'
     )
     cmd_edit.set_defaults(run=commands.edit)
@@ -141,7 +151,7 @@ def setup_parser() -> argparse.ArgumentParser:
     cmd_fsck = subcmds.add_parser(
         'fsck',
         description=commands.fsck.__doc__,
-        formatter_class=SubcommandHelpFormatter,
+        formatter_class=parser.formatter_class,
         help='Run a suite of integrity checks on the Onyo repository and its contents.'
     )
     cmd_fsck.set_defaults(run=commands.fsck)
@@ -151,7 +161,7 @@ def setup_parser() -> argparse.ArgumentParser:
     cmd_get = subcmds.add_parser(
         'get',
         description=commands.get.__doc__,
-        formatter_class=SubcommandHelpFormatter,
+        formatter_class=parser.formatter_class,
         help='Return and sort asset values matching query patterns.'
     )
     cmd_get.set_defaults(run=commands.get)
@@ -162,7 +172,7 @@ def setup_parser() -> argparse.ArgumentParser:
     cmd_history = subcmds.add_parser(
         'history',
         description=commands.history.__doc__,
-        formatter_class=SubcommandHelpFormatter,
+        formatter_class=parser.formatter_class,
         help='Display the history of an asset or directory.'
     )
     cmd_history.set_defaults(run=commands.history)
@@ -173,7 +183,7 @@ def setup_parser() -> argparse.ArgumentParser:
     cmd_init = subcmds.add_parser(
         'init',
         description=commands.init.__doc__,
-        formatter_class=SubcommandHelpFormatter,
+        formatter_class=parser.formatter_class,
         help='Initialize a new Onyo repository.'
     )
     cmd_init.set_defaults(run=commands.init)
@@ -184,7 +194,7 @@ def setup_parser() -> argparse.ArgumentParser:
     cmd_mkdir = subcmds.add_parser(
         'mkdir',
         description=commands.mkdir.__doc__,
-        formatter_class=SubcommandHelpFormatter,
+        formatter_class=parser.formatter_class,
         help='Create directories.'
     )
     cmd_mkdir.set_defaults(run=commands.mkdir)
@@ -195,7 +205,7 @@ def setup_parser() -> argparse.ArgumentParser:
     cmd_mv = subcmds.add_parser(
         'mv',
         description=commands.mv.__doc__,
-        formatter_class=SubcommandHelpFormatter,
+        formatter_class=parser.formatter_class,
         help='Move assets or directories into a destination directory; or rename a directory.'
     )
     cmd_mv.set_defaults(run=commands.mv)
@@ -206,7 +216,7 @@ def setup_parser() -> argparse.ArgumentParser:
     cmd_new = subcmds.add_parser(
         'new',
         description=commands.new.__doc__,
-        formatter_class=SubcommandHelpFormatter,
+        formatter_class=parser.formatter_class,
         help='Create new assets and populate with key-value pairs.'
     )
     cmd_new.set_defaults(run=commands.new)
@@ -217,7 +227,7 @@ def setup_parser() -> argparse.ArgumentParser:
     cmd_rm = subcmds.add_parser(
         'rm',
         description=commands.rm.__doc__,
-        formatter_class=SubcommandHelpFormatter,
+        formatter_class=parser.formatter_class,
         help='Delete assets and directories.'
     )
     cmd_rm.set_defaults(run=commands.rm)
@@ -228,7 +238,7 @@ def setup_parser() -> argparse.ArgumentParser:
     cmd_set = subcmds.add_parser(
         'set',
         description=commands.set.__doc__,
-        formatter_class=SubcommandHelpFormatter,
+        formatter_class=parser.formatter_class,
         help='Set the value of keys for assets.'
     )
     cmd_set.set_defaults(run=commands.set)
@@ -239,7 +249,7 @@ def setup_parser() -> argparse.ArgumentParser:
     cmd_shell_completion = subcmds.add_parser(
         'shell-completion',
         description=commands.shell_completion.__doc__,
-        formatter_class=SubcommandHelpFormatter,
+        formatter_class=parser.formatter_class,
         help='Display a tab-completion script for Onyo.'
     )
     cmd_shell_completion.set_defaults(run=commands.shell_completion)
@@ -250,7 +260,7 @@ def setup_parser() -> argparse.ArgumentParser:
     cmd_tree = subcmds.add_parser(
         'tree',
         description=commands.tree.__doc__,
-        formatter_class=SubcommandHelpFormatter,
+        formatter_class=parser.formatter_class,
         help='List the assets and directories of a directory in ``tree`` format.'
     )
     cmd_tree.set_defaults(run=commands.tree)
@@ -261,7 +271,7 @@ def setup_parser() -> argparse.ArgumentParser:
     cmd_unset = subcmds.add_parser(
         'unset',
         description=commands.unset.__doc__,
-        formatter_class=SubcommandHelpFormatter,
+        formatter_class=parser.formatter_class,
         help='Remove keys from assets.'
     )
     cmd_unset.set_defaults(run=commands.unset)

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 import sys
 import textwrap
 from argparse import ArgumentParser, PARSER
@@ -55,8 +56,24 @@ def prepare_rst_for_rich(text: str) -> str:
     # de-indent text
     text = textwrap.dedent(text).strip()
 
-    # strip `` (inline code blocks)
-    text = text.replace('``', '')
+    # stylize arg descriptors (ALL CAPS ARGS)
+    text = re.sub('\*\*([A-Z\-]+)\*\*', r'[dark_cyan]\1[/dark_cyan]', text)
+
+    # stylize ** (bold)
+    text = re.sub('\*\*([^*]+)\*\*', r'[bold]\1[/bold]', text)
+
+    # stylize ``` (code blocks)
+    text = re.sub('```([^`]+)```', r'[underline]\1[/underline]', text)
+
+    # strip `` (inline code markers) for flags
+    # flags are auto-colorized by rich-argparse
+    text = re.sub('``(-[^`]+)``', r'\1', text)
+
+    # stylize remaining `` (inline code markers)
+    text = re.sub('``([^`]+)``', r'[bold magenta]\1[/bold magenta]', text)
+
+    # make bullet points prettier
+    text = text.replace(' * ', ' • ')
 
     # remove escaping
     text = text.replace('\\', '')

--- a/onyo/onyo_arguments.py
+++ b/onyo/onyo_arguments.py
@@ -11,7 +11,7 @@ args_onyo = {
         default=Path.cwd(),
         type=directory,
         help="""
-            Run Onyo from DIR instead of the current working directory.
+            Run Onyo from **DIR** instead of the current working directory.
         """
     ),
 

--- a/onyo/shared_arguments.py
+++ b/onyo/shared_arguments.py
@@ -4,8 +4,8 @@ shared_arg_message = dict(
     action='append',
     type=str,
     help="""
-        Use the given MESSAGE as the commit message (rather than the default).
-        If multiple ``-m`` options are given, their values are concatenated as
-        separate paragraphs.
+        Use the given **MESSAGE** as the commit message (rather than the default).
+        If multiple ``--message`` options are given, their values are
+        concatenated as separate paragraphs.
     """
 )

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
     install_requires=[
         'ruamel.yaml',
         'rich',
+        'rich-argparse',
     ],
     extras_require={
         'tests': [


### PR DESCRIPTION
This PR:

- adds rich styling to help text
- don't leak RST-isms into CLI help text (fix #429)
- improves and normalize styling across help text 
- improves wording of some help text

This introduces a new dependency: `rich-argparse`

Sadly, there is no `rich.RST` analogue to `rich.Markdown`, so I intercept the help text, and convert relevant RST-isms into rich markup. It's not elegant, but functional.

Annoyingly, rich-argparse passes around rich `Text` objects rather than strings, which lacks basic string functionality. Thus, I need to intercept text at all three originating points, rather than the single rendering point.

If we want to remove the dependency, we could lift some pieces from the `rich-argparse` project (MIT licensed), and integrate our changes into them (flattening the structure by a layer).