### PR TITLE
`new`: Allow actual paths for `--template`

### DIFF
--- a/onyo/cli/new.py
+++ b/onyo/cli/new.py
@@ -31,7 +31,10 @@ args_new = {
         metavar='TEMPLATE',
         required=False,
         help=r"""
-            Name of a template to populate the contents of new assets.
+            Path to a template to populate the contents of new assets.
+            Relative paths will first attempt to resolve relative the to the
+            template directory (i.e. just the template name), otherwise it
+            will resolve relative to the current working directory.
 
             This cannot be used with the ``--clone`` flag nor the ``template``
             Reserved Key.
@@ -159,9 +162,17 @@ def new(args: argparse.Namespace) -> None:
         used with the ``--clone`` or ``--template`` flags.
     """
     inventory = Inventory(repo=OnyoRepo(Path.cwd(), find_root=True))
+    if args.template:
+        template = Path(args.template)
+        if not template.is_absolute():
+            probe_template = inventory.root / inventory.repo.TEMPLATE_DIR / template
+            if probe_template.exists():
+                template = probe_template
+    else:
+        template = None
     onyo_new(inventory=inventory,
              directory=Path(args.directory).resolve() if args.directory else None,
-             template=args.template,
+             template=template,
              clone=Path(args.clone).resolve() if args.clone else None,
              tsv=Path(args.tsv).resolve() if args.tsv else None,
              keys=args.keys,

--- a/onyo/cli/tests/test_new.py
+++ b/onyo/cli/tests/test_new.py
@@ -385,7 +385,7 @@ def test_new_with_flags_edit_keys_template(repo: OnyoRepo, directory: str) -> No
     """
     # set editor, template, key=value and asset
     os.environ['EDITOR'] = "printf 'key: value' >>"
-    template = "laptop.example"
+    template = repo.git.root / repo.TEMPLATE_DIR / "laptop.example"
     asset = Path(f"{directory}/laptop_apple_macbookpro.0")
     key_values = asset_spec + ["mode=keys"]
 

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -675,7 +675,7 @@ def onyo_mv(inventory: Inventory,
 @raise_on_inventory_state
 def onyo_new(inventory: Inventory,
              directory: Path | None = None,
-             template: str | None = None,
+             template: Path | str | None = None,
              clone: Path | None = None,
              tsv: Path | None = None,
              keys: list[Dict[str, str | int | float]] | None = None,
@@ -717,8 +717,8 @@ def onyo_new(inventory: Inventory,
         table column.
 
     template
-        The name of a template file in ``.onyo/templates/`` that is copied as a
-        base for the new assets to be created.
+        Path to a template file. If relative, this is allowed to be relative to ``.onyo/templates/``.
+        The template is copied as a base for the new assets to be created.
 
     clone
         Path to an asset to clone. Mutually exclusive with `template`.
@@ -840,7 +840,8 @@ def onyo_new(inventory: Inventory,
             asset = inventory.get_asset(clone)
             asset.pop('path')
         else:
-            asset = inventory.get_asset_from_template(spec.pop('template', None) or template)
+            t = spec.pop('template', None) or template
+            asset = inventory.get_asset_from_template(Path(t) if t else None)
         # 3. fill in asset specification
         asset.update(spec)
         # 4. (try to) add to inventory

--- a/onyo/lib/inventory.py
+++ b/onyo/lib/inventory.py
@@ -555,7 +555,7 @@ class Inventory(object):
         """
         return (self.get_asset(p) for p in self.repo.get_asset_paths(subtrees=paths, depth=depth))
 
-    def get_asset_from_template(self, template: str) -> dict:
+    def get_asset_from_template(self, template: Path | str | None) -> dict:
         # TODO: Possibly join with get_asset (path optional)
         return self.repo.get_template(template)
 

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -462,14 +462,17 @@ class OnyoRepo(object):
         return False
 
     def get_template(self,
-                     name: str | None = None) -> dict:
-        r"""Select and return a template from the directory `.onyo/templates/`.
+                     path: Path | str | None = None) -> dict:
+        r"""Select a template file and return an asset dict from it.
+         from the directory `.onyo/templates/`
 
         Parameters
         ----------
-        name
-            The name of the template to look for. If no name is given, the
-            template defined in the config file `.onyo/config` is returned.
+        path
+            Template file. If this a relative path or a string, then this
+            is interpreted as relative to the template directory.
+            If no path is given, the template defined in the config file
+            `.onyo/config` is returned.
 
         Returns
         -------
@@ -483,14 +486,15 @@ class OnyoRepo(object):
         ValueError
             If the requested template can't be found or is not a file.
         """
-        if not name:
-            name = self.get_config('onyo.new.template')
-            if name is None:
+        if not path:
+            path = self.get_config('onyo.new.template')
+            if path is None:
                 return dict()
-
-        template_file = self.git.root / self.TEMPLATE_DIR / name
+        template_file = self.git.root / self.TEMPLATE_DIR / path \
+            if isinstance(path, str) or not path.is_absolute() \
+            else path
         if not template_file.is_file():
-            raise ValueError(f"Template {name} does not exist.")
+            raise ValueError(f"Template {path} does not exist.")
         return get_asset_content(template_file)
 
     def validate_anchors(self) -> bool:

--- a/onyo/lib/tests/test_onyo.py
+++ b/onyo/lib/tests/test_onyo.py
@@ -141,8 +141,9 @@ def test_is_onyo_path(onyorepo) -> None:
 def test_Repo_get_template(onyorepo: OnyoRepo) -> None:
     """
     The function `OnyoRepo.get_template` returns a dictionary representing
-    a template in `.onyo/templates/*`. Default can be configured via 'onyo.new.template'.
-    With no config and no name given, returns an empty dict.
+    a template file. If a relative path is specified, it will first look in
+    `.onyo/templates/`. A default template can be configured via
+    'onyo.new.template'. With no config and no name given, returns an empty dict.
     """
     # Call the function without parameter to get the empty template:
     assert onyorepo.get_template() == dict()
@@ -153,12 +154,14 @@ def test_Repo_get_template(onyorepo: OnyoRepo) -> None:
         if path.name == OnyoRepo.ANCHOR_FILE_NAME:
             continue
 
-        template = onyorepo.get_template(path.name)
-        assert isinstance(template, dict)
-        if path.name != 'empty':  # TODO: Make issue about removing `empty` file. That's pointless.
-            assert template != dict()  # TODO: compare content
-        else:
-            assert template == dict()
+        # specify path as absolute, relative to template dir and relative to CWD (repo root):
+        for given_path in [path, path.name, path.relative_to(onyorepo.git.root)]:
+            template = onyorepo.get_template(path.name)
+            assert isinstance(template, dict)
+            if path.name != 'empty':  # TODO: Make issue about removing `empty` file. That's pointless.
+                assert template != dict()  # TODO: compare content
+            else:
+                assert template == dict()
 
     # verify the correct error response when called with a template name that
     # does not exist


### PR DESCRIPTION
Changes `new`'s `--template` parameter to accept actual paths rather than just names. If a path given is relative, it is first looked for underneath the template dir, maintaining the previous behavior when one gives a name of template file therein. Only, if that doesn't exist is a relative path resolved normally (CWD).

Closes #593