### PR TITLE
`mkdir`: Allow adding existing non-inventory dirs

### DIFF
--- a/onyo/cli/tests/test_mkdir.py
+++ b/onyo/cli/tests/test_mkdir.py
@@ -136,13 +136,13 @@ def test_mkdir_quiet_flag(repo: OnyoRepo) -> None:
 def test_dir_exists(repo: OnyoRepo, directory: str) -> None:
     r"""
     Test the correct behavior when `onyo mkdir <path>` is called on an
-    existing directory name.
+    existing directory.
     """
     ret = subprocess.run(['onyo', 'mkdir', directory], capture_output=True, text=True)
 
     # verify output
     assert not ret.stdout
-    assert "already is a directory" in ret.stderr
+    assert "already is an inventory directory" in ret.stderr
     assert ret.returncode == 1
 
     d = Path(directory)
@@ -150,6 +150,16 @@ def test_dir_exists(repo: OnyoRepo, directory: str) -> None:
     assert (d / ".anchor").is_file()
 
     # verify that the repository is clean
+    assert repo.git.is_clean_worktree()
+
+    # existing non-inventory dir
+    regular_dir = repo.git.root / "something new"
+    regular_dir.mkdir()
+    ret = subprocess.run(['onyo', '--yes', 'mkdir', regular_dir], capture_output=True, text=True)
+    assert ret.returncode == 0
+    assert regular_dir.is_dir()
+    assert (regular_dir / ".anchor").is_file()
+    assert repo.is_inventory_dir(regular_dir)
     assert repo.git.is_clean_worktree()
 
 

--- a/onyo/lib/tests/test_commands_mkdir.py
+++ b/onyo/lib/tests/test_commands_mkdir.py
@@ -162,7 +162,7 @@ def test_onyo_mkdir_create_multiple_subdirectories(inventory: Inventory) -> None
 
     old_hexsha = inventory.repo.git.get_hexsha()
 
-    # call onyo_mkdir with the deepest new directory, and create the other dirs implicitely
+    # call onyo_mkdir with the deepest new directory, and create the other dirs implicitly
     onyo_mkdir(inventory,
                dirs=[dir_z],
                message="some subject\n\nAnd a body")
@@ -178,6 +178,41 @@ def test_onyo_mkdir_create_multiple_subdirectories(inventory: Inventory) -> None
     assert (dir_y / OnyoRepo.ANCHOR_FILE_NAME).is_file()
     assert (dir_y / OnyoRepo.ANCHOR_FILE_NAME) in inventory.repo.git.files
     # directory x was created and anchor exists
+    assert dir_z.is_dir()
+    assert inventory.repo.is_inventory_dir(dir_z)
+    assert (dir_z / OnyoRepo.ANCHOR_FILE_NAME).is_file()
+    assert (dir_z / OnyoRepo.ANCHOR_FILE_NAME) in inventory.repo.git.files
+    # exactly one commit added
+    assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
+    assert inventory.repo.git.is_clean_worktree()
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_mkdir_add_multiple_subdirectories(inventory: Inventory) -> None:
+    r"""Add multiple existing subdirectories to the inventory at once."""
+    dir_x = inventory.root / 'x'
+    dir_y = inventory.root / 'x' / 'y'
+    dir_z = inventory.root / 'x' / 'y' / 'z'
+    dir_z.mkdir(parents=True)
+    assert dir_x.is_dir() and dir_y.is_dir() and dir_z.is_dir()
+    old_hexsha = inventory.repo.git.get_hexsha()
+
+    # call onyo_mkdir with the deepest directory, and add the other dirs implicitly
+    onyo_mkdir(inventory,
+               dirs=[dir_z],
+               message="some subject\n\nAnd a body")
+
+    # directory x was added and anchor exists
+    assert dir_x.is_dir()
+    assert inventory.repo.is_inventory_dir(dir_x)
+    assert (dir_x / OnyoRepo.ANCHOR_FILE_NAME).is_file()
+    assert (dir_x / OnyoRepo.ANCHOR_FILE_NAME) in inventory.repo.git.files
+    # directory x was added and anchor exists
+    assert dir_y.is_dir()
+    assert inventory.repo.is_inventory_dir(dir_y)
+    assert (dir_y / OnyoRepo.ANCHOR_FILE_NAME).is_file()
+    assert (dir_y / OnyoRepo.ANCHOR_FILE_NAME) in inventory.repo.git.files
+    # directory x was added and anchor exists
     assert dir_z.is_dir()
     assert inventory.repo.is_inventory_dir(dir_z)
     assert (dir_z / OnyoRepo.ANCHOR_FILE_NAME).is_file()
@@ -223,7 +258,7 @@ def test_onyo_mkdir_asset(inventory: Inventory) -> None:
     assert inventory.repo.is_inventory_dir(asset_path)
 
     # re-execution fails:
-    with pytest.raises(NoopError, match="already is a directory"):
+    with pytest.raises(NoopError, match="already is an inventory directory"):
         onyo_mkdir(inventory,
                    dirs=[asset_path],
                    message="some subject\n\nAnd a body")

--- a/onyo/lib/tests/test_inventory_operations.py
+++ b/onyo/lib/tests/test_inventory_operations.py
@@ -281,12 +281,6 @@ def test_add_directory(repo: OnyoRepo) -> None:
     invalid_inventory_dir = repo.git.root / '.git' / 'new'
     pytest.raises(ValueError, inventory.add_directory, invalid_inventory_dir)
 
-    # can not add existing dirs:  (TODO: Same as new_asset - this behavior is not entirely correct at this level.
-    #                                    dir w/o anchor could get one. Could also be untracked and now to be added.
-    existing_inventory_dir = repo.git.root / 'exists'
-    existing_inventory_dir.mkdir()
-    pytest.raises(ValueError, inventory.add_directory, existing_inventory_dir)
-
     new_dir = repo.git.root / 'newdir'
     inventory.add_directory(new_dir)
 


### PR DESCRIPTION
This changes `onyo mkdir` to not fail on an existing non-inventory dir, but make it one instead.

Closes #597