### PR TITLE
Fix checks for non-empty, required keys

### DIFF
--- a/onyo/lib/tests/test_inventory_operations.py
+++ b/onyo/lib/tests/test_inventory_operations.py
@@ -87,6 +87,10 @@ def test_add_asset(repo: OnyoRepo) -> None:
     asset.update(dict(model=""))
     pytest.raises(ValueError, inventory.add_asset, asset)
 
+    # required keys must not be None
+    asset.update(dict(model=None))  # pyre-ignore[6]
+    pytest.raises(ValueError, inventory.add_asset, asset)
+
     # To be added Asset requires a path:
     asset = dict(a_key='a_value')
     pytest.raises(ValueError, inventory.add_asset, asset)
@@ -227,7 +231,10 @@ def test_modify_asset(repo: OnyoRepo) -> None:
     new_asset.update(asset_changes)
 
     # required keys must not be empty
-    pytest.raises(ValueError, inventory.add_asset, asset)
+    pytest.raises(ValueError, inventory.modify_asset, asset, new_asset)
+    # required keys must not be None
+    new_asset.update(model=None)  # pyre-ignore[6]
+    pytest.raises(ValueError, inventory.modify_asset, asset, new_asset)
 
     new_asset.update(dict(model="CORRECTED-MODEL"))  # implies rename w/ default name config
 


### PR DESCRIPTION
This fixes the check for required keys with empty values to account for a possible `None`. Also move this check in `add_asset` and `modify_asset` after auto-generated values (faux-serials) but before name generation.
It's intentionally not integrated in the name generation for two reasons:
- While currently identical, required keys and keys used for name generation are conceptionally different. We could eventually allow for optional name fields.
- This type of validation needs refactoring to become cleaner and reduce code duplication. Narrower functions will make this more straight-forward.

Closes #594