### PR TITLE
DOC/BF: drop `rich_argparse` for home-grown solution

### DIFF
--- a/onyo/cli/tests/test_new.py
+++ b/onyo/cli/tests/test_new.py
@@ -298,7 +298,7 @@ def test_error_keys_flag_mismatch_count(repo: OnyoRepo) -> None:
 
     # verify correct error
     assert not ret.stdout
-    assert "All keys given multiple times must be given the same number of times" in ret.stderr
+    assert "All keys given multiple times must be given the same number" in ret.stderr
     assert ret.returncode == 2
 
     # verify that no new assets were created and the repository stays clean

--- a/onyo/cli/tests/test_onyo.py
+++ b/onyo/cli/tests/test_onyo.py
@@ -20,7 +20,7 @@ def test_onyo_debug(repo: OnyoRepo, variant: str) -> None:
 def test_onyo_help(repo: OnyoRepo, variant: str) -> None:
     ret = subprocess.run(['onyo', variant], capture_output=True, text=True)
     assert ret.returncode == 0
-    assert 'Usage: onyo [-h]' in ret.stdout
+    assert 'usage: onyo [-h]' in ret.stdout
     assert not ret.stderr
     assert repo.git.is_clean_worktree()
 
@@ -37,6 +37,6 @@ def test_onyo_without_subcommand(repo: OnyoRepo, helpers) -> None:
 
             ret = subprocess.run(full_cmd, capture_output=True, text=True)
             assert ret.returncode == 1
-            assert 'Usage: onyo [-h]' in ret.stdout
+            assert 'usage: onyo [-h]' in ret.stdout
             assert not ret.stderr
     assert repo.git.is_clean_worktree()

--- a/onyo/cli/tests/test_set.py
+++ b/onyo/cli/tests/test_set.py
@@ -146,7 +146,7 @@ def test_set_without_path(repo: OnyoRepo,
                          capture_output=True, text=True)
 
     assert ret.returncode != 0
-    assert "Usage:" in ret.stderr  # argparse should already complain
+    assert "usage:" in ret.stderr  # argparse should already complain
     assert repo.git.is_clean_worktree()
 
 

--- a/onyo/cli/tests/test_unset.py
+++ b/onyo/cli/tests/test_unset.py
@@ -224,7 +224,7 @@ def test_unset_without_path(repo: OnyoRepo,
     # verify the output
     assert ret.returncode != 0
     assert repo.git.is_clean_worktree()
-    assert "Usage:" in ret.stderr
+    assert "usage:" in ret.stderr
 
 
 @pytest.mark.repo_contents(*convert_contents([t for t in asset_contents if "num" in t[1]]))

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -29,7 +29,8 @@ class WrappedTextRichHelpFormatter(RichHelpFormatter):
     RichHelpFormatter
     """
 
-    def _rich_format_action(self, action: Action) -> Iterator[tuple[Text, Text | None]]:
+    def _rich_format_action(self,
+                            action: Action) -> Iterator[tuple[Text, Text | None]]:
         r"""Remove <COMMANDS> from subcommands section of help.
 
         Parameters
@@ -44,7 +45,9 @@ class WrappedTextRichHelpFormatter(RichHelpFormatter):
 
         return parts
 
-    def _rich_split_lines(self, text: Text, width: int) -> Lines:
+    def _rich_split_lines(self,
+                          text: Text,
+                          width: int) -> Lines:
         r"""Wrap lines according to width.
 
         Parameters
@@ -59,7 +62,10 @@ class WrappedTextRichHelpFormatter(RichHelpFormatter):
             lines.extend(line.wrap(self.console, width))
         return lines
 
-    def _rich_fill_text(self, text: Text, width: int, indent: Text) -> Text:
+    def _rich_fill_text(self,
+                        text: Text,
+                        width: int,
+                        indent: Text) -> Text:
         r"""Wrap lines in description text according to width.
 
         Parameters
@@ -74,7 +80,8 @@ class WrappedTextRichHelpFormatter(RichHelpFormatter):
         lines = self._rich_split_lines(text, width)
         return Text("\n").join(indent + line for line in lines) + "\n"
 
-    def _rich_format_text(self, text: str) -> Text:
+    def _rich_format_text(self,
+                          text: str) -> Text:
         r"""Convert RST docstrings to Rich syntax ready for help text.
 
         Parameters
@@ -126,7 +133,8 @@ def rst_to_rich(text: str) -> str:
     return text
 
 
-def build_parser(parser, args: dict) -> None:
+def build_parser(parser: ArgumentParser,
+                 args: dict) -> None:
     r"""Add options or arguments to an ArgumentParser.
 
     Parameters
@@ -372,7 +380,8 @@ def setup_parser() -> ArgumentParser:
     return parser
 
 
-def get_subcmd_index(arglist: list, start: int = 1) -> int | None:
+def get_subcmd_index(arglist: list,
+                     start: int = 1) -> int | None:
     r"""Get the index of the Onyo subcommand in a list of arguments.
 
     Parameters

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ classifiers = [
 dependencies = [
     "ruamel.yaml",
     "rich",
-    "rich-argparse",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
This has multiple advantages:

- drops a dependency (that is also unpackaged in Debian)
- `rst_to_rich()` is only used in the parser, thus rich markup no longer leaks into sphinx output
- fixes the "usage" section of sphinx output (which was garbled with CLI colorization syntax)

I also moved the commit from #616 to cleanup `main.py` that I missed in #615 that @TobiasKadelka pointed out.