### PR TITLE
BF/DOC: unify syntax of `OnyoRepo` and `GitRepo` `.clear_cache()`

### DIFF
--- a/onyo/commands/tests/test_set.py
+++ b/onyo/commands/tests/test_set.py
@@ -407,7 +407,7 @@ def test_update_many_faux_serial_numbers(repo: OnyoRepo) -> None:
     # this does not work when called in set.py or onyo.py, because this test
     # function still has its own repo object, which does not get updated when
     # calling `onyo set` with subprocess.run()
-    repo.clear_caches()
+    repo.clear_cache()
 
     # verify that the name fields were not added to the contents and the names
     # are actually new

--- a/onyo/lib/git.py
+++ b/onyo/lib/git.py
@@ -21,8 +21,6 @@ class GitRepo(object):
       The absolute path to the root of the git worktree.
     files: list of Path
       A property containing the absolute paths to all files tracked by git.
-      This property is cached. Usage of private or external functions might
-      require a manual reset via `GitRepo.get_subtree.cache_clear()`.
     """
 
     def __init__(self,
@@ -103,19 +101,25 @@ class GitRepo(object):
     def files(self) -> list[Path]:
         """Get the absolute `Path`s of all tracked files.
 
-        This property is cached. The cache is reset on `GitRepo.commit()`.
-        If changes are made by different means, `GitRepo.clear_caches()`
-        is available to reset the cache.
+        This property is cached, and is reset automatically on `GitRepo.commit()`.
+
+        If changes are made by different means, use `GitRepo.clear_cache()` to
+        reset the cache.
         """
         if not self._files:
             self._files = self.get_subtrees()
         return self._files
 
     def clear_cache(self) -> None:
-        """Clear the `files` cache of this instance of GitRepo.
+        """Clear cache of this instance of GitRepo.
 
-        Needed if changes to the repository are made by other means
-        than `GitRepo.commit()`
+        Caches cleared are:
+        - `GitRepo.files`
+
+        If the repository is exclusively modified via public API functions, the
+        cache of the `GitRepo` object is consistent. If the repository is
+        modified otherwise, use of this function may be necessary to ensure that
+        the cache does not contain stale information.
         """
         self._files = None
 

