### PR TITLE
`rm`: Replace modes with simple recursive flag

### DIFF
--- a/onyo/cli/rm.py
+++ b/onyo/cli/rm.py
@@ -20,29 +20,13 @@ args_rm = {
         """
     ),
 
-    'assets': dict(
-        args=('-a', '--asset'),
+    'recursive': dict(
+        args=('-r', '--recursive'),
         required=False,
         default=False,
         action='store_true',
         help=r"""
-            Operate only on assets. Asset Files are removed. Asset Directories
-            are converted into normal directories.
-
-            This cannot be used with the ``--dir`` flag.
-        """
-    ),
-
-    'dirs': dict(
-        args=('-d', '--dir'),
-        required=False,
-        default=False,
-        action='store_true',
-        help=r"""
-            Operate only on directories. Directories are removed. Asset
-            Directories are converted into Asset Files.
-
-            This cannot be used with the ``--asset`` flag.
+            If set, remove directories recursively including their content.
         """
     ),
 
@@ -70,25 +54,16 @@ def rm(args: argparse.Namespace) -> None:
     r"""
     Delete **ASSET**\ s and/or **DIRECTORY**\ s.
 
-    Directories and asset directories are deleted along with their contents.
-
-    The ``--asset`` and ``--dir`` flags can be used to constrain actions to
-    either assets or directories (respectively).
+    Directories and asset directories are deleted along with their contents,
+    if the ``--recursive`` flag is set. Otherwise, fails on non-empty directories.
 
     If any of the given paths are invalid, Onyo will error and delete none of
     them.
     """
     inventory = Inventory(repo=OnyoRepo(Path.cwd(), find_root=True))
     paths = [Path(p).resolve() for p in args.path]
-    if args.assets and args.dirs:
-        raise ValueError("'--dir' and '--asset' are mutually exclusive.")
-    mode = "all"
-    if args.assets:
-        mode = "asset"
-    elif args.dirs:
-        mode = "dir"
 
     onyo_rm(inventory,
             paths=paths,
-            mode=mode,  # pyre-ignore[6]  check doesn't understand that this is in fact one of "all", "asset", "dir"
+            recursive=args.recursive,
             message='\n\n'.join(m for m in args.message) if args.message else None)

--- a/onyo/cli/tests/test_rm.py
+++ b/onyo/cli/tests/test_rm.py
@@ -69,7 +69,7 @@ def test_rm_single_dirs_with_files(repo: OnyoRepo, directory: str) -> None:
     Test that `onyo rm DIRECTORY` deletes directories successfully and leaves
     the repository in a clean state.
     """
-    ret = subprocess.run(['onyo', '--yes', 'rm', directory],
+    ret = subprocess.run(['onyo', '--yes', 'rm', '--recursive', directory],
                          capture_output=True, text=True)
     assert ret.returncode == 0
     assert "The following will be deleted:" in ret.stdout
@@ -86,7 +86,7 @@ def test_rm_multiple_directories(repo: OnyoRepo) -> None:
     Test that `onyo rm DIRECTORY` deletes a list of directories all at once and
     leaves the repository in a clean state.
     """
-    ret = subprocess.run(['onyo', '--yes', 'rm', *directories[1:]],
+    ret = subprocess.run(['onyo', '--yes', 'rm', '--recursive', *directories[1:]],
                          capture_output=True, text=True)
     assert ret.returncode == 0
     assert "The following will be deleted:" in ret.stdout
@@ -183,17 +183,3 @@ def test_rm_message_flag(repo: OnyoRepo, asset: str) -> None:
     ret = subprocess.run(['onyo', 'history', '-I', '.'], capture_output=True, text=True)
     assert msg in ret.stdout
     assert repo.git.is_clean_worktree()
-
-
-@pytest.mark.repo_files(*assets)
-@pytest.mark.parametrize('asset', assets)
-def test_rm_modes(repo: OnyoRepo, asset: str) -> None:
-    # Note: Doesn't actually test modes, just that the flags
-    #       are recognized (otherwise we should get a usage-message)
-    #       and fail if both are given.
-    #       Actual mode test done in python.
-    msg = "Some message"
-    ret = subprocess.run(['onyo', 'rm', '-a', '-d', '-m', msg, asset],
-                         capture_output=True, text=True)
-    assert ret.returncode != 0
-    assert "mutually exclusive" in ret.stderr

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -12,7 +12,7 @@ from typing import (
 from functools import wraps
 
 from rich import box
-from rich.table import Table
+from rich.table import Table  # pyre-ignore[21] for some reason pyre doesn't find Table
 
 from onyo.lib.command_utils import fill_unset, natural_sort
 from onyo.lib.consts import PSEUDO_KEYS, RESERVED_KEYS
@@ -23,6 +23,7 @@ from onyo.lib.exceptions import (
     OnyoInvalidRepoError,
     OnyoRepoError,
     PendingInventoryOperationError,
+    InventoryDirNotEmpty,
 )
 from onyo.lib.inventory import Inventory, OPERATIONS_MAPPING
 from onyo.lib.ui import ui
@@ -874,7 +875,7 @@ def onyo_new(inventory: Inventory,
 def onyo_rm(inventory: Inventory,
             paths: list[Path] | Path,
             message: str | None,
-            mode: Literal["asset", "dir", "all"] = "all") -> None:
+            recursive: bool = False) -> None:
     r"""Delete assets and/or directories from the inventory.
 
     Parameters
@@ -886,44 +887,27 @@ def onyo_rm(inventory: Inventory,
         List of paths to assets and/or directories to delete from the Inventory.
         If any path given is not valid, none of them gets deleted.
 
-    mode
-        One of 'asset', 'dir', or 'all'.
-        In mode 'all' any given path is removed (recursively).
-        In mode 'asset' only paths to assets are accepted. If an asset
-        is in fact an asset dir, this removes the asset aspect of it only,
-        leaving behind a regular inventory dir.
-        In mode 'dir' only paths to dirs are accepted. If a dir happens to
-        be an asset dir, this removes the dir aspect from it, turning it
-        into a regular asset file.
+    recursive
+        Recursively remove a directory with all its content. If not set,
+        fail on non-empty directories.
 
     message
         An optional string to overwrite Onyo's default commit message.
     """
     paths = [paths] if not isinstance(paths, list) else paths
 
-    if mode == "all":
-        for p in paths:
-            try:
-                inventory.remove_asset(p)
-                is_asset = True
-            except NotAnAssetError:
-                is_asset = False
-            if not is_asset or inventory.repo.is_asset_dir(p):
-                inventory.remove_directory(p)
-    elif mode == "asset":
-        invalid_paths = [str(p) for p in paths if not inventory.repo.is_asset_path(p)]
-        if invalid_paths:
-            raise ValueError("The following paths aren't assets:\n%s" %
-                             "\n".join(invalid_paths))
-        for p in paths:
+    for p in paths:
+        try:
             inventory.remove_asset(p)
-    elif mode == "dir":
-        invalid_paths = [str(p) for p in paths if not inventory.repo.is_inventory_dir(p)]
-        if invalid_paths:
-            raise ValueError("The following paths aren't inventory directories:\n%s" %
-                             "\n".join(invalid_paths))
-        for p in paths:
-            inventory.remove_directory(p)
+            is_asset = True
+        except NotAnAssetError:
+            is_asset = False
+        if not is_asset or inventory.repo.is_asset_dir(p):
+            try:
+                inventory.remove_directory(p, recursive=recursive)
+            except InventoryDirNotEmpty as e:
+                # Enhance message from failed operation with command specific context:
+                raise InventoryDirNotEmpty(f"{str(e)}\nDid you forget '--recursive'?") from e
 
     if inventory.operations_pending():
         ui.print('The following will be deleted:')

--- a/onyo/lib/exceptions.py
+++ b/onyo/lib/exceptions.py
@@ -25,6 +25,10 @@ class InvalidInventoryOperationError(InventoryOperationError):
     r"""Thrown if an invalid inventory operation is requested."""
 
 
+class InventoryDirNotEmpty(InvalidInventoryOperationError):
+    r"""Thrown if an inventory directory needs to be empty to perform an operation but isn't."""
+
+
 class PendingInventoryOperationError(InventoryOperationError):
     r"""Thrown if there are unexpected pending operations."""
     # TODO  -> enhance message w/ hint to Inventory.reset/commit?

--- a/onyo/lib/utils.py
+++ b/onyo/lib/utils.py
@@ -78,7 +78,7 @@ def get_asset_content(asset_file: Path) -> dict[str, bool | float | int | str | 
     contents = dict()
     try:
         contents = yaml.load(asset_file)
-    except scanner.ScannerError as e:
+    except scanner.ScannerError as e:  # pyre-ignore[66]
         ui.error(f"{asset_file} has invalid YAML syntax: {str(e)}")
     if contents is None:
         return dict()
@@ -134,7 +134,7 @@ def validate_yaml(asset_files: list[Path] | None) -> bool:
         # TODO: use valid_yaml()
         try:
             YAML(typ='rt').load(asset)
-        except scanner.ScannerError:
+        except scanner.ScannerError:  # pyre-ignore[66]
             invalid_yaml.append(str(asset))
 
     if invalid_yaml:

--- a/onyo/shell_completion/zsh/_onyo
+++ b/onyo/shell_completion/zsh/_onyo
@@ -133,8 +133,7 @@ _onyo() {
                 args+=(
                     '(- : *)'{-h,--help}'[show this help message and exit]'
                     '(-m --message)'{-m,--message}'[use the given MESSAGE as the commit message]:MESSAGE: '
-                    '(-d --dir -a --asset)'{-d,--dir}'[only remove directories]'
-                    '(-a --asset -d --dir)'{-a,--asset}'[only remove assets]'
+                    '(-r --recursive)'{-r,--recursive}'[remove directories and their contents]'
                     '*:PATH:_files -W "$(_onyo_dir)"'
                 )
                 ;;


### PR DESCRIPTION
Simplify the `rm` command, by removing the modes that would have the
command operate on asset or directory 'aspects' only. Instead have a
standard `--recursive` flag, making `onyo rm` aligned with standard
`rm`.

For only removing an aspect of an asset dir, `onyo set` is still
available.

Closes #596 