### PR TITLE
NF: rename misleading `--path` flag for `new`, `set`, and `unset`

### DIFF
--- a/demo/generate_demo_repo.sh
+++ b/demo/generate_demo_repo.sh
@@ -127,11 +127,10 @@ onyo -y mv warehouse/headphones_JBL_pro.e98t2p "ethics/Achilles Book"
 onyo -y mv "ethics/Achilles Book/laptop_lenovo_thinkpad.owh8e2" repair
 onyo -y mv warehouse/laptop_microsoft_surface.oq782j "ethics/Achilles Book"
 
-# specify number of USB type A ports on all laptops
-onyo get --match type=laptop -H --keys path | xargs onyo -y set --keys USB_A=2 --path
+onyo get --match type=laptop -H --keys path | xargs onyo -y set --keys USB_A=2 --asset
 
 # specify the number of USB ports (type A and C) on MacBooks
-onyo get --match model=macbook -H --keys path | xargs onyo -y set --keys USB_A=2 USB_C=1 --path
+onyo get --match model=macbook -H --keys path | xargs onyo -y set --keys USB_A=2 USB_C=1 --asset
 
 # add three newly purchased laptops; shell brace-expansion can be very useful
 onyo -y new --keys type=laptop make=apple model=macbook serial={uef82b3,9il2b4,73b2cn} RAM=8GB display=13.3 USB_A=2 USB_C=1 \
@@ -145,7 +144,7 @@ onyo -y new --keys type=headphones make=apple model=airpods serial=uzl8e1 --dire
 onyo -y mv warehouse/monitor_dell_PH123.86JZho warehouse/laptop_apple_macbook.oiw629 warehouse/headphones_apple_airpods.uzl8e1 "accounting/Bingo Bob"
 
 # the broken laptop has been repaired (bad RAM, which has also been increased)
-onyo -y set --keys RAM=32GB --path repair/laptop_lenovo_thinkpad.owh8e2
+onyo -y set --keys RAM=32GB --asset repair/laptop_lenovo_thinkpad.owh8e2
 onyo -y mv repair/laptop_lenovo_thinkpad.owh8e2 warehouse
 
 # Max's laptop is old; retire it and replace with a new one

--- a/demo/generate_demo_repo.sh
+++ b/demo/generate_demo_repo.sh
@@ -96,19 +96,19 @@ onyo --yes mkdir repair
 onyo -y new --tsv "${SCRIPT_DIR}/inventory.tsv"
 
 # add a set of newly bought assets
-onyo -y new --keys type=laptop make=apple model=macbook serial=9r32he RAM=8GB display=13.3 --path warehouse/
-onyo -y new --keys type=laptop make=apple model=macbook serial=9r5qlk RAM=8GB display=13.3 --path warehouse/
-onyo -y new --keys type=laptop make=lenovo model=thinkpad serial=owh8e2 RAM=8GB display=14.6 --path warehouse/
-onyo -y new --keys type=laptop make=lenovo model=thinkpad serial=iu7h6d RAM=8GB display=14.6 --path warehouse/
-onyo -y new --keys type=laptop make=microsoft model=surface serial=oq782j RAM=8GB display=12.4 touchscreen=yes --path warehouse/
+onyo -y new --keys type=laptop make=apple model=macbook serial=9r32he RAM=8GB display=13.3 --directory warehouse/
+onyo -y new --keys type=laptop make=apple model=macbook serial=9r5qlk RAM=8GB display=13.3 --directory warehouse/
+onyo -y new --keys type=laptop make=lenovo model=thinkpad serial=owh8e2 RAM=8GB display=14.6 --directory warehouse/
+onyo -y new --keys type=laptop make=lenovo model=thinkpad serial=iu7h6d RAM=8GB display=14.6 --directory warehouse/
+onyo -y new --keys type=laptop make=microsoft model=surface serial=oq782j RAM=8GB display=12.4 touchscreen=yes --directory warehouse/
 
 # NOTE: headphones normally do not have a serial number, and thus a faux serial
 # would be generated (e.g. headphones_JBL_pro.faux). However, for the sake of a
 # reproducible demo, explicit serials are specified.
-onyo -y new --keys type=headphones make=apple model=airpods serial=7h8f04 --path warehouse/
-onyo -y new --keys type=headphones make=JBL model=pro serial=325gtt --path warehouse/
-onyo -y new --keys type=headphones make=JBL model=pro serial=e98t2p --path warehouse/
-onyo -y new --keys type=headphones make=JBL model=pro serial=ph9527 --path warehouse/
+onyo -y new --keys type=headphones make=apple model=airpods serial=7h8f04 --directory warehouse/
+onyo -y new --keys type=headphones make=JBL model=pro serial=325gtt --directory warehouse/
+onyo -y new --keys type=headphones make=JBL model=pro serial=e98t2p --directory warehouse/
+onyo -y new --keys type=headphones make=JBL model=pro serial=ph9527 --directory warehouse/
 
 # one of the headphones was added by accident; remove it.
 onyo -y rm warehouse/headphones_JBL_pro.ph9527
@@ -135,13 +135,13 @@ onyo get --match model=macbook -H --keys path | xargs onyo -y set --keys USB_A=2
 
 # add three newly purchased laptops; shell brace-expansion can be very useful
 onyo -y new --keys type=laptop make=apple model=macbook serial={uef82b3,9il2b4,73b2cn} RAM=8GB display=13.3 USB_A=2 USB_C=1 \
-    --path warehouse/
+    --directory warehouse/
 
 # Bingo Bob was hired; and new hardware was purchased for him
 onyo --yes mkdir "accounting/Bingo Bob"
-onyo -y new --keys type=monitor make=dell model=PH123 serial=86JZho display=22.0 --path warehouse/
-onyo -y new --keys type=laptop make=apple model=macbook serial=oiw629 RAM=8GB display=13.3 USB_A=2 --path warehouse/
-onyo -y new --keys type=headphones make=apple model=airpods serial=uzl8e1 --path warehouse/
+onyo -y new --keys type=monitor make=dell model=PH123 serial=86JZho display=22.0 --directory warehouse/
+onyo -y new --keys type=laptop make=apple model=macbook serial=oiw629 RAM=8GB display=13.3 USB_A=2 --directory warehouse/
+onyo -y new --keys type=headphones make=apple model=airpods serial=uzl8e1 --directory warehouse/
 onyo -y mv warehouse/monitor_dell_PH123.86JZho warehouse/laptop_apple_macbook.oiw629 warehouse/headphones_apple_airpods.uzl8e1 "accounting/Bingo Bob"
 
 # the broken laptop has been repaired (bad RAM, which has also been increased)
@@ -156,7 +156,7 @@ onyo -y mv warehouse/laptop_apple_macbook.uef82b3 ethics/Max\ Mustermann/
 onyo -y mkdir "management"
 onyo -y mv "ethics/Max Mustermann" management
 onyo -y mkdir "management/Alice Wonder"
-onyo -y new --keys type=laptop make=apple model=macbook serial=83hd0 RAM=8GB display=13.3 USB_A=2 --path "management/Alice Wonder/"
+onyo -y new --keys type=laptop make=apple model=macbook serial=83hd0 RAM=8GB display=13.3 USB_A=2 --directory "management/Alice Wonder/"
 
 # Theo joins; assign them a laptop from the warehouse
 onyo -y mkdir "ethics/Theo Turtle"

--- a/demo/generate_demo_repo.sh
+++ b/demo/generate_demo_repo.sh
@@ -93,77 +93,78 @@ onyo --yes mkdir repair
 
 # import some existing hardware
 # TSV files can be very useful when adding large amounts of assets
-onyo -y new --tsv "${SCRIPT_DIR}/inventory.tsv"
+onyo --yes new --tsv "${SCRIPT_DIR}/inventory.tsv"
 
 # add a set of newly bought assets
-onyo -y new --keys type=laptop make=apple model=macbook serial=9r32he RAM=8GB display=13.3 --directory warehouse/
-onyo -y new --keys type=laptop make=apple model=macbook serial=9r5qlk RAM=8GB display=13.3 --directory warehouse/
-onyo -y new --keys type=laptop make=lenovo model=thinkpad serial=owh8e2 RAM=8GB display=14.6 --directory warehouse/
-onyo -y new --keys type=laptop make=lenovo model=thinkpad serial=iu7h6d RAM=8GB display=14.6 --directory warehouse/
-onyo -y new --keys type=laptop make=microsoft model=surface serial=oq782j RAM=8GB display=12.4 touchscreen=yes --directory warehouse/
+onyo --yes new --keys type=laptop make=apple model=macbook serial=9r32he RAM=8GB display=13.3 --directory warehouse/
+onyo --yes new --keys type=laptop make=apple model=macbook serial=9r5qlk RAM=8GB display=13.3 --directory warehouse/
+onyo --yes new --keys type=laptop make=lenovo model=thinkpad serial=owh8e2 RAM=8GB display=14.6 --directory warehouse/
+onyo --yes new --keys type=laptop make=lenovo model=thinkpad serial=iu7h6d RAM=8GB display=14.6 --directory warehouse/
+onyo --yes new --keys type=laptop make=microsoft model=surface serial=oq782j RAM=8GB display=12.4 touchscreen=yes --directory warehouse/
 
 # NOTE: headphones normally do not have a serial number, and thus a faux serial
 # would be generated (e.g. headphones_JBL_pro.faux). However, for the sake of a
 # reproducible demo, explicit serials are specified.
-onyo -y new --keys type=headphones make=apple model=airpods serial=7h8f04 --directory warehouse/
-onyo -y new --keys type=headphones make=JBL model=pro serial=325gtt --directory warehouse/
-onyo -y new --keys type=headphones make=JBL model=pro serial=e98t2p --directory warehouse/
-onyo -y new --keys type=headphones make=JBL model=pro serial=ph9527 --directory warehouse/
+onyo --yes new --keys type=headphones make=apple model=airpods serial=7h8f04 --directory warehouse/
+onyo --yes new --keys type=headphones make=JBL model=pro serial=325gtt --directory warehouse/
+onyo --yes new --keys type=headphones make=JBL model=pro serial=e98t2p --directory warehouse/
+onyo --yes new --keys type=headphones make=JBL model=pro serial=ph9527 --directory warehouse/
 
 # one of the headphones was added by accident; remove it.
-onyo -y rm warehouse/headphones_JBL_pro.ph9527
+onyo --yes rm warehouse/headphones_JBL_pro.ph9527
 
 # a few new users join
 onyo --yes mkdir "ethics/Max Mustermann" "ethics/Achilles Book"
 
 # assign equipment to Max and Achilles
-onyo -y mv warehouse/laptop_apple_macbook.9r32he "ethics/Max Mustermann"
-onyo -y mv warehouse/headphones_apple_airpods.7h8f04 "ethics/Max Mustermann"
+onyo --yes mv warehouse/laptop_apple_macbook.9r32he "ethics/Max Mustermann"
+onyo --yes mv warehouse/headphones_apple_airpods.7h8f04 "ethics/Max Mustermann"
 
-onyo -y mv warehouse/laptop_lenovo_thinkpad.owh8e2 "ethics/Achilles Book"
-onyo -y mv warehouse/headphones_JBL_pro.e98t2p "ethics/Achilles Book"
+onyo --yes mv warehouse/laptop_lenovo_thinkpad.owh8e2 "ethics/Achilles Book"
+onyo --yes mv warehouse/headphones_JBL_pro.e98t2p "ethics/Achilles Book"
 
 # Achilles' laptop broke; set it aside to repair and give him a new one
-onyo -y mv "ethics/Achilles Book/laptop_lenovo_thinkpad.owh8e2" repair
-onyo -y mv warehouse/laptop_microsoft_surface.oq782j "ethics/Achilles Book"
+onyo --yes mv "ethics/Achilles Book/laptop_lenovo_thinkpad.owh8e2" repair
+onyo --yes mv warehouse/laptop_microsoft_surface.oq782j "ethics/Achilles Book"
 
-onyo get --match type=laptop -H --keys path | xargs onyo -y set --keys USB_A=2 --asset
+# specify number of USB type A ports on all laptops
+onyo get --match type=laptop --machine-readable --keys path | xargs onyo --yes set --keys USB_A=2 --asset
 
 # specify the number of USB ports (type A and C) on MacBooks
-onyo get --match model=macbook -H --keys path | xargs onyo -y set --keys USB_A=2 USB_C=1 --asset
+onyo get --match model=macbook --machine-readable --keys path | xargs onyo --yes set --keys USB_A=2 USB_C=1 --asset
 
 # add three newly purchased laptops; shell brace-expansion can be very useful
-onyo -y new --keys type=laptop make=apple model=macbook serial={uef82b3,9il2b4,73b2cn} RAM=8GB display=13.3 USB_A=2 USB_C=1 \
+onyo --yes new --keys type=laptop make=apple model=macbook serial={uef82b3,9il2b4,73b2cn} RAM=8GB display=13.3 USB_A=2 USB_C=1 \
     --directory warehouse/
 
 # Bingo Bob was hired; and new hardware was purchased for him
 onyo --yes mkdir "accounting/Bingo Bob"
-onyo -y new --keys type=monitor make=dell model=PH123 serial=86JZho display=22.0 --directory warehouse/
-onyo -y new --keys type=laptop make=apple model=macbook serial=oiw629 RAM=8GB display=13.3 USB_A=2 --directory warehouse/
-onyo -y new --keys type=headphones make=apple model=airpods serial=uzl8e1 --directory warehouse/
-onyo -y mv warehouse/monitor_dell_PH123.86JZho warehouse/laptop_apple_macbook.oiw629 warehouse/headphones_apple_airpods.uzl8e1 "accounting/Bingo Bob"
+onyo --yes new --keys type=monitor make=dell model=PH123 serial=86JZho display=22.0 --directory warehouse/
+onyo --yes new --keys type=laptop make=apple model=macbook serial=oiw629 RAM=8GB display=13.3 USB_A=2 --directory warehouse/
+onyo --yes new --keys type=headphones make=apple model=airpods serial=uzl8e1 --directory warehouse/
+onyo --yes mv warehouse/monitor_dell_PH123.86JZho warehouse/laptop_apple_macbook.oiw629 warehouse/headphones_apple_airpods.uzl8e1 "accounting/Bingo Bob"
 
 # the broken laptop has been repaired (bad RAM, which has also been increased)
-onyo -y set --keys RAM=32GB --asset repair/laptop_lenovo_thinkpad.owh8e2
-onyo -y mv repair/laptop_lenovo_thinkpad.owh8e2 warehouse
+onyo --yes set --keys RAM=32GB --asset repair/laptop_lenovo_thinkpad.owh8e2
+onyo --yes mv repair/laptop_lenovo_thinkpad.owh8e2 warehouse
 
 # Max's laptop is old; retire it and replace with a new one
-onyo -y mv ethics/Max\ Mustermann/laptop_apple_macbook.9r32he recycling
-onyo -y mv warehouse/laptop_apple_macbook.uef82b3 ethics/Max\ Mustermann/
+onyo --yes mv ethics/Max\ Mustermann/laptop_apple_macbook.9r32he recycling
+onyo --yes mv warehouse/laptop_apple_macbook.uef82b3 ethics/Max\ Mustermann/
 
 # a new group is created ("management"); transfer people to their new group
-onyo -y mkdir "management"
-onyo -y mv "ethics/Max Mustermann" management
-onyo -y mkdir "management/Alice Wonder"
-onyo -y new --keys type=laptop make=apple model=macbook serial=83hd0 RAM=8GB display=13.3 USB_A=2 --directory "management/Alice Wonder/"
+onyo --yes mkdir "management"
+onyo --yes mv "ethics/Max Mustermann" management
+onyo --yes mkdir "management/Alice Wonder"
+onyo --yes new --keys type=laptop make=apple model=macbook serial=83hd0 RAM=8GB display=13.3 USB_A=2 --directory "management/Alice Wonder/"
 
 # Theo joins; assign them a laptop from the warehouse
-onyo -y mkdir "ethics/Theo Turtle"
-onyo -y mv warehouse/laptop_lenovo_thinkpad.owh8e2 "ethics/Theo Turtle"
+onyo --yes mkdir "ethics/Theo Turtle"
+onyo --yes mv warehouse/laptop_lenovo_thinkpad.owh8e2 "ethics/Theo Turtle"
 
 # Max retired; return all of his hardware and delete his directory
-onyo -y mv management/Max\ Mustermann/* warehouse
-onyo -y rm "management/Max Mustermann"
+onyo --yes mv management/Max\ Mustermann/* warehouse
+onyo --yes rm "management/Max Mustermann"
 
 # TODO: add "onyo fsck"
 # TODO: compare

--- a/docs/source/cmd_new.rst
+++ b/docs/source/cmd_new.rst
@@ -19,7 +19,7 @@ new assets at once with a different value for each asset.
 
 **directory**
 
-    The ``directory`` key is an alternative to ``onyo new --path`` to specify
+    The ``directory`` key is an alternative to ``onyo new --directory`` to specify
     the location in which to create new assets.
 
 **template**
@@ -37,7 +37,7 @@ Use ``onyo new`` to add a new asset and add some content to it:
 
 .. code:: shell
 
-   onyo new --keys RAM=8GB display=14.6 type=laptop make=lenovo model=T490s serial=abc123 --path shelf/
+   onyo new --keys RAM=8GB display=14.6 type=laptop make=lenovo model=T490s serial=abc123 --directory shelf/
 
 This command writes a YAML file to ``shelf/laptop_lenovo_T490s.abc123``:
 
@@ -110,7 +110,7 @@ will be written into the asset file
 To facilitate the creation of many similar devices, add templates under
 ``.onyo/templates/`` and use them with ``onyo new --template <template>``.
 
-``onyo new --edit --template laptop_lenovo --path shelf/`` adds a new laptop to
+``onyo new --edit --template laptop_lenovo --directory shelf/`` adds a new laptop to
 the inventory, using ``.onyo/templates/laptop_lenovo`` as a pre-filled template:
 
 .. code:: yaml

--- a/onyo/argparse_helpers.py
+++ b/onyo/argparse_helpers.py
@@ -85,38 +85,3 @@ def parse_key_values(string):
                 pass
 
     return results
-
-
-def directory(string: str) -> str:
-    """
-    A no-op type-check for ArgParse. Used to hint for shell tab-completion.
-    """
-    return string
-
-
-def file(string: str) -> str:
-    """
-    A no-op type-check for ArgParse. Used to hint for shell tab-completion.
-    """
-    return string
-
-
-def git_config(string: str) -> str:
-    """
-    A no-op type-check for ArgParse. Used to hint for shell tab-completion.
-    """
-    return string
-
-
-def path(string: str) -> str:
-    """
-    A no-op type-check for ArgParse. Used to hint for shell tab-completion.
-    """
-    return string
-
-
-def template(string: str) -> str:
-    """
-    A no-op type-check for ArgParse. Used to hint for shell tab-completion.
-    """
-    return string

--- a/onyo/commands/cat.py
+++ b/onyo/commands/cat.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from onyo.argparse_helpers import file
 from onyo.lib.commands import onyo_cat
 from onyo.lib.inventory import Inventory
 from onyo.lib.onyo import OnyoRepo
@@ -15,7 +14,6 @@ args_cat = {
     'asset': dict(
         metavar='ASSET',
         nargs='+',
-        type=file,
         help='Paths of assets to print'
     ),
 }

--- a/onyo/commands/config.py
+++ b/onyo/commands/config.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from onyo import OnyoRepo
-from onyo.argparse_helpers import git_config
 from onyo.lib.commands import onyo_config
 from onyo.lib.inventory import Inventory
 
@@ -15,7 +14,6 @@ args_config = {
     'git_config_args': dict(
         metavar='ARGS',
         nargs='+',
-        type=git_config,
         help='Config options to set in ``.onyo/config``.'
     ),
 }

--- a/onyo/commands/edit.py
+++ b/onyo/commands/edit.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from onyo.argparse_helpers import file
 from onyo.lib.commands import onyo_edit
 from onyo.lib.inventory import Inventory
 from onyo.lib.onyo import OnyoRepo
@@ -16,7 +15,6 @@ args_edit = {
     'asset': dict(
         metavar='ASSET',
         nargs='+',
-        type=file,
         help='Paths of assets to edit.'
     ),
 

--- a/onyo/commands/get.py
+++ b/onyo/commands/get.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from onyo import OnyoRepo
-from onyo.argparse_helpers import path
 from onyo.lib.commands import onyo_get
 from onyo.lib.filters import Filter
 from onyo.lib.inventory import Inventory
@@ -64,7 +63,6 @@ args_get = {
     'path': dict(
         args=('-p', '--path'),
         metavar='PATH',
-        type=path,
         nargs='+',
         help="""
             Assets or directories to query.

--- a/onyo/commands/history.py
+++ b/onyo/commands/history.py
@@ -7,7 +7,6 @@ from shlex import quote
 from typing import TYPE_CHECKING
 
 from onyo import OnyoRepo
-from onyo.argparse_helpers import path
 from onyo.lib.command_utils import get_history_cmd
 from onyo.lib.ui import ui
 
@@ -28,7 +27,6 @@ args_history = {
     'path': dict(
         metavar='PATH',
         nargs='?',
-        type=path,
         help="""
             Path of an asset or directory to display the history of.
         """

--- a/onyo/commands/init.py
+++ b/onyo/commands/init.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from onyo.argparse_helpers import directory
 from onyo.lib.onyo import OnyoRepo
 
 if TYPE_CHECKING:
@@ -13,7 +12,6 @@ args_init = {
     'directory': dict(
         metavar='DIR',
         nargs='?',
-        type=directory,
         help="""
             Directory to initialize as an Onyo repository.
         """

--- a/onyo/commands/mkdir.py
+++ b/onyo/commands/mkdir.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from onyo import OnyoRepo
-from onyo.argparse_helpers import path
 from onyo.lib.commands import onyo_mkdir
 from onyo.lib.inventory import Inventory
 from onyo.shared_arguments import shared_arg_message
@@ -16,7 +15,6 @@ args_mkdir = {
     'directory': dict(
         metavar='DIR',
         nargs='+',
-        type=path,
         help="""
             Directories to create; or assets to convert into an Asset Directory.
         """

--- a/onyo/commands/mv.py
+++ b/onyo/commands/mv.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from onyo import OnyoRepo
-from onyo.argparse_helpers import path
 from onyo.lib.commands import onyo_mv
 from onyo.lib.inventory import Inventory
 from onyo.shared_arguments import shared_arg_message
@@ -16,7 +15,6 @@ args_mv = {
     'source': dict(
         metavar='SOURCE',
         nargs='+',
-        type=path,
         help="""
             Assets and/or directories to move into **DEST**.
         """
@@ -24,7 +22,6 @@ args_mv = {
 
     'destination': dict(
         metavar='DEST',
-        type=path,
         help="""
             Destination to move **SOURCE**\s into.
         """

--- a/onyo/commands/new.py
+++ b/onyo/commands/new.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from onyo import OnyoRepo
-from onyo.argparse_helpers import template, path, StoreKeyValuePairs
+from onyo.argparse_helpers import directory, path, template, StoreKeyValuePairs
 from onyo.lib.commands import onyo_new
 from onyo.lib.inventory import Inventory
 from onyo.shared_arguments import shared_arg_message
@@ -69,12 +69,12 @@ args_new = {
 
             For example, create three new laptops with different serials:
             ```
-            $ onyo new --keys type=laptop make=apple model=macbookpro serial=1 serial=2 serial=3 --path shelf/
+            $ onyo new --keys type=laptop make=apple model=macbookpro serial=1 serial=2 serial=3 --directory shelf/
             ```
 
             Shell brace-expansion makes this even more succinct:
             ```
-            $ onyo new --keys type=laptop make=apple model=macbookpro serial={1,2,3} --path shelf/
+            $ onyo new --keys type=laptop make=apple model=macbookpro serial={1,2,3} --directory shelf/
             ```
         """
     ),
@@ -89,10 +89,10 @@ args_new = {
         """
     ),
 
-    'path': dict(
-        args=('-p', '--path'),
-        metavar='PATH',
-        type=path,
+    'directory': dict(
+        args=('-d', '--directory'),
+        metavar='DIRECTORY',
+        type=directory,
         help="""
             Directory to create new assets in.
 
@@ -127,7 +127,7 @@ def new(args: argparse.Namespace) -> None:
     Some key names are reserved, and are not stored as keys in asset contents:
 
       * ``directory``: directory to create the asset in relative to the root of
-        the repository. This key cannot be used with the ``--path`` flag.
+        the repository. This key cannot be used with the ``--directory`` flag.
       * ``is_asset_directory``: whether to create the asset as an Asset
         Directory.  Default is ``false``.
       * ``template``: which template to use for the asset. This key cannot be
@@ -135,7 +135,7 @@ def new(args: argparse.Namespace) -> None:
     """
     inventory = Inventory(repo=OnyoRepo(Path.cwd(), find_root=True))
     onyo_new(inventory=inventory,
-             path=Path(args.path).resolve() if args.path else None,
+             directory=Path(args.directory).resolve() if args.directory else None,
              template=args.template,
              clone=Path(args.clone).resolve() if args.clone else None,
              tsv=Path(args.tsv).resolve() if args.tsv else None,

--- a/onyo/commands/new.py
+++ b/onyo/commands/new.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from onyo import OnyoRepo
-from onyo.argparse_helpers import directory, path, template, StoreKeyValuePairs
+from onyo.argparse_helpers import StoreKeyValuePairs
 from onyo.lib.commands import onyo_new
 from onyo.lib.inventory import Inventory
 from onyo.shared_arguments import shared_arg_message
@@ -18,7 +18,6 @@ args_new = {
         args=('-c', '--clone'),
         metavar='CLONE',
         required=False,
-        type=path,
         help="""
             Path of an asset to clone.
 
@@ -31,7 +30,6 @@ args_new = {
         args=('-t', '--template'),
         metavar='TEMPLATE',
         required=False,
-        type=template,
         help="""
             Name of a template to populate the contents of new assets.
 
@@ -44,7 +42,6 @@ args_new = {
         args=('-tsv', '--tsv'),
         metavar='TSV',
         required=False,
-        type=path,
         help="""
             Path to a **TSV** file describing new assets.
 
@@ -92,7 +89,6 @@ args_new = {
     'directory': dict(
         args=('-d', '--directory'),
         metavar='DIRECTORY',
-        type=directory,
         help="""
             Directory to create new assets in.
 

--- a/onyo/commands/rm.py
+++ b/onyo/commands/rm.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from onyo import OnyoRepo
-from onyo.argparse_helpers import path
 from onyo.lib.commands import onyo_rm
 from onyo.lib.inventory import Inventory
 from onyo.shared_arguments import shared_arg_message
@@ -16,7 +15,6 @@ args_rm = {
     'path': dict(
         metavar='PATH',
         nargs='+',
-        type=path,
         help="""
             Assets and/or directories to delete.
         """

--- a/onyo/commands/set.py
+++ b/onyo/commands/set.py
@@ -38,15 +38,15 @@ args_set = {
 
             Quotes are necessary when using spaces or shell command characters:
             ```
-            $ onyo set --keys title='Bob Bozniffiq: Saint of the Awkward' --path ...
+            $ onyo set --keys title='Bob Bozniffiq: Saint of the Awkward' --asset ...
             ```
         """
     ),
 
-    'path': dict(
-        args=('-p', '--path'),
+    'asset': dict(
+        args=('-a', '--asset'),
         required=True,
-        metavar='PATH',
+        metavar='ASSET',
         nargs='+',
         type=path,
         help="""
@@ -79,14 +79,14 @@ def set(args: argparse.Namespace) -> None:
     """
 
     inventory = Inventory(repo=OnyoRepo(Path.cwd(), find_root=True))
-    paths = [Path(p).resolve() for p in args.path]
+    assets = [Path(a).resolve() for a in args.asset]
     # TODO: The following check should be incorporated in the argparse Action.
     #       IOW: This requires a variant of StoreKeyValuePairs, that does not
     #       allow for key duplication (and can tell which keys are affected)
     if len(args.keys) > 1:
         raise ValueError("Keys must not be given multiple times.")
     onyo_set(inventory=inventory,
-             paths=paths,
+             assets=assets,
              keys=args.keys[0],
              rename=args.rename,
              message='\n\n'.join(m for m in args.message) if args.message else None)

--- a/onyo/commands/set.py
+++ b/onyo/commands/set.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from onyo.argparse_helpers import path, StoreKeyValuePairs
+from onyo.argparse_helpers import StoreKeyValuePairs
 from onyo.lib.commands import onyo_set
 from onyo.lib.inventory import Inventory
 from onyo.lib.onyo import OnyoRepo
@@ -48,7 +48,6 @@ args_set = {
         required=True,
         metavar='ASSET',
         nargs='+',
-        type=path,
         help="""
             Assets to set **KEY-VALUE**\s in.
         """

--- a/onyo/commands/tests/test_new.py
+++ b/onyo/commands/tests/test_new.py
@@ -31,7 +31,7 @@ def test_new(repo: OnyoRepo, directory: str) -> None:
     Test that `onyo new` can create an asset in different directories.
     """
     file_ = f'{directory}/laptop_apple_macbookpro.0'
-    ret = subprocess.run(['onyo', '--yes', 'new', '--path', directory, '--keys'] + asset_spec,
+    ret = subprocess.run(['onyo', '--yes', 'new', '--directory', directory, '--keys'] + asset_spec,
                          capture_output=True, text=True)
 
     # verify correct output
@@ -53,7 +53,7 @@ def test_new_interactive(repo: OnyoRepo) -> None:
     'y' as input in the dialog, instead of using the flag '--yes'.
     """
     file_ = f'{directories[0]}/laptop_apple_macbookpro.0'
-    ret = subprocess.run(['onyo', 'new', '--path', directories[0], '--keys'] + asset_spec,
+    ret = subprocess.run(['onyo', 'new', '--directory', directories[0], '--keys'] + asset_spec,
                          input='y', capture_output=True, text=True)
 
     # verify correct output
@@ -72,7 +72,7 @@ def test_new_interactive(repo: OnyoRepo) -> None:
 def test_new_top_level(repo: OnyoRepo) -> None:
     """
     Test that `onyo new` can create an asset on the top level of
-    the repository. This relies on CWD being the default for `--path`
+    the repository. This relies on CWD being the default for `--directory`
     and on the `repo` fixture CD'ing into the repo's root dir.
     """
     file_ = 'laptop_apple_macbookpro.0'
@@ -94,7 +94,7 @@ def test_new_top_level(repo: OnyoRepo) -> None:
 @pytest.mark.repo_dirs(*directories)
 def test_new_sub_dir_absolute_path(repo: OnyoRepo) -> None:
     """
-    Test that `onyo new --path <path>` can create an asset in sub-directories of
+    Test that `onyo new --directory <path>` can create an asset in sub-directories of
     the repository while the cwd is inside a different sub-directory.
     """
     # Change cwd to sub-directory
@@ -105,7 +105,7 @@ def test_new_sub_dir_absolute_path(repo: OnyoRepo) -> None:
     subdir = repo.git.root / "just another path"
     file_ = subdir / "laptop_apple_macbookpro.0"
 
-    ret = subprocess.run(['onyo', '--yes', 'new', '--path', subdir, '--keys'] + asset_spec,
+    ret = subprocess.run(['onyo', '--yes', 'new', '--directory', subdir, '--keys'] + asset_spec,
                          capture_output=True, text=True)
 
     # verify correct output
@@ -122,7 +122,7 @@ def test_new_sub_dir_absolute_path(repo: OnyoRepo) -> None:
 @pytest.mark.repo_dirs(*directories)
 def test_new_sub_dir_relative_path(repo: OnyoRepo) -> None:
     """
-    Test that `onyo new --path <path>` can create an asset in sub-directories of
+    Test that `onyo new --directory <path>` can create an asset in sub-directories of
     the repository while the cwd is inside a different sub-directory with a
     relative path.
     """
@@ -136,7 +136,7 @@ def test_new_sub_dir_relative_path(repo: OnyoRepo) -> None:
     # build a path for the new asset as a relative path
     subdir = Path(var) / "just another path"
 
-    ret = subprocess.run(['onyo', '--yes', 'new', '--path', subdir, '--keys'] + asset_spec,
+    ret = subprocess.run(['onyo', '--yes', 'new', '--directory', subdir, '--keys'] + asset_spec,
                          capture_output=True, text=True)
 
     # verify correct output
@@ -159,7 +159,7 @@ def test_folder_creation_with_new(repo: OnyoRepo, directory: str) -> None:
     existing dir 'overlap'.
     """
     asset = f"{directory}/laptop_apple_macbookpro.0"
-    ret = subprocess.run(['onyo', '--yes', 'new', '--path', directory, '--keys'] + asset_spec,
+    ret = subprocess.run(['onyo', '--yes', 'new', '--directory', directory, '--keys'] + asset_spec,
                          capture_output=True, text=True)
 
     # verify correct output
@@ -181,7 +181,7 @@ def test_with_faux_serial_number(repo: OnyoRepo) -> None:
     Test that `onyo new` can create multiple assets with faux serial numbers in
     multiple directories at once. To specify several assets, at least one key-value-pair
     has to be given multiple times. This test also needs to use the 'directory'
-    (reserved) key instead of `--path` in order to specify the directory per asset.
+    (reserved) key instead of `--directory` in order to specify the directory per asset.
     """
     filename_prefix = "laptop_apple_macbookpro.faux"  # created asset files are expected to be this plus a random suffix
 
@@ -238,7 +238,7 @@ def test_yes_flag(repo: OnyoRepo, directory: str) -> None:
     Test that `onyo new --yes` creates assets in different directories.
     """
     asset = f'{directory}/laptop_apple_macbookpro.0'
-    ret = subprocess.run(['onyo', '--yes', 'new', '--path', directory, '--keys'] + asset_spec,
+    ret = subprocess.run(['onyo', '--yes', 'new', '--directory', directory, '--keys'] + asset_spec,
                          capture_output=True, text=True)
 
     # verify correct output
@@ -269,7 +269,7 @@ def test_keys_flag(repo: OnyoRepo, directory: str) -> None:
 
     # create asset with --keys
     ret = subprocess.run(
-        ['onyo', '--yes', 'new', '--path', directory, '--keys', key_values] + asset_spec,
+        ['onyo', '--yes', 'new', '--directory', directory, '--keys', key_values] + asset_spec,
         capture_output=True, text=True)
 
     # verify output
@@ -293,7 +293,7 @@ def test_new_message_flag(repo: OnyoRepo, directory: str) -> None:
     msg = "I am here to test the --message flag with spe\"cial\\char\'acteஞrs!"
 
     asset = f'{directory}/laptop_apple_macbookpro.0'
-    ret = subprocess.run(['onyo', '--yes', 'new', '--message', msg, '--path', directory, '--keys'] + asset_spec,
+    ret = subprocess.run(['onyo', '--yes', 'new', '--message', msg, '--directory', directory, '--keys'] + asset_spec,
                          capture_output=True, text=True)
     assert ret.returncode == 0
     assert not ret.stderr
@@ -311,7 +311,7 @@ def test_discard_changes(repo: OnyoRepo, directory: str) -> None:
     Test that `onyo new` can discard new assets and the repository stays clean.
     """
     asset = f'{directory}/laptop_apple_macbookpro.0'
-    ret = subprocess.run(['onyo', 'new', '--path', directory, '--keys'] + asset_spec,
+    ret = subprocess.run(['onyo', 'new', '--directory', directory, '--keys'] + asset_spec,
                          input='n', capture_output=True, text=True)
 
     # verify correct output
@@ -344,7 +344,7 @@ def test_new_protected_folder(repo: OnyoRepo, protected_folder: str) -> None:
     instead of creating an asset.
     """
     asset = f"{protected_folder}/laptop_apple_macbookpro.0"
-    ret = subprocess.run(['onyo', 'new', '--path', protected_folder, '--keys'] + asset_spec,
+    ret = subprocess.run(['onyo', 'new', '--directory', protected_folder, '--keys'] + asset_spec,
                          capture_output=True, text=True)
     assert ret.returncode == 1
     assert not ret.stdout
@@ -369,7 +369,7 @@ def test_new_with_flags_edit_keys_template(repo: OnyoRepo, directory: str) -> No
 
     # create asset with --edit, --template and --keys
     ret = subprocess.run(['onyo', '--yes', 'new', '--edit',
-                          '--template', template, '--path', directory, '--keys'] + key_values,
+                          '--template', template, '--directory', directory, '--keys'] + key_values,
                          capture_output=True, text=True)
 
     # verify output
@@ -405,7 +405,7 @@ def test_new_with_keys_overwrite_template(repo: OnyoRepo, directory: str) -> Non
 
     # create asset with --template and --keys
     ret = subprocess.run(['onyo', '--yes', 'new', '--template', template,
-                          '--path', directory, '--keys'] + key_values,
+                          '--directory', directory, '--keys'] + key_values,
                          capture_output=True, text=True)
 
     # verify output
@@ -442,7 +442,7 @@ def test_with_special_characters(
     asset = f'{directory}/{variant[0]}_{variant[1]}_{variant[2]}.{variant[3]}'
     keys = [f"type={variant[0]}", f"make={variant[1]}",
             f"model={variant[2]}", f"serial={variant[3]}"]
-    ret = subprocess.run(['onyo', '--yes', 'new', '--path', directory, '--keys'] + keys,
+    ret = subprocess.run(['onyo', '--yes', 'new', '--directory', directory, '--keys'] + keys,
                          capture_output=True, text=True)
 
     # verify correct output
@@ -464,7 +464,7 @@ def test_error_asset_exists_already(repo: OnyoRepo, directory: str) -> None:
     an asset name that already exists elsewhere in the directory.
     """
     asset = f"{directory}/laptop_apple_macbookpro.0"
-    ret = subprocess.run(['onyo', 'new', '--path', directory, '--keys'] + asset_spec,
+    ret = subprocess.run(['onyo', 'new', '--directory', directory, '--keys'] + asset_spec,
                          capture_output=True, text=True)
 
     # verify correct error
@@ -659,10 +659,10 @@ def test_conflicting_and_missing_arguments(repo: OnyoRepo) -> None:
 
     # error if `onyo new` is called with TSV and assets in CLI
     ret = subprocess.run(['onyo', 'new', "--tsv", table_path,
-                          '--path', 'simple/laptop_apple_macbookpro.0'],
+                          '--directory', 'simple/laptop_apple_macbookpro.0'],
                          capture_output=True, text=True)
     assert not ret.stdout
-    assert "Can\'t use \'--path\' option and \'directory\' column in tsv." in ret.stderr
+    assert "Can\'t use \'--directory\' option and \'directory\' column in tsv." in ret.stderr
     assert ret.returncode == 1
 
     # error if both `--template` and 'template' column in tsv header are given

--- a/onyo/commands/tests/test_set.py
+++ b/onyo/commands/tests/test_set.py
@@ -55,7 +55,7 @@ def test_set(repo: OnyoRepo,
              asset: str,
              set_values: list[str]) -> None:
     """Test that `onyo set KEY=VALUE <asset>` updates contents of assets."""
-    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', *set_values, '--path', asset],
+    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', *set_values, '--asset', asset],
                          capture_output=True, text=True)
 
     # verify output
@@ -77,7 +77,7 @@ def test_set_interactive(repo: OnyoRepo,
                          asset: str,
                          set_values: list[str]) -> None:
     """Test that `onyo set KEY=VALUE <asset>` updates contents of assets."""
-    ret = subprocess.run(['onyo', 'set', '--keys', *set_values, '--path', asset],
+    ret = subprocess.run(['onyo', 'set', '--keys', *set_values, '--asset', asset],
                          input='y', capture_output=True, text=True)
 
     # verify output
@@ -101,7 +101,7 @@ def test_set_multiple_assets(repo: OnyoRepo,
     assets in a single call.
     """
     ret = subprocess.run(['onyo', '--yes', 'set', '--keys', *set_values,
-                          '--path', *asset_paths],
+                          '--asset', *asset_paths],
                          capture_output=True, text=True)
 
     # verify output
@@ -127,7 +127,7 @@ def test_set_error_non_existing_assets(repo: OnyoRepo,
     - one non-existing asset in a list of existing ones
     """
     ret = subprocess.run(['onyo', 'set', '--keys', 'key=value',
-                          '--path', *no_assets], capture_output=True, text=True)
+                          '--asset', *no_assets], capture_output=True, text=True)
 
     # verify output and the state of the repository
     assert not ret.stdout
@@ -157,7 +157,7 @@ def test_set_discard_changes_single_assets(repo: OnyoRepo,
                                            asset: str,
                                            set_values: list[str]) -> None:
     """Test that `onyo set` discards changes for assets successfully."""
-    ret = subprocess.run(['onyo', 'set', '--keys', *set_values, '--path', asset],
+    ret = subprocess.run(['onyo', 'set', '--keys', *set_values, '--asset', asset],
                          input='n',
                          capture_output=True, text=True)
 
@@ -187,7 +187,7 @@ def test_set_message_flag(repo: OnyoRepo,
     """
     msg = "I am here to test the --message flag with spe\"cial\\char\'acteஞrs!"
     ret = subprocess.run(['onyo', '--yes', 'set', '--message', msg,
-                          '--keys', *set_values, '--path', asset],
+                          '--keys', *set_values, '--asset', asset],
                          capture_output=True, text=True)
     assert ret.returncode == 0
     assert not ret.stderr
@@ -206,7 +206,7 @@ def test_add_new_key_to_existing_content(repo: OnyoRepo,
     different `KEY`, and adds it without overwriting existing values.
     """
     set_1 = "change=one"
-    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', set_1, '--path', asset],
+    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', set_1, '--asset', asset],
                          capture_output=True, text=True)
 
     # verify output
@@ -219,7 +219,7 @@ def test_add_new_key_to_existing_content(repo: OnyoRepo,
 
     # call again and add a different KEY, without overwriting existing contents
     set_2 = "different=key"
-    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', set_2, '--path', asset],
+    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', set_2, '--asset', asset],
                          capture_output=True, text=True)
 
     # verify output
@@ -249,7 +249,7 @@ def test_set_overwrite_key(repo: OnyoRepo,
     different VALUE for the same KEY, and overwrites existing values correctly.
     """
     set_value = "value=original"
-    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', set_value, '--path', asset],
+    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', set_value, '--asset', asset],
                          capture_output=True, text=True)
 
     # verify output
@@ -262,7 +262,7 @@ def test_set_overwrite_key(repo: OnyoRepo,
 
     # call again with same key, but different value
     set_value_2 = "value=updated"
-    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', set_value_2, '--path', asset],
+    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', set_value_2, '--asset', asset],
                          capture_output=True, text=True)
 
     # verify output
@@ -288,7 +288,7 @@ def test_setting_new_values_if_some_values_already_set(repo: OnyoRepo,
     the correct output if called multiple times, and that the output is correct.
     """
     set_values = "change=one"
-    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', set_values, '--path', asset],
+    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', set_values, '--asset', asset],
                          capture_output=True, text=True)
 
     # verify output
@@ -301,7 +301,7 @@ def test_setting_new_values_if_some_values_already_set(repo: OnyoRepo,
     # call with two values, one of which is already set and should not appear
     # again in the output.
     set_values = ["change=one", "different=key"]
-    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', *set_values, '--path', asset],
+    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', *set_values, '--asset', asset],
                          capture_output=True, text=True)
 
     # verify output
@@ -336,7 +336,7 @@ def test_values_already_set(repo: OnyoRepo,
     """
 
     ret = subprocess.run(['onyo', '--yes', 'set', '--keys', *set_values,
-                          '--path', asset],
+                          '--asset', asset],
                          capture_output=True, text=True)
 
     # verify output
@@ -348,7 +348,7 @@ def test_values_already_set(repo: OnyoRepo,
     assert ret.returncode == 0
 
     # call `onyo set` again with the same values
-    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', *set_values, '--path', asset],
+    ret = subprocess.run(['onyo', '--yes', 'set', '--keys', *set_values, '--asset', asset],
                          capture_output=True, text=True)
 
     # verify second output
@@ -374,7 +374,7 @@ def test_set_update_name_fields(repo: OnyoRepo,
     with a list of content fields.
     """
     ret = subprocess.run(['onyo', '--yes', 'set', '--rename', '--keys', *set_values,
-                          '--path', asset], capture_output=True, text=True)
+                          '--asset', asset], capture_output=True, text=True)
 
     # verify output
     assert "The following assets will be changed:" in ret.stdout
@@ -396,7 +396,7 @@ def test_update_many_faux_serial_numbers(repo: OnyoRepo) -> None:
     # remember old assets before renaming
     old_asset_names = repo.asset_paths
     ret = subprocess.run(['onyo', '--yes', 'set', '--rename', '--keys',
-                          'serial=faux', '--path', *asset_paths], capture_output=True, text=True)
+                          'serial=faux', '--asset', *asset_paths], capture_output=True, text=True)
 
     # verify output
     assert "The following assets will be changed:" in ret.stdout
@@ -429,7 +429,7 @@ def test_duplicate_keys(repo: OnyoRepo,
     """Test that `onyo set` fails, if the same key is given multiple times."""
 
     ret = subprocess.run(['onyo', '--yes', 'set', '--keys',
-                          *set_values, 'dup_key=1', 'dup_key=2', '--path', asset],
+                          *set_values, 'dup_key=1', 'dup_key=2', '--asset', asset],
                          capture_output=True, text=True)
 
     # verify output

--- a/onyo/commands/tests/test_unset.py
+++ b/onyo/commands/tests/test_unset.py
@@ -112,7 +112,7 @@ def test_unset(repo: OnyoRepo,
                asset: str,
                key: str) -> None:
     """Test that `onyo unset KEY <asset>` removes keys from of assets."""
-    ret = subprocess.run(['onyo', '--yes', 'unset', '--keys', key, '--path', asset],
+    ret = subprocess.run(['onyo', '--yes', 'unset', '--keys', key, '--asset', asset],
                          capture_output=True, text=True)
 
     # verify output
@@ -134,7 +134,7 @@ def test_unset_interactive(repo: OnyoRepo,
                            asset: str,
                            key: str) -> None:
     """Test that `onyo unset KEY <asset>` removes keys from of assets."""
-    ret = subprocess.run(['onyo', 'unset', '--keys', key, '--path', asset], input='y',
+    ret = subprocess.run(['onyo', 'unset', '--keys', key, '--asset', asset], input='y',
                          capture_output=True, text=True)
 
     # verify output
@@ -154,12 +154,12 @@ def test_unset_interactive(repo: OnyoRepo,
 @pytest.mark.parametrize('asset', [t[0] for t in asset_contents if "num" not in t[1]])
 def test_unset_key_does_not_exist(repo: OnyoRepo,
                                   asset: str) -> None:
-    """Test that `onyo unset --keys KEY --path ASSET` does not error when one of the KEYs does not
+    """Test that `onyo unset --keys KEY --asset ASSET` does not error when one of the KEYs does not
     exist."""
     no_key = "non_existing"
 
     # test un-setting a non-existing key from an empty file
-    ret = subprocess.run(['onyo', '--yes', 'unset', '--keys', no_key, '--path', asset],
+    ret = subprocess.run(['onyo', '--yes', 'unset', '--keys', no_key, '--asset', asset],
                          capture_output=True, text=True)
 
     # verify reaction of onyo
@@ -173,11 +173,11 @@ def test_unset_key_does_not_exist(repo: OnyoRepo,
 @pytest.mark.parametrize('key', ['num'])
 def test_unset_multiple_assets(repo: OnyoRepo,
                                key: str) -> None:
-    """Test that `onyo unset --keys KEY --path ASSET [ASSET2 ...]` removes keys from of assets."""
+    """Test that `onyo unset --keys KEY --asset ASSET [ASSET2 ...]` removes keys from of assets."""
     assets = repo.get_asset_paths()
 
     # test unsetting keys for multiple assets:
-    ret = subprocess.run(['onyo', '--yes', 'unset', '--keys', key, '--path', *assets],
+    ret = subprocess.run(['onyo', '--yes', 'unset', '--keys', key, '--asset', *assets],
                          capture_output=True, text=True)
 
     # verify output
@@ -202,8 +202,8 @@ def test_unset_multiple_assets(repo: OnyoRepo,
 def test_unset_error_non_existing_assets(repo: OnyoRepo,
                                          no_assets: list[str],
                                          key: str) -> None:
-    """Test that `onyo unset --keys KEY --path ASSET` errors correctly for non-existing assets."""
-    ret = subprocess.run(['onyo', 'unset', '--keys', key, '--path', *no_assets],
+    """Test that `onyo unset --keys KEY --asset ASSET` errors correctly for non-existing assets."""
+    ret = subprocess.run(['onyo', 'unset', '--keys', key, '--asset', *no_assets],
                          capture_output=True, text=True)
 
     # verify output
@@ -235,7 +235,7 @@ def test_unset_discard_changes_single_assets(repo: OnyoRepo,
                                              key: str) -> None:
     """Test that `onyo unset` discards changes for assets successfully."""
     # do an `onyo unset`, but answer "n" to discard the changes done by unset
-    ret = subprocess.run(['onyo', 'unset', '--keys', key, '--path', asset], input='n',
+    ret = subprocess.run(['onyo', 'unset', '--keys', key, '--asset', asset], input='n',
                          capture_output=True, text=True)
 
     assert f"-{key}" in ret.stdout
@@ -258,7 +258,7 @@ def test_unset_message_flag(repo: OnyoRepo,
     by the user containing different special characters."""
     msg = "I am here to test the --message flag with spe\"cial\\char\'acteஞrs!"
     ret = subprocess.run(['onyo', '--yes', 'unset', '--message', msg, '--keys', key,
-                          '--path', asset],
+                          '--asset', asset],
                          capture_output=True, text=True)
     assert ret.returncode == 0
     assert not ret.stderr
@@ -285,7 +285,7 @@ def test_unset_error_unset_name_fields(repo: OnyoRepo,
     """
     asset = 'laptop_apple_macbookpro.1'
     ret = subprocess.run(['onyo', '--yes', 'unset', '--keys', *name_field,
-                          '--path', asset],
+                          '--asset', asset],
                          capture_output=True, text=True)
 
     # verify output

--- a/onyo/commands/tree.py
+++ b/onyo/commands/tree.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from onyo import OnyoRepo
-from onyo.argparse_helpers import directory
 from onyo.lib.commands import onyo_tree
 from onyo.lib.inventory import Inventory
 
@@ -15,7 +14,6 @@ args_tree = {
     'directory': dict(
         metavar='DIR',
         nargs='*',
-        type=directory,
         help='Directories to list'
     )
 }

--- a/onyo/commands/unset.py
+++ b/onyo/commands/unset.py
@@ -25,10 +25,10 @@ args_unset = {
         """
     ),
 
-    'path': dict(
-        args=('-p', '--path'),
+    'asset': dict(
+        args=('-a', '--asset'),
         required=True,
-        metavar="PATH",
+        metavar="ASSET",
         nargs='+',
         type=path,
         help="""
@@ -53,8 +53,8 @@ def unset(args: argparse.Namespace) -> None:
     """
 
     inventory = Inventory(repo=OnyoRepo(Path.cwd(), find_root=True))
-    paths = [Path(p).resolve() for p in args.path]
+    assets = [Path(a).resolve() for a in args.asset]
     unset_cmd(inventory,
               keys=args.keys,
-              paths=paths,
+              assets=assets,
               message='\n\n'.join(m for m in args.message) if args.message else None)

--- a/onyo/commands/unset.py
+++ b/onyo/commands/unset.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from onyo import OnyoRepo
-from onyo.argparse_helpers import path
 from onyo.lib.commands import onyo_unset as unset_cmd
 from onyo.lib.inventory import Inventory
 from onyo.shared_arguments import shared_arg_message
@@ -30,7 +29,6 @@ args_unset = {
         required=True,
         metavar="ASSET",
         nargs='+',
-        type=path,
         help="""
             Assets to unset **KEY**s in.
         """

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -1077,7 +1077,7 @@ def onyo_tree(inventory: Inventory,
 @raise_on_inventory_state
 def onyo_unset(inventory: Inventory,
                keys: list[str],
-               paths: list[Path],
+               assets: list[Path],
                message: Optional[str] = None) -> None:
     """Remove keys from assets.
 
@@ -1090,7 +1090,7 @@ def onyo_unset(inventory: Inventory,
         If keys do not exist in an asset, a debug message is logged.
         If keys are specified which appear in asset names an error is raised.
         If `keys` is empty an error is raised.
-    paths: list of Path
+    assets: list of Path
         Paths to assets for which to unset key-value pairs.
     message: str, optional
         An optional string to overwrite Onyo's default commit message.
@@ -1098,12 +1098,12 @@ def onyo_unset(inventory: Inventory,
     Raises
     ------
     ValueError
-        If paths are invalid, or `keys` are empty or invalid.
+        If assets are invalid paths, or `keys` are empty or invalid.
 
     """
     if not keys:
         raise ValueError("At least one key must be specified.")
-    non_asset_paths = [str(p) for p in paths if not inventory.repo.is_asset_path(p)]
+    non_asset_paths = [str(a) for a in assets if not inventory.repo.is_asset_path(a)]
     if non_asset_paths:
         raise ValueError("The following paths aren't assets:\n%s" % "\n".join(non_asset_paths))
     if any(k in inventory.repo.get_asset_name_keys() for k in keys):
@@ -1111,7 +1111,7 @@ def onyo_unset(inventory: Inventory,
     if any(k in RESERVED_KEYS + PSEUDO_KEYS for k in keys):
         raise ValueError(f"Can't unset reserved or pseudo keys ({', '.join(RESERVED_KEYS + PSEUDO_KEYS)}).")
 
-    for asset in [inventory.get_asset(p) for p in paths]:
+    for asset in [inventory.get_asset(a) for a in assets]:
         new_content = copy.deepcopy(asset)
         # remove keys to unset, if they exist
         for key in keys:

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -957,7 +957,7 @@ def onyo_rm(inventory: Inventory,
 @raise_on_inventory_state
 def onyo_set(inventory: Inventory,
              keys: Dict[str, str | int | float],
-             paths: list[Path],
+             assets: list[Path],
              rename: bool = False,
              message: Optional[str] = None) -> Optional[str]:
     """Set key-value pairs of assets, and change asset names.
@@ -966,7 +966,7 @@ def onyo_set(inventory: Inventory,
     ----------
     inventory: Inventory
         The Inventory in which to set key/values for assets.
-    paths: list of Path
+    assets: list of Path
         Paths to assets for which to set key-value pairs.
     keys: dict
         Key-value pairs that will be set in assets. If keys already exist in an
@@ -988,7 +988,7 @@ def onyo_set(inventory: Inventory,
         If a given path is invalid or changes are made that would result in
         renaming an asset, while `rename` is not true, or if `keys` is empty.
     """
-    if not paths:
+    if not assets:
         raise ValueError("At least one asset must be specified.")
     if not keys:
         raise ValueError("At least one key-value pair must be specified.")
@@ -1003,12 +1003,12 @@ def onyo_set(inventory: Inventory,
     if any(k in disallowed_keys for k in keys.keys()):
         raise ValueError(f"Can't set any of the keys ({', '.join(disallowed_keys)}).")
 
-    non_asset_paths = [str(p) for p in paths if not inventory.repo.is_asset_path(p)]
+    non_asset_paths = [str(a) for a in assets if not inventory.repo.is_asset_path(a)]
     if non_asset_paths:
         raise ValueError("The following paths aren't assets:\n%s" %
                          "\n".join(non_asset_paths))
 
-    for asset in [inventory.get_asset(p) for p in paths]:
+    for asset in [inventory.get_asset(a) for a in assets]:
         new_content = copy.deepcopy(asset)
         new_content.update(keys)
         for k in PSEUDO_KEYS:

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -682,7 +682,7 @@ def onyo_mv(inventory: Inventory,
 
 @raise_on_inventory_state
 def onyo_new(inventory: Inventory,
-             path: Optional[Path] = None,
+             directory: Optional[Path] = None,
              template: Optional[str] = None,
              clone: Optional[Path] = None,
              tsv: Optional[Path] = None,
@@ -695,7 +695,7 @@ def onyo_new(inventory: Inventory,
     If keys and tsv and keys define multiple assets: Number of assets must match.
     If only one value pair key: Update tsv assets with them.
     If `keys` and tsv conflict: raise, there's no priority overwriting or something.
-    --path and `directory` reserved key given -> raise, no priority
+    --directory and `directory` reserved key given -> raise, no priority
     pseudo-keys must not be given -> PSEUDO_KEYS
 
     TODO: Document special keys (directory, asset dir, template, etc) -> RESERVED_KEYS
@@ -717,7 +717,7 @@ def onyo_new(inventory: Inventory,
     inventory: Inventory
         The Inventory in which to create new assets.
 
-    path: Path, optional
+    directory: Path, optional
         The directory to create new asset(s) in. Defaults to CWD.
         Note, that it technically is not a default (as per signature of this
         function), because we need to be able to tell whether a path was given
@@ -779,8 +779,8 @@ def onyo_new(inventory: Inventory,
                 raise ValueError("Can't use '--template' option and 'template' column in tsv.")
             if clone and 'template' in reader.fieldnames:
                 raise ValueError("Can't use '--clone' option and 'template' column in tsv.")
-            if path and 'directory' in reader.fieldnames:
-                raise ValueError("Can't use '--path' option and 'directory' column in tsv.")
+            if directory and 'directory' in reader.fieldnames:
+                raise ValueError("Can't use '--directory' option and 'directory' column in tsv.")
             tsv_dicts = [row for row in reader]
             # Any line's remainder (values beyond available columns) would be stored in the `None` key.
             # Note, that `i` is shifted by one in order to give the correct line number (header line + index of dict):
@@ -816,11 +816,11 @@ def onyo_new(inventory: Inventory,
     #       where everything after the first one comes from repetition (However, what about python interface where one
     #       could pass an arbitrary list of dicts? -> requires consistency check like TSV + doc).
     if any('directory' in d.keys() for d in specs):
-        if path:
-            raise ValueError("Can't use '--path' option and specify 'directory' key.")
+        if directory:
+            raise ValueError("Can't use '--directory' option and specify 'directory' key.")
     else:
         # default
-        path = path or Path.cwd()
+        directory = directory or Path.cwd()
     if template and any('template' in d.keys() for d in specs):
         raise ValueError("Can't use 'template' key and 'template' option.")
     if clone and any('template' in d.keys() for d in specs):
@@ -839,7 +839,7 @@ def onyo_new(inventory: Inventory,
 
     for spec in specs:
         # 1. Unify directory specification
-        directory = Path(spec.get('directory', path))
+        directory = Path(spec.get('directory', directory))
         if not directory.is_absolute():
             directory = inventory.root / directory
         spec['directory'] = directory

--- a/onyo/lib/tests/test_commands_new.py
+++ b/onyo/lib/tests/test_commands_new.py
@@ -65,7 +65,7 @@ def test_onyo_new_keys(inventory: Inventory) -> None:
               'serial': '003'}]
     old_hexsha = inventory.repo.git.get_hexsha()
     onyo_new(inventory,
-             path=inventory.root / "empty",
+             directory=inventory.root / "empty",
              keys=specs)  # pyre-ignore[6] How is that not fitting `List[Dict[str, int | float | str]]`?
     # exactly one commit added
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
@@ -89,13 +89,13 @@ def test_onyo_new_keys(inventory: Inventory) -> None:
               'model': 'serial',
               'directory': 'completely/elsewhere',
               'serial': 'faux'}]
-    # 'directory' is in conflict with `path` being given:
+    # 'directory' is in conflict with `directory` being given:
     pytest.raises(ValueError,
                   onyo_new,
                   inventory,
-                  path=inventory.root / "empty",
+                  directory=inventory.root / "empty",
                   keys=specs)
-    # w/o `path` everything is fine:
+    # w/o `directory` everything is fine:
     onyo_new(inventory,
              keys=specs)  # pyre-ignore[6] How is that not fitting `List[Dict[str, int | float | str]]`?
     # another commit added
@@ -124,7 +124,7 @@ def test_onyo_new_keys(inventory: Inventory) -> None:
     specs = [{'somekey': 'somevalue'}]
     pytest.raises(ValueError, onyo_new, inventory, keys=specs)
 
-    # use templates and `path`'s default - CWD.
+    # use templates and `directory`'s default - CWD.
     # Attention: CWD being inventory.root relies on current implementation of
     # the repo fixture, which the inventory fixture builds upon.
     specs = [{'type': 'flavor',
@@ -150,7 +150,7 @@ def test_onyo_new_keys(inventory: Inventory) -> None:
 @pytest.mark.ui({'yes': True})
 def test_onyo_new_creates_directories(inventory: Inventory) -> None:
     """`onyo_new()` must create new directories and subdirectories when called
-    on a `path` that does not yet exist, and add assets correctly to it.
+    on a `directory` that does not yet exist, and add assets correctly to it.
     """
     specs = [{'type': 'a type',
               'make': 'I made it',
@@ -164,7 +164,7 @@ def test_onyo_new_creates_directories(inventory: Inventory) -> None:
     old_hexsha = inventory.repo.git.get_hexsha()
 
     onyo_new(inventory,
-             path=new_directory,
+             directory=new_directory,
              keys=specs)  # pyre-ignore[6] How is that not fitting `List[Dict[str, int | float | str]]`?
 
     # exactly one commit added
@@ -198,7 +198,7 @@ def test_onyo_new_edit(inventory: Inventory, monkeypatch) -> None:
               'serial': 'totally_random'}]
     onyo_new(inventory,
              keys=specs,  # pyre-ignore[6] How is that not fitting `List[Dict[str, int | float | str]]`?
-             path=directory,
+             directory=directory,
              edit=True)
     expected_path = directory / "TYPE_MAKER_MODEL.totally_random"
     assert inventory.repo.is_asset_path(expected_path)
@@ -214,7 +214,7 @@ def test_onyo_new_edit(inventory: Inventory, monkeypatch) -> None:
     # document is "{}" not "". Hence, appending would lead to a
     # YAML parser error.
     monkeypatch.setenv('EDITOR', "printf 'key: value' >")
-    pytest.raises(ValueError, onyo_new, inventory, keys=specs, path=directory, edit=True)
+    pytest.raises(ValueError, onyo_new, inventory, keys=specs, directory=directory, edit=True)
 
     # file already exists:
     edit_str = f"model: MODEL{os.linesep}make: MAKER{os.linesep}type: TYPE{os.linesep}"
@@ -222,13 +222,13 @@ def test_onyo_new_edit(inventory: Inventory, monkeypatch) -> None:
     specs = [{'template': 'empty',
               'serial': 'totally_random'}]
 
-    pytest.raises(ValueError, onyo_new, inventory, keys=specs, path=directory, edit=True)
+    pytest.raises(ValueError, onyo_new, inventory, keys=specs, directory=directory, edit=True)
 
     # asset already exists (but elsewhere - see fixture):
     edit_str = f"model: MODEL{os.linesep}make: MAKER{os.linesep}type: TYPE{os.linesep}serial: SERIAL{os.linesep}"
     monkeypatch.setenv('EDITOR', f"printf '{edit_str}' >>")
     specs = [{'template': 'empty'}]
-    pytest.raises(ValueError, onyo_new, inventory, keys=specs, path=directory, edit=True)
+    pytest.raises(ValueError, onyo_new, inventory, keys=specs, directory=directory, edit=True)
     assert inventory.repo.git.is_clean_worktree()
 
 
@@ -243,7 +243,7 @@ def test_onyo_new_clones(inventory: Inventory) -> None:
              keys=[{'serial': 'ANOTHER'},
                    {'serial': 'whatever'}],
              clone=existing_asset_path,
-             path=asset_dir)
+             directory=asset_dir)
 
     # exactly one commit added
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha

--- a/onyo/lib/tests/test_commands_set.py
+++ b/onyo/lib/tests/test_commands_set.py
@@ -17,7 +17,7 @@ def test_onyo_set_errors(inventory: Inventory) -> None:
     pytest.raises(ValueError,
                   onyo_set,
                   inventory,
-                  paths=[inventory.root / "not-existing" / "TYPE_MAKER_MODEL.SERIAL"],
+                  assets=[inventory.root / "not-existing" / "TYPE_MAKER_MODEL.SERIAL"],
                   keys=key_value,
                   message="some subject\n\nAnd a body")
 
@@ -25,7 +25,7 @@ def test_onyo_set_errors(inventory: Inventory) -> None:
     pytest.raises(ValueError,
                   onyo_set,
                   inventory,
-                  paths=[inventory.root / "somewhere"],
+                  assets=[inventory.root / "somewhere"],
                   keys=key_value,
                   message="some subject\n\nAnd a body")
 
@@ -33,7 +33,7 @@ def test_onyo_set_errors(inventory: Inventory) -> None:
     pytest.raises(ValueError,
                   onyo_set,
                   inventory,
-                  paths=[(inventory.root / "..").resolve()],
+                  assets=[(inventory.root / "..").resolve()],
                   keys=key_value,
                   message="some subject\n\nAnd a body")
 
@@ -41,7 +41,7 @@ def test_onyo_set_errors(inventory: Inventory) -> None:
     pytest.raises(ValueError,
                   onyo_set,
                   inventory,
-                  paths=[asset_path],
+                  assets=[asset_path],
                   keys=[],
                   message="some subject\n\nAnd a body")
 
@@ -49,7 +49,7 @@ def test_onyo_set_errors(inventory: Inventory) -> None:
     pytest.raises(ValueError,
                   onyo_set,
                   inventory,
-                  paths=[inventory.root / "somewhere" / OnyoRepo.ANCHOR_FILE_NAME],
+                  assets=[inventory.root / "somewhere" / OnyoRepo.ANCHOR_FILE_NAME],
                   keys=key_value,
                   message="some subject\n\nAnd a body")
 
@@ -57,7 +57,7 @@ def test_onyo_set_errors(inventory: Inventory) -> None:
     pytest.raises(ValueError,
                   onyo_set,
                   inventory,
-                  paths=[inventory.root / ".git"],
+                  assets=[inventory.root / ".git"],
                   keys=key_value,
                   message="some subject\n\nAnd a body")
 
@@ -65,7 +65,7 @@ def test_onyo_set_errors(inventory: Inventory) -> None:
     pytest.raises(ValueError,
                   onyo_set,
                   inventory,
-                  paths=[inventory.root / ".onyo"],
+                  assets=[inventory.root / ".onyo"],
                   keys=key_value,
                   message="some subject\n\nAnd a body")
 
@@ -90,7 +90,7 @@ def test_onyo_set_empty_keys_or_values(inventory: Inventory) -> None:
         pytest.raises(ValueError,
                       onyo_set,
                       inventory,
-                      paths=[asset_path],
+                      assets=[asset_path],
                       keys=empty,
                       message="some subject\n\nAnd a body")
 
@@ -99,7 +99,7 @@ def test_onyo_set_empty_keys_or_values(inventory: Inventory) -> None:
 
     # set a key with an empty value works
     onyo_set(inventory,
-             paths=[asset_path],
+             assets=[asset_path],
              keys={"key": ""},
              message="some subject\n\nAnd a body")
 
@@ -128,7 +128,7 @@ def test_onyo_set_illegal_fields(inventory: Inventory) -> None:
         pytest.raises(ValueError,
                       onyo_set,
                       inventory,
-                      paths=[asset_path],
+                      assets=[asset_path],
                       keys=illegal,
                       message="some subject\n\nAnd a body")
 
@@ -153,8 +153,8 @@ def test_onyo_set_errors_before_set(inventory: Inventory) -> None:
     pytest.raises(ValueError,
                   onyo_set,
                   inventory,
-                  paths=[asset_path,
-                         non_existing_asset_path],
+                  assets=[asset_path,
+                          non_existing_asset_path],
                   keys=key_value,
                   message="some subject\n\nAnd a body")
 
@@ -175,7 +175,7 @@ def test_onyo_set_simple(inventory: Inventory) -> None:
 
     # set a value in an asset
     onyo_set(inventory,
-             paths=[asset_path],
+             assets=[asset_path],
              keys=key_value,  # pyre-ignore[6]
              message="some subject\n\nAnd a body")
 
@@ -202,7 +202,7 @@ def test_onyo_set_already_set(inventory: Inventory) -> None:
 
     # set a value in an asset
     onyo_set(inventory,
-             paths=[asset_path],
+             assets=[asset_path],
              keys=key_value,  # pyre-ignore[6]
              message="some subject\n\nAnd a body")
 
@@ -229,7 +229,7 @@ def test_onyo_set_overwrite_existing_value(inventory: Inventory) -> None:
 
     # set a value in an asset
     onyo_set(inventory,
-             paths=[asset_path],
+             assets=[asset_path],
              keys=new_key_value,  # pyre-ignore[6]
              message="some subject\n\nAnd a body")
 
@@ -263,7 +263,7 @@ def test_onyo_set_some_values_already_set(inventory: Inventory) -> None:
 
     # set a value in an asset
     onyo_set(inventory,
-             paths=[asset_path],
+             assets=[asset_path],
              keys=new_key_values,  # pyre-ignore[6]
              message="some subject\n\nAnd a body")
 
@@ -290,8 +290,8 @@ def test_onyo_set_multiple(inventory: Inventory) -> None:
 
     # set a value in multiple assets at once
     onyo_set(inventory,
-             paths=[asset_path1,
-                    asset_path2],
+             assets=[asset_path1,
+                     asset_path2],
              keys=key_value,  # pyre-ignore[6]
              message="some subject\n\nAnd a body")
 
@@ -316,7 +316,7 @@ def test_onyo_set_allows_duplicates(inventory: Inventory) -> None:
 
     # call `onyo_set()` with `paths` containing duplicates
     onyo_set(inventory,
-             paths=[asset_path, asset_path, asset_path],
+             assets=[asset_path, asset_path, asset_path],
              keys=key_value,  # pyre-ignore[6]
              message="some subject\n\nAnd a body")
 
@@ -346,7 +346,7 @@ def test_onyo_set_asset_dir(inventory: Inventory) -> None:
 
     # set a value in an asset dir
     onyo_set(inventory,
-             paths=[asset_dir],
+             assets=[asset_dir],
              keys={'other': 2})
     assert inventory.repo.git.is_clean_worktree()
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
@@ -354,7 +354,7 @@ def test_onyo_set_asset_dir(inventory: Inventory) -> None:
 
     # turn asset dir into asset file:
     onyo_set(inventory,
-             paths=[asset_dir],
+             assets=[asset_dir],
              keys={'is_asset_directory': False})
     assert inventory.repo.git.is_clean_worktree()
     assert inventory.repo.git.get_hexsha('HEAD~2') == old_hexsha
@@ -364,7 +364,7 @@ def test_onyo_set_asset_dir(inventory: Inventory) -> None:
 
     # turn it back into an asset dir
     onyo_set(inventory,
-             paths=[asset_dir],
+             assets=[asset_dir],
              keys={'is_asset_directory': True})
     assert inventory.repo.git.is_clean_worktree()
     assert inventory.repo.git.get_hexsha('HEAD~3') == old_hexsha

--- a/onyo/lib/tests/test_commands_unset.py
+++ b/onyo/lib/tests/test_commands_unset.py
@@ -15,7 +15,7 @@ def test_onyo_unset_errors(inventory: Inventory) -> None:
     pytest.raises(ValueError,
                   onyo_unset,
                   inventory,
-                  paths=[inventory.root / "not-existing" / "TYPE_MAKER_MODEL.SERIAL"],
+                  assets=[inventory.root / "not-existing" / "TYPE_MAKER_MODEL.SERIAL"],
                   keys=[key],
                   message="some subject\n\nAnd a body")
 
@@ -23,7 +23,7 @@ def test_onyo_unset_errors(inventory: Inventory) -> None:
     pytest.raises(ValueError,
                   onyo_unset,
                   inventory,
-                  paths=[(inventory.root / "..").resolve()],
+                  assets=[(inventory.root / "..").resolve()],
                   keys=[key],
                   message="some subject\n\nAnd a body")
 
@@ -31,7 +31,7 @@ def test_onyo_unset_errors(inventory: Inventory) -> None:
     pytest.raises(ValueError,
                   onyo_unset,
                   inventory,
-                  paths=[asset_path],
+                  assets=[asset_path],
                   keys=[],
                   message="some subject\n\nAnd a body")
 
@@ -39,7 +39,7 @@ def test_onyo_unset_errors(inventory: Inventory) -> None:
     pytest.raises(ValueError,
                   onyo_unset,
                   inventory,
-                  paths=[inventory.root / "somewhere" / OnyoRepo.ANCHOR_FILE_NAME],
+                  assets=[inventory.root / "somewhere" / OnyoRepo.ANCHOR_FILE_NAME],
                   keys=[key],
                   message="some subject\n\nAnd a body")
 
@@ -47,7 +47,7 @@ def test_onyo_unset_errors(inventory: Inventory) -> None:
     pytest.raises(ValueError,
                   onyo_unset,
                   inventory,
-                  paths=[inventory.root / ".git"],
+                  assets=[inventory.root / ".git"],
                   keys=[key],
                   message="some subject\n\nAnd a body")
 
@@ -55,7 +55,7 @@ def test_onyo_unset_errors(inventory: Inventory) -> None:
     pytest.raises(ValueError,
                   onyo_unset,
                   inventory,
-                  paths=[inventory.root / ".onyo"],
+                  assets=[inventory.root / ".onyo"],
                   keys=[key],
                   message="some subject\n\nAnd a body")
 
@@ -79,7 +79,7 @@ def test_onyo_unset_name_fields_error(inventory: Inventory) -> None:
         pytest.raises(ValueError,
                       onyo_unset,
                       inventory,
-                      paths=[asset_path],
+                      assets=[asset_path],
                       keys=[illegal],
                       message="some subject\n\nAnd a body")
         # name fields are still in the asset
@@ -105,7 +105,7 @@ def test_onyo_unset_illegal_fields(inventory: Inventory) -> None:
         pytest.raises(ValueError,
                       onyo_unset,
                       inventory,
-                      paths=[asset_path],
+                      assets=[asset_path],
                       keys=[illegal],
                       message="some subject\n\nAnd a body")
 
@@ -128,8 +128,8 @@ def test_onyo_unset_errors_before_unset(inventory: Inventory) -> None:
     pytest.raises(ValueError,
                   onyo_unset,
                   inventory,
-                  paths=[asset_path,
-                         non_existing_asset_path],
+                  assets=[asset_path,
+                          non_existing_asset_path],
                   keys=[key],
                   message="some subject\n\nAnd a body")
 
@@ -155,7 +155,7 @@ def test_onyo_unset_simple(inventory: Inventory) -> None:
 
     # unset a value
     onyo_unset(inventory,
-               paths=[asset_path],
+               assets=[asset_path],
                keys=[key],
                message="some subject\n\nAnd a body")
 
@@ -183,8 +183,8 @@ def test_onyo_unset_multiple(inventory: Inventory) -> None:
 
     # create a new directory
     onyo_unset(inventory,
-               paths=[asset_path1,
-                      asset_path2],
+               assets=[asset_path1,
+                       asset_path2],
                keys=[key],
                message="some subject\n\nAnd a body")
 
@@ -207,7 +207,7 @@ def test_onyo_unset_allows_asset_duplicates(inventory: Inventory) -> None:
 
     # call `onyo_unset()` with asset duplicates
     onyo_unset(inventory,
-               paths=[asset_path, asset_path, asset_path],
+               assets=[asset_path, asset_path, asset_path],
                keys=[key],
                message="some subject\n\nAnd a body")
 
@@ -232,7 +232,7 @@ def test_onyo_unset_non_existing_keys(inventory: Inventory) -> None:
     # trying to remove a non-existing key in an asset that does not exist does not error
     assert other_key not in inventory.repo.get_asset_content(asset_path1).keys()
     onyo_unset(inventory,
-               paths=[asset_path1],
+               assets=[asset_path1],
                keys=[other_key],
                message="some subject\n\nAnd a body")
 
@@ -243,8 +243,8 @@ def test_onyo_unset_non_existing_keys(inventory: Inventory) -> None:
     assert other_key not in inventory.repo.get_asset_content(asset_path1).keys()
     assert other_key in inventory.repo.get_asset_content(asset_path2).keys()
     onyo_unset(inventory,
-               paths=[asset_path1,
-                      asset_path2],
+               assets=[asset_path1,
+                       asset_path2],
                keys=[other_key],
                message="some subject\n\nAnd a body")
 
@@ -265,7 +265,7 @@ def test_onyo_unset_allows_key_duplicates(inventory: Inventory) -> None:
 
     # call `onyo_unset()` with key duplicates
     onyo_unset(inventory,
-               paths=[asset_path],
+               assets=[asset_path],
                keys=[key, key, key],
                message="some subject\n\nAnd a body")
 
@@ -293,7 +293,7 @@ def test_onyo_unset_asset_dir(inventory: Inventory) -> None:
 
     # set a value in an asset dir
     onyo_unset(inventory,
-               paths=[asset_dir],
+               assets=[asset_dir],
                keys=['other', 'some_key'])
     assert inventory.repo.git.is_clean_worktree()
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha

--- a/onyo/onyo_arguments.py
+++ b/onyo/onyo_arguments.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 from onyo._version import __version__
-from onyo.argparse_helpers import directory
 
 args_onyo = {
     'opdir': dict(
@@ -9,7 +8,6 @@ args_onyo = {
         metavar='DIR',
         required=False,
         default=Path.cwd(),
-        type=directory,
         help="""
             Run Onyo from **DIR** instead of the current working directory.
         """

--- a/onyo/shell_completion/zsh/_onyo
+++ b/onyo/shell_completion/zsh/_onyo
@@ -163,7 +163,7 @@ _onyo() {
                 args+=(
                     '(- : *)'{-h,--help}'[show this help message and exit]'
                     '(-k --keys)'{-k,--keys}'[keys to unset in assets; multiple keys can be given (key key2 key3)]:*-*:KEYS: '
-                    '(-p --path)'{-p,--path}'[assets and/or directories to unset values in]:*-*::PATH:_files -W "$(_onyo_dir)"'
+                    '(-a --asset)'{-a,--asset}'[assets to unset values in]:*-*::ASSET:_files -W "$(_onyo_dir)"'
                     '(-m --message)'{-m,--message}'[use the given MESSAGE as the commit message]:MESSAGE: '
                 )
                 ;;

--- a/onyo/shell_completion/zsh/_onyo
+++ b/onyo/shell_completion/zsh/_onyo
@@ -124,7 +124,7 @@ _onyo() {
                     '(-c --clone -t --template)'{-c,--clone}'[asset path to clone from]:CLONE:_files -W "$(_onyo_dir)"'
                     '(-e --edit)'{-e,--edit}'[open new assets in an editor before creation]'
                     '(-k --keys)'{-k,--keys}'[key-value pairs to set in the new assets]:*-*:KEYS: '
-                    '(-p --path)'{-p,--path}'[directory to create new assets in]:PATH:_files -W "$(_onyo_dir)" -/'
+                    '(-d --directory)'{-d,--directory}'[directory to create new assets in]:DIRECTORY:_files -W "$(_onyo_dir)" -/'
                     '(-tsv --tsv)'{-tsv,--tsv}'[path to a TSV file describing the new assets]:TSV:_files -W "$(_onyo_dir)"'
                     '(-m --message)'{-m,--message}'[use the given MESSAGE as the commit message]:MESSAGE: '
                 )

--- a/onyo/shell_completion/zsh/_onyo
+++ b/onyo/shell_completion/zsh/_onyo
@@ -143,7 +143,7 @@ _onyo() {
                     '(- : *)'{-h,--help}'[show this help message and exit]'
                     '(-r --rename)'{-r,--rename}'[allow assigning values to keys that would result in renaming asset filenames]'
                     '(-k --keys)'{-k,--keys}'[key-value pairs to set in assets; multiple pairs can be given (key=value key2=value2)]:*-*:KEYS: '
-                    '(-p --path)'{-p,--path}'[assets and/or directories to set KEY=VALUE in]:*-*::PATH:_files -W "$(_onyo_dir)"'
+                    '(-a --asset)'{-a,--asset}'[assets to set KEY=VALUE in]:*-*::ASSET:_files -W "$(_onyo_dir)"'
                     '(-m --message)'{-m,--message}'[use the given MESSAGE as the commit message]:MESSAGE: '
                 )
                 ;;

--- a/onyo/tests/test_usecases.py
+++ b/onyo/tests/test_usecases.py
@@ -65,7 +65,7 @@ def test_workflow_cli(repo: OnyoRepo) -> None:
 
     # 2d. Assign newly purchased laptop to user
     laptop = member / "lenovo_thinkpad_laptop.123"
-    cmd = ['onyo', '--yes', 'new', '-p', str(member), '-m', "New purchase: ThinkPad",
+    cmd = ['onyo', '--yes', 'new', '--directory', str(member), '--message', "New purchase: ThinkPad",
            '--keys', 'memory=8GB', 'model=laptop', 'type=lenovo', 'make=thinkpad', 'serial=123']
     ret = subprocess.run(cmd, capture_output=True, text=True)
     assert ret.returncode == 0
@@ -75,7 +75,7 @@ def test_workflow_cli(repo: OnyoRepo) -> None:
     ret = subprocess.run(cmd, capture_output=True, text=True)
     assert ret.returncode == 0
 
-    cmd = ['onyo', '--yes', 'new', '-p', str(member), '-m', "New purchase: ThinkPad",
+    cmd = ['onyo', '--yes', 'new', '--directory', str(member), '--message', "New purchase: ThinkPad",
            '--keys', 'RAM=8GB', 'build-date=20160310', 'type=laptop', 'make=lenovo', 'model=thinkpad', 'serial=SN123Z']
     ret = subprocess.run(cmd, capture_output=True, text=True)
     assert ret.returncode == 0

--- a/onyo/tests/test_usecases.py
+++ b/onyo/tests/test_usecases.py
@@ -88,7 +88,7 @@ def test_workflow_cli(repo: OnyoRepo) -> None:
     laptop = Path(ret.stdout.splitlines()[0].split('\t')[-1].strip("\""))
 
     # 3b. Set the inventory number
-    cmd = ['onyo', '--yes', 'set', '-k', 'fzj_inventory=123A4', '-p', str(laptop)]
+    cmd = ['onyo', '--yes', 'set', '--keys', 'fzj_inventory=123A4', '--asset', str(laptop)]
     ret = subprocess.run(cmd, capture_output=True, text=True)
     assert ret.returncode == 0
 
@@ -115,7 +115,7 @@ def test_workflow_cli(repo: OnyoRepo) -> None:
     assert ret.returncode == 0
     laptop = Path(ret.stdout.splitlines()[0].split('\t')[-1].strip("\""))
     # 5b. Change recorded RAM size
-    cmd = ['onyo', '--yes', 'set', '-k', 'RAM=16GB', '-p', str(laptop)]
+    cmd = ['onyo', '--yes', 'set', '--keys', 'RAM=16GB', '--asset', str(laptop)]
     ret = subprocess.run(cmd, capture_output=True, text=True)
     assert ret.returncode == 0
 


### PR DESCRIPTION
These commands each used `--path`:
- `new`: -> `--path` (now matches the `directory` pseudo key)
- `set`: -> `--asset` (only operates on assets as of #557)
- `unset` -> `--asset` (only operates on assets as of #557)

This PR also:
- Removes no-op "types" from argparse that we were using to expose information to the tab completion script generation. That's all static now, so these are unused.
- Converts many short opts to long opts in the tests. They may the text more readable and thus self-documenting..