--- a/onyo/lib/inventory.py
+++ b/onyo/lib/inventory.py
@@ -114,7 +114,7 @@ OPERATIONS_MAPPING: dict = {'new_directories': InventoryOperator(executor=exec_n
 # TODO: Conflict w/ existing operations?
 #       operations: raise InvalidInventoryOperationError on conflicts with pending operations,
 #       like removing something that is to be created. -> reset() or commit()
-# TODO: clear_caches from within commit? What about operations?
+# TODO: clear_cache from within commit? What about operations?
 class Inventory(object):
     """"""
 

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -35,9 +35,6 @@ class OnyoRepo(object):
 
     asset_paths: list of Path
         The paths to all assets in the Repository.
-        This property is cached and consistent when only the public functions of
-        OnyoRepo are called. Usage of private or external functions might
-        require a manual reset of the cache with `OnyoRepo.clear_caches()`.
     """
 
     ONYO_DIR = Path('.onyo')
@@ -190,31 +187,20 @@ class OnyoRepo(object):
 
         return editor
 
-    def clear_caches(self,
-                     assets: bool = True) -> None:
-        """Clear caches of the instance of the repository object.
+    def clear_cache(self) -> None:
+        """Clear cache of this instance of GitRepo.
 
-        Paths such as files, assets, and directories are cached, and can become
-        stale when the repository contents are modified. This function clears
-        the caches of the properties.
-
-        By default all caches are cleared, and arguments make it possible to
-        specify which caches which should remain set.
+        Caches cleared are:
+        - `OnyoRepo.asset_paths`
+        - `GitRepo.git.clear_cache()`
 
         If the repository is exclusively modified via public API functions, the
-        caches of the `Repo` object are consistent. If the repository is
-        modified otherwise, this function clears the caches to ensure that the
-        caches do not contain stale information.
-
-        Parameters
-        ----------
-        assets: bool
-            An option to deactivate or activate the clearing of the
-            `asset_paths` cache.
+        cache of the `OnyoRepo` object is consistent. If the repository is
+        modified otherwise, use of this function may be necessary to ensure that
+        the cache does not contain stale information.
         """
-        if assets:
-            self._asset_paths = None
-            self.git.clear_cache()
+        self._asset_paths = None
+        self.git.clear_cache()
 
     @staticmethod
     def generate_commit_message(format_string: str,
@@ -270,12 +256,12 @@ class OnyoRepo(object):
 
     @property
     def asset_paths(self) -> list[Path]:
-        """Get the absolute `Path`s of all assets of this
-        repository.
+        """Get the absolute `Path`s of all assets in this repository.
 
-        This property is cached and the cache can be reset via `self.clear_caches()`.
-        Only committed files are considered to be assets, hence an automatic cache
-        invalidation only happens upon `self.commit()`.
+        This property is cached, and is reset automatically on `OnyoRepo.commit()`.
+
+        If changes are made by different means, use `OnyoRepo.clear_cache()` to
+        reset the cache.
         """
         if self._asset_paths is None:
             self._asset_paths = self.get_asset_paths()
@@ -684,8 +670,8 @@ class OnyoRepo(object):
     def commit(self, paths: Iterable[Path] | Path, message: str):
         """Commit changes to the repository.
 
-        This is resetting the cache for `self.asset_paths` and otherwise
-        just a proxy for `GitRepo.commit`.
+        This is resets the cache and is otherwise just a proxy for
+        `GitRepo.commit`.
 
         Parameters
         ----------
@@ -695,4 +681,4 @@ class OnyoRepo(object):
           The git commit message.
         """
         self.git.commit(paths=paths, message=message)
-        self.clear_caches()
+        self.clear_cache()

--- a/onyo/lib/tests/test_commands_rm.py
+++ b/onyo/lib/tests/test_commands_rm.py
@@ -245,7 +245,7 @@ def test_onyo_rm_asset_dir(inventory: Inventory) -> None:
     assert not asset_dir.exists()
 
     inventory.repo.git._git(['reset', '--hard', 'HEAD~1'])
-    inventory.repo.clear_caches()
+    inventory.repo.clear_cache()
     # remove asset aspect only
     onyo_rm(inventory,
             paths=asset_dir,
@@ -258,7 +258,7 @@ def test_onyo_rm_asset_dir(inventory: Inventory) -> None:
     assert not inventory.repo.is_asset_path(asset_dir)
 
     inventory.repo.git._git(['reset', '--hard', 'HEAD~1'])
-    inventory.repo.clear_caches()
+    inventory.repo.clear_cache()
     # remove dir aspect only
     onyo_rm(inventory,
             paths=asset_dir,

--- a/onyo/lib/tests/test_git.py
+++ b/onyo/lib/tests/test_git.py
@@ -87,9 +87,9 @@ def test_GitRepo_find_root(tmp_path: Path) -> None:
         GitRepo.find_root(tmp_path / 'non-existing/directory')
 
 
-def test_GitRepo_clear_caches(gitrepo) -> None:
+def test_GitRepo_clear_cache(gitrepo) -> None:
     """
-    The function `GitRepo.clear_caches()` must allow to empty the cache of the
+    The function `GitRepo.clear_cache()` must allow to empty the cache of the
     GitRepo, so that an invalid cache can be re-loaded by a new call of the
     property.
     """
@@ -107,7 +107,7 @@ def test_GitRepo_clear_caches(gitrepo) -> None:
     assert file in gitrepo.files
     assert not file.exists()
 
-    # test GitRepo.clear_caches() fixes the cache
+    # test GitRepo.clear_cache() fixes the cache
     gitrepo.clear_cache()
     assert file not in gitrepo.files
 

--- a/onyo/lib/tests/test_onyo.py
+++ b/onyo/lib/tests/test_onyo.py
@@ -64,8 +64,8 @@ def test_OnyoRepo_incorrect_input_arguments_raise_error(onyorepo: OnyoRepo,
                                    model="test",
                                    serial=0,
                                    path=Path('a') / 'test' / 'asset_for_test.0'))
-def test_clear_caches(onyorepo) -> None:
-    """The function `OnyoRepo.clear_caches()` must allow to empty the cache of
+def test_clear_cache(onyorepo) -> None:
+    """The function `OnyoRepo.clear_cache()` must allow to empty the cache of
     the OnyoRepo, so that an invalid cache can be re-loaded by a newly call of
     the property.
     """
@@ -85,8 +85,8 @@ def test_clear_caches(onyorepo) -> None:
     onyorepo.git.commit(asset, "asset deleted")
     assert asset in onyorepo.asset_paths
 
-    # clear_caches() fixes the cache:
-    onyorepo.clear_caches(assets=True)
+    # clear_cache() fixes the cache:
+    onyorepo.clear_cache()
     assert asset not in onyorepo.asset_paths
 
 


### PR DESCRIPTION
I noticed these while looking into #322

This unifies the approach, and updates the doc strings.