### PR TITLE
DOC/TST: assorted flake8 and docstring improvements

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,7 +4,5 @@ ignore =
     E501,
     # W504: Line break occurred after a binary operator
     W504,
-    # W605: Invalid escape sequence
-    W605,
 exclude =
     build/

--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,10 @@
 [flake8]
-ignore = E501, W504, W605
-per-file-ignores =
-    tests/*test_*.py:E302
+ignore =
+    # E501: Line too long (82 > 79 characters)
+    E501,
+    # W504: Line break occurred after a binary operator
+    W504,
+    # W605: Invalid escape sequence
+    W605,
 exclude =
     build/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,7 +5,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.12"
   jobs:
     pre_build:
       - make -C docs generate

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,6 +25,9 @@ extensions = [
 ]
 
 typehints_defaults = 'braces'
+autodoc_default_options = {
+    'special-members': '__init__,__call__',
+}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/onyo/argparse_helpers.py
+++ b/onyo/argparse_helpers.py
@@ -61,27 +61,3 @@ class StoreKeyValuePairs(argparse.Action):
                 d[k] = cvt(v)
             results.append(d)
         setattr(namespace, self.dest, results)
-
-
-def parse_key_values(string):
-    r"""
-    Convert a string of key-value pairs to a dictionary.
-
-    The shell interprets the key-value string before it is passed to argparse.
-    As a result, no quotes are passed through, but the chunking follows what the
-    quoting declared.
-
-    Because of the lack of quoting, this function cannot handle a comma in
-    either the key or value.
-    """
-    results = {k: v for k, v in (pair.split('=') for pair in string.split(','))}
-    for k, v in results.items():
-        try:
-            results.update({k: int(v)})
-        except ValueError:
-            try:
-                results.update({k: float(v)})
-            except ValueError:
-                pass
-
-    return results

--- a/onyo/argparse_helpers.py
+++ b/onyo/argparse_helpers.py
@@ -18,7 +18,7 @@ class StoreKeyValuePairs(argparse.Action):
                  namespace: argparse.Namespace,
                  key_values: list[str],
                  option_string: str | None = None) -> None:
-        """Turn a list of 'key=value' pairs into a list of dictionaries
+        r"""Turn a list of 'key=value' pairs into a list of dictionaries
 
         Every key appearing multiple times in `key=value` is applied to a new dictionary every time.
         All keys appearing multiple times, must appear the same number of times (and thereby define the number of dicts
@@ -64,7 +64,7 @@ class StoreKeyValuePairs(argparse.Action):
 
 
 def parse_key_values(string):
-    """
+    r"""
     Convert a string of key-value pairs to a dictionary.
 
     The shell interprets the key-value string before it is passed to argparse.

--- a/onyo/argparse_helpers.py
+++ b/onyo/argparse_helpers.py
@@ -5,11 +5,22 @@ from typing import Sequence
 
 
 class StoreKeyValuePairs(argparse.Action):
+    r"""Store a list of dictionaries of key-value pairs.
+    """
+
     def __init__(self,
                  option_strings: Sequence[str],
                  dest: str,
                  nargs: int | str | None = None,
                  **kwargs) -> None:
+        r"""
+        Parameters
+        ----------
+        option_strings
+        dest
+        nargs
+        **kwargs
+        """
         self._nargs = nargs
         super().__init__(option_strings, dest, nargs=nargs, **kwargs)
 
@@ -18,12 +29,24 @@ class StoreKeyValuePairs(argparse.Action):
                  namespace: argparse.Namespace,
                  key_values: list[str],
                  option_string: str | None = None) -> None:
-        r"""Turn a list of 'key=value' pairs into a list of dictionaries
+        r"""Turn a list of 'KEY=VALUE' pairs into a list of dictionaries.
 
-        Every key appearing multiple times in `key=value` is applied to a new dictionary every time.
-        All keys appearing multiple times, must appear the same number of times (and thereby define the number of dicts
-        to be created). In case of different counts: raise.
-        Every key appearing once in `key_values` will be applied to all dictionaries.
+        Each KEY can be defined either 1 or N times (where N is the number of
+        dictionaries to be created).
+
+        A KEY that is declared once will apply to all dictionaries.
+
+        All KEYs appearing N times must appear the same number of times. If not,
+        a message will print to standard error and the program will exit with
+        status code 2.
+
+        Parameters
+        ----------
+        parser
+        namespace
+        key_values
+            List of strings containing key-value pairs.
+        option_string
         """
 
         for kv in key_values:

--- a/onyo/cli/cat.py
+++ b/onyo/cli/cat.py
@@ -20,7 +20,7 @@ args_cat = {
 
 
 def cat(args: argparse.Namespace) -> None:
-    """
+    r"""
     Print the contents of **ASSET**\ s to the terminal.
 
     If any of the paths are invalid, then no contents are printed and an error

--- a/onyo/cli/cat.py
+++ b/onyo/cli/cat.py
@@ -21,7 +21,7 @@ args_cat = {
 
 def cat(args: argparse.Namespace) -> None:
     """
-    Print the contents of **ASSET**\s to the terminal.
+    Print the contents of **ASSET**\ s to the terminal.
 
     If any of the paths are invalid, then no contents are printed and an error
     is returned.

--- a/onyo/cli/config.py
+++ b/onyo/cli/config.py
@@ -20,7 +20,7 @@ args_config = {
 
 
 def config(args: argparse.Namespace) -> None:
-    """
+    r"""
     Set, query, and unset Onyo repository configuration options.
 
     These options are stored in ``.onyo/config``, which is tracked by git and

--- a/onyo/cli/edit.py
+++ b/onyo/cli/edit.py
@@ -24,9 +24,9 @@ args_edit = {
 
 def edit(args: argparse.Namespace) -> None:
     """
-    Open **ASSET**\s using an editor.
+    Open **ASSET**\ s using an editor.
 
-    When multiple **ASSET**\s are given, they are opened sequentially.
+    When multiple **ASSET**\ s are given, they are opened sequentially.
 
     The editor is selected by (in order):
 
@@ -34,7 +34,7 @@ def edit(args: argparse.Namespace) -> None:
       * ``EDITOR`` environment variable
       * ``nano`` (as a final fallback)
 
-    The contents of all edited **ASSET**\s are checked for validity before
+    The contents of all edited **ASSET**\ s are checked for validity before
     committing. If problems are found, a prompt is offered to either reopen the
     editor or discard the changes.
     """

--- a/onyo/cli/edit.py
+++ b/onyo/cli/edit.py
@@ -23,7 +23,7 @@ args_edit = {
 
 
 def edit(args: argparse.Namespace) -> None:
-    """
+    r"""
     Open **ASSET**\ s using an editor.
 
     When multiple **ASSET**\ s are given, they are opened sequentially.

--- a/onyo/cli/fsck.py
+++ b/onyo/cli/fsck.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 
 def fsck(args: argparse.Namespace) -> None:
-    """
+    r"""
     Run a suite of integrity checks on the Onyo repository and its contents.
 
     By default, the following tests are performed:

--- a/onyo/cli/get.py
+++ b/onyo/cli/get.py
@@ -91,10 +91,10 @@ args_get = {
 
 def get(args: argparse.Namespace) -> None:
     """
-    Return values of the requested **KEY**\s for matching assets.
+    Return values of the requested **KEY**\ s for matching assets.
 
-    If no **KEY**\s are given, the path and all keys in the asset name are
-    printed (see ``onyo.assets.filename``). If no **PATH**\s are given, the
+    If no **KEY**\ s are given, the path and all keys in the asset name are
+    printed (see ``onyo.assets.filename``). If no **PATH**\ s are given, the
     current working directory is used.
 
     In addition to keys in asset contents, **PSEUDO-KEYS** can be queried and

--- a/onyo/cli/get.py
+++ b/onyo/cli/get.py
@@ -18,7 +18,7 @@ args_get = {
         type=int,
         required=False,
         default=0,
-        help="""
+        help=r"""
             Descend up to **DEPTH** levels into the directories specified. A
             depth of **0** descends recursively without limit.
         """
@@ -28,7 +28,7 @@ args_get = {
         args=('-k', '--keys'),
         metavar='KEY',
         nargs='+',
-        help="""
+        help=r"""
             **KEY**s to print the values of. Pseudo-keys (information not stored
             in the asset file) are also available for queries.
         """
@@ -37,7 +37,7 @@ args_get = {
     'machine_readable': dict(
         args=('-H', '--machine-readable'),
         action='store_true',
-        help="""
+        help=r"""
             Useful for scripting. Do not print headers and separate values with
             a single tab instead of variable white space.
         """
@@ -49,7 +49,7 @@ args_get = {
         nargs='+',
         type=str,
         default=None,
-        help="""
+        help=r"""
             Criteria to match assets in the form ``KEY=VALUE``, where **VALUE**
             is a python regular expression. Pseudo-keys such as ``path`` can
             also be used. Special values supported are:
@@ -64,7 +64,7 @@ args_get = {
         args=('-p', '--path'),
         metavar='PATH',
         nargs='+',
-        help="""
+        help=r"""
             Assets or directories to query.
         """
     ),
@@ -73,7 +73,7 @@ args_get = {
         args=('-s', '--sort-ascending'),
         action='store_true',
         default=False,
-        help="""
+        help=r"""
             Sort output in ascending order (excludes ``--sort-descending``).
         """
     ),
@@ -82,7 +82,7 @@ args_get = {
         args=('-S', '--sort-descending'),
         action='store_true',
         default=False,
-        help="""
+        help=r"""
             Sort output in descending order (excludes ``--sort-ascending``).
         """
     ),
@@ -90,7 +90,7 @@ args_get = {
 
 
 def get(args: argparse.Namespace) -> None:
-    """
+    r"""
     Return values of the requested **KEY**\ s for matching assets.
 
     If no **KEY**\ s are given, the path and all keys in the asset name are

--- a/onyo/cli/history.py
+++ b/onyo/cli/history.py
@@ -19,7 +19,7 @@ args_history = {
         required=False,
         default=True,
         action='store_false',
-        help="""
+        help=r"""
             Use the non-interactive tool to display history.
         """
     ),
@@ -27,7 +27,7 @@ args_history = {
     'path': dict(
         metavar='PATH',
         nargs='?',
-        help="""
+        help=r"""
             Path of an asset or directory to display the history of.
         """
     ),
@@ -35,7 +35,7 @@ args_history = {
 
 
 def history(args: argparse.Namespace) -> None:
-    """
+    r"""
     Display the history of **PATH**.
 
     Onyo makes an effort to detect if the TTY is interactive in order to

--- a/onyo/cli/init.py
+++ b/onyo/cli/init.py
@@ -12,7 +12,7 @@ args_init = {
     'directory': dict(
         metavar='DIR',
         nargs='?',
-        help="""
+        help=r"""
             Directory to initialize as an Onyo repository.
         """
     )
@@ -20,7 +20,7 @@ args_init = {
 
 
 def init(args: argparse.Namespace) -> None:
-    """
+    r"""
     Initialize an Onyo repository.
 
     The current working directory will be initialized if neither **DIR** nor the

--- a/onyo/cli/mkdir.py
+++ b/onyo/cli/mkdir.py
@@ -15,7 +15,7 @@ args_mkdir = {
     'directory': dict(
         metavar='DIR',
         nargs='+',
-        help="""
+        help=r"""
             Directories to create; or assets to convert into an Asset Directory.
         """
     ),
@@ -25,7 +25,7 @@ args_mkdir = {
 
 
 def mkdir(args: argparse.Namespace) -> None:
-    """
+    r"""
     Create **DIRECTORY**\ s or convert Asset Files into an Asset Directory.
 
     Intermediate directories are created as needed (i.e. parent and child

--- a/onyo/cli/mkdir.py
+++ b/onyo/cli/mkdir.py
@@ -26,7 +26,7 @@ args_mkdir = {
 
 def mkdir(args: argparse.Namespace) -> None:
     """
-    Create **DIRECTORY**\s or convert Asset Files into an Asset Directory.
+    Create **DIRECTORY**\ s or convert Asset Files into an Asset Directory.
 
     Intermediate directories are created as needed (i.e. parent and child
     directories can be created in one call).

--- a/onyo/cli/mv.py
+++ b/onyo/cli/mv.py
@@ -23,7 +23,7 @@ args_mv = {
     'destination': dict(
         metavar='DEST',
         help="""
-            Destination to move **SOURCE**\s into.
+            Destination to move **SOURCE**\ s into.
         """
     ),
 
@@ -33,11 +33,11 @@ args_mv = {
 
 def mv(args: argparse.Namespace) -> None:
     """
-    Move **SOURCE**\s (assets or directories) into the **DEST** directory, or
+    Move **SOURCE**\ s (assets or directories) into the **DEST** directory, or
     rename a **SOURCE** directory to **DEST**.
 
     If **DEST** is an asset file, it will be converted into an Asset Directory and
-    then the **SOURCE**\s will be moved into it.
+    then the **SOURCE**\ s will be moved into it.
 
     Assets cannot be renamed using ``onyo mv``. Their names are generated from
     keys in their contents. To rename a file, use ``onyo set`` or ``onyo edit``.

--- a/onyo/cli/mv.py
+++ b/onyo/cli/mv.py
@@ -15,14 +15,14 @@ args_mv = {
     'source': dict(
         metavar='SOURCE',
         nargs='+',
-        help="""
+        help=r"""
             Assets and/or directories to move into **DEST**.
         """
     ),
 
     'destination': dict(
         metavar='DEST',
-        help="""
+        help=r"""
             Destination to move **SOURCE**\ s into.
         """
     ),
@@ -32,7 +32,7 @@ args_mv = {
 
 
 def mv(args: argparse.Namespace) -> None:
-    """
+    r"""
     Move **SOURCE**\ s (assets or directories) into the **DEST** directory, or
     rename a **SOURCE** directory to **DEST**.
 

--- a/onyo/cli/new.py
+++ b/onyo/cli/new.py
@@ -102,7 +102,7 @@ args_new = {
 
 def new(args: argparse.Namespace) -> None:
     """
-    Create new **ASSET**\s and populate with **KEY-VALUE** pairs. Destination
+    Create new **ASSET**\ s and populate with **KEY-VALUE** pairs. Destination
     directories are created if they are missing.
 
     Asset contents are populated in a waterfall pattern and can overwrite
@@ -113,7 +113,7 @@ def new(args: argparse.Namespace) -> None:
       3) ``--keys``
       4) ``--edit`` (i.e. manual user input)
 
-    The **KEY**\s that comprise the asset filename are required (configured by
+    The **KEY**\ s that comprise the asset filename are required (configured by
     ``onyo.assets.filename``).
 
     The contents of all new assets are checked for validity before committing.

--- a/onyo/cli/new.py
+++ b/onyo/cli/new.py
@@ -18,7 +18,7 @@ args_new = {
         args=('-c', '--clone'),
         metavar='CLONE',
         required=False,
-        help="""
+        help=r"""
             Path of an asset to clone.
 
             This cannot be used with the ``--template`` flag nor the
@@ -30,7 +30,7 @@ args_new = {
         args=('-t', '--template'),
         metavar='TEMPLATE',
         required=False,
-        help="""
+        help=r"""
             Name of a template to populate the contents of new assets.
 
             This cannot be used with the ``--clone`` flag nor the ``template``
@@ -42,7 +42,7 @@ args_new = {
         args=('-tsv', '--tsv'),
         metavar='TSV',
         required=False,
-        help="""
+        help=r"""
             Path to a **TSV** file describing new assets.
 
             The header declares the key names to be populated. The values to
@@ -56,7 +56,7 @@ args_new = {
         action=StoreKeyValuePairs,
         metavar="KEY",
         nargs='+',
-        help="""
+        help=r"""
             **KEY-VALUE** pairs to populate content of new assets.
 
             Each **KEY** can be defined either 1 or N times (where N is the number
@@ -81,7 +81,7 @@ args_new = {
         required=False,
         default=False,
         action='store_true',
-        help="""
+        help=r"""
             Open new assets in an editor.
         """
     ),
@@ -89,7 +89,7 @@ args_new = {
     'directory': dict(
         args=('-d', '--directory'),
         metavar='DIRECTORY',
-        help="""
+        help=r"""
             Directory to create new assets in.
 
             This cannot be used with the ``directory`` Reserved Key.
@@ -101,7 +101,7 @@ args_new = {
 
 
 def new(args: argparse.Namespace) -> None:
-    """
+    r"""
     Create new **ASSET**\ s and populate with **KEY-VALUE** pairs. Destination
     directories are created if they are missing.
 

--- a/onyo/cli/rm.py
+++ b/onyo/cli/rm.py
@@ -15,7 +15,7 @@ args_rm = {
     'path': dict(
         metavar='PATH',
         nargs='+',
-        help="""
+        help=r"""
             Assets and/or directories to delete.
         """
     ),
@@ -25,7 +25,7 @@ args_rm = {
         required=False,
         default=False,
         action='store_true',
-        help="""
+        help=r"""
             Operate only on assets. Asset Files are removed. Asset Directories
             are converted into normal directories.
 
@@ -38,7 +38,7 @@ args_rm = {
         required=False,
         default=False,
         action='store_true',
-        help="""
+        help=r"""
             Operate only on directories. Directories are removed. Asset
             Directories are converted into Asset Files.
 
@@ -51,7 +51,7 @@ args_rm = {
 
 
 def rm(args: argparse.Namespace) -> None:
-    """
+    r"""
     Delete **ASSET**\ s and/or **DIRECTORY**\ s.
 
     Directories and asset directories are deleted along with their contents.

--- a/onyo/cli/rm.py
+++ b/onyo/cli/rm.py
@@ -52,7 +52,7 @@ args_rm = {
 
 def rm(args: argparse.Namespace) -> None:
     """
-    Delete **ASSET**\s and/or **DIRECTORY**\s.
+    Delete **ASSET**\ s and/or **DIRECTORY**\ s.
 
     Directories and asset directories are deleted along with their contents.
 

--- a/onyo/cli/set.py
+++ b/onyo/cli/set.py
@@ -20,7 +20,7 @@ args_set = {
         required=False,
         default=False,
         action='store_true',
-        help="""
+        help=r"""
             Allow setting **KEY**\ s that are part of the asset name.
             (see the ``onyo.assets.filename`` configuration option)
         """
@@ -32,7 +32,7 @@ args_set = {
         action=StoreKeyValuePairs,
         metavar="KEY",
         nargs='+',
-        help="""
+        help=r"""
             **KEY-VALUE** pairs to set in assets. Multiple pairs can be given
             (e.g. ``key1=value1 key2=value2 key3=value3``).
 
@@ -48,7 +48,7 @@ args_set = {
         required=True,
         metavar='ASSET',
         nargs='+',
-        help="""
+        help=r"""
             Assets to set **KEY-VALUE**\ s in.
         """
     ),
@@ -58,7 +58,7 @@ args_set = {
 
 
 def set(args: argparse.Namespace) -> None:
-    """
+    r"""
     Set **KEY**\ s to **VALUE**\ s for assets.
 
     **KEY** names can be any valid YAML key-name. If a key is not present in an

--- a/onyo/cli/set.py
+++ b/onyo/cli/set.py
@@ -21,7 +21,7 @@ args_set = {
         default=False,
         action='store_true',
         help="""
-            Allow setting **KEY**\s that are part of the asset name.
+            Allow setting **KEY**\ s that are part of the asset name.
             (see the ``onyo.assets.filename`` configuration option)
         """
     ),
@@ -49,7 +49,7 @@ args_set = {
         metavar='ASSET',
         nargs='+',
         help="""
-            Assets to set **KEY-VALUE**\s in.
+            Assets to set **KEY-VALUE**\ s in.
         """
     ),
 
@@ -59,12 +59,12 @@ args_set = {
 
 def set(args: argparse.Namespace) -> None:
     """
-    Set **KEY**\s to **VALUE**\s for assets.
+    Set **KEY**\ s to **VALUE**\ s for assets.
 
     **KEY** names can be any valid YAML key-name. If a key is not present in an
     asset, it is added and set appropriately.
 
-    Setting **KEY**\s that are used in the asset name requires the ``--rename``
+    Setting **KEY**\ s that are used in the asset name requires the ``--rename``
     flag.
 
     In addition to keys in asset contents, some PSEUDO-KEYS can be set:

--- a/onyo/cli/shell_completion.py
+++ b/onyo/cli/shell_completion.py
@@ -13,7 +13,7 @@ args_shell_completion = {
         required=False,
         default='zsh',
         choices=['zsh'],
-        help="""
+        help=r"""
             The shell to generate a tab-completion script for.
         """
     )
@@ -21,7 +21,7 @@ args_shell_completion = {
 
 
 def shell_completion(args: argparse.Namespace) -> None:
-    """
+    r"""
     Display a tab-completion shell script for Onyo.
 
     The output of this command should be "sourced" to enable tab completion.

--- a/onyo/cli/tests/test_cat.py
+++ b/onyo/cli/tests/test_cat.py
@@ -33,7 +33,7 @@ contents: List[List[str]] = [[x, content_str] for x in assets]
 @pytest.mark.repo_contents(*contents)
 @pytest.mark.parametrize('asset', assets)
 def test_cat(repo: OnyoRepo, asset: str) -> None:
-    """
+    r"""
     Test that a single file is cat successfully, and that stdout matches file
     content.
     """
@@ -45,7 +45,7 @@ def test_cat(repo: OnyoRepo, asset: str) -> None:
 
 @pytest.mark.repo_contents(*contents)
 def test_cat_multiple_inputs(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test that multiple files are cat successfully, and that stdout matches file
     content.
     """
@@ -62,7 +62,7 @@ def test_cat_multiple_inputs(repo: OnyoRepo) -> None:
                                      ]
                          )
 def test_cat_non_existing_path(repo: OnyoRepo, variant: str) -> None:
-    """
+    r"""
     Test that cat fails for a path that doesn't exist.
     """
     ret = subprocess.run(['onyo', 'cat', variant], capture_output=True, text=True)
@@ -78,7 +78,7 @@ def test_cat_non_existing_path(repo: OnyoRepo, variant: str) -> None:
     ['one_that_exists.test', 'dir/two_that_exists.test', 'does_not_exist.test']]
 )
 def test_cat_multiple_paths_missing(repo: OnyoRepo, variant: list[str]) -> None:
-    """
+    r"""
     Test that cat fails with multiple paths if at least one doesn't exist.
     """
     ret = subprocess.run(['onyo', 'cat', *variant], capture_output=True, text=True)
@@ -90,7 +90,7 @@ def test_cat_multiple_paths_missing(repo: OnyoRepo, variant: list[str]) -> None:
 @pytest.mark.repo_contents(*contents)
 @pytest.mark.parametrize('directory', directories)
 def test_cat_error_with_directory(repo: OnyoRepo, directory: str) -> None:
-    """
+    r"""
     Test that cat fails if path provided not a file.
     """
     ret = subprocess.run(['onyo', 'cat', directory], capture_output=True, text=True)
@@ -102,7 +102,7 @@ def test_cat_error_with_directory(repo: OnyoRepo, directory: str) -> None:
 @pytest.mark.repo_contents(*contents)
 @pytest.mark.parametrize('asset', assets)
 def test_same_target(repo: OnyoRepo, asset: str) -> None:
-    """
+    r"""
     Test that cat succeeds if the same path is provided more than once.
     """
     ret = subprocess.run(['onyo', 'cat', asset, asset], capture_output=True, text=True)
@@ -116,7 +116,7 @@ def test_same_target(repo: OnyoRepo, asset: str) -> None:
 @pytest.mark.parametrize('variant', [["no_trailing_newline.test",
                                       "---\nRAM:\nSize:\nUSB:"]])
 def test_no_trailing_newline(repo: OnyoRepo, variant: list[str]) -> None:
-    """
+    r"""
     Test that `onyo cat` outputs the file content exactly, and doesn't add any
     newlines or other characters.
     """
@@ -129,7 +129,7 @@ def test_no_trailing_newline(repo: OnyoRepo, variant: list[str]) -> None:
 
 @pytest.mark.repo_files(*assets)
 def test_no_trailing_newline_with_many_empty_assets(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test that `onyo cat ASSET ASSET [...]` does not print empty lines when given
     a list of empty files.
 
@@ -146,7 +146,7 @@ def test_no_trailing_newline_with_many_empty_assets(repo: OnyoRepo) -> None:
 @pytest.mark.parametrize('variant',
                          [["bad_yaml_file.test", "I: \nam:bad:\nbad:yaml\n"]])
 def test_invalid_yaml(repo: OnyoRepo, variant: list[str]) -> None:
-    """
+    r"""
     Test that `onyo cat` returns non-zero for a file with invalid yaml content,
     but does print the content plus an error message.
     """

--- a/onyo/cli/tests/test_config.py
+++ b/onyo/cli/tests/test_config.py
@@ -16,7 +16,7 @@ def test_config_set(repo: OnyoRepo) -> None:
 
 
 def test_config_already_set(repo: OnyoRepo) -> None:
-    """`onyo config` does not error if a legal value is
+    r"""`onyo config` does not error if a legal value is
     already set and no changes are made."""
     assert 'onyo "history"' in Path('.onyo/config').read_text()
     assert 'interactive = tig --follow' in Path('.onyo/config').read_text()
@@ -45,7 +45,7 @@ def test_config_get_onyo(repo: OnyoRepo) -> None:
 
 
 def test_config_get_pristine(repo: OnyoRepo) -> None:
-    """
+    r"""
     onyo should not alter git config's output (newline, etc)
     """
     ret = subprocess.run(["onyo", "config", "onyo.test.get-pristine",
@@ -107,7 +107,7 @@ def test_config_unset(repo: OnyoRepo) -> None:
 
 
 def test_config_help(repo: OnyoRepo) -> None:
-    """
+    r"""
     `onyo config --help` is shown and not `git config --help`.
     """
     for flag in ['-h', '--help']:
@@ -120,7 +120,7 @@ def test_config_help(repo: OnyoRepo) -> None:
 
 
 def test_config_forbidden_flags(repo: OnyoRepo) -> None:
-    """
+    r"""
     Flags that change the source of values are not allowed.
     """
     for flag in ['--system', '--global', '--local', '--worktree', '--file',
@@ -133,7 +133,7 @@ def test_config_forbidden_flags(repo: OnyoRepo) -> None:
 
 
 def test_config_bubble_retcode(repo: OnyoRepo) -> None:
-    """
+    r"""
     Bubble up git-config's retcodes.
     According to the git config manpage, attempting to unset an option which
     does not exist exits with "5".
@@ -147,7 +147,7 @@ def test_config_bubble_retcode(repo: OnyoRepo) -> None:
 
 
 def test_config_bubble_stderr(repo: OnyoRepo) -> None:
-    """
+    r"""
     Bubble up git-config printing to stderr.
     """
     ret = subprocess.run(["onyo", "config", "--invalid-flag-oopsies",

--- a/onyo/cli/tests/test_edit.py
+++ b/onyo/cli/tests/test_edit.py
@@ -18,7 +18,7 @@ assets = [['laptop_apple_macbookpro.0', "type: laptop\nmake: apple\nmodel: macbo
 
 @pytest.mark.parametrize('variant', ['local', 'onyo'])
 def test_get_editor_git(repo: OnyoRepo, variant: str) -> None:
-    """
+    r"""
     Get the editor from git or onyo configs.
     """
     repo.set_config('onyo.core.editor', variant, location=variant)
@@ -29,7 +29,7 @@ def test_get_editor_git(repo: OnyoRepo, variant: str) -> None:
 
 
 def test_get_editor_envvar(repo: OnyoRepo) -> None:
-    """
+    r"""
     Get the editor from $EDITOR.
     """
     # verify that onyo.core.editor is not set
@@ -41,7 +41,7 @@ def test_get_editor_envvar(repo: OnyoRepo) -> None:
 
 
 def test_get_editor_fallback(repo: OnyoRepo) -> None:
-    """
+    r"""
     When no editor is set, nano is the fallback.
     """
     # verify that onyo.core.editor is not set
@@ -56,7 +56,7 @@ def test_get_editor_fallback(repo: OnyoRepo) -> None:
 
 
 def test_get_editor_precedence(repo: OnyoRepo) -> None:
-    """
+    r"""
     The order of precedence should be git > onyo > $EDITOR.
     """
     # set locations
@@ -82,7 +82,7 @@ def test_get_editor_precedence(repo: OnyoRepo) -> None:
 @pytest.mark.repo_contents(*assets)
 @pytest.mark.parametrize('asset', [a[0] for a in assets])
 def test_edit_single_asset(repo: OnyoRepo, asset: str) -> None:
-    """
+    r"""
     Test that for different paths it is possible to call `onyo edit` on a single
     asset file.
     """
@@ -102,7 +102,7 @@ def test_edit_single_asset(repo: OnyoRepo, asset: str) -> None:
 
 @pytest.mark.repo_contents(*assets)
 def test_edit_multiple_assets(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test that it is possible to call `onyo edit` with a list of multiple assets
     containing different file names at once.
     """
@@ -125,7 +125,7 @@ def test_edit_multiple_assets(repo: OnyoRepo) -> None:
 
 @pytest.mark.repo_contents(*assets)
 def test_edit_with_user_response(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test that without the --yes flag, `onyo edit` requests a user response
     before saving changes.
     """
@@ -147,7 +147,7 @@ def test_edit_with_user_response(repo: OnyoRepo) -> None:
 @pytest.mark.repo_contents(*assets)
 @pytest.mark.parametrize('asset', [a[0] for a in assets])
 def test_edit_message_flag(repo: OnyoRepo, asset: str) -> None:
-    """
+    r"""
     Test that `onyo edit --message msg` overwrites the default commit message
     with one specified by the user containing different special characters.
     """
@@ -169,7 +169,7 @@ def test_edit_message_flag(repo: OnyoRepo, asset: str) -> None:
 
 @pytest.mark.repo_contents(*assets)
 def test_quiet_flag(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test that `onyo edit --yes --quiet` does not print anything.
     """
     os.environ['EDITOR'] = "printf 'key: quiet' >>"
@@ -191,7 +191,7 @@ def test_quiet_flag(repo: OnyoRepo) -> None:
 
 @pytest.mark.repo_contents(*assets)
 def test_quiet_errors_without_yes_flag(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test that `onyo edit --quiet` does error without --yes flag.
     """
     os.environ['EDITOR'] = "printf 'key: quiet' >>"
@@ -210,7 +210,7 @@ def test_quiet_errors_without_yes_flag(repo: OnyoRepo) -> None:
 @pytest.mark.repo_contents(*assets)
 @pytest.mark.parametrize('asset', [a[0] for a in assets])
 def test_edit_discard(repo: OnyoRepo, asset: str) -> None:
-    """
+    r"""
     Test that if an asset got correctly changed, but the user answers to the
     "Save changes?" dialog with 'n', that the changes get discarded.
     """
@@ -242,7 +242,7 @@ def test_edit_discard(repo: OnyoRepo, asset: str) -> None:
     '.git/index'
 ])
 def test_edit_protected(repo: OnyoRepo, no_asset: str) -> None:
-    """
+    r"""
     Test the error behavior when called on protected files.
     """
     os.environ['EDITOR'] = "printf 'key: NOT_USED' >>"
@@ -264,7 +264,7 @@ def test_edit_protected(repo: OnyoRepo, no_asset: str) -> None:
     "very/very/very/deep/non_existing_asset.0"
 ])
 def test_edit_non_existing_file(repo: OnyoRepo, no_asset: str) -> None:
-    """
+    r"""
     Test the error behavior when called on non-existing files, that Onyo does
     not create the files, and the repository stays valid.
     """
@@ -282,7 +282,7 @@ def test_edit_non_existing_file(repo: OnyoRepo, no_asset: str) -> None:
 @pytest.mark.repo_contents(*assets)
 @pytest.mark.parametrize('asset', [a[0] for a in assets])
 def test_continue_edit_no(repo: OnyoRepo, asset: str) -> None:
-    """
+    r"""
     Test that Onyo detects yaml-errors, and responds correctly if the user
     answers the "cancel edit?" dialog with 'y' to discard the changes
     """
@@ -303,7 +303,7 @@ def test_continue_edit_no(repo: OnyoRepo, asset: str) -> None:
 
 @pytest.mark.repo_contents(*assets)
 def test_edit_without_changes(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test that onyo does not fail when no changes were made.
     This still requires a confirmation after editing an asset.
     """
@@ -320,7 +320,7 @@ def test_edit_without_changes(repo: OnyoRepo) -> None:
 @pytest.mark.repo_contents(*assets)
 @pytest.mark.parametrize('asset', [a[0] for a in assets])
 def test_edit_with_dot_dot(repo: OnyoRepo, asset: str) -> None:
-    """
+    r"""
     Check that in an onyo repository it is possible to call `onyo edit` on an
     asset path that contains ".." leading outside and back into the repository.
     """

--- a/onyo/cli/tests/test_get.py
+++ b/onyo/cli/tests/test_get.py
@@ -92,7 +92,7 @@ asset_contents = [
 
 def convert_contents(
         raw_assets: list[tuple[str, dict[str, Any]]]) -> Generator:
-    """Convert content dictionary to a plain-text string"""
+    r"""Convert content dictionary to a plain-text string"""
     for file, raw_contents in raw_assets:
         contents = ''
         for k, v in raw_contents.items():
@@ -109,7 +109,7 @@ def convert_contents(
                                                           'one/laptop_dell_precision.2',
                                                           'one/two/headphones_apple_pro.3']]))
 def test_get_defaults(repo: OnyoRepo) -> None:
-    """Test `onyo get` using default values"""
+    r"""Test `onyo get` using default values"""
     cmd = ['onyo', 'get']
     ret = subprocess.run(cmd, capture_output=True, text=True)
     keys = ['type', 'make', 'model', 'serial', 'path']
@@ -137,7 +137,7 @@ def test_get_all(
         repo: OnyoRepo, matches: list[str], depth: str, keys: list[str],
         paths: list[str], machine_readable: str | None,
         sort: str | None) -> None:
-    """
+    r"""
     Test `onyo get` with a combination of arguments.
     """
     keys = keys if keys else repo.get_asset_name_keys()
@@ -187,7 +187,7 @@ def test_get_all(
     ([], 4)])
 def test_get_filter(
         repo: OnyoRepo, matches: list[str], expected: int) -> None:
-    """
+    r"""
     Test that `onyo get --match KEY=VALUE` retrieves the expected
     files.
     """
@@ -222,7 +222,7 @@ def test_get_filter(
     ([r'num=9\d*|\d{1,}'], 3)])
 def test_get_filter_regex(
         repo: OnyoRepo, matches: list[str], expected: int) -> None:
-    """
+    r"""
     Test that `onyo get --match KEY=VALUE` retrieves the expected
     files using a regular expression as value
     """
@@ -253,7 +253,7 @@ def test_get_filter_regex(
     ['num'],
     ['']])
 def test_get_filter_errors(repo: OnyoRepo, matches: list[str]) -> None:
-    """
+    r"""
     Test that `onyo get --match KEY=VALUE` returns an error if
     missing a value.
     """
@@ -282,7 +282,7 @@ def test_get_filter_errors(repo: OnyoRepo, matches: list[str]) -> None:
 def test_get_keys(
         repo: OnyoRepo, raw_assets: list[tuple[str, dict[str, Any]]],
         keys: list) -> None:
-    """
+    r"""
     Test that `onyo get --keys x y z` retrieves the expected keys.
     """
     from onyo.lib.consts import PSEUDO_KEYS
@@ -319,7 +319,7 @@ def test_get_keys(
 @pytest.mark.parametrize('depth,expected', [
     ('0', 5), ('1', 1), ('2', 2), ('3', 3), ('4', 4), ('999', 5)])
 def test_get_depth(repo: OnyoRepo, depth: str, expected: int) -> None:
-    """
+    r"""
     Test that `onyo get --depth x` retrieves the expected assets.
     """
     cmd = ['onyo', 'get', '--depth', depth, '-H']
@@ -344,7 +344,7 @@ def test_get_depth(repo: OnyoRepo, depth: str, expected: int) -> None:
                                                           'one/two/three/headphones_apple_pro.4',
                                                           'one/two/three/four/headphones_apple_pro.5']]))
 def test_get_depth_error(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test that `onyo get --depth x` when a negative integer is used returns the
     expected exception
     """
@@ -379,7 +379,7 @@ def test_get_depth_error(repo: OnyoRepo) -> None:
 def test_get_path_at_depth(
         repo: OnyoRepo, paths: str, depth: str | None,
         expected: int) -> None:
-    """
+    r"""
     Test that `onyo get --path x --depth y` retrieves the expected assets by
     ensuring that `depth` is assessed relative to the given paths.
 
@@ -419,7 +419,7 @@ def test_get_path_at_depth(
     'path/that/does/not/exist/and/does/not/start/with/dot/slash',
     'def/ghi'])
 def test_get_path_error(repo: OnyoRepo, path: str) -> None:
-    """
+    r"""
     Test that `onyo get --path x --depth y` returns an exception if an invalid
     path is being used
     """
@@ -442,7 +442,7 @@ def test_get_path_error(repo: OnyoRepo, path: str) -> None:
 def test_get_sort(
         repo: OnyoRepo, sort: str | None, keys: list[str],
         expected: list[str]) -> None:
-    """
+    r"""
     Test that `onyo get --keys x y z` with `-s` (ascending) or `-S`
     (descending)  retrieves assets in the expected 'natural sorted' order.
     """
@@ -464,7 +464,7 @@ def test_get_sort(
 
 
 def test_get_sort_error(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test that when using -s and -S simultaneously the appropriate error is
     returned.
     """
@@ -486,7 +486,7 @@ def test_get_sort_error(repo: OnyoRepo) -> None:
 def test_natural_sort(
         assets: list[dict], keys: list | None,
         reverse: bool) -> None:
-    """Test implementation of natural sorting algorithm"""
+    r"""Test implementation of natural sorting algorithm"""
     sorted_assets = natural_sort(assets, keys=keys, reverse=reverse)
     ids = [data.get('id') for data in sorted_assets]
 
@@ -509,7 +509,7 @@ def test_natural_sort(
     'type', 'make', 'model', 'serial', 'num', 'str', 'id']])
 def test_fill_unset(
         assets: list[dict], keys: list[str]) -> None:
-    """
+    r"""
     Test that the `fill_unset()` function fills unset keys with the value
     `'<unset>'`
     """

--- a/onyo/cli/tests/test_history.py
+++ b/onyo/cli/tests/test_history.py
@@ -27,7 +27,7 @@ assets: List[str] = [f"{d}/{f}.{i}" for f in files for i, d in enumerate(directo
 @pytest.mark.repo_files(*assets)
 @pytest.mark.parametrize('asset', assets)
 def test_history_noninteractive(repo: OnyoRepo, asset: str) -> None:
-    """
+    r"""
     Test that the default `onyo history -I ASSET` command runs and print to
     std.out, but not std.err.
     """
@@ -43,7 +43,7 @@ def test_history_noninteractive(repo: OnyoRepo, asset: str) -> None:
 @pytest.mark.parametrize('asset', ['does_not_exist.test',
                                    'subdir/does_not_exist.test'])
 def test_history_noninteractive_not_exist(repo: OnyoRepo, asset: str) -> None:
-    """
+    r"""
     Test that `onyo history -I ASSET` when called on non-existing assets does
     correctly print into ret.stderr.
     """
@@ -62,7 +62,7 @@ def test_history_noninteractive_not_exist(repo: OnyoRepo, asset: str) -> None:
                           ['does_not_exist.test', 'file_does_exist.test']]
                          )
 def test_history_noninteractive_too_many_args(repo: OnyoRepo, variant: list[str]) -> None:
-    """
+    r"""
     Test that `onyo history -I` does not allow multiple input arguments.
     """
     ret = subprocess.run(['onyo', 'history', '-I', *variant],
@@ -75,7 +75,7 @@ def test_history_noninteractive_too_many_args(repo: OnyoRepo, variant: list[str]
 
 @pytest.mark.repo_files(assets[0])
 def test_history_interactive_fallback(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test `onyo history` does work without the `-I` flag.
 
     Note that the interactive mode cannot be tested directly, as onyo detects
@@ -91,7 +91,7 @@ def test_history_interactive_fallback(repo: OnyoRepo) -> None:
 
 @pytest.mark.repo_files(assets[0])
 def test_history_config_unset(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test that `onyo history` errors when no tool is configured.
     """
     # unset config for history tool
@@ -113,7 +113,7 @@ def test_history_config_unset(repo: OnyoRepo) -> None:
 
 @pytest.mark.repo_files(assets[0])
 def test_history_config_invalid(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test that `onyo history -I` does error correctly when the history-tool does
     not exist.
     """
@@ -134,7 +134,7 @@ def test_history_config_invalid(repo: OnyoRepo) -> None:
 @pytest.mark.repo_files(*assets)
 @pytest.mark.parametrize('asset', assets)
 def test_history_fake_noninteractive_stdout(repo: OnyoRepo, asset: str) -> None:
-    """
+    r"""
     Test that the history tool can be reconfigured, so that `onyo history` can
     run commands different from the default options.
     """
@@ -154,7 +154,7 @@ def test_history_fake_noninteractive_stdout(repo: OnyoRepo, asset: str) -> None:
 @pytest.mark.repo_files(*assets)
 @pytest.mark.parametrize('asset', assets)
 def test_history_fake_noninteractive_stderr(repo: OnyoRepo, asset: str) -> None:
-    """
+    r"""
     Test that the history tool can be so reconfigured, that it prints into
     stderr instead of stdout.
     """
@@ -179,7 +179,7 @@ def test_history_fake_noninteractive_stderr(repo: OnyoRepo, asset: str) -> None:
                            'retval': 129}
                           ])
 def test_history_fake_noninteractive_bubble_exit_code(repo: OnyoRepo, variant: dict) -> None:
-    """
+    r"""
     Test that `onyo history` does bubble up the different exit codes that the
     tools configured return.
     """

--- a/onyo/cli/tests/test_init.py
+++ b/onyo/cli/tests/test_init.py
@@ -6,7 +6,7 @@ from onyo.lib.onyo import OnyoRepo
 
 
 def fully_populated_dot_onyo(directory: Path) -> bool:
-    """
+    r"""
     Assert whether a .onyo dir is fully populated.
     """
     dot_onyo = directory / '.onyo'
@@ -25,7 +25,7 @@ def fully_populated_dot_onyo(directory: Path) -> bool:
 
 
 def test_init_cwd(tmp_path: Path) -> None:
-    """
+    r"""
     Test that `onyo init` without a path argument uses the cwd to initialize a
     new onyo repository.
     """
@@ -42,7 +42,7 @@ def test_init_cwd(tmp_path: Path) -> None:
 
 
 def test_init_with_path(tmp_path: Path) -> None:
-    """
+    r"""
     Test that `onyo init PATH` uses a provided path to initialize a new onyo
     repository.
     """
@@ -59,7 +59,7 @@ def test_init_with_path(tmp_path: Path) -> None:
 
 
 def test_init_error_on_existing_repository(tmp_path: Path) -> None:
-    """
+    r"""
     Test that `onyo init PATH` errors correctly, when called on an existing
     repository.
     """

--- a/onyo/cli/tests/test_mkdir.py
+++ b/onyo/cli/tests/test_mkdir.py
@@ -17,7 +17,7 @@ directories = ['simple',
 
 @pytest.mark.parametrize('directory', directories)
 def test_mkdir(repo: OnyoRepo, directory: str) -> None:
-    """
+    r"""
     Test that `onyo mkdir <dir>` creates new directories correctly for different
     depths and directory names.
     """
@@ -40,7 +40,7 @@ def test_mkdir(repo: OnyoRepo, directory: str) -> None:
 
 
 def test_mkdir_multiple_inputs(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test that `onyo mkdir <dirs>` creates new directories all in one call when
     given a list of inputs.
     """
@@ -63,7 +63,7 @@ def test_mkdir_multiple_inputs(repo: OnyoRepo) -> None:
 
 
 def test_mkdir_no_response(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test that `onyo mkdir <dirs>` creates no new directories when user responds
     with "no".
     """
@@ -85,7 +85,7 @@ def test_mkdir_no_response(repo: OnyoRepo) -> None:
 
 
 def test_mkdir_message_flag(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test that `onyo mkdir --message msg` overwrites the default commit message
     with one specified by the user containing different special characters.
     """
@@ -107,7 +107,7 @@ def test_mkdir_message_flag(repo: OnyoRepo) -> None:
 
 
 def test_mkdir_quiet_flag(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test that `onyo mkdir --yes --quiet <dirs>` creates new directories without
     printing output.
     """
@@ -134,7 +134,7 @@ def test_mkdir_quiet_flag(repo: OnyoRepo) -> None:
 @pytest.mark.repo_dirs(*directories)
 @pytest.mark.parametrize('directory', directories)
 def test_dir_exists(repo: OnyoRepo, directory: str) -> None:
-    """
+    r"""
     Test the correct behavior when `onyo mkdir <path>` is called on an
     existing directory name.
     """
@@ -164,7 +164,7 @@ protected_paths = [".anchor",
 @pytest.mark.repo_dirs("simple")
 @pytest.mark.parametrize('protected_path', protected_paths)
 def test_dir_protected(repo: OnyoRepo, protected_path: str) -> None:
-    """
+    r"""
     Test the correct error behavior of `onyo mkdir <path>` on protected paths.
     """
     ret = subprocess.run(["onyo", "mkdir", protected_path], capture_output=True, text=True)
@@ -181,7 +181,7 @@ def test_dir_protected(repo: OnyoRepo, protected_path: str) -> None:
 
 @pytest.mark.repo_dirs("simple")
 def test_mkdir_relative_path(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test `onyo mkdir <path>` with a relative path given as input.
     """
     ret = subprocess.run(["onyo", "--yes", "mkdir", "simple/../relative"], capture_output=True, text=True)

--- a/onyo/cli/tests/test_mv.py
+++ b/onyo/cli/tests/test_mv.py
@@ -15,7 +15,7 @@ assets = ['laptop_apple_macbookpro.0',
 
 @pytest.mark.repo_files('subdir/laptop_apple_macbook.abc123')
 def test_mv_interactive_missing_y(repo: OnyoRepo) -> None:
-    """Default mode is interactive. It requires a "y" to approve."""
+    r"""Default mode is interactive. It requires a "y" to approve."""
     ret = subprocess.run(['onyo', 'mv', 'subdir/laptop_apple_macbook.abc123', './'],
                          capture_output=True, text=True)
     assert ret.returncode == 1
@@ -29,7 +29,7 @@ def test_mv_interactive_missing_y(repo: OnyoRepo) -> None:
 
 @pytest.mark.repo_files('subdir/laptop_apple_macbook.abc123')
 def test_mv_errors_non_existing_destination(repo: OnyoRepo) -> None:
-    """Moving an existing asset or directory into a non-existing destination must error."""
+    r"""Moving an existing asset or directory into a non-existing destination must error."""
     # Verify error for asset:
     ret = subprocess.run(
         ['onyo', 'mv', 'subdir/laptop_apple_macbook.abc123', 'non/existing/directory'],
@@ -55,7 +55,7 @@ def test_mv_errors_non_existing_destination(repo: OnyoRepo) -> None:
 
 @pytest.mark.repo_files('subdir/laptop_apple_macbook.abc123')
 def test_mv_interactive_abort(repo: OnyoRepo) -> None:
-    """Default mode is interactive. Provide the "n" to abort."""
+    r"""Default mode is interactive. Provide the "n" to abort."""
     ret = subprocess.run(['onyo', 'mv', 'subdir/laptop_apple_macbook.abc123', './'],
                          input='n', capture_output=True, text=True)
     assert ret.returncode == 0
@@ -69,7 +69,7 @@ def test_mv_interactive_abort(repo: OnyoRepo) -> None:
 
 @pytest.mark.repo_files('subdir/laptop_apple_macbook.abc123')
 def test_mv_interactive(repo: OnyoRepo) -> None:
-    """Default mode is interactive. Provide the "y" to approve."""
+    r"""Default mode is interactive. Provide the "y" to approve."""
     ret = subprocess.run(['onyo', 'mv', 'subdir/laptop_apple_macbook.abc123', './'],
                          input='y', capture_output=True, text=True)
     assert ret.returncode == 0
@@ -85,7 +85,7 @@ def test_mv_interactive(repo: OnyoRepo) -> None:
 @pytest.mark.repo_dirs("destination/")
 @pytest.mark.parametrize('asset', assets)
 def test_mv_message_flag(repo: OnyoRepo, asset: str) -> None:
-    """Test that `onyo mv --message msg` overwrites the default commit message with one specified by
+    r"""Test that `onyo mv --message msg` overwrites the default commit message with one specified by
     the user containing different special characters.
     """
     msg = "I am here to test the --message flag with spe\"cial\\char\'acteஞrs!"

--- a/onyo/cli/tests/test_new.py
+++ b/onyo/cli/tests/test_new.py
@@ -284,6 +284,28 @@ def test_keys_flag(repo: OnyoRepo, directory: str) -> None:
     assert repo.git.is_clean_worktree()
 
 
+def test_error_keys_flag_mismatch_count(repo: OnyoRepo) -> None:
+    r"""
+    Test that `onyo new --keys KEY=VALUE` requires that repeated keys are given
+    the same number of times.
+    """
+    key_values = asset_spec + ['serial=1', 'mode=0', 'mode=1', 'mode=2']
+
+    # create asset with --keys
+    ret = subprocess.run(
+        ['onyo', '--yes', 'new', '--keys'] + key_values,
+        capture_output=True, text=True)
+
+    # verify correct error
+    assert not ret.stdout
+    assert "All keys given multiple times must be given the same number of times" in ret.stderr
+    assert ret.returncode == 2
+
+    # verify that no new assets were created and the repository stays clean
+    assert len(repo.asset_paths) == 0
+    assert repo.git.is_clean_worktree()
+
+
 @pytest.mark.parametrize('directory', directories)
 def test_new_message_flag(repo: OnyoRepo, directory: str) -> None:
     r"""

--- a/onyo/cli/tests/test_new.py
+++ b/onyo/cli/tests/test_new.py
@@ -27,7 +27,7 @@ asset_spec = ['type=laptop', 'make=apple', 'model=macbookpro', 'serial=0']
 @pytest.mark.repo_dirs(*directories)
 @pytest.mark.parametrize('directory', directories)
 def test_new(repo: OnyoRepo, directory: str) -> None:
-    """
+    r"""
     Test that `onyo new` can create an asset in different directories.
     """
     file_ = f'{directory}/laptop_apple_macbookpro.0'
@@ -48,7 +48,7 @@ def test_new(repo: OnyoRepo, directory: str) -> None:
 
 @pytest.mark.repo_dirs(*directories)
 def test_new_interactive(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test that `onyo new` can create an asset in different directories when given
     'y' as input in the dialog, instead of using the flag '--yes'.
     """
@@ -70,7 +70,7 @@ def test_new_interactive(repo: OnyoRepo) -> None:
 
 
 def test_new_top_level(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test that `onyo new` can create an asset on the top level of
     the repository. This relies on CWD being the default for `--directory`
     and on the `repo` fixture CD'ing into the repo's root dir.
@@ -93,7 +93,7 @@ def test_new_top_level(repo: OnyoRepo) -> None:
 
 @pytest.mark.repo_dirs(*directories)
 def test_new_sub_dir_absolute_path(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test that `onyo new --directory <path>` can create an asset in sub-directories of
     the repository while the cwd is inside a different sub-directory.
     """
@@ -121,7 +121,7 @@ def test_new_sub_dir_absolute_path(repo: OnyoRepo) -> None:
 
 @pytest.mark.repo_dirs(*directories)
 def test_new_sub_dir_relative_path(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test that `onyo new --directory <path>` can create an asset in sub-directories of
     the repository while the cwd is inside a different sub-directory with a
     relative path.
@@ -153,7 +153,7 @@ def test_new_sub_dir_relative_path(repo: OnyoRepo) -> None:
 @pytest.mark.repo_dirs('overlap')  # to test sub-dir creation for existing dir
 @pytest.mark.parametrize('directory', directories)
 def test_folder_creation_with_new(repo: OnyoRepo, directory: str) -> None:
-    """
+    r"""
     Test that `onyo new` can create new folders for assets.
     Tests that folders are created when a sub-folder already exist, too, through
     existing dir 'overlap'.
@@ -177,7 +177,7 @@ def test_folder_creation_with_new(repo: OnyoRepo, directory: str) -> None:
 
 
 def test_with_faux_serial_number(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test that `onyo new` can create multiple assets with faux serial numbers in
     multiple directories at once. To specify several assets, at least one key-value-pair
     has to be given multiple times. This test also needs to use the 'directory'
@@ -204,7 +204,7 @@ def test_with_faux_serial_number(repo: OnyoRepo) -> None:
 
 
 def test_new_assets_in_multiple_directories_at_once(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test that `onyo new` cat create new assets in multiple different
     directories in one call.
     """
@@ -234,7 +234,7 @@ def test_new_assets_in_multiple_directories_at_once(repo: OnyoRepo) -> None:
 
 @pytest.mark.parametrize('directory', directories)
 def test_yes_flag(repo: OnyoRepo, directory: str) -> None:
-    """
+    r"""
     Test that `onyo new --yes` creates assets in different directories.
     """
     asset = f'{directory}/laptop_apple_macbookpro.0'
@@ -260,7 +260,7 @@ def test_yes_flag(repo: OnyoRepo, directory: str) -> None:
 
 @pytest.mark.parametrize('directory', directories)
 def test_keys_flag(repo: OnyoRepo, directory: str) -> None:
-    """
+    r"""
     Test that `onyo new --keys KEY=VALUE` creates assets with contents added.
     """
     # set `key=value` for --keys, and asset name
@@ -286,7 +286,7 @@ def test_keys_flag(repo: OnyoRepo, directory: str) -> None:
 
 @pytest.mark.parametrize('directory', directories)
 def test_new_message_flag(repo: OnyoRepo, directory: str) -> None:
-    """
+    r"""
     Test that `onyo new --message msg` overwrites the default commit message
     with one specified by the user containing different special characters.
     """
@@ -307,7 +307,7 @@ def test_new_message_flag(repo: OnyoRepo, directory: str) -> None:
 
 @pytest.mark.parametrize('directory', directories)
 def test_discard_changes(repo: OnyoRepo, directory: str) -> None:
-    """
+    r"""
     Test that `onyo new` can discard new assets and the repository stays clean.
     """
     asset = f'{directory}/laptop_apple_macbookpro.0'
@@ -339,7 +339,7 @@ def test_discard_changes(repo: OnyoRepo, directory: str) -> None:
     '.git/info'
 ])
 def test_new_protected_folder(repo: OnyoRepo, protected_folder: str) -> None:
-    """
+    r"""
     Test that `onyo new` when called on protected folders errors correctly
     instead of creating an asset.
     """
@@ -357,7 +357,7 @@ def test_new_protected_folder(repo: OnyoRepo, protected_folder: str) -> None:
 
 @pytest.mark.parametrize('directory', directories)
 def test_new_with_flags_edit_keys_template(repo: OnyoRepo, directory: str) -> None:
-    """
+    r"""
     Test `onyo new --edit --keys KEY=VALUE --template <TEMPLATE>` works when
     called and all flags get executed together and modify the output correctly.
     """
@@ -394,7 +394,7 @@ def test_new_with_flags_edit_keys_template(repo: OnyoRepo, directory: str) -> No
 
 @pytest.mark.parametrize('directory', directories)
 def test_new_with_keys_overwrite_template(repo: OnyoRepo, directory: str) -> None:
-    """
+    r"""
     Test `onyo new --keys <KEY=VALUE> --template <TEMPLATE>` does overwrite the
     contents of <TEMPLATE> with <KEY=VALUE>
     """
@@ -436,7 +436,7 @@ def test_new_with_keys_overwrite_template(repo: OnyoRepo, directory: str) -> Non
 ])
 def test_with_special_characters(
         repo: OnyoRepo, directory: str, variant: str) -> None:
-    """
+    r"""
     Test `onyo new` with names containing special characters.
     """
     asset = f'{directory}/{variant[0]}_{variant[1]}_{variant[2]}.{variant[3]}'
@@ -459,7 +459,7 @@ def test_with_special_characters(
 @pytest.mark.repo_files('laptop_apple_macbookpro.0')
 @pytest.mark.parametrize('directory', directories)
 def test_error_asset_exists_already(repo: OnyoRepo, directory: str) -> None:
-    """
+    r"""
     Test that `onyo new` errors in all possible locations when it is called with
     an asset name that already exists elsewhere in the directory.
     """
@@ -481,7 +481,7 @@ def test_error_asset_exists_already(repo: OnyoRepo, directory: str) -> None:
 @pytest.mark.parametrize('directory', directories)
 def test_error_two_identical_assets_in_input(
         repo: OnyoRepo, directory: str) -> None:
-    """
+    r"""
     Test that `onyo new` errors in all possible locations when it is called with
     the same asset name twice, in two different locations.
     """
@@ -500,7 +500,7 @@ def test_error_two_identical_assets_in_input(
 
 
 def test_error_template_does_not_exist(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test that `onyo new --template` errors when it is called with a non-existing
     template name.
     """
@@ -521,7 +521,7 @@ def test_error_template_does_not_exist(repo: OnyoRepo) -> None:
 @pytest.mark.repo_dirs('simple',
                        'overlap/one')
 def test_tsv(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test `onyo new --tsv <table>` with a table containing the minimal set of
     columns to create assets: type, make, model, serial, directory.
 
@@ -551,7 +551,7 @@ def test_tsv(repo: OnyoRepo) -> None:
 @pytest.mark.repo_dirs('simple',
                        'overlap/one')
 def test_tsv_with_value_columns(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test `onyo new --tsv <table>` with a table containing a column with the age
     of the device and a group to which it belongs.
     """
@@ -577,7 +577,7 @@ def test_tsv_with_value_columns(repo: OnyoRepo) -> None:
 @pytest.mark.repo_dirs('simple',
                        'overlap/one')
 def test_tsv_with_flags_template_keys_edit(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test `onyo new --tsv <table> --template <template> <key=value> --edit`
     with a table containing the minimal set of columns to create assets, a
     non-empty template, values to set with --keys, and an editor.
@@ -616,7 +616,7 @@ def test_tsv_with_flags_template_keys_edit(repo: OnyoRepo) -> None:
 @pytest.mark.repo_dirs('simple',
                        'overlap/one')
 def test_tsv_with_template_column(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test `onyo new --tsv <table>` with a table containing an additional column
     specifying the template to use.
 
@@ -640,7 +640,7 @@ def test_tsv_with_template_column(repo: OnyoRepo) -> None:
 
 
 def test_conflicting_and_missing_arguments(repo: OnyoRepo) -> None:
-    """
+    r"""
     Onyo should inform the user with specific error messages when arguments are
     either missing or conflicting:
     - error if `onyo new` gets neither table nor asset names
@@ -686,7 +686,7 @@ def test_conflicting_and_missing_arguments(repo: OnyoRepo) -> None:
 
 
 def test_tsv_errors(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test error behavior for `onyo new --tsv <TSV>`:
     - <TSV> does not exist
     - <TSV> exists, but is empty (no columns/header)
@@ -735,7 +735,7 @@ def test_tsv_errors(repo: OnyoRepo) -> None:
 
 @pytest.mark.repo_files("laptop_apple_macbookpro.0")
 def test_tsv_error_asset_exists_already(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test that `onyo new --tsv` errors correctly when the table contains an
     asset name that already exists in the repository.
     """
@@ -756,7 +756,7 @@ def test_tsv_error_asset_exists_already(repo: OnyoRepo) -> None:
 
 
 def test_tsv_error_identical_entries(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test that `onyo new --tsv` errors when the table contains two assets with
     the same name (type, make, model and serial identical, but directories
     different).
@@ -777,7 +777,7 @@ def test_tsv_error_identical_entries(repo: OnyoRepo) -> None:
 
 
 def test_tsv_error_template_does_not_exist(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test that `onyo new --tsv` errors when the template column contains entries
     for which no template exist (e.g. typos).
     """

--- a/onyo/cli/tests/test_onyo.py
+++ b/onyo/cli/tests/test_onyo.py
@@ -27,7 +27,7 @@ def test_onyo_help(repo: OnyoRepo, variant: str) -> None:
 
 # TODO: this would be better if parametrized
 def test_onyo_without_subcommand(repo: OnyoRepo, helpers) -> None:
-    """
+    r"""
     Test all possible combinations of flags for onyo, without any subcommand.
     """
     for i in helpers.powerset(helpers.onyo_flags()):

--- a/onyo/cli/tests/test_rm.py
+++ b/onyo/cli/tests/test_rm.py
@@ -24,7 +24,7 @@ assets: List[str] = [f"{d}/{f}.{i}" for f in files for i, d in enumerate(directo
 @pytest.mark.repo_files(*assets)
 @pytest.mark.parametrize('asset', assets)
 def test_rm(repo: OnyoRepo, asset: str) -> None:
-    """
+    r"""
     Test that `onyo rm ASSET` deletes assets and leaves the repository in a
     clean state.
     """
@@ -41,7 +41,7 @@ def test_rm(repo: OnyoRepo, asset: str) -> None:
 
 @pytest.mark.repo_files(*assets)
 def test_rm_multiple_inputs(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test that `onyo rm ASSET` deletes a list of assets all at once and leaves
     the repository in a clean state.
     """
@@ -60,7 +60,7 @@ def test_rm_multiple_inputs(repo: OnyoRepo) -> None:
 @pytest.mark.repo_files(*assets)
 @pytest.mark.parametrize('directory', directories[1:])  # do not use "." as dir
 def test_rm_single_dirs_with_files(repo: OnyoRepo, directory: str) -> None:
-    """
+    r"""
     Test that `onyo rm DIRECTORY` deletes directories successfully and leaves
     the repository in a clean state.
     """
@@ -77,7 +77,7 @@ def test_rm_single_dirs_with_files(repo: OnyoRepo, directory: str) -> None:
 
 @pytest.mark.repo_files(*assets)
 def test_rm_multiple_directories(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test that `onyo rm DIRECTORY` deletes a list of directories all at once and
     leaves the repository in a clean state.
     """
@@ -95,7 +95,7 @@ def test_rm_multiple_directories(repo: OnyoRepo) -> None:
 
 @pytest.mark.repo_dirs(*directories[1:])  # skip "." for directory creation
 def test_rm_empty_directories(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test that `onyo rm DIRECTORY` deletes empty directories and leaves the
     repository in a clean state.
     """
@@ -113,7 +113,7 @@ def test_rm_empty_directories(repo: OnyoRepo) -> None:
 
 @pytest.mark.repo_files(*assets)
 def test_rm_interactive_missing_y(repo: OnyoRepo) -> None:
-    """
+    r"""
     Default mode is interactive. It requires a "y" to approve.
     """
     ret = subprocess.run(['onyo', 'rm', *assets], capture_output=True, text=True)
@@ -129,7 +129,7 @@ def test_rm_interactive_missing_y(repo: OnyoRepo) -> None:
 
 @pytest.mark.repo_files(*assets)
 def test_rm_interactive_abort(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test that `onyo rm ASSET` does not delete any asset, when the user provides
     "n" as response in interactive mode.
     """
@@ -147,7 +147,7 @@ def test_rm_interactive_abort(repo: OnyoRepo) -> None:
 @pytest.mark.repo_files(*assets)
 @pytest.mark.parametrize('asset', assets)
 def test_rm_interactive(repo: OnyoRepo, asset: str) -> None:
-    """
+    r"""
     Test that `onyo rm ASSET` deletes ASSET successfully, when the user provides
     "y" as the response in interactive mode.
     """
@@ -164,7 +164,7 @@ def test_rm_interactive(repo: OnyoRepo, asset: str) -> None:
 @pytest.mark.repo_files(*assets)
 @pytest.mark.parametrize('asset', assets)
 def test_rm_message_flag(repo: OnyoRepo, asset: str) -> None:
-    """
+    r"""
     Test that `onyo rm --message MESSAGE` overwrites the default commit message
     with one specified by the user containing different special characters.
     """

--- a/onyo/cli/tests/test_set.py
+++ b/onyo/cli/tests/test_set.py
@@ -54,7 +54,7 @@ name_fields = [["type=desktop"],
 def test_set(repo: OnyoRepo,
              asset: str,
              set_values: list[str]) -> None:
-    """Test that `onyo set KEY=VALUE <asset>` updates contents of assets."""
+    r"""Test that `onyo set KEY=VALUE <asset>` updates contents of assets."""
     ret = subprocess.run(['onyo', '--yes', 'set', '--keys', *set_values, '--asset', asset],
                          capture_output=True, text=True)
 
@@ -76,7 +76,7 @@ def test_set(repo: OnyoRepo,
 def test_set_interactive(repo: OnyoRepo,
                          asset: str,
                          set_values: list[str]) -> None:
-    """Test that `onyo set KEY=VALUE <asset>` updates contents of assets."""
+    r"""Test that `onyo set KEY=VALUE <asset>` updates contents of assets."""
     ret = subprocess.run(['onyo', 'set', '--keys', *set_values, '--asset', asset],
                          input='y', capture_output=True, text=True)
 
@@ -97,7 +97,7 @@ def test_set_interactive(repo: OnyoRepo,
 @pytest.mark.parametrize('set_values', values)
 def test_set_multiple_assets(repo: OnyoRepo,
                              set_values: list[str]) -> None:
-    """Test that `onyo set KEY=VALUE <asset>` can update the contents of multiple
+    r"""Test that `onyo set KEY=VALUE <asset>` can update the contents of multiple
     assets in a single call.
     """
     ret = subprocess.run(['onyo', '--yes', 'set', '--keys', *set_values,
@@ -121,7 +121,7 @@ def test_set_multiple_assets(repo: OnyoRepo,
 @pytest.mark.parametrize('no_assets', non_existing_assets)
 def test_set_error_non_existing_assets(repo: OnyoRepo,
                                        no_assets: list[str]) -> None:
-    """Test that `onyo set KEY=VALUE <asset>` errors correctly for:
+    r"""Test that `onyo set KEY=VALUE <asset>` errors correctly for:
     - non-existing assets on root
     - non-existing assets in directories
     - one non-existing asset in a list of existing ones
@@ -140,7 +140,7 @@ def test_set_error_non_existing_assets(repo: OnyoRepo,
 @pytest.mark.parametrize('set_values', values)
 def test_set_without_path(repo: OnyoRepo,
                           set_values: list[str]) -> None:
-    """Test that `onyo set KEY=VALUE` without a given path fails.
+    r"""Test that `onyo set KEY=VALUE` without a given path fails.
     """
     ret = subprocess.run(['onyo', '--yes', 'set', '--keys', *set_values],
                          capture_output=True, text=True)
@@ -156,7 +156,7 @@ def test_set_without_path(repo: OnyoRepo,
 def test_set_discard_changes_single_assets(repo: OnyoRepo,
                                            asset: str,
                                            set_values: list[str]) -> None:
-    """Test that `onyo set` discards changes for assets successfully."""
+    r"""Test that `onyo set` discards changes for assets successfully."""
     ret = subprocess.run(['onyo', 'set', '--keys', *set_values, '--asset', asset],
                          input='n',
                          capture_output=True, text=True)
@@ -181,7 +181,7 @@ def test_set_discard_changes_single_assets(repo: OnyoRepo,
 def test_set_message_flag(repo: OnyoRepo,
                           asset: str,
                           set_values: list[str]) -> None:
-    """Test that `onyo set --message msg` overwrites the
+    r"""Test that `onyo set --message msg` overwrites the
     default commit message with one specified by the user
     containing various special characters.
     """
@@ -202,7 +202,7 @@ def test_set_message_flag(repo: OnyoRepo,
 @pytest.mark.parametrize('asset', [asset_paths[0]])
 def test_add_new_key_to_existing_content(repo: OnyoRepo,
                                          asset: str) -> None:
-    """Test that `onyo set KEY=VALUE <asset>` can be called two times with
+    r"""Test that `onyo set KEY=VALUE <asset>` can be called two times with
     different `KEY`, and adds it without overwriting existing values.
     """
     set_1 = "change=one"
@@ -244,7 +244,7 @@ def test_add_new_key_to_existing_content(repo: OnyoRepo,
 @pytest.mark.parametrize('asset', [asset_paths[0]])
 def test_set_overwrite_key(repo: OnyoRepo,
                            asset: str) -> None:
-    """
+    r"""
     Test that `onyo set KEY=VALUE <asset>` can be called two times with
     different VALUE for the same KEY, and overwrites existing values correctly.
     """
@@ -284,7 +284,7 @@ def test_set_overwrite_key(repo: OnyoRepo,
 @pytest.mark.parametrize('asset', [asset_paths[0]])
 def test_setting_new_values_if_some_values_already_set(repo: OnyoRepo,
                                                        asset: str) -> None:
-    """Test that `onyo set KEY=VALUE <asset>` updates contents of assets and adds
+    r"""Test that `onyo set KEY=VALUE <asset>` updates contents of assets and adds
     the correct output if called multiple times, and that the output is correct.
     """
     set_values = "change=one"
@@ -328,7 +328,7 @@ def test_setting_new_values_if_some_values_already_set(repo: OnyoRepo,
 def test_values_already_set(repo: OnyoRepo,
                             asset: str,
                             set_values: list[str]) -> None:
-    """Test that `onyo set KEY=VALUE <asset>` updates
+    r"""Test that `onyo set KEY=VALUE <asset>` updates
     contents of assets once, and if called again with
     same valid values the command does display the correct
     info message without error, and the repository stays
@@ -366,7 +366,7 @@ def test_values_already_set(repo: OnyoRepo,
 def test_set_update_name_fields(repo: OnyoRepo,
                                 asset: str,
                                 set_values: list[str]) -> None:
-    """Test that `onyo set --rename --keys KEY=VALUE <asset>` can
+    r"""Test that `onyo set --rename --keys KEY=VALUE <asset>` can
     successfully change the names of assets, when KEY is
     type, make, model or/and serial number. Test also, that
     faux serials can be set and name fields are recognized
@@ -387,7 +387,7 @@ def test_set_update_name_fields(repo: OnyoRepo,
 
 @pytest.mark.repo_contents(*assets)
 def test_update_many_faux_serial_numbers(repo: OnyoRepo) -> None:
-    """Test that `onyo set --rename serial=faux <asset>`
+    r"""Test that `onyo set --rename serial=faux <asset>`
     can successfully update many assets with new faux
     serial numbers in one call.
     """
@@ -426,7 +426,7 @@ def test_update_many_faux_serial_numbers(repo: OnyoRepo) -> None:
 def test_duplicate_keys(repo: OnyoRepo,
                         asset: str,
                         set_values: list[str]) -> None:
-    """Test that `onyo set` fails, if the same key is given multiple times."""
+    r"""Test that `onyo set` fails, if the same key is given multiple times."""
 
     ret = subprocess.run(['onyo', '--yes', 'set', '--keys',
                           *set_values, 'dup_key=1', 'dup_key=2', '--asset', asset],

--- a/onyo/cli/tests/test_tree.py
+++ b/onyo/cli/tests/test_tree.py
@@ -23,7 +23,7 @@ assets: List[str] = [f"{d}/{f}.{i}" for f in files
 
 @pytest.mark.repo_files(*assets)
 def test_tree(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test that `onyo tree` works without input paths.
     """
     ret = subprocess.run(['onyo', 'tree'], capture_output=True, text=True)
@@ -41,7 +41,7 @@ def test_tree(repo: OnyoRepo) -> None:
 @pytest.mark.repo_files(*assets)
 @pytest.mark.parametrize('directory', directories)
 def test_tree_with_directory(repo: OnyoRepo, directory: str) -> None:
-    """
+    r"""
     Test that `onyo tree DIRECTORY` displays directories correctly.
     """
     ret = subprocess.run(['onyo', 'tree', directory], capture_output=True, text=True)
@@ -62,7 +62,7 @@ def test_tree_with_directory(repo: OnyoRepo, directory: str) -> None:
 
 @pytest.mark.repo_files(*assets)
 def test_tree_multiple_inputs(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test that `onyo tree <dirs>` displays all directories when given a list of
     paths in one call.
     """
@@ -82,7 +82,7 @@ def test_tree_multiple_inputs(repo: OnyoRepo) -> None:
 @pytest.mark.parametrize('directory', ["does_not_exist"] + [
     d + "/subdir" for d in directories])
 def test_tree_error_dir_does_not_exist(repo: OnyoRepo, directory: str) -> None:
-    """
+    r"""
     Test the correct error behavior when `onyo tree <path>` is called on
     non-existing directories and sub-directories.
     """
@@ -98,7 +98,7 @@ def test_tree_error_dir_does_not_exist(repo: OnyoRepo, directory: str) -> None:
 @pytest.mark.repo_files(*assets)
 @pytest.mark.parametrize('asset', assets)
 def test_tree_error_is_file(repo: OnyoRepo, asset: str) -> None:
-    """
+    r"""
     Test the correct error behavior when `onyo tree ASSET` is called on assets.
     """
     ret = subprocess.run(['onyo', 'tree', asset], capture_output=True, text=True)
@@ -112,7 +112,7 @@ def test_tree_error_is_file(repo: OnyoRepo, asset: str) -> None:
 
 @pytest.mark.repo_files(*assets)
 def test_tree_relative_path(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test `onyo tree <path>` with a relative path given as input.
     """
     ret = subprocess.run(["onyo", "tree", "simple/../s p a c e s"], capture_output=True, text=True)
@@ -125,7 +125,7 @@ def test_tree_relative_path(repo: OnyoRepo) -> None:
 
 @pytest.mark.repo_files(*assets)
 def test_tree_error_relative_path_outside_repo(repo: OnyoRepo) -> None:
-    """
+    r"""
     Test `onyo tree <path>` gives error with a relative path that leads outside
     of the repository.
     """

--- a/onyo/cli/tests/test_unset.py
+++ b/onyo/cli/tests/test_unset.py
@@ -9,7 +9,7 @@ from onyo.lib.onyo import OnyoRepo
 
 def convert_contents(
         raw_assets: list[tuple[str, dict[str, Any]]]) -> Generator:
-    """Convert content dictionary to a plain-text string."""
+    r"""Convert content dictionary to a plain-text string."""
     for file, raw_contents in raw_assets:
         contents = ''
         for k, v in raw_contents.items():
@@ -111,7 +111,7 @@ asset_contents = [
 def test_unset(repo: OnyoRepo,
                asset: str,
                key: str) -> None:
-    """Test that `onyo unset KEY <asset>` removes keys from of assets."""
+    r"""Test that `onyo unset KEY <asset>` removes keys from of assets."""
     ret = subprocess.run(['onyo', '--yes', 'unset', '--keys', key, '--asset', asset],
                          capture_output=True, text=True)
 
@@ -133,7 +133,7 @@ def test_unset(repo: OnyoRepo,
 def test_unset_interactive(repo: OnyoRepo,
                            asset: str,
                            key: str) -> None:
-    """Test that `onyo unset KEY <asset>` removes keys from of assets."""
+    r"""Test that `onyo unset KEY <asset>` removes keys from of assets."""
     ret = subprocess.run(['onyo', 'unset', '--keys', key, '--asset', asset], input='y',
                          capture_output=True, text=True)
 
@@ -154,7 +154,7 @@ def test_unset_interactive(repo: OnyoRepo,
 @pytest.mark.parametrize('asset', [t[0] for t in asset_contents if "num" not in t[1]])
 def test_unset_key_does_not_exist(repo: OnyoRepo,
                                   asset: str) -> None:
-    """Test that `onyo unset --keys KEY --asset ASSET` does not error when one of the KEYs does not
+    r"""Test that `onyo unset --keys KEY --asset ASSET` does not error when one of the KEYs does not
     exist."""
     no_key = "non_existing"
 
@@ -173,7 +173,7 @@ def test_unset_key_does_not_exist(repo: OnyoRepo,
 @pytest.mark.parametrize('key', ['num'])
 def test_unset_multiple_assets(repo: OnyoRepo,
                                key: str) -> None:
-    """Test that `onyo unset --keys KEY --asset ASSET [ASSET2 ...]` removes keys from of assets."""
+    r"""Test that `onyo unset --keys KEY --asset ASSET [ASSET2 ...]` removes keys from of assets."""
     assets = repo.get_asset_paths()
 
     # test unsetting keys for multiple assets:
@@ -202,7 +202,7 @@ def test_unset_multiple_assets(repo: OnyoRepo,
 def test_unset_error_non_existing_assets(repo: OnyoRepo,
                                          no_assets: list[str],
                                          key: str) -> None:
-    """Test that `onyo unset --keys KEY --asset ASSET` errors correctly for non-existing assets."""
+    r"""Test that `onyo unset --keys KEY --asset ASSET` errors correctly for non-existing assets."""
     ret = subprocess.run(['onyo', 'unset', '--keys', key, '--asset', *no_assets],
                          capture_output=True, text=True)
 
@@ -217,7 +217,7 @@ def test_unset_error_non_existing_assets(repo: OnyoRepo,
 @pytest.mark.parametrize('key', ['num'])
 def test_unset_without_path(repo: OnyoRepo,
                             key: str) -> None:
-    """Test that `onyo unset --keys KEY` without a given path selects all assets recursively."""
+    r"""Test that `onyo unset --keys KEY` without a given path selects all assets recursively."""
     ret = subprocess.run(['onyo', '--yes', 'unset', '--keys', key],
                          capture_output=True, text=True)
 
@@ -233,7 +233,7 @@ def test_unset_without_path(repo: OnyoRepo,
 def test_unset_discard_changes_single_assets(repo: OnyoRepo,
                                              asset: str,
                                              key: str) -> None:
-    """Test that `onyo unset` discards changes for assets successfully."""
+    r"""Test that `onyo unset` discards changes for assets successfully."""
     # do an `onyo unset`, but answer "n" to discard the changes done by unset
     ret = subprocess.run(['onyo', 'unset', '--keys', key, '--asset', asset], input='n',
                          capture_output=True, text=True)
@@ -254,7 +254,7 @@ def test_unset_discard_changes_single_assets(repo: OnyoRepo,
 def test_unset_message_flag(repo: OnyoRepo,
                             asset: str,
                             key: str) -> None:
-    """Test that `onyo unset --message msg` overwrites the default commit message with one specified
+    r"""Test that `onyo unset --message msg` overwrites the default commit message with one specified
     by the user containing different special characters."""
     msg = "I am here to test the --message flag with spe\"cial\\char\'acteஞrs!"
     ret = subprocess.run(['onyo', '--yes', 'unset', '--message', msg, '--keys', key,
@@ -279,7 +279,7 @@ def test_unset_message_flag(repo: OnyoRepo,
     ["num", "type"]])
 def test_unset_error_unset_name_fields(repo: OnyoRepo,
                                        name_field: list[str]) -> None:
-    """Test that `onyo unset KEY <asset>` throws the correct error without printing the usual
+    r"""Test that `onyo unset KEY <asset>` throws the correct error without printing the usual
     information (e.g. diff output), when called with a KEY that is a name field (type, make, model
     or/and serial number), not a content field.
     """

--- a/onyo/cli/tree.py
+++ b/onyo/cli/tree.py
@@ -21,7 +21,7 @@ args_tree = {
 
 def tree(args: argparse.Namespace) -> None:
     """
-    List the assets and directories of **DIRECTORY**\s in a tree-like format.
+    List the assets and directories of **DIRECTORY**\ s in a tree-like format.
 
     If no directory is provided, the tree for the current working directory is
     listed.

--- a/onyo/cli/tree.py
+++ b/onyo/cli/tree.py
@@ -20,7 +20,7 @@ args_tree = {
 
 
 def tree(args: argparse.Namespace) -> None:
-    """
+    r"""
     List the assets and directories of **DIRECTORY**\ s in a tree-like format.
 
     If no directory is provided, the tree for the current working directory is

--- a/onyo/cli/unset.py
+++ b/onyo/cli/unset.py
@@ -18,7 +18,7 @@ args_unset = {
         metavar="KEY",
         nargs='+',
         type=str,
-        help="""
+        help=r"""
             Keys to unset in assets. Multiple keys can be given
             (e.g. **key1 key2 key3**).
         """
@@ -29,7 +29,7 @@ args_unset = {
         required=True,
         metavar="ASSET",
         nargs='+',
-        help="""
+        help=r"""
             Assets to unset **KEY**s in.
         """
     ),
@@ -39,7 +39,7 @@ args_unset = {
 
 
 def unset(args: argparse.Namespace) -> None:
-    """
+    r"""
     Remove **KEY**\ s from assets.
 
     Keys that are used in asset names (see the ``onyo.assets.filename``

--- a/onyo/cli/unset.py
+++ b/onyo/cli/unset.py
@@ -40,7 +40,7 @@ args_unset = {
 
 def unset(args: argparse.Namespace) -> None:
     """
-    Remove **KEY**\s from assets.
+    Remove **KEY**\ s from assets.
 
     Keys that are used in asset names (see the ``onyo.assets.filename``
     configuration option) cannot be unset.

--- a/onyo/conftest.py
+++ b/onyo/conftest.py
@@ -15,7 +15,7 @@ from onyo.lib.onyo import OnyoRepo
 
 
 def params(d: dict) -> MarkDecorator:
-    """
+    r"""
     Parameterizes a dictionary of the form:
     {
         "<ids>": {"variant": <variable>},
@@ -116,7 +116,7 @@ def onyorepo(gitrepo, request, monkeypatch) -> Generator[AnnotatedOnyoRepo, None
 
 @pytest.fixture(scope='function')
 def repo(tmp_path: Path, monkeypatch, request) -> Generator[OnyoRepo, None, None]:
-    """
+    r"""
     This fixture:
     - creates a new repository in a temporary directory
     - `cd`s into the repository
@@ -202,7 +202,7 @@ def inventory(repo) -> Generator:
 
 @pytest.fixture(scope="function", autouse=True)
 def clean_env(request) -> None:
-    """
+    r"""
     Ensure that $EDITOR is not inherited from the environment or other tests.
     """
     try:
@@ -240,7 +240,7 @@ def helpers() -> Type[Helpers]:
 
 @pytest.fixture(scope='function', autouse=True)
 def set_ui(request) -> None:
-    """Set up onyo.lib.ui according to a dict provided by the 'ui' marker"""
+    r"""Set up onyo.lib.ui according to a dict provided by the 'ui' marker"""
     from onyo.lib.ui import ui
     m = request.node.get_closest_marker('ui')
     if m:

--- a/onyo/lib/command_utils.py
+++ b/onyo/lib/command_utils.py
@@ -30,7 +30,7 @@ log: logging.Logger = logging.getLogger('onyo.command_utils')
 
 
 def sanitize_args_config(git_config_args: list[str]) -> list[str]:
-    """
+    r"""
     Check the git config arguments against a list of conflicting options. If
     conflicts are present, the conflict list will be printed and will exit with
     error.
@@ -58,7 +58,7 @@ def sanitize_args_config(git_config_args: list[str]) -> list[str]:
 
 def fill_unset(assets: Generator[dict, None, None] | filter,
                keys: list[str]) -> Generator[dict, None, None]:
-    """Fill values for missing `keys` in `assets` with `UNSET_VALUE`.
+    r"""Fill values for missing `keys` in `assets` with `UNSET_VALUE`.
 
     Helper for the onyo-get command.
 
@@ -76,7 +76,7 @@ def fill_unset(assets: Generator[dict, None, None] | filter,
 def natural_sort(assets: list[dict],
                  keys: list[str] | None = None,
                  reverse: bool = False) -> list[dict]:
-    """Sort an asset list by a given list of `keys`.
+    r"""Sort an asset list by a given list of `keys`.
 
     Parameters
     ----------
@@ -103,7 +103,7 @@ def natural_sort(assets: list[dict],
 
 
 def get_history_cmd(interactive: bool, repo: OnyoRepo) -> str:
-    """
+    r"""
     Get the command used to display history. The appropriate one is selected
     according to the interactive mode, and basic checks are performed for
     validity.

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -33,7 +33,7 @@ P = ParamSpec('P')
 
 
 def raise_on_inventory_state(func: Callable[P, T]) -> Callable[P, T]:
-    """Raises if it's not OK to run an onyo command on `inventory`.
+    r"""Raises if it's not OK to run an onyo command on `inventory`.
 
     Decorator for onyo commands. Expects an `Inventory` to be part of
     the arguments to the decorated function.
@@ -70,7 +70,7 @@ def raise_on_inventory_state(func: Callable[P, T]) -> Callable[P, T]:
 
 def fsck(repo: OnyoRepo,
          tests: list[str] | None = None) -> None:
-    """Run a suite of checks to verify the integrity and validity of an Onyo
+    r"""Run a suite of checks to verify the integrity and validity of an Onyo
     repository and its contents.
 
     By default, the following tests will be performed:
@@ -140,7 +140,7 @@ def fsck(repo: OnyoRepo,
 @raise_on_inventory_state
 def onyo_cat(inventory: Inventory,
              paths: list[Path]) -> None:
-    """Print the contents of assets.
+    r"""Print the contents of assets.
 
     At least one valid asset path is required.
     The same paths can be given multiple times.
@@ -186,7 +186,7 @@ def onyo_cat(inventory: Inventory,
 @raise_on_inventory_state
 def onyo_config(inventory: Inventory,
                 config_args: list[str]) -> None:
-    """Interface the configuration of an onyo repository.
+    r"""Interface the configuration of an onyo repository.
 
     The config file for the Repo will be identified and the config_args passed
     into a ``git config`` call on the config file.
@@ -221,7 +221,7 @@ def _edit_asset(inventory: Inventory,
                 asset: dict,
                 operation: Callable,
                 editor: str | None) -> dict:
-    """Edit `asset` via configured editor and a temporary asset file.
+    r"""Edit `asset` via configured editor and a temporary asset file.
 
     Utility function for `onyo_edit` and `onyo_new(edit=True)`.
     This is editing a temporary file initialized with `asset`. Once
@@ -327,7 +327,7 @@ def _edit_asset(inventory: Inventory,
 def onyo_edit(inventory: Inventory,
               paths: list[Path],
               message: str | None) -> None:
-    """Edit the content of assets.
+    r"""Edit the content of assets.
 
     Parameters
     ----------
@@ -392,7 +392,7 @@ def onyo_get(inventory: Inventory,
              match: list[Callable[[dict], bool]] | None = None,
              keys: list[str] | None = None,
              sort: Literal['ascending', 'descending'] = 'ascending') -> list[dict]:
-    """Query the repository for information about assets.
+    r"""Query the repository for information about assets.
 
     Parameters
     ----------
@@ -496,7 +496,7 @@ def onyo_get(inventory: Inventory,
 def onyo_mkdir(inventory: Inventory,
                dirs: list[Path],
                message: str | None) -> None:
-    """Create new directories in the inventory.
+    r"""Create new directories in the inventory.
 
     Intermediate directories will be created as needed (i.e. parent and
     child directories can be created in one call).
@@ -554,7 +554,7 @@ def onyo_mkdir(inventory: Inventory,
 def move_asset_or_dir(inventory: Inventory,
                       source: Path,
                       destination: Path) -> None:
-    """Move a source asset or directory to a destination.
+    r"""Move a source asset or directory to a destination.
 
     Parameters
     ----------
@@ -575,7 +575,7 @@ def move_asset_or_dir(inventory: Inventory,
 def _maybe_rename(inventory: Inventory,
                   src: Path,
                   dst: Path) -> None:
-    """Helper for `onyo_mv`"""
+    r"""Helper for `onyo_mv`"""
 
     try:
         inventory.rename_directory(src, dst)
@@ -590,7 +590,7 @@ def onyo_mv(inventory: Inventory,
             source: list[Path] | Path,
             destination: Path,
             message: str | None = None) -> None:
-    """Move assets or directories, or rename a directory.
+    r"""Move assets or directories, or rename a directory.
 
     If `destination` is an asset file, turns it into an asset dir first.
 
@@ -685,7 +685,7 @@ def onyo_new(inventory: Inventory,
              keys: list[Dict[str, str | int | float]] | None = None,
              edit: bool = False,
              message: str | None = None) -> None:
-    """Create new assets and add them to the inventory.
+    r"""Create new assets and add them to the inventory.
 
     Either keys, tsv or edit must be given.
     If keys and tsv and keys define multiple assets: Number of assets must match.
@@ -880,7 +880,7 @@ def onyo_rm(inventory: Inventory,
             paths: list[Path] | Path,
             message: str | None,
             mode: Literal["asset", "dir", "all"] = "all") -> None:
-    """Delete assets and/or directories from the inventory.
+    r"""Delete assets and/or directories from the inventory.
 
     Parameters
     ----------
@@ -956,7 +956,7 @@ def onyo_set(inventory: Inventory,
              assets: list[Path],
              rename: bool = False,
              message: str | None = None) -> str | None:
-    """Set key-value pairs of assets, and change asset names.
+    r"""Set key-value pairs of assets, and change asset names.
 
     Parameters
     ----------
@@ -1039,7 +1039,7 @@ def onyo_set(inventory: Inventory,
 @raise_on_inventory_state
 def onyo_tree(inventory: Inventory,
               dirs: list[tuple[str, Path]]) -> None:
-    """Print the directory tree of paths.
+    r"""Print the directory tree of paths.
 
     Parameters
     ----------
@@ -1072,7 +1072,7 @@ def onyo_tree(inventory: Inventory,
 
 
 def _tree(dir_path: Path, prefix: str = '') -> Generator[str, None, None]:
-    """Yield lines that assemble tree-like output, stylized by rich.
+    r"""Yield lines that assemble tree-like output, stylized by rich.
 
     Parameters
     ----------
@@ -1117,7 +1117,7 @@ def onyo_unset(inventory: Inventory,
                keys: list[str],
                assets: list[Path],
                message: str | None = None) -> None:
-    """Remove keys from assets.
+    r"""Remove keys from assets.
 
     Parameters
     ----------

--- a/onyo/lib/exceptions.py
+++ b/onyo/lib/exceptions.py
@@ -2,45 +2,45 @@ from __future__ import annotations
 
 
 class OnyoRepoError(Exception):
-    """Thrown if something is wrong with an onyo repository."""
+    r"""Thrown if something is wrong with an onyo repository."""
 
 
 class OnyoInvalidRepoError(OnyoRepoError):
-    """Thrown if the repository is invalid."""
+    r"""Thrown if the repository is invalid."""
 
 
 class OnyoProtectedPathError(Exception):
-    """Thrown if path is protected (.anchor, .git/, .onyo/)."""
+    r"""Thrown if path is protected (.anchor, .git/, .onyo/)."""
 
 
 class OnyoInvalidFilterError(Exception):
-    """Raise if filters are invalidly defined"""
+    r"""Raise if filters are invalidly defined"""
 
 
 class InventoryOperationError(Exception):
-    """Thrown if an inventory operation cannot be executed."""
+    r"""Thrown if an inventory operation cannot be executed."""
 
 
 class InvalidInventoryOperationError(InventoryOperationError):
-    """Thrown if an invalid inventory operation is requested."""
+    r"""Thrown if an invalid inventory operation is requested."""
 
 
 class PendingInventoryOperationError(InventoryOperationError):
-    """Thrown if there are unexpected pending operations."""
+    r"""Thrown if there are unexpected pending operations."""
     # TODO  -> enhance message w/ hint to Inventory.reset/commit?
     #          would be useful in python context only
 
 
 class NoopError(InventoryOperationError):
-    """Thrown if a requested operation is a Noop."""
+    r"""Thrown if a requested operation is a Noop."""
     # This is intended to signal that an inventory operation would not result in any change, so that callers can decide
     # on their failure paradigm:
     # "Result oriented already-fine-no-failure" vs "Task oriented can't-do-failure".
 
 
 class NotAnAssetError(Exception):
-    """Thrown if an object was expected to be an asset but isn't"""
+    r"""Thrown if an object was expected to be an asset but isn't"""
 
 
 class NotADirError(Exception):
-    """Thrown if an object was expected to be a directory but isn't"""
+    r"""Thrown if an object was expected to be a directory but isn't"""

--- a/onyo/lib/executors.py
+++ b/onyo/lib/executors.py
@@ -15,7 +15,7 @@ from onyo.lib.onyo import OnyoRepo
 
 
 def exec_new_assets(repo: OnyoRepo, operands: tuple) -> tuple[list[Path], list[Path]]:
-    """Executor for the 'new_asset' operation
+    r"""Executor for the 'new_asset' operation
 
     Parameters
     ----------
@@ -38,7 +38,7 @@ def exec_new_assets(repo: OnyoRepo, operands: tuple) -> tuple[list[Path], list[P
 
 
 def exec_new_directories(repo: OnyoRepo, operands: tuple) -> tuple[list[Path], list[Path]]:
-    """Executor for the 'new_directory' operation
+    r"""Executor for the 'new_directory' operation
     """
     p: Path = operands[0]
     asset = dict()
@@ -92,7 +92,7 @@ def exec_remove_directories(repo: OnyoRepo, operands: tuple) -> tuple[list[Path]
 
 
 def mover(src: Path, dst: Path) -> list[Path]:
-    """helper function for move assets/directories executors"""
+    r"""helper function for move assets/directories executors"""
     # expected: dst is inventory dir!
     src.rename(dst / src.name)
     return [src, dst / src.name]
@@ -128,7 +128,7 @@ def exec_modify_assets(repo: OnyoRepo, operands: tuple) -> tuple[list[Path], lis
 
 
 def generic_executor(func: Callable, repo: OnyoRepo, operands: tuple) -> tuple[list[Path], list[Path]]:
-    """This is intended for simple FS operations on non-inventory files
+    r"""This is intended for simple FS operations on non-inventory files
 
     only current usecase is recursive remove_directory. Not yet meant to be a stable implementation"""
     func(operands)

--- a/onyo/lib/filters.py
+++ b/onyo/lib/filters.py
@@ -9,7 +9,7 @@ from onyo.lib.exceptions import OnyoInvalidFilterError
 
 @dataclass
 class Filter:
-    """This class translates a string expression to a match function
+    r"""This class translates a string expression to a match function
     suitable for the builtin `filter`.
 
     Intended for use with string patterns used with onyo's CLI.
@@ -19,7 +19,7 @@ class Filter:
     value: str = field(init=False)
 
     def __post_init__(self) -> None:
-        """
+        r"""
         Set up a `key=value` conditional as a filter, to allow assets to be
         matched with the filter. Asset keys are then assessed on whether the
         given key matches the given value. This can be used along with the
@@ -35,7 +35,7 @@ class Filter:
 
     @staticmethod
     def _format(arg: str) -> list[str]:
-        """Split filters by the first occurrence of the `=` (equals) sign."""
+        r"""Split filters by the first occurrence of the `=` (equals) sign."""
         if not isinstance(arg, str) or '=' not in arg:
             raise OnyoInvalidFilterError(
                 'Filters must be formatted as `key=value`')
@@ -49,7 +49,7 @@ class Filter:
             return False
 
     def match(self, asset: dict) -> bool:
-        """match self on a dictionary"""
+        r"""match self on a dictionary"""
         string_types = {'<list>': list, '<dict>': dict}
 
         # Check if filter is <unset> and there is no data

--- a/onyo/lib/git.py
+++ b/onyo/lib/git.py
@@ -10,7 +10,7 @@ log: logging.Logger = logging.getLogger('onyo.git')
 
 
 class GitRepo(object):
-    """Representation of a git repository.
+    r"""Representation of a git repository.
 
     This relies on subprocesses running on a git worktree.
     Does not currently support bare repositories.
@@ -24,7 +24,7 @@ class GitRepo(object):
     def __init__(self,
                  path: Path,
                  find_root: bool = False) -> None:
-        """Instantiates a `GitRepo` object with `path` as the root directory.
+        r"""Instantiates a `GitRepo` object with `path` as the root directory.
 
         Parameters
         ----------
@@ -39,7 +39,7 @@ class GitRepo(object):
 
     @staticmethod
     def find_root(path: Path) -> Path:
-        """Returns the git worktree root `path` belongs to.
+        r"""Returns the git worktree root `path` belongs to.
 
         Parameters
         ----------
@@ -70,7 +70,7 @@ class GitRepo(object):
              args: list[str], *,
              cwd: Path | None = None,
              raise_error: bool = True) -> str:
-        """A wrapper function for git calls, returning the output of commands.
+        r"""A wrapper function for git calls, returning the output of commands.
 
         Parameters
         ----------
@@ -97,7 +97,7 @@ class GitRepo(object):
 
     @property
     def files(self) -> list[Path]:
-        """Get the absolute ``Path``\ s of all tracked files.
+        r"""Get the absolute ``Path``\ s of all tracked files.
 
         This property is cached, and is reset automatically on `GitRepo.commit()`.
 
@@ -109,7 +109,7 @@ class GitRepo(object):
         return self._files
 
     def clear_cache(self) -> None:
-        """Clear cache of this instance of GitRepo.
+        r"""Clear cache of this instance of GitRepo.
 
         Caches cleared are:
         - `GitRepo.files`
@@ -123,7 +123,7 @@ class GitRepo(object):
 
     def get_subtrees(self,
                      paths: Iterable[Path] | None = None) -> list[Path]:
-        """Get tracked files in the subtrees rooted at `paths`.
+        r"""Get tracked files in the subtrees rooted at `paths`.
 
         Parameters
         ----------
@@ -153,7 +153,7 @@ class GitRepo(object):
         return files
 
     def is_clean_worktree(self) -> bool:
-        """Check whether the git worktree is clean.
+        r"""Check whether the git worktree is clean.
 
         Returns
         -------
@@ -163,7 +163,7 @@ class GitRepo(object):
         return not bool(self._git(['status', '--porcelain']))
 
     def maybe_init(self) -> None:
-        """Initialize `self.root` as a git repository
+        r"""Initialize `self.root` as a git repository
         if it is not already one.
         """
         # Note: Why? git-init would do that
@@ -181,7 +181,7 @@ class GitRepo(object):
     def commit(self,
                paths: Iterable[Path] | Path,
                message: str) -> None:
-        """Stage and commit changes in git.
+        r"""Stage and commit changes in git.
 
         Parameters
         ----------
@@ -199,7 +199,7 @@ class GitRepo(object):
 
     @staticmethod
     def is_git_path(path: Path) -> bool:
-        """Whether `path` is a git file or directory.
+        r"""Whether `path` is a git file or directory.
 
         A 'git path' is considered a path that is used by git
         itself (tracked or not) and therefore not valid for use
@@ -223,7 +223,7 @@ class GitRepo(object):
     def get_config(self,
                    name: str,
                    file_: Path | None = None) -> str | None:
-        """Get the value for a configuration option specified by `name`.
+        r"""Get the value for a configuration option specified by `name`.
 
         By default, git-config is read following its order of precedence (worktree,
         local, global, system). If a `file_` is given, this is read instead.
@@ -269,7 +269,7 @@ class GitRepo(object):
                    name: str,
                    value: str,
                    location: str | Path | None = None) -> None:
-        """Set the configuration option `name` to `value`.
+        r"""Set the configuration option `name` to `value`.
 
         Parameters
         ----------
@@ -310,7 +310,7 @@ class GitRepo(object):
     def get_hexsha(self,
                    commitish: str | None = None,
                    short: bool = False) -> str | None:
-        """Return the hexsha of a given commit-ish.
+        r"""Return the hexsha of a given commit-ish.
 
         Parameters
         ----------
@@ -346,7 +346,7 @@ class GitRepo(object):
 
     def get_commit_msg(self,
                        commitish: str | None = None) -> str:
-        """Returns the full commit message of a commit-ish.
+        r"""Returns the full commit message of a commit-ish.
 
         Parameters
         ----------
@@ -361,7 +361,7 @@ class GitRepo(object):
         return self._git(['log', commitish or 'HEAD', '-n1', '--pretty=%B'])
 
     def check_ignore(self, ignore: Path, paths: list[Path]) -> list[Path]:
-        """Get the `paths` that are matched by patterns defined in `ignore`.
+        r"""Get the `paths` that are matched by patterns defined in `ignore`.
 
         This is utilizing ``git-check-ignore`` to evaluate `paths` against
         a file `ignore`, that defines exclude patterns the gitignore-way.

--- a/onyo/lib/inventory.py
+++ b/onyo/lib/inventory.py
@@ -115,7 +115,7 @@ OPERATIONS_MAPPING: dict = {'new_directories': InventoryOperator(executor=exec_n
 #       like removing something that is to be created. -> reset() or commit()
 # TODO: clear_cache from within commit? What about operations?
 class Inventory(object):
-    """"""
+    r""""""
 
     def __init__(self, repo: OnyoRepo) -> None:
         self.repo: OnyoRepo = repo
@@ -124,15 +124,15 @@ class Inventory(object):
 
     @property
     def root(self):
-        """Path to root inventory directory"""
+        r"""Path to root inventory directory"""
         return self.repo.git.root
 
     def reset(self) -> None:
-        """throw away pending operations"""
+        r"""throw away pending operations"""
         self.operations = []
 
     def commit(self, message: str) -> None:
-        """Execute and git-commit pending operations"""
+        r"""Execute and git-commit pending operations"""
         # get user message + generate appendix from operations
         # does order matter for execution? Prob.
         # ^  Nope. Fail on conflicts.
@@ -170,12 +170,12 @@ class Inventory(object):
             yield from operation.diff()
 
     def operations_pending(self) -> bool:
-        """Returns whether there's something to commit"""
+        r"""Returns whether there's something to commit"""
         # Note: Seems superfluous now (operations is a list rather than dict of lists)
         return bool(self.operations)
 
     def _get_pending_asset_names(self) -> list[str]:
-        """List of asset names that are targets of pending operations
+        r"""List of asset names that are targets of pending operations
 
         This is extracting paths that would exist if the currently
         pending operations were executed, in order to provide the
@@ -201,7 +201,7 @@ class Inventory(object):
         return names
 
     def _get_pending_dirs(self) -> list[Path]:
-        """Gets inventory dirs that would come into existence due to pending operations.
+        r"""Gets inventory dirs that would come into existence due to pending operations.
 
         Extracts paths to inventory dirs, that are the anticipated results of pending
         moves and creations.
@@ -226,7 +226,7 @@ class Inventory(object):
 
     def _get_pending_removals(self,
                               mode: Literal['assets', 'dirs', 'all'] = 'all') -> list[Path]:
-        """Get paths that are removed by pending operations.
+        r"""Get paths that are removed by pending operations.
 
         Parameters
         ----------
@@ -262,7 +262,7 @@ class Inventory(object):
     #
 
     def _add_operation(self, name: str, operands: tuple) -> InventoryOperation:
-        """Internal convenience helper to register an operation"""
+        r"""Internal convenience helper to register an operation"""
         op = InventoryOperation(operator=OPERATIONS_MAPPING[name],
                                 operands=operands,
                                 repo=self.repo)
@@ -528,7 +528,7 @@ class Inventory(object):
     def get_assets(self,
                    paths: list[Path] | None = None,
                    depth: int = 0) -> Generator[dict, None, None]:
-        """Yield all assets under `paths` up to `depth` directory levels.
+        r"""Yield all assets under `paths` up to `depth` directory levels.
 
         Generator, because it needs to read file content. This allows to act upon
         results while they are coming in.
@@ -556,7 +556,7 @@ class Inventory(object):
                             paths: list[Path] | None = None,
                             depth: int | None = 0,
                             match: list[Callable[[dict], bool]] | None = None) -> Generator | filter:
-        """Get assets matching paths and filters.
+        r"""Get assets matching paths and filters.
 
         Convenience to run the builtin `filter` on all assets retrieved by
         `self.get(paths, depth)` for each callable in `filters`, thus
@@ -590,7 +590,7 @@ class Inventory(object):
         return assets
 
     def asset_paths_available(self, assets: Asset | list[Asset]) -> None:
-        """Test whether path(s) used by `assets` are available in the inventory.
+        r"""Test whether path(s) used by `assets` are available in the inventory.
 
         Availability not only requires the path to not yet exist, but also the filename to be unique.
 
@@ -634,7 +634,7 @@ class Inventory(object):
     def get_faux_serials(self,
                          length: int = 6,
                          num: int = 1) -> set[str]:
-        """
+        r"""
         Generate a unique faux serial and verify that it is not used by any
         other asset in the repository. The length of the faux serial must be 4
         or greater.
@@ -665,7 +665,7 @@ class Inventory(object):
         return faux_serials
 
     def _required_key_empty(self, asset: dict) -> bool:
-        """Whether `asset` has an empty value for a required key.
+        r"""Whether `asset` has an empty value for a required key.
 
         Validation helper.
 

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -16,7 +16,7 @@ log: logging.Logger = logging.getLogger('onyo.onyo')
 
 
 class OnyoRepo(object):
-    """
+    r"""
     An object representing an Onyo repository.
 
     Allows identifying and working with asset paths and directories, getting and
@@ -45,7 +45,7 @@ class OnyoRepo(object):
                  path: Path,
                  init: bool = False,
                  find_root: bool = False) -> None:
-        """Instantiates an `OnyoRepo` object with `path` as the root directory.
+        r"""Instantiates an `OnyoRepo` object with `path` as the root directory.
 
         Parameters
         ----------
@@ -94,7 +94,7 @@ class OnyoRepo(object):
                    name: str,
                    value: str,
                    location: str = 'onyo') -> None:
-        """Set the configuration option `name` to `value`.
+        r"""Set the configuration option `name` to `value`.
 
         Parameters
         ----------
@@ -120,7 +120,7 @@ class OnyoRepo(object):
 
     def get_config(self,
                    name: str) -> str | None:
-        """Get effective value of config `name`.
+        r"""Get effective value of config `name`.
 
         This is considering regular git-config locations and checks
         `OnyoRepo.ONYO_CONFIG` as fallback.
@@ -128,7 +128,7 @@ class OnyoRepo(object):
         return self.git.get_config(name) or self.git.get_config(name, self.git.root / self.ONYO_CONFIG)
 
     def get_asset_name_keys(self) -> list[str]:
-        """Get a list of keys required for generating asset names
+        r"""Get a list of keys required for generating asset names
 
         This is extracting names of used keys from the
         ``onyo.assets.filename`` config, which is supposed to be
@@ -140,7 +140,7 @@ class OnyoRepo(object):
         '{', followed by a key name, which is then either closed
         directly via '}' or first followed by some formatting options
         in which case there's '[', '.', '!', etc.
-        Note, that '\\w' is used to match the key name, which includes
+        Note, that '\w' is used to match the key name, which includes
         alphanumeric characters as well as underscores, therefore
         matching python variable name restrictions. This is relevant,
         because we want to get a dict from the YAML and making the
@@ -166,7 +166,7 @@ class OnyoRepo(object):
         return re.findall(search_regex, config_str) if config_str else []
 
     def get_editor(self) -> str:
-        """Returns the editor, progressing through git, onyo, $EDITOR, and finally
+        r"""Returns the editor, progressing through git, onyo, $EDITOR, and finally
         fallback to "nano".
         """
         # onyo config and git config
@@ -185,7 +185,7 @@ class OnyoRepo(object):
         return editor
 
     def clear_cache(self) -> None:
-        """Clear cache of this instance of GitRepo.
+        r"""Clear cache of this instance of GitRepo.
 
         Caches cleared are:
         - `OnyoRepo.asset_paths`
@@ -203,7 +203,7 @@ class OnyoRepo(object):
     def generate_commit_message(format_string: str,
                                 max_length: int = 80,
                                 **kwargs) -> str:
-        """Generate a commit message subject.
+        r"""Generate a commit message subject.
 
         The function will shorten paths in the resulting string in order to try to fit into
         `max_length`.
@@ -253,7 +253,7 @@ class OnyoRepo(object):
 
     @property
     def asset_paths(self) -> list[Path]:
-        """Get the absolute ``Path``\ s of all assets in this repository.
+        r"""Get the absolute ``Path``\ s of all assets in this repository.
 
         This property is cached, and is reset automatically on `OnyoRepo.commit()`.
 
@@ -265,7 +265,7 @@ class OnyoRepo(object):
         return self._asset_paths
 
     def is_valid_onyo_repo(self) -> bool:
-        """Assert whether this is a properly set up onyo repository and has a fully
+        r"""Assert whether this is a properly set up onyo repository and has a fully
         populated `.onyo/` directory.
 
         Returns
@@ -291,7 +291,7 @@ class OnyoRepo(object):
 
     def _init(self,
               path: Path) -> None:
-        """Initialize an Onyo repository at `path`.
+        r"""Initialize an Onyo repository at `path`.
 
         Re-init-ing an existing repository is safe. It will not overwrite
         anything; it will raise an exception.
@@ -348,7 +348,7 @@ class OnyoRepo(object):
 
     def is_onyo_path(self,
                      path: Path) -> bool:
-        """Determine whether an absolute `path` is used by onyo internally.
+        r"""Determine whether an absolute `path` is used by onyo internally.
 
         Currently anything underneath `.onyo/`, anything named `.onyo*`,
         and an anchor files in an inventory directory is considered an
@@ -369,7 +369,7 @@ class OnyoRepo(object):
 
     def is_inventory_dir(self,
                          path: Path) -> bool:
-        """Whether `path` is an inventory directory.
+        r"""Whether `path` is an inventory directory.
 
         This only considers directories w/ committed anchor file.
         """
@@ -378,7 +378,7 @@ class OnyoRepo(object):
 
     def is_asset_path(self,
                       path: Path) -> bool:
-        """Whether `path` is an asset in the repository.
+        r"""Whether `path` is an asset in the repository.
 
         Parameters
         ----------
@@ -394,7 +394,7 @@ class OnyoRepo(object):
 
     def is_inventory_path(self,
                           path: Path) -> bool:
-        """Whether `path` is valid for tracking an asset or an inventory directory.
+        r"""Whether `path` is valid for tracking an asset or an inventory directory.
 
         This only checks whether `path` is suitable in principle.
         It does not check whether that path already exists or if it would be valid
@@ -416,7 +416,7 @@ class OnyoRepo(object):
             not self.is_onyo_ignored(path)
 
     def is_asset_dir(self, path: Path) -> bool:
-        """Whether `path` is an asset directory.
+        r"""Whether `path` is an asset directory.
 
         An asset directory is both, an asset and an inventory directory.
 
@@ -433,7 +433,7 @@ class OnyoRepo(object):
         return self.is_inventory_dir(path) and self.is_asset_path(path)
 
     def is_onyo_ignored(self, path: Path) -> bool:
-        """Whether `path` is matched by an ``.onyoignore`` file.
+        r"""Whether `path` is matched by an ``.onyoignore`` file.
 
         Such a path would be tracked by git, but not considered
         to be an inventory item by onyo.
@@ -460,7 +460,7 @@ class OnyoRepo(object):
 
     def get_template(self,
                      name: str | None = None) -> dict:
-        """Select and return a template from the directory `.onyo/templates/`.
+        r"""Select and return a template from the directory `.onyo/templates/`.
 
         Parameters
         ----------
@@ -491,7 +491,7 @@ class OnyoRepo(object):
         return yaml_to_dict(template_file)
 
     def validate_anchors(self) -> bool:
-        """Check if all dirs (except those in `.onyo/`) contain an .anchor file.
+        r"""Check if all dirs (except those in `.onyo/`) contain an .anchor file.
 
         Returns
         -------
@@ -527,7 +527,7 @@ class OnyoRepo(object):
     def get_asset_paths(self,
                         subtrees: Iterable[Path] | None = None,
                         depth: int = 0) -> List[Path]:
-        """Select all assets in the repository that are relative to the given
+        r"""Select all assets in the repository that are relative to the given
         `subtrees` descending at most `depth` directories.
 
         Parameters
@@ -561,7 +561,7 @@ class OnyoRepo(object):
 
     def get_asset_content(self,
                           path: Path) -> dict:
-        """Get a dictionary representing `path`'s content.
+        r"""Get a dictionary representing `path`'s content.
 
         Parameters
         ----------
@@ -607,7 +607,7 @@ class OnyoRepo(object):
 
     def mk_inventory_dirs(self,
                           dirs: Iterable[Path] | Path) -> list[Path]:
-        """Create inventory directories `dirs`.
+        r"""Create inventory directories `dirs`.
 
         Creates `dirs` including anchor files.
 
@@ -667,7 +667,7 @@ class OnyoRepo(object):
         return added_files
 
     def commit(self, paths: Iterable[Path] | Path, message: str):
-        """Commit changes to the repository.
+        r"""Commit changes to the repository.
 
         This is resets the cache and is otherwise just a proxy for
         `GitRepo.commit`.

--- a/onyo/lib/tests/test_commands_cat.py
+++ b/onyo/lib/tests/test_commands_cat.py
@@ -11,7 +11,7 @@ from ..commands import onyo_cat
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_cat_errors(inventory: Inventory) -> None:
-    """`onyo_cat` must raise the correct error in different illegal or impossible calls."""
+    r"""`onyo_cat` must raise the correct error in different illegal or impossible calls."""
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     dir_path = inventory.root / 'empty'
 
@@ -80,7 +80,7 @@ def test_onyo_cat_errors(inventory: Inventory) -> None:
 @pytest.mark.ui({'yes': True})
 def test_onyo_cat_single(inventory: Inventory,
                          capsys) -> None:
-    """`onyo_cat()` a single valid asset."""
+    r"""`onyo_cat()` a single valid asset."""
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
 
     # cat single asset
@@ -94,7 +94,7 @@ def test_onyo_cat_single(inventory: Inventory,
 @pytest.mark.ui({'yes': True})
 def test_onyo_cat_multiple(inventory: Inventory,
                            capsys) -> None:
-    """`onyo_cat()` on multiple valid assets."""
+    r"""`onyo_cat()` on multiple valid assets."""
     asset_path1 = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     # TODO: simplify with new fixtures
     # add a different second asset to the inventory
@@ -123,7 +123,7 @@ def test_onyo_cat_multiple(inventory: Inventory,
 @pytest.mark.ui({'yes': True})
 def test_onyo_cat_with_duplicate_path(inventory: Inventory,
                                       capsys) -> None:
-    """`onyo_cat()` Multiple times on the same asset succeeds."""
+    r"""`onyo_cat()` Multiple times on the same asset succeeds."""
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
 
     # cat single asset

--- a/onyo/lib/tests/test_commands_get.py
+++ b/onyo/lib/tests/test_commands_get.py
@@ -10,7 +10,7 @@ from ..commands import onyo_get
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_errors(inventory: Inventory) -> None:
-    """`onyo_get()` must raise the correct error in different illegal or impossible calls."""
+    r"""`onyo_get()` must raise the correct error in different illegal or impossible calls."""
 
     # get on non-existing asset
     pytest.raises(ValueError,
@@ -54,7 +54,7 @@ def test_onyo_get_errors(inventory: Inventory) -> None:
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_empty_keys(inventory: Inventory,
                              capsys) -> None:
-    """Verify `onyo_get()` prints values for non-existing keys as unset,
+    r"""Verify `onyo_get()` prints values for non-existing keys as unset,
     and values for keys that exist but have an empty value correctly."""
     from onyo.lib.consts import UNSET_VALUE
     asset_path1 = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
@@ -87,7 +87,7 @@ def test_onyo_get_empty_keys(inventory: Inventory,
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_on_empty_directory(inventory: Inventory) -> None:
-    """`onyo_get()` does not error when called on a valid but empty directory."""
+    r"""`onyo_get()` does not error when called on a valid but empty directory."""
     dir_path = inventory.root / 'empty'
 
     # `onyo_get()` on a directory without assets does not error
@@ -98,7 +98,7 @@ def test_onyo_get_on_empty_directory(inventory: Inventory) -> None:
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_reserved_keys(inventory: Inventory,
                                 capsys) -> None:
-    """`onyo_get()` allows to specify all reserved keys to query
+    r"""`onyo_get()` allows to specify all reserved keys to query
     and display information for."""
     from onyo.lib.consts import RESERVED_KEYS, PSEUDO_KEYS
     reserved = ["type", "make", "model", "serial"] + PSEUDO_KEYS + RESERVED_KEYS
@@ -120,7 +120,7 @@ def test_onyo_get_reserved_keys(inventory: Inventory,
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_name_keys(inventory: Inventory,
                             capsys) -> None:
-    """If no keys are specified when calling `onyo_get()`
+    r"""If no keys are specified when calling `onyo_get()`
     the name keys are printed by default."""
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     name_keys = ["type", "make", "model", "serial"]
@@ -138,7 +138,7 @@ def test_onyo_get_name_keys(inventory: Inventory,
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_errors_before_get(inventory: Inventory) -> None:
-    """`onyo_get()` must raise the correct error if one of
+    r"""`onyo_get()` must raise the correct error if one of
     the specified paths is not valid.
     """
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
@@ -155,7 +155,7 @@ def test_onyo_get_errors_before_get(inventory: Inventory) -> None:
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_simple(inventory: Inventory,
                          capsys) -> None:
-    """`onyo_get()` gets a value in an asset."""
+    r"""`onyo_get()` gets a value in an asset."""
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     get_key = "some_key"
 
@@ -173,7 +173,7 @@ def test_onyo_get_simple(inventory: Inventory,
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_machine_readable(inventory: Inventory,
                                    capsys) -> None:
-    """`onyo_get()` with machine_readable=True gives different
+    r"""`onyo_get()` with machine_readable=True gives different
     output that contains all requested information."""
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     get_key = "some_key"
@@ -204,7 +204,7 @@ def test_onyo_get_machine_readable(inventory: Inventory,
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_sorting(inventory: Inventory,
                           capsys) -> None:
-    """`onyo_get()` allows different types of sorting the output,
+    r"""`onyo_get()` allows different types of sorting the output,
     but errors if illegal sorting is specified."""
     asset_path1 = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     asset_path2 = inventory.root / "one_that_exists.test"
@@ -242,7 +242,7 @@ def test_onyo_get_sorting(inventory: Inventory,
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_on_directory(inventory: Inventory,
                                capsys) -> None:
-    """`onyo_get()` gets a value in assets inside a directory."""
+    r"""`onyo_get()` gets a value in assets inside a directory."""
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     dir_path = inventory.root / "somewhere"
     get_key = "some_key"
@@ -263,7 +263,7 @@ def test_onyo_get_on_directory(inventory: Inventory,
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_match(inventory: Inventory,
                         capsys) -> None:
-    """`onyo_get()` lists just matching assets when `match` is used."""
+    r"""`onyo_get()` lists just matching assets when `match` is used."""
     asset_path1 = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     asset_path2 = inventory.root / "one_that_exists.test"
     matches = [Filter("other=1").match]
@@ -291,7 +291,7 @@ def test_onyo_get_match(inventory: Inventory,
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_no_matches(inventory: Inventory,
                              capsys) -> None:
-    """`onyo_get()` behaves correctly when `match` matches no assets."""
+    r"""`onyo_get()` behaves correctly when `match` matches no assets."""
     asset_path1 = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     asset_path2 = inventory.root / "one_that_exists.test"
     matches = [Filter("unfound=values").match]
@@ -313,7 +313,7 @@ def test_onyo_get_no_matches(inventory: Inventory,
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_multiple(inventory: Inventory,
                            capsys) -> None:
-    """`onyo_get()` finds information about multiple assets in a single call."""
+    r"""`onyo_get()` finds information about multiple assets in a single call."""
     asset_path1 = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     asset_path2 = inventory.root / "one_that_exists.test"
     get_key = "some_key"
@@ -337,7 +337,7 @@ def test_onyo_get_multiple(inventory: Inventory,
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_depth(inventory: Inventory,
                         capsys) -> None:
-    """`onyo_get()` with depth selects the correct assets."""
+    r"""`onyo_get()` with depth selects the correct assets."""
     asset_path1 = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     asset_path2 = inventory.root / "one_that_exists.test"
 
@@ -358,7 +358,7 @@ def test_onyo_get_depth(inventory: Inventory,
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_depth_zero(inventory: Inventory,
                              capsys) -> None:
-    """Calling `onyo_get(depth=0)` is legal and selects all assets from all subpaths."""
+    r"""Calling `onyo_get(depth=0)` is legal and selects all assets from all subpaths."""
     onyo_get(inventory,
              paths=[inventory.root],
              depth=0)
@@ -375,7 +375,7 @@ def test_onyo_get_depth_zero(inventory: Inventory,
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_default_inventory_root(inventory: Inventory,
                                          capsys) -> None:
-    """Calling `onyo_get()` without path uses inventory.root as default
+    r"""Calling `onyo_get()` without path uses inventory.root as default
     and selects all assets of the inventory."""
     onyo_get(inventory)
 
@@ -389,7 +389,7 @@ def test_onyo_get_default_inventory_root(inventory: Inventory,
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_allows_duplicates(inventory: Inventory,
                                     capsys) -> None:
-    """Calling `onyo_get()` with a list containing the same asset multiple
+    r"""Calling `onyo_get()` with a list containing the same asset multiple
     times does not error, but displays information just once."""
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
 

--- a/onyo/lib/tests/test_commands_mkdir.py
+++ b/onyo/lib/tests/test_commands_mkdir.py
@@ -8,7 +8,7 @@ from ..exceptions import NoopError
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_mkdir_errors(inventory: Inventory) -> None:
-    """`onyo_mkdir` must raise the correct error in different illegal or impossible calls."""
+    r"""`onyo_mkdir` must raise the correct error in different illegal or impossible calls."""
     dir_path = inventory.root / 'empty'
 
     # mkdir on existing directory path
@@ -73,7 +73,7 @@ def test_onyo_mkdir_errors(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_mkdir_errors_before_mkdir(inventory: Inventory) -> None:
-    """`onyo_mkdir` must raise the correct error and is not allowed to create/commit anything, if
+    r"""`onyo_mkdir` must raise the correct error and is not allowed to create/commit anything, if
     one of the specified paths is not valid.
     """
     dir_path_new = inventory.root / 'new_dir'
@@ -99,7 +99,7 @@ def test_onyo_mkdir_errors_before_mkdir(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_mkdir_simple(inventory: Inventory) -> None:
-    """Create a single new directory."""
+    r"""Create a single new directory."""
     dir_path_new = inventory.root / 'new_dir'
     old_hexsha = inventory.repo.git.get_hexsha()
 
@@ -120,7 +120,7 @@ def test_onyo_mkdir_simple(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_mkdir_multiple(inventory: Inventory) -> None:
-    """Create multiple new directories in a single call and with one commit."""
+    r"""Create multiple new directories in a single call and with one commit."""
     dir_path_new1 = inventory.root / 'new_dir1'
     dir_path_new2 = inventory.root / 'new_dir2'
     dir_path_new3 = inventory.root / 'new_dir3'
@@ -155,7 +155,7 @@ def test_onyo_mkdir_multiple(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_mkdir_create_multiple_subdirectories(inventory: Inventory) -> None:
-    """Create multiple not-yet-existing subdirectories at once."""
+    r"""Create multiple not-yet-existing subdirectories at once."""
     dir_x = inventory.root / 'x'
     dir_y = inventory.root / 'x' / 'y'
     dir_z = inventory.root / 'x' / 'y' / 'z'
@@ -189,7 +189,7 @@ def test_onyo_mkdir_create_multiple_subdirectories(inventory: Inventory) -> None
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_mkdir_allows_duplicates(inventory: Inventory) -> None:
-    """Calling `onyo_mkdir()` with a list containing the same path multiple times does not error."""
+    r"""Calling `onyo_mkdir()` with a list containing the same path multiple times does not error."""
     dir_path_new = inventory.root / 'new_dir'
     old_hexsha = inventory.repo.git.get_hexsha()
 
@@ -210,7 +210,7 @@ def test_onyo_mkdir_allows_duplicates(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_mkdir_asset(inventory: Inventory) -> None:
-    """`onyo_mkdir` turns an existing asset into an asset dir."""
+    r"""`onyo_mkdir` turns an existing asset into an asset dir."""
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     old_hexsha = inventory.repo.git.get_hexsha()
 

--- a/onyo/lib/tests/test_commands_mv.py
+++ b/onyo/lib/tests/test_commands_mv.py
@@ -7,7 +7,7 @@ from ..commands import onyo_mv
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_mv_errors(inventory: Inventory) -> None:
-    """`onyo_mv` must raise the correct error in different illegal or impossible calls."""
+    r"""`onyo_mv` must raise the correct error in different illegal or impossible calls."""
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     dir_path = inventory.root / 'empty'
     dir_path2 = inventory.root / 'different' / 'place'
@@ -76,7 +76,7 @@ def test_onyo_mv_errors(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_mv_errors_before_mv(inventory: Inventory) -> None:
-    """`onyo_mv` must raise the correct error and is not allowed to move/commit anything, if one of
+    r"""`onyo_mv` must raise the correct error and is not allowed to move/commit anything, if one of
     the sources does not exist.
     """
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
@@ -102,7 +102,7 @@ def test_onyo_mv_errors_before_mv(inventory: Inventory) -> None:
 @pytest.mark.ui({'yes': True})
 @pytest.mark.repo_dirs("a/b/c", "a/d/c")
 def test_onyo_mv_src_to_dest_with_same_name(inventory: Inventory) -> None:
-    """Allow to move a directory into another one with the same name."""
+    r"""Allow to move a directory into another one with the same name."""
     source_path = inventory.root / "a" / "b" / "c"
     destination_path = inventory.root / "a" / "d" / "c"
     old_hexsha = inventory.repo.git.get_hexsha()
@@ -128,7 +128,7 @@ def test_onyo_mv_src_to_dest_with_same_name(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_mv_move_simple(inventory: Inventory) -> None:
-    """Move an asset and a directory in one commit into a destination."""
+    r"""Move an asset and a directory in one commit into a destination."""
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     dir_path = inventory.root / 'empty'
     destination_path = inventory.root / 'different' / 'place'
@@ -157,7 +157,7 @@ def test_onyo_mv_move_simple(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_mv_move_to_explicit_destination(inventory: Inventory) -> None:
-    """Allow moving a source to a destination stating the
+    r"""Allow moving a source to a destination stating the
     destination name explicitely, e.g.:
     inventory.root/dir1/asset -> inventory.root/dir2/asset.
     """
@@ -186,7 +186,7 @@ def test_onyo_mv_move_to_explicit_destination(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_mv_rename_directory(inventory: Inventory) -> None:
-    """`onyo_mv` must allow renaming of a directory."""
+    r"""`onyo_mv` must allow renaming of a directory."""
     dir_path = inventory.root / 'somewhere' / 'nested'
     destination_path = dir_path.parent / 'newname'
     old_hexsha = inventory.repo.git.get_hexsha()

--- a/onyo/lib/tests/test_commands_new.py
+++ b/onyo/lib/tests/test_commands_new.py
@@ -50,7 +50,7 @@ def test_onyo_new_tsv(inventory: Inventory, tsv: Path) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_new_keys(inventory: Inventory) -> None:
-    """`onyo_new()` must create new assets with the contents set correctly
+    r"""`onyo_new()` must create new assets with the contents set correctly
     when called with `keys`.
 
     Each successful call of `onyo_new()` must add one commit.
@@ -148,7 +148,7 @@ def test_onyo_new_keys(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_new_creates_directories(inventory: Inventory) -> None:
-    """`onyo_new()` must create new directories and subdirectories when called
+    r"""`onyo_new()` must create new directories and subdirectories when called
     on a `directory` that does not yet exist, and add assets correctly to it.
     """
     specs = [{'type': 'a type',

--- a/onyo/lib/tests/test_commands_rm.py
+++ b/onyo/lib/tests/test_commands_rm.py
@@ -8,7 +8,7 @@ from ..commands import onyo_rm
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_rm_errors(inventory: Inventory) -> None:
-    """`onyo_rm` must raise the correct error in different illegal or impossible calls."""
+    r"""`onyo_rm` must raise the correct error in different illegal or impossible calls."""
     # delete non-existing asset
     pytest.raises(InvalidInventoryOperationError,
                   onyo_rm,
@@ -74,7 +74,7 @@ def test_onyo_rm_errors(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_rm_errors_before_rm(inventory: Inventory) -> None:
-    """`onyo_rm` must raise the correct error and is not allowed to delete anything if one of
+    r"""`onyo_rm` must raise the correct error and is not allowed to delete anything if one of
     the paths does not exist.
     """
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
@@ -99,7 +99,7 @@ def test_onyo_rm_errors_before_rm(inventory: Inventory) -> None:
 @pytest.mark.ui({'yes': True})
 @pytest.mark.repo_dirs("a/b/c", "a/b/c/c")
 def test_onyo_rm_with_same_input_path_twice(inventory: Inventory) -> None:
-    """`onyo rm` should not fail when the same path is implied for removal multiple times."""
+    r"""`onyo rm` should not fail when the same path is implied for removal multiple times."""
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     old_hexsha = inventory.repo.git.get_hexsha()
 
@@ -133,7 +133,7 @@ def test_onyo_rm_with_same_input_path_twice(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_rm_move_single(inventory: Inventory) -> None:
-    """Delete a single asset path."""
+    r"""Delete a single asset path."""
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     old_hexsha = inventory.repo.git.get_hexsha()
 
@@ -152,7 +152,7 @@ def test_onyo_rm_move_single(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_rm_delete_directory(inventory: Inventory) -> None:
-    """Delete a single directory path."""
+    r"""Delete a single directory path."""
     dir_path = inventory.root / 'empty'
     old_hexsha = inventory.repo.git.get_hexsha()
 
@@ -171,7 +171,7 @@ def test_onyo_rm_delete_directory(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_rm_list(inventory: Inventory) -> None:
-    """Delete a directory and an asset together as a list in one commit."""
+    r"""Delete a directory and an asset together as a list in one commit."""
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     dir_path = inventory.root / 'empty'
     old_hexsha = inventory.repo.git.get_hexsha()
@@ -194,7 +194,7 @@ def test_onyo_rm_list(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_rm_subpath_and_contents(inventory: Inventory) -> None:
-    """Delete a directory with contents."""
+    r"""Delete a directory with contents."""
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     nested = inventory.root / "somewhere" / "nested"
     old_hexsha = inventory.repo.git.get_hexsha()

--- a/onyo/lib/tests/test_commands_set.py
+++ b/onyo/lib/tests/test_commands_set.py
@@ -9,7 +9,7 @@ from ..commands import onyo_set
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_set_errors(inventory: Inventory) -> None:
-    """`onyo_set()` must raise the correct error in different illegal or impossible calls."""
+    r"""`onyo_set()` must raise the correct error in different illegal or impossible calls."""
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     key_value = {"this_key": "that_value"}
 
@@ -75,7 +75,7 @@ def test_onyo_set_errors(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_set_empty_keys_or_values(inventory: Inventory) -> None:
-    """Verify the correct behavior for empty keys or values in `onyo_set()`."""
+    r"""Verify the correct behavior for empty keys or values in `onyo_set()`."""
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     old_hexsha = inventory.repo.git.get_hexsha()
 
@@ -112,7 +112,7 @@ def test_onyo_set_empty_keys_or_values(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_set_illegal_fields(inventory: Inventory) -> None:
-    """`onyo_set()` must raise an error when requested to set an
+    r"""`onyo_set()` must raise an error when requested to set an
     illegal/reserverd field without `rename=True`."""
     from onyo.lib.consts import RESERVED_KEYS, PSEUDO_KEYS
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
@@ -141,7 +141,7 @@ def test_onyo_set_illegal_fields(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_set_errors_before_set(inventory: Inventory) -> None:
-    """`onyo_set()` must raise the correct error and is not allowed to
+    r"""`onyo_set()` must raise the correct error and is not allowed to
     modify/commit anything, if one of the specified paths is not valid.
     """
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
@@ -168,7 +168,7 @@ def test_onyo_set_errors_before_set(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_set_simple(inventory: Inventory) -> None:
-    """`onyo_set()` sets a value in an asset."""
+    r"""`onyo_set()` sets a value in an asset."""
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     key_value = {"this_key": "that_value"}
     old_hexsha = inventory.repo.git.get_hexsha()
@@ -190,7 +190,7 @@ def test_onyo_set_simple(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_set_already_set(inventory: Inventory) -> None:
-    """`onyo_set()` does not error if called with values
+    r"""`onyo_set()` does not error if called with values
     that are already set."""
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     key_value = {"some_key": "some_value"}
@@ -217,7 +217,7 @@ def test_onyo_set_already_set(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_set_overwrite_existing_value(inventory: Inventory) -> None:
-    """`onyo_set()` overwrites an existing value with a new one in an asset."""
+    r"""`onyo_set()` overwrites an existing value with a new one in an asset."""
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     new_key_value = {"some_key": "that_new_value"}
     old_hexsha = inventory.repo.git.get_hexsha()
@@ -246,7 +246,7 @@ def test_onyo_set_overwrite_existing_value(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_set_some_values_already_set(inventory: Inventory) -> None:
-    """When `onyo_set()` is called with two key value pairs, and one
+    r"""When `onyo_set()` is called with two key value pairs, and one
     is already set and the other not, onyo changes the second one
     without error.
     """
@@ -282,7 +282,7 @@ def test_onyo_set_some_values_already_set(inventory: Inventory) -> None:
     ["one_that_exists.test", "type: one\nmake: that\nmodel: exists\nserial: test"])
 @pytest.mark.ui({'yes': True})
 def test_onyo_set_multiple(inventory: Inventory) -> None:
-    """Modify multiple assets in a single call and with one commit."""
+    r"""Modify multiple assets in a single call and with one commit."""
     asset_path1 = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     asset_path2 = inventory.root / "one_that_exists.test"
     key_value = {"this_key": "that_value"}
@@ -308,7 +308,7 @@ def test_onyo_set_multiple(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_set_allows_duplicates(inventory: Inventory) -> None:
-    """Calling `onyo_set()` with a list containing the same asset multiple
+    r"""Calling `onyo_set()` with a list containing the same asset multiple
     times does not error."""
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     key_value = {"this_key": "that_value"}

--- a/onyo/lib/tests/test_commands_tree.py
+++ b/onyo/lib/tests/test_commands_tree.py
@@ -8,7 +8,7 @@ from ..commands import onyo_tree
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_tree_errors(inventory: Inventory) -> None:
-    """`onyo_tree` must raise the correct error in different illegal or impossible calls."""
+    r"""`onyo_tree` must raise the correct error in different illegal or impossible calls."""
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     dir_path = inventory.root / 'empty'
 
@@ -45,7 +45,7 @@ def test_onyo_tree_errors(inventory: Inventory) -> None:
 @pytest.mark.ui({'yes': True})
 def test_onyo_tree_single(inventory: Inventory,
                           capsys) -> None:
-    """Display a tree for a directory."""
+    r"""Display a tree for a directory."""
     directory_path = inventory.root / "somewhere" / "nested"
 
     # move an asset and a dir to the same destination
@@ -62,7 +62,7 @@ def test_onyo_tree_single(inventory: Inventory,
 @pytest.mark.ui({'yes': True})
 def test_onyo_tree_multiple_paths(inventory: Inventory,
                                   capsys) -> None:
-    """Display multiple trees with one call."""
+    r"""Display multiple trees with one call."""
     dir_path = inventory.root / 'somewhere' / 'nested'
 
     onyo_tree(inventory,
@@ -79,7 +79,7 @@ def test_onyo_tree_multiple_paths(inventory: Inventory,
 @pytest.mark.ui({'yes': True})
 def test_onyo_tree_relative_single(inventory: Inventory,
                                    capsys) -> None:
-    """Display a tree for a relative subdirectory."""
+    r"""Display a tree for a relative subdirectory."""
     directory_path = inventory.root / "somewhere" / "nested"
 
     # move an asset and a dir to the same destination
@@ -95,7 +95,7 @@ def test_onyo_tree_relative_single(inventory: Inventory,
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_tree_errors_before_showing_trees(inventory: Inventory) -> None:
-    """`onyo_tree` must raise the correct error if one of the paths does not exist."""
+    r"""`onyo_tree` must raise the correct error if one of the paths does not exist."""
     directory_path = inventory.root / "somewhere" / "nested"
     non_existing_path = inventory.root / "doesnotexist"
 
@@ -113,7 +113,7 @@ def test_onyo_tree_errors_before_showing_trees(inventory: Inventory) -> None:
 @pytest.mark.repo_dirs("a/b/c", "a/d/c")
 def test_onyo_tree_with_same_dir_twice(inventory: Inventory,
                                        capsys) -> None:
-    """Allow to display the tree to a directory twice when
+    r"""Allow to display the tree to a directory twice when
     `onyo_tree()` is called with the same path twice at once."""
     directory_path = inventory.root / "somewhere" / "nested"
 

--- a/onyo/lib/ui.py
+++ b/onyo/lib/ui.py
@@ -20,7 +20,7 @@ log: logging.Logger = logging.getLogger('onyo')
 
 
 class UI(object):
-    """
+    r"""
     An object handling user interaction, including printing, errors, requests,
     and others.
 
@@ -44,7 +44,7 @@ class UI(object):
                  yes: bool = False) -> None:
         # TODO: interactive mode with default values or autodetecting tty? And
         # should this be unified with the whole business of rich-coloring etc?
-        """Initialize the User Interface object for user communication of Onyo.
+        r"""Initialize the User Interface object for user communication of Onyo.
 
         Parameters
         ----------
@@ -77,7 +77,7 @@ class UI(object):
 
     def set_debug(self,
                   debug: bool = False) -> None:
-        """Toggle debug mode.
+        r"""Toggle debug mode.
 
         Parameters
         ----------
@@ -91,7 +91,7 @@ class UI(object):
 
     def set_quiet(self,
                   quiet: bool = False) -> None:
-        """Toggle quiet mode.
+        r"""Toggle quiet mode.
 
         Parameters
         ----------
@@ -111,7 +111,7 @@ class UI(object):
 
     def set_yes(self,
                 yes: bool = False) -> None:
-        """Toggle auto-response 'yes' to all questions.
+        r"""Toggle auto-response 'yes' to all questions.
 
         Parameters
         ----------
@@ -124,7 +124,7 @@ class UI(object):
     def error(self,
               error: str | Exception,
               end: str = os.linesep) -> None:
-        """Print an error message, if the `UI` is not set to quiet mode.
+        r"""Print an error message, if the `UI` is not set to quiet mode.
 
         Parameters
         ----------
@@ -149,7 +149,7 @@ class UI(object):
 
     def log(self,
             message: str) -> None:
-        """Log a message at `logging.INFO` level.
+        r"""Log a message at `logging.INFO` level.
 
         Parameters
         ----------
@@ -161,7 +161,7 @@ class UI(object):
     def log_debug(self,
                   *args,
                   **kwargs) -> None:
-        """Log at `logging.DEBUG` level.
+        r"""Log at `logging.DEBUG` level.
 
         Parameters
         ----------
@@ -176,7 +176,7 @@ class UI(object):
     def print(self,
               *args,
               **kwargs) -> None:
-        """Print a message, if the `UI` is not set to quiet mode.
+        r"""Print a message, if the `UI` is not set to quiet mode.
 
         Parameters
         ----------
@@ -191,7 +191,7 @@ class UI(object):
 
     def request_user_response(self,
                               question: str) -> bool:
-        """Print `question` and read a response from `stdin`.
+        r"""Print `question` and read a response from `stdin`.
 
         Returns True when user answers yes, False when no, and asks again if the
         input is neither.
@@ -215,7 +215,7 @@ class UI(object):
                 return False
 
     def rich_print(self, *args, **kwargs) -> None:
-        """Refactoring helper to print via the `rich` package.
+        r"""Refactoring helper to print via the `rich` package.
 
         Proxy for `rich.Console.print`.
         Takes `stderr: bool` option to use a stderr `Console`

--- a/onyo/lib/utils.py
+++ b/onyo/lib/utils.py
@@ -11,7 +11,7 @@ from onyo.lib.ui import ui
 
 
 def deduplicate(sequence: list | None) -> list | None:
-    """Get a deduplicated list, while preserving order.
+    r"""Get a deduplicated list, while preserving order.
 
     For ease of use, accepts `None` (and returns it in that case).
     """

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -75,8 +75,9 @@ def prepare_rst_for_rich(text: str) -> str:
     # make bullet points prettier
     text = text.replace(' * ', ' • ')
 
-    # remove escaping
-    text = text.replace('\\', '')
+    # remove space-escaping
+    # (rST oddity that ``ASSET``s is illegal, but ``ASSET``\ s -> ASSETs)
+    text = text.replace('\\ ', '')
 
     return text
 

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -47,7 +47,7 @@ class WrappedTextRichHelpFormatter(RichHelpFormatter):
 
 
 def prepare_rst_for_rich(text: str) -> str:
-    """
+    r"""
     This is a very naive approach to cleanup docstrings and help text in
     preparation to print to the terminal.
 
@@ -83,7 +83,7 @@ def prepare_rst_for_rich(text: str) -> str:
 
 
 def build_parser(parser, args: dict) -> None:
-    """
+    r"""
     Add arguments to a parser.
     """
     for cmd in args:
@@ -299,7 +299,7 @@ def setup_parser() -> ArgumentParser:
 
 
 def get_subcmd_index(arglist, start: int = 1) -> int | None:
-    """
+    r"""
     Get the index of the subcommand from a provided list of arguments (usually sys.argv).
 
     Returns the index on success, and None in failure.

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -57,10 +57,10 @@ def prepare_rst_for_rich(text: str) -> str:
     text = textwrap.dedent(text).strip()
 
     # stylize arg descriptors (ALL CAPS ARGS)
-    text = re.sub('\*\*([A-Z\-]+)\*\*', r'[dark_cyan]\1[/dark_cyan]', text)
+    text = re.sub(r'\*\*([A-Z\-]+)\*\*', r'[dark_cyan]\1[/dark_cyan]', text)
 
     # stylize ** (bold)
-    text = re.sub('\*\*([^*]+)\*\*', r'[bold]\1[/bold]', text)
+    text = re.sub(r'\*\*([^*]+)\*\*', r'[bold]\1[/bold]', text)
 
     # stylize ``` (code blocks)
     text = re.sub('```([^`]+)```', r'[underline]\1[/underline]', text)

--- a/onyo/onyo_arguments.py
+++ b/onyo/onyo_arguments.py
@@ -8,7 +8,7 @@ args_onyo = {
         metavar='DIR',
         required=False,
         default=Path.cwd(),
-        help="""
+        help=r"""
             Run Onyo from **DIR** instead of the current working directory.
         """
     ),
@@ -18,7 +18,7 @@ args_onyo = {
         required=False,
         default=False,
         action='store_true',
-        help="""
+        help=r"""
             Enable debug logging.
         """
     ),
@@ -27,7 +27,7 @@ args_onyo = {
         args=('-v', '--version'),
         action='version',
         version='%(prog)s {version}'.format(version=__version__),
-        help="""
+        help=r"""
             Print Onyo's version and exit.
         """
     ),
@@ -37,7 +37,7 @@ args_onyo = {
         required=False,
         default=False,
         action='store_true',
-        help="""
+        help=r"""
             Silence messages printed to stdout; does not suppress interactive
             editors. Requires the ``--yes`` flag.
         """
@@ -48,7 +48,7 @@ args_onyo = {
         required=False,
         default=False,
         action='store_true',
-        help="""
+        help=r"""
             Respond "yes" to any prompts.
         """
     ),

--- a/onyo/shared_arguments.py
+++ b/onyo/shared_arguments.py
@@ -3,7 +3,7 @@ shared_arg_message = dict(
     metavar='MESSAGE',
     action='append',
     type=str,
-    help="""
+    help=r"""
         Use the given **MESSAGE** as the commit message (rather than the default).
         If multiple ``--message`` options are given, their values are
         concatenated as separate paragraphs.

--- a/onyo/tests/demo/test_generate_demo_repo.py
+++ b/onyo/tests/demo/test_generate_demo_repo.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 
 def test_generate_demo_repo(tmp_path, request) -> None:
-    """
+    r"""
     Generate an Onyo demo repository, and compare it against the git log of
     another known-good-demo-repo.
     """

--- a/onyo/tests/test_main.py
+++ b/onyo/tests/test_main.py
@@ -5,7 +5,7 @@ from onyo.conftest import Helpers
 
 
 def test_get_subcmd_index_missing(helpers: Helpers) -> None:
-    """
+    r"""
     All combinations of flags for onyo, without any subcommand.
     """
     for i in helpers.powerset(helpers.onyo_flags()):
@@ -17,7 +17,7 @@ def test_get_subcmd_index_missing(helpers: Helpers) -> None:
 
 
 def test_get_subcmd_index_valid(helpers: Helpers) -> None:
-    """
+    r"""
     All combinations of flags for onyo, with a subcommand.
     """
     for i in helpers.powerset(helpers.onyo_flags()):
@@ -29,7 +29,7 @@ def test_get_subcmd_index_valid(helpers: Helpers) -> None:
 
 
 def test_get_subcmd_index_overlap(helpers: Helpers) -> None:
-    """
+    r"""
     Arg values overlap with onyo or its subcommands. Borderline pathological.
     """
     full_cmd = ['onyo', '-C', 'onyo', '-d', 'mv', 'onyo', 'mv']


### PR DESCRIPTION
This PR is eclectic, but it all relates.

- brings comments into the flake8 config
- escapes "\`\`ASSET\`\`\ s" consistently (needed for Python 3.12; flake8; unknown future Python version)
- converts all docstrings and help text into raw strings
- retires one ignored rule from flake8 (thanks to the above fixes)
- bumps RTD to Python 3.12 (thanks to the above fixes)
- makes sphinx render docstrings for `__init__` and `__call__`
- improves the docstring for `StoreKeyValuePairs`
- improves the error message generated by `StoreKeyValuePairs`
- adds a test for conflicting number of keys passed to `onyo new`