### PR TITLE
BF: `onyo get` fixes

### DIFF
--- a/onyo/commands/get.py
+++ b/onyo/commands/get.py
@@ -93,9 +93,9 @@ def get(args: argparse.Namespace) -> None:
     """
     Return values of the requested **KEY**\s for matching assets.
 
-    If no **KEY**\s are given, all keys in the asset name are printed (see
-    ``onyo.assets.filename``). If no **PATH**\s are given, the current working
-    directory is used.
+    If no **KEY**\s are given, the path and all keys in the asset name are
+    printed (see ``onyo.assets.filename``). If no **PATH**\s are given, the
+    current working directory is used.
 
     In addition to keys in asset contents, **PSEUDO-KEYS** can be queried and
     matched.

--- a/onyo/commands/get.py
+++ b/onyo/commands/get.py
@@ -101,7 +101,8 @@ def get(args: argparse.Namespace) -> None:
     matched.
 
       * ``is_asset_directory``: is the asset an Asset Directory
-      * ``path``: path of the asset from repo root
+      * ``directory``: parent directory of the asset relative to repo root
+      * ``path``: path of the asset relative to repo root
 
     By default, the results are sorted by ``path``.
     """

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -481,7 +481,7 @@ def onyo_get(inventory: Inventory,
             box=box.HORIZONTALS, title='', show_header=True,
             header_style='bold')
         for key in selected_keys:
-            table.add_column(key, no_wrap=True)
+            table.add_column(key, overflow='fold')
         for data in results:
             values = [str(data[k]) for k in selected_keys]
             table.add_row(*values)

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -417,8 +417,8 @@ def onyo_get(inventory: Inventory,
       this list.
     keys: list of str, optional
       Defines what key-value pairs of an asset a result is composed of.
-      If no `keys` are given the keys then the asset name keys are
-      used. The 'path' pseudo-key is always appended.
+      If no `keys` are given the keys then the asset name keys and
+      `path` are used.
       Keys may be repeated.
     sort: str
       How to sort the results by `keys`. Possible values are
@@ -453,7 +453,7 @@ def onyo_get(inventory: Inventory,
     if sort not in allowed_sorting:
         raise ValueError(f"Allowed sorting modes: {', '.join(allowed_sorting)}")
 
-    selected_keys = selected_keys or inventory.repo.get_asset_name_keys()
+    selected_keys = selected_keys or inventory.repo.get_asset_name_keys() + ['path']
     results = inventory.get_assets_by_query(paths=paths,
                                             depth=depth,
                                             match=match)
@@ -468,10 +468,6 @@ def onyo_get(inventory: Inventory,
         keys=selected_keys if keys else ['path'],
         reverse=sort == 'descending')
 
-    # for now, always include path to match previous behavior:
-    # TODO: Should we hardcode 'path' here?
-    if 'path' not in selected_keys:
-        selected_keys.append('path')
     # filter output for `keys` only
     results = [{k: v for k, v in r.items() if k in selected_keys} for r in results]
 

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -604,6 +604,7 @@ class OnyoRepo(object):
             a['is_asset_directory'] = False
         # Add pseudo-keys:
         a['path'] = path
+        a['directory'] = path.parent
         return a
 
     def write_asset_content(self,

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -601,6 +601,7 @@ class OnyoRepo(object):
             a['is_asset_directory'] = True
         else:
             a = yaml_to_dict(path)
+            a['is_asset_directory'] = False
         # Add pseudo-keys:
         a['path'] = path
         return a

--- a/onyo/lib/tests/test_commands_get.py
+++ b/onyo/lib/tests/test_commands_get.py
@@ -66,7 +66,7 @@ def test_onyo_get_empty_keys(inventory: Inventory,
     assert missing_key not in Path.read_text(asset_path1)
     onyo_get(inventory,
              paths=[asset_path1],
-             keys=[missing_key])
+             keys=[missing_key, "path"])
 
     # verify output
     output1 = capsys.readouterr().out
@@ -77,7 +77,7 @@ def test_onyo_get_empty_keys(inventory: Inventory,
     assert empty_key in Path.read_text(asset_path2)
     onyo_get(inventory,
              paths=[asset_path2],
-             keys=[empty_key])
+             keys=[empty_key, "path"])
 
     # verify output
     output2 = capsys.readouterr().out
@@ -106,11 +106,15 @@ def test_onyo_get_reserved_keys(inventory: Inventory,
 
     # get on reserved fields
     for reserved_key in reserved:
-        onyo_get(inventory, keys=[reserved_key])
-        # verify output
-        output = capsys.readouterr().out
-        assert asset_path.name in output
-        assert reserved_key in output
+        keys = [reserved_key]
+        if reserved_key != "path":
+            keys.append("path")
+        # verify that the key is in the header
+        onyo_get(inventory, keys=keys)
+        assert reserved_key in capsys.readouterr().out
+        # verify asset is returned
+        onyo_get(inventory, keys=keys, machine_readable=True)
+        assert asset_path.name in capsys.readouterr().out
 
 
 @pytest.mark.ui({'yes': True})
@@ -158,7 +162,7 @@ def test_onyo_get_simple(inventory: Inventory,
     # get a value in an asset
     onyo_get(inventory,
              paths=[asset_path],
-             keys=[get_key])
+             keys=[get_key, "path"])
 
     # verify output
     output = capsys.readouterr().out
@@ -177,14 +181,14 @@ def test_onyo_get_machine_readable(inventory: Inventory,
     # call `onyo_get()` without machine readable mode
     onyo_get(inventory,
              paths=[asset_path],
-             keys=[get_key])
+             keys=[get_key, "path"])
 
     standard_output = capsys.readouterr().out
 
     # call `onyo_get()` in machine readable mode
     onyo_get(inventory,
              paths=[asset_path],
-             keys=[get_key],
+             keys=[get_key, "path"],
              machine_readable=True)
 
     # verify output contains the correct information but is different from normal mode
@@ -209,13 +213,13 @@ def test_onyo_get_sorting(inventory: Inventory,
     # call `onyo_get()` with sort=ascending
     onyo_get(inventory,
              sort="ascending",
-             keys=[get_key])
+             keys=[get_key, "path"])
     ascending_output = capsys.readouterr().out
 
     # call `onyo_get()` with sort=descending
     onyo_get(inventory,
              sort="descending",
-             keys=[get_key])
+             keys=[get_key, "path"])
     descending_output = capsys.readouterr().out
 
     # verify output contains the correct information but is different depending on sorting
@@ -232,7 +236,7 @@ def test_onyo_get_sorting(inventory: Inventory,
                   onyo_get,
                   inventory,
                   sort="ILLEGAL",
-                  keys=[get_key])
+                  keys=[get_key, "path"])
 
 
 @pytest.mark.ui({'yes': True})
@@ -246,7 +250,7 @@ def test_onyo_get_on_directory(inventory: Inventory,
     # call `onyo_get()` on a directory
     onyo_get(inventory,
              paths=[dir_path],
-             keys=[get_key])
+             keys=[get_key, "path"])
 
     # verify output contains the asset inside the directory
     output = capsys.readouterr().out
@@ -273,7 +277,7 @@ def test_onyo_get_match(inventory: Inventory,
     onyo_get(inventory,
              paths=[asset_path1, asset_path2],
              match=matches,  # pyre-ignore[6]
-             keys=[get_key])
+             keys=[get_key, "path"])
 
     # verify output contains just information for matching assets
     output = capsys.readouterr().out
@@ -318,7 +322,7 @@ def test_onyo_get_multiple(inventory: Inventory,
     onyo_get(inventory,
              paths=[asset_path1,
                     asset_path2],
-             keys=[get_key])
+             keys=[get_key, "path"])
 
     # verify output contains all assets and "path" as default key
     output = capsys.readouterr().out

--- a/onyo/lib/tests/test_commands_get.py
+++ b/onyo/lib/tests/test_commands_get.py
@@ -415,5 +415,13 @@ def test_onyo_get_asset_dir(inventory: Inventory,
                         )
     asset_dir = inventory.root / "TYPE_MAKER_MODEL.SERIAL2"
     inventory.commit("add an asset dir")
-    onyo_get(inventory, match=[Filter("other=1").match])
-    assert str(asset_dir.relative_to(inventory.root)) in capsys.readouterr().out
+    onyo_get(inventory, match=[Filter("other=1").match], keys=["path", "is_asset_directory"])
+    output = capsys.readouterr().out
+    assert str(asset_dir.relative_to(inventory.root)) in output
+    assert str(True) in output
+
+
+def test_onyo_get_is_asset_dir(inventory: Inventory,
+                               capsys) -> None:
+    onyo_get(inventory, keys=["path", "is_asset_directory"])
+    assert str(False) in capsys.readouterr().out

--- a/onyo/lib/tests/test_commands_new.py
+++ b/onyo/lib/tests/test_commands_new.py
@@ -113,8 +113,7 @@ def test_onyo_new_keys(inventory: Inventory) -> None:
         assert files[0] in inventory.repo.git.files
         new_asset = inventory.get_asset(files[0])
         assert new_asset.get("path") == files[0]
-        # reserved key 'directory' is not part of the asset's content
-        assert 'directory' not in new_asset.keys()
+        assert new_asset.get("directory") == files[0].parent
         # content equals spec:
         assert all(new_asset[k] == s[k]
                    for k in s.keys()
@@ -254,16 +253,16 @@ def test_onyo_new_clones(inventory: Inventory) -> None:
     new_asset_path1 = asset_dir / f"{existing_asset_path.name.split('.')[0]}.ANOTHER"
     assert inventory.repo.is_asset_path(new_asset_path1)
     new_asset = inventory.get_asset(new_asset_path1)
-    # equals existing asset except for path and serial:
-    assert all(v == new_asset[k] for k, v in existing_asset.items() if k not in ['serial', 'path'])
+    # equals existing asset except for directory, path, and serial:
+    assert all(v == new_asset[k] for k, v in existing_asset.items() if k not in ['directory', 'path', 'serial'])
     assert new_asset['serial'] == 'ANOTHER'
 
     # second new asset
     new_asset_path2 = asset_dir / f"{existing_asset_path.name.split('.')[0]}.whatever"
     assert inventory.repo.is_asset_path(new_asset_path2)
     new_asset = inventory.get_asset(new_asset_path2)
-    # equals existing asset except for path and serial:
-    assert all(v == new_asset[k] for k, v in existing_asset.items() if k not in ['serial', 'path'])
+    # equals existing asset except for directory, path, and serial:
+    assert all(v == new_asset[k] for k, v in existing_asset.items() if k not in ['directory', 'path', 'serial'])
     assert new_asset['serial'] == 'whatever'
     assert inventory.repo.git.is_clean_worktree()
 

--- a/onyo/lib/tests/test_inventory_operations.py
+++ b/onyo/lib/tests/test_inventory_operations.py
@@ -80,7 +80,9 @@ def test_add_asset(repo: OnyoRepo) -> None:
     assert repo.is_asset_path(asset_file)
     asset_from_disc = repo.get_asset_content(asset_file)
     assert asset_file == asset_from_disc.pop('path')
-    assert asset_from_disc == {k: v for k, v in asset.items() if k not in RESERVED_KEYS + PSEUDO_KEYS}
+    for k, v in asset.items():
+        if k not in RESERVED_KEYS + PSEUDO_KEYS:
+            assert asset_from_disc[k] == v
     # TODO: check commit message
 
     # required keys must not be empty
@@ -260,7 +262,9 @@ def test_modify_asset(repo: OnyoRepo) -> None:
     assert not new_asset_file.exists()
     asset_on_disc = repo.get_asset_content(asset_file)
     assert asset_file == asset_on_disc.pop('path')
-    assert asset_on_disc == {k: v for k, v in asset.items() if k not in RESERVED_KEYS + PSEUDO_KEYS}
+    for k, v in asset.items():
+        if k not in RESERVED_KEYS + PSEUDO_KEYS:
+            assert asset_on_disc[k] == v
 
     # TODO: diff
 
@@ -270,6 +274,7 @@ def test_modify_asset(repo: OnyoRepo) -> None:
     assert repo.is_asset_path(new_asset_file)
     expected_asset = {k: v for k, v in new_asset.items() if k not in RESERVED_KEYS}
     expected_asset['path'] = new_asset_file
+    expected_asset['is_asset_directory'] = False
     assert repo.get_asset_content(new_asset_file) == expected_asset
 
 

--- a/onyo/lib/tests/test_inventory_operations.py
+++ b/onyo/lib/tests/test_inventory_operations.py
@@ -274,6 +274,7 @@ def test_modify_asset(repo: OnyoRepo) -> None:
     assert repo.is_asset_path(new_asset_file)
     expected_asset = {k: v for k, v in new_asset.items() if k not in RESERVED_KEYS}
     expected_asset['path'] = new_asset_file
+    expected_asset['directory'] = new_asset_file.parent
     expected_asset['is_asset_directory'] = False
     assert repo.get_asset_content(new_asset_file) == expected_asset
 
@@ -762,7 +763,8 @@ def test_modify_asset_dir(repo: OnyoRepo) -> None:
                   serial="SERIAL",
                   other=1,
                   is_asset_directory=True,
-                  path=asset_path
+                  path=asset_path,
+                  directory=asset_path.parent
                   )
     inventory.add_asset(asset)
     inventory.commit("asset dir added")

--- a/onyo/tests/test_usecases.py
+++ b/onyo/tests/test_usecases.py
@@ -188,7 +188,7 @@ def test_workflow_cli(repo: OnyoRepo) -> None:
     # TODO: Not directly possible via CLI at the moment. Best I can think of is
     # `onyo get --machine-readable --match type=laptop --keys build-date -s | grep -v retired | grep -v unset`
     # and do the date comparison in a loop over its output.
-    cmd = ['onyo', 'get', '--machine-readable', '--match', 'type=laptop', '--keys', 'build-date']
+    cmd = ['onyo', 'get', '--machine-readable', '--match', 'type=laptop', '--keys', 'build-date', 'path']
     ret = subprocess.run(cmd, capture_output=True, text=True)
     assert ret.returncode == 0
     results = []


### PR DESCRIPTION
This PR fixes the following bugs:

- #579 
- #583
- #578
- #592

As a brief digression... the test `test_onyo_get_reserved_keys()` ended up running into bug #583. Printing `path` twice exceeded the 80 char limit that Rich detects when running in a virtual TTY.

I looked into how to increase the faux-terminal width, but I could not find a reasonable way. [This rich bug](https://github.com/Textualize/rich/issues/317) was infuriatingly closed with no explanation, and the rich docs make no mention of `capsys`, and only `pytest` once...

Other suggestions involve [monkey patching `Popen`](https://stackoverflow.com/questions/60272369/pytest-monkeypatch-terminal-size), but it wasn't clear to me the right way to mock this through fixtures.

And at that point... I decided that if we don't want output to be interfered with, then we should use `machine-readable=True`. 