### PR TITLE
DOC/TST/NF/RF: another collection of docstrings and general improvements

### DIFF
--- a/onyo/cli/cat.py
+++ b/onyo/cli/cat.py
@@ -14,7 +14,9 @@ args_cat = {
     'asset': dict(
         metavar='ASSET',
         nargs='+',
-        help='Paths of assets to print'
+        help=r"""
+            Paths of assets to print.
+        """
     ),
 }
 

--- a/onyo/cli/config.py
+++ b/onyo/cli/config.py
@@ -14,7 +14,9 @@ args_config = {
     'git_config_args': dict(
         metavar='ARGS',
         nargs='+',
-        help='Config options to set in ``.onyo/config``.'
+        help=r"""
+            Configuration arguments to operate on ``.onyo/config``.
+        """
     ),
 }
 

--- a/onyo/cli/edit.py
+++ b/onyo/cli/edit.py
@@ -31,7 +31,7 @@ Edit an asset (file or directory):
 .. code:: shell
 
     $ onyo edit accounting/Bingo\ Bob/laptop_lenovo_T490s.abc123
-    <spawns $EDITOR>
+    <spawns editor>
 """
 
 

--- a/onyo/cli/edit.py
+++ b/onyo/cli/edit.py
@@ -15,7 +15,9 @@ args_edit = {
     'asset': dict(
         metavar='ASSET',
         nargs='+',
-        help='Paths of assets to edit.'
+        help=r"""
+            Paths of assets to edit.
+        """
     ),
 
     'message': shared_arg_message,

--- a/onyo/cli/tests/test_cat.py
+++ b/onyo/cli/tests/test_cat.py
@@ -1,11 +1,16 @@
+from __future__ import annotations
+
 import subprocess
-from typing import List
+from typing import TYPE_CHECKING
 
 import pytest
 
 from onyo.lib.onyo import OnyoRepo
 from onyo.lib.commands import fsck
 from onyo.lib.exceptions import OnyoInvalidRepoError
+
+if TYPE_CHECKING:
+    from typing import List
 
 files = ['laptop_apple_macbookpro',
          'lap top_ap ple_mac book pro']

--- a/onyo/cli/tests/test_edit.py
+++ b/onyo/cli/tests/test_edit.py
@@ -113,8 +113,7 @@ def test_edit_multiple_assets(repo: OnyoRepo) -> None:
     ret = subprocess.run(['onyo', '--yes', 'edit', *repo_assets],
                          capture_output=True, text=True)
     assert ret.returncode == 0
-    # diffs are currently listed twice: once per asset and in a summary at the end
-    assert ret.stdout.count("+key: multiple_assets") == 2 * len(repo_assets)
+    assert ret.stdout.count("+key: multiple_assets") == len(repo_assets)
     assert not ret.stderr
 
     # verify the changes were saved for all assets and the repository is clean
@@ -251,7 +250,7 @@ def test_edit_protected(repo: OnyoRepo, no_asset: str) -> None:
                          capture_output=True, text=True)
     assert ret.returncode == 1
     assert not ret.stdout
-    assert "is not an asset" in ret.stderr
+    assert "The following paths are not assets" in ret.stderr
     assert Path(no_asset).is_file()
     assert repo.git.is_clean_worktree()
 
@@ -274,7 +273,7 @@ def test_edit_non_existing_file(repo: OnyoRepo, no_asset: str) -> None:
                          capture_output=True, text=True)
     assert ret.returncode == 1
     assert not ret.stdout
-    assert "is not an asset" in ret.stderr
+    assert "The following paths are not assets" in ret.stderr
     assert not Path(no_asset).is_file()
     assert repo.git.is_clean_worktree()
 

--- a/onyo/cli/tests/test_get.py
+++ b/onyo/cli/tests/test_get.py
@@ -1,12 +1,20 @@
+from __future__ import annotations
+
 import re
 import subprocess
 from pathlib import Path
-from typing import Any, Generator
+from typing import TYPE_CHECKING
 
 import pytest
 
 from onyo.lib.onyo import OnyoRepo
 from onyo.lib.command_utils import fill_unset, natural_sort
+
+if TYPE_CHECKING:
+    from typing import (
+        Any,
+        Generator,
+    )
 
 asset_contents = [
     ('laptop_apple_macbookpro.1', {'num': 8,

--- a/onyo/cli/tests/test_history.py
+++ b/onyo/cli/tests/test_history.py
@@ -1,11 +1,16 @@
+from __future__ import annotations
+
 import subprocess
 from pathlib import Path
-from typing import List
+from typing import TYPE_CHECKING
 
 import pytest
 
 from onyo.lib.onyo import OnyoRepo
 from onyo.lib.commands import fsck
+
+if TYPE_CHECKING:
+    from typing import List
 
 # NOTE: the output of `onyo history` is not tested for formatting or content, as
 #       the commands called by `onyo history` are user-configurable. Instead, it

--- a/onyo/cli/tests/test_rm.py
+++ b/onyo/cli/tests/test_rm.py
@@ -1,10 +1,15 @@
+from __future__ import annotations
+
 import subprocess
 from pathlib import Path
-from typing import List
+from typing import TYPE_CHECKING
 
 import pytest
 
 from onyo.lib.onyo import OnyoRepo
+
+if TYPE_CHECKING:
+    from typing import List
 
 files = ['laptop_apple_macbookpro',
          'lap top_ap ple_mac book pro',

--- a/onyo/cli/tests/test_set.py
+++ b/onyo/cli/tests/test_set.py
@@ -1,10 +1,15 @@
+from __future__ import annotations
+
 import subprocess
 from pathlib import Path
-from typing import List
+from typing import TYPE_CHECKING
 
 import pytest
 
 from onyo.lib.onyo import OnyoRepo
+
+if TYPE_CHECKING:
+    from typing import List
 
 directories = ['.',
                'simple',

--- a/onyo/cli/tests/test_tree.py
+++ b/onyo/cli/tests/test_tree.py
@@ -1,10 +1,15 @@
+from __future__ import annotations
+
 import subprocess
 from pathlib import Path
-from typing import List
+from typing import TYPE_CHECKING
 
 import pytest
 
 from onyo.lib.onyo import OnyoRepo
+
+if TYPE_CHECKING:
+    from typing import List
 
 files = ['laptop_apple_macbookpro',
          'lap top_ap ple_mac book pro']

--- a/onyo/cli/tests/test_unset.py
+++ b/onyo/cli/tests/test_unset.py
@@ -1,10 +1,18 @@
+from __future__ import annotations
+
 import subprocess
 from pathlib import Path
-from typing import Any, Generator
+from typing import TYPE_CHECKING
 
 import pytest
 
 from onyo.lib.onyo import OnyoRepo
+
+if TYPE_CHECKING:
+    from typing import (
+        Any,
+        Generator,
+    )
 
 
 def convert_contents(

--- a/onyo/cli/tree.py
+++ b/onyo/cli/tree.py
@@ -14,7 +14,9 @@ args_tree = {
     'directory': dict(
         metavar='DIR',
         nargs='*',
-        help='Directories to list'
+        help=r"""
+            Directories to list.
+        """
     )
 }
 

--- a/onyo/conftest.py
+++ b/onyo/conftest.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import os
 import subprocess
 from collections.abc import Iterable
 from itertools import chain, combinations
 from pathlib import Path
-from typing import Generator, List, Type
+from typing import TYPE_CHECKING
 
 import pytest
 from _pytest.mark.structures import MarkDecorator
@@ -11,6 +13,13 @@ from _pytest.mark.structures import MarkDecorator
 from onyo.lib.git import GitRepo
 from onyo.lib.inventory import Inventory
 from onyo.lib.onyo import OnyoRepo
+
+if TYPE_CHECKING:
+    from typing import (
+        Generator,
+        List,
+        Type,
+    )
 
 
 def params(d: dict) -> MarkDecorator:

--- a/onyo/lib/command_utils.py
+++ b/onyo/lib/command_utils.py
@@ -12,13 +12,23 @@ from .onyo import OnyoRepo
 log: logging.Logger = logging.getLogger('onyo.command_utils')
 
 
-def sanitize_args_config(git_config_args: list[str]) -> list[str]:
-    r"""
-    Check the git config arguments against a list of conflicting options. If
-    conflicts are present, the conflict list will be printed and will exit with
-    error.
+def allowed_config_args(git_config_args: list[str]) -> bool:
+    r"""Check a list of arguments for disallowed ``git config`` flags.
 
-    Returns the unmodified  git config args on success.
+    ``git-config`` stores configuration information in a variety of locations.
+    This makes sure that such location flags aren't in the list (and --help).
+
+    A helper for the ``onyo config`` command.
+
+    Parameters
+    ----------
+    git_config_args
+        The list of arguments to pass to ``git config``.
+
+    Raises
+    ------
+    ValueError
+        If a disallowed flag is detected.
     """
     # git-config supports multiple layers of git configuration. Onyo uses
     # ``--file`` to write to .onyo/config. Other options are excluded.
@@ -36,7 +46,7 @@ def sanitize_args_config(git_config_args: list[str]) -> list[str]:
         if a in forbidden_flags:
             raise ValueError("The following options cannot be used with onyo config:\n%s\nExiting. Nothing was set." %
                              '\n'.join(forbidden_flags))
-    return git_config_args
+    return True
 
 
 def fill_unset(assets: Generator[dict, None, None] | filter,

--- a/onyo/lib/command_utils.py
+++ b/onyo/lib/command_utils.py
@@ -4,10 +4,14 @@ import logging
 import re
 import shutil
 import sys
-from typing import Generator
+from typing import TYPE_CHECKING
 
 from .consts import UNSET_VALUE
-from .onyo import OnyoRepo
+
+if TYPE_CHECKING:
+    from typing import Generator
+
+    from .onyo import OnyoRepo
 
 log: logging.Logger = logging.getLogger('onyo.command_utils')
 

--- a/onyo/lib/command_utils.py
+++ b/onyo/lib/command_utils.py
@@ -12,23 +12,6 @@ from .onyo import OnyoRepo
 log: logging.Logger = logging.getLogger('onyo.command_utils')
 
 
-# Note: Several functions only stage changes. Implies: This function somewhat
-# assumes commit to be called later, which is out of its own control.
-# May be better to only do the modification and have the caller take care of
-# what to do with those modifications.
-# Related: Staging probably not necessary. We can commit directly. Saves
-# overhead for git-calls and would only have a different effect if changes were
-# already staged before an onyo operation and are to be included in the commit.
-# Which sounds like a bad idea, b/c of obfuscating history. So, probably:
-# have functions to assemble paths/modifications and commit at once w/o staging
-# anything in-between.
-
-
-# Note: logging for user messaging rather than logging progress along internal
-# call paths. DataLad does, too, and it's bad. Conflates debugging with "real"
-# output.
-
-
 def sanitize_args_config(git_config_args: list[str]) -> list[str]:
     r"""
     Check the git config arguments against a list of conflicting options. If

--- a/onyo/lib/command_utils.py
+++ b/onyo/lib/command_utils.py
@@ -16,7 +16,7 @@ def allowed_config_args(git_config_args: list[str]) -> bool:
     r"""Check a list of arguments for disallowed ``git config`` flags.
 
     ``git-config`` stores configuration information in a variety of locations.
-    This makes sure that such location flags aren't in the list (and --help).
+    This makes sure that such location flags aren't in the list (and ``--help``).
 
     A helper for the ``onyo config`` command.
 
@@ -51,16 +51,20 @@ def allowed_config_args(git_config_args: list[str]) -> bool:
 
 def fill_unset(assets: Generator[dict, None, None] | filter,
                keys: list[str]) -> Generator[dict, None, None]:
-    r"""Fill values for missing `keys` in `assets` with `UNSET_VALUE`.
+    r"""Fill values for missing ``keys`` in ``assets`` with ``UNSET_VALUE``.
 
-    Helper for the onyo-get command.
+    A helper for the ``onyo get`` command.
+
+    See Also
+    --------
+    onyo.lib.consts.UNSET_VALUE
 
     Parameters
     ----------
     assets
-      Asset dictionaries to fill.
+        Asset dictionaries to fill.
     keys
-      Keys for which to set `UNSET_VALUE` if not present in an asset.
+        Keys to create if not present in an asset, and set with ``UNSET_VALUE``.
     """
     for asset in assets:
         yield {k: UNSET_VALUE for k in keys} | asset
@@ -69,16 +73,16 @@ def fill_unset(assets: Generator[dict, None, None] | filter,
 def natural_sort(assets: list[dict],
                  keys: list[str] | None = None,
                  reverse: bool = False) -> list[dict]:
-    r"""Sort an asset list by a given list of `keys`.
+    r"""Sort an asset list by a list of ``keys``.
 
     Parameters
     ----------
     assets
-      Assets to sort.
+        Assets to sort.
     keys
-      Keys to sort `assets` by. Default: ['path'].
+        Keys to sort ``assets`` by. Default: ``['path']``.
     reverse
-      Whether to sort in reverse order.
+        Whether to sort in reverse order.
     """
     keys = keys or ['path']
 
@@ -95,13 +99,27 @@ def natural_sort(assets: list[dict],
     return assets
 
 
-def get_history_cmd(interactive: bool, repo: OnyoRepo) -> str:
-    r"""
-    Get the command used to display history. The appropriate one is selected
-    according to the interactive mode, and basic checks are performed for
-    validity.
+def get_history_cmd(interactive: bool,
+                    repo: OnyoRepo) -> str:
+    r"""Get the command to display history.
 
-    Returns the command on success.
+    The command is selected according to the (non)interactive mode, and
+    ``which`` verifies that it exists.
+
+    A helper for the ``onyo history`` command.
+
+    Parameters
+    ----------
+    interactive
+        Whether the CLI mode is interactive or not.
+    repo
+        The OnyoRepo to search through for the configuration.
+
+    Raises
+    ------
+    ValueError
+        If the configuration key is either not set or the configured history
+        program cannot be found by ``which``.
     """
     history_cmd = None
     config_name = 'onyo.history.interactive'

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -17,15 +17,14 @@ from rich.table import Table
 from onyo.lib.command_utils import fill_unset, natural_sort
 from onyo.lib.consts import PSEUDO_KEYS, RESERVED_KEYS
 from onyo.lib.exceptions import (
-    OnyoRepoError,
-    OnyoInvalidRepoError,
-    PendingInventoryOperationError,
     NotADirError,
     NotAnAssetError,
     NoopError,
+    OnyoInvalidRepoError,
+    OnyoRepoError,
+    PendingInventoryOperationError,
 )
 from onyo.lib.inventory import Inventory, OPERATIONS_MAPPING
-from onyo.lib.onyo import OnyoRepo
 from onyo.lib.ui import ui
 from onyo.lib.utils import deduplicate, write_asset_file
 
@@ -36,6 +35,7 @@ if TYPE_CHECKING:
         Generator,
         Literal,
     )
+    from onyo.lib.onyo import OnyoRepo
 
 log: logging.Logger = logging.getLogger('onyo.commands')
 
@@ -160,6 +160,7 @@ def onyo_cat(inventory: Inventory,
         If ``paths`` contains an invalid asset (e.g. content is invalid YAML).
     """
 
+    from onyo.lib.onyo import OnyoRepo
     from onyo.lib.utils import validate_yaml
 
     if not paths:

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -193,13 +193,13 @@ def onyo_config(inventory: Inventory,
     config_args
         The options to be passed to the underlying call of ``git config``.
     """
-    from onyo.lib.command_utils import sanitize_args_config
-    git_config_args = sanitize_args_config(config_args)
+    from onyo.lib.command_utils import allowed_config_args
+    allowed_config_args(config_args)
 
     subprocess.run(["git", 'config', '-f', str(inventory.repo.ONYO_CONFIG)] +
-                   git_config_args, cwd=inventory.repo.git.root, check=True)
+                   config_args, cwd=inventory.repo.git.root, check=True)
 
-    if not any(a.startswith('--get') or a == '--list' for a in git_config_args):
+    if not any(a.startswith('--get') or a == '--list' for a in config_args):
         # It's a write operation, and we'd want to commit
         # if there were any changes.
         try:

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -5,7 +5,11 @@ import logging
 import subprocess
 import sys
 from pathlib import Path
-from typing import Callable, Dict, Generator, Literal, ParamSpec, TypeVar
+from typing import (
+    ParamSpec,
+    TYPE_CHECKING,
+    TypeVar,
+)
 from functools import wraps
 
 from rich import box
@@ -25,6 +29,14 @@ from onyo.lib.inventory import Inventory, OPERATIONS_MAPPING
 from onyo.lib.onyo import OnyoRepo
 from onyo.lib.ui import ui
 from onyo.lib.utils import deduplicate, write_asset_file
+
+if TYPE_CHECKING:
+    from typing import (
+        Callable,
+        Dict,
+        Generator,
+        Literal,
+    )
 
 log: logging.Logger = logging.getLogger('onyo.commands')
 

--- a/onyo/lib/differs.py
+++ b/onyo/lib/differs.py
@@ -1,11 +1,15 @@
+from __future__ import annotations
+
 from difflib import unified_diff
 from functools import partial
 from pathlib import Path
-from typing import Generator
+from typing import TYPE_CHECKING
 
 from onyo.lib.onyo import OnyoRepo
 from onyo.lib.utils import dict_to_asset_yaml
 
+if TYPE_CHECKING:
+    from typing import Generator
 
 # Differs signature: (repo: OnyoRepo, operands: tuple) -> Generator[str, None, None]:
 # yielded strings are supposed to be lines of a diff for a given operation

--- a/onyo/lib/executors.py
+++ b/onyo/lib/executors.py
@@ -1,8 +1,12 @@
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Callable
+from typing import TYPE_CHECKING
 
 from onyo.lib.onyo import OnyoRepo
 
+if TYPE_CHECKING:
+    from typing import Callable
 
 # Executors signature: (repo: OnyoRepo, operands: tuple) -> tuple[list[Path], list[Path]]
 #                      first returned list are the paths that need to be committed

--- a/onyo/lib/git.py
+++ b/onyo/lib/git.py
@@ -1,10 +1,15 @@
+from __future__ import annotations
+
 import logging
 import subprocess
 from pathlib import Path
-from typing import Iterable
+from typing import TYPE_CHECKING
 
 from onyo.lib.exceptions import OnyoInvalidRepoError
 from onyo.lib.ui import ui
+
+if TYPE_CHECKING:
+    from typing import Iterable
 
 log: logging.Logger = logging.getLogger('onyo.git')
 

--- a/onyo/lib/inventory.py
+++ b/onyo/lib/inventory.py
@@ -4,11 +4,7 @@ import copy
 from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
-from typing import (
-    Callable,
-    Generator,
-    Literal,
-)
+from typing import TYPE_CHECKING
 
 from onyo.lib.differs import (
     differ_new_assets,
@@ -53,6 +49,13 @@ from onyo.lib.recorders import (
 )
 from onyo.lib.utils import deduplicate
 from onyo.lib.ui import ui
+
+if TYPE_CHECKING:
+    from typing import (
+        Callable,
+        Generator,
+        Literal,
+    )
 
 
 @dataclass

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -5,12 +5,15 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Iterable, List
+from typing import TYPE_CHECKING
 
 from .exceptions import OnyoInvalidRepoError, OnyoProtectedPathError
 from .git import GitRepo
 from .ui import ui
 from .utils import get_asset_content, write_asset_file
+
+if TYPE_CHECKING:
+    from typing import Iterable, List
 
 log: logging.Logger = logging.getLogger('onyo.onyo')
 

--- a/onyo/lib/utils.py
+++ b/onyo/lib/utils.py
@@ -10,7 +10,10 @@ from onyo.lib.consts import PSEUDO_KEYS, RESERVED_KEYS
 from onyo.lib.ui import ui
 
 if TYPE_CHECKING:
-    from typing import Dict, Set
+    from typing import (
+        Dict,
+        Set,
+    )
 
 
 def deduplicate(sequence: list | None) -> list | None:

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -15,7 +15,10 @@ from onyo.lib.ui import ui
 
 if TYPE_CHECKING:
     from argparse import Action
-    from typing import List
+    from typing import (
+        IO,
+        List,
+    )
 
 
 class OnyoArgumentParser(ArgumentParser):
@@ -28,7 +31,7 @@ class OnyoArgumentParser(ArgumentParser):
 
     def _print_message(self,
                        message: str,
-                       file=None) -> None:
+                       file: IO[str] | None = None) -> None:
         r"""Print help text with Rich.
         """
         if message:


### PR DESCRIPTION
This PR again focuses on docstrings, and then makes adjustments/cleanups that i encountered while focusing on them.

Docstring improvements:
- all of `command_utils.py`
- about 20% of `commands.py`

Non-docstring improvements include:
- `sanitize_args_config()` -> `allowed_config_args()`
- `onyo_edit()`'s behavior has been changed to match other onyo commands
- normalization of type checking imports
- normalization of some help text string declaration

Works towards:
- #489 
- #492 
- #493 