### PR TITLE
Allow subcommands to fail on invalid arguments in a way consistent with argparse

### DIFF
--- a/onyo/cli/get.py
+++ b/onyo/cli/get.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 from onyo.lib.onyo import OnyoRepo
 from onyo.lib.commands import onyo_get
+from onyo.lib.exceptions import InvalidArgumentError
 from onyo.lib.filters import Filter
 from onyo.lib.inventory import Inventory
 
@@ -130,8 +131,7 @@ def get(args: argparse.Namespace) -> None:
     By default, the results are sorted by ``path``.
     """
     if args.sort_ascending and args.sort_descending:
-        raise ValueError('--sort-ascending (-s) and --sort-descending (-S) cannot be '
-                         'used together')
+        raise InvalidArgumentError('-s/--sort-ascending and -S/--sort-descending are mutually exclusive')
     sort = 'descending' if args.sort_descending else 'ascending'
     inventory = Inventory(repo=OnyoRepo(Path.cwd(), find_root=True))
 

--- a/onyo/cli/new.py
+++ b/onyo/cli/new.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from onyo.lib.onyo import OnyoRepo
 from onyo.argparse_helpers import StoreMultipleKeyValuePairs
 from onyo.lib.commands import onyo_new
+from onyo.lib.exceptions import InvalidArgumentError
 from onyo.lib.inventory import Inventory
 from onyo.shared_arguments import shared_arg_message
 
@@ -92,6 +93,7 @@ args_new = {
     'directory': dict(
         args=('-d', '--directory'),
         metavar='DIRECTORY',
+        action='append',
         help=r"""
             Directory to create new assets in.
 
@@ -162,6 +164,12 @@ def new(args: argparse.Namespace) -> None:
         used with the ``--clone`` or ``--template`` flags.
     """
     inventory = Inventory(repo=OnyoRepo(Path.cwd(), find_root=True))
+    if isinstance(args.directory, list):
+        if len(args.directory) > 1:
+            raise InvalidArgumentError("-d/--directory:  must be given only once")
+        else:
+            args.directory = args.directory[0]
+
     if args.template:
         template = Path(args.template)
         if not template.is_absolute():

--- a/onyo/cli/tests/test_get.py
+++ b/onyo/cli/tests/test_get.py
@@ -474,11 +474,9 @@ def test_get_sort_error(repo: OnyoRepo) -> None:
     """
     cmd = ['onyo', 'get', '-s', '-S']
     ret = subprocess.run(cmd, capture_output=True, text=True)
-    msg = (
-        '--sort-ascending (-s) and --sort-descending (-S) cannot be used '
-        'together')
+    msg = "-s/--sort-ascending and -S/--sort-descending are mutually exclusive"
     assert msg in ret.stderr
-    assert ret.returncode == 1
+    assert ret.returncode == 2
 
 
 @pytest.mark.parametrize('assets', [[

--- a/onyo/cli/tests/test_new.py
+++ b/onyo/cli/tests/test_new.py
@@ -703,6 +703,14 @@ def test_conflicting_and_missing_arguments(repo: OnyoRepo) -> None:
     assert "Asset keys specified twice:" in ret.stderr and "group" in ret.stderr
     assert ret.returncode == 1
 
+    # error on -d/--directory given multiple times
+    ret = subprocess.run(['onyo', 'new', '--keys', 'make=some', 'model=other', 'type=different',
+                          'serial=faux', '-d', 'some/where', '-d', 'else/where'],
+                         capture_output=True, text=True)
+    assert not ret.stdout
+    assert "-d/--directory" in ret.stderr
+    assert ret.returncode == 2
+
     # verify that the repository is in a clean state
     assert repo.git.is_clean_worktree()
 

--- a/onyo/lib/exceptions.py
+++ b/onyo/lib/exceptions.py
@@ -17,6 +17,10 @@ class OnyoInvalidFilterError(Exception):
     r"""Raise if filters are invalidly defined"""
 
 
+class InvalidArgumentError(Exception):
+    r"""Raised a (CLI-) command is invalidly called beyond what's covered by argparse."""
+
+
 class InventoryOperationError(Exception):
     r"""Thrown if an inventory operation cannot be executed."""
 

--- a/onyo/lib/exceptions.py
+++ b/onyo/lib/exceptions.py
@@ -30,7 +30,7 @@ class InvalidInventoryOperationError(InventoryOperationError):
 
 
 class InventoryDirNotEmpty(InvalidInventoryOperationError):
-    r"""Thrown if an inventory directory needs to be empty to perform an operation but isn't."""
+    r"""Raised if an inventory directory needs to be empty to perform an operation but is not."""
 
 
 class PendingInventoryOperationError(InventoryOperationError):

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 import rich
 
 from onyo import cli
+from onyo.lib.exceptions import InvalidArgumentError
 from onyo.lib.ui import ui
 
 if TYPE_CHECKING:
@@ -535,6 +536,12 @@ def main() -> None:
         os.chdir(args.opdir)
         try:
             args.run(args)
+        except InvalidArgumentError as e:
+            # special treatment for this error b/c it's meant to capture
+            # malformed calls, that aren't covered by argparse itself.
+            # Same style of reporting as any other argparse error:
+            subcmds._name_parser_map[args.cmd].print_usage(file=sys.stderr)
+            parser.error(str(e))
         except Exception as e:
             # TODO: This may need to be nicer, but in any case: Turn any exception/error into a message and exit
             #       non-zero here, in order to have this generic last catcher.


### PR DESCRIPTION
Allow subcommands to fail on invalid arguments in a way
consistent with argparse, when the constraint can't be (or isn't anyway)
put into the argument specification dict.
Introduces a dedicated exception, that is handled to look like an
argparse error in `main.py`. Meaning: style of error reporting, printing
usage of subcommand and return code 2.

With that, allow `new`'s `-d/--directory` option only once.

Closes #539