### PR TITLE
Reenable test for missing values

### DIFF
--- a/onyo/cli/tests/test_new.py
+++ b/onyo/cli/tests/test_new.py
@@ -745,19 +745,18 @@ def test_tsv_errors(repo: OnyoRepo) -> None:
     table = prepared_tsvs / "error_incomplete_rows.tsv"
     ret = subprocess.run(['onyo', 'new', "--tsv", table],
                          capture_output=True, text=True)
-    pytest.skip("TODO: 'Missing' fields, but unique asset names -> Feature or Bug?")
 
     assert not ret.stdout
-    assert "The fields 'type', 'make', 'model', 'serial' and 'directory' are required" in ret.stderr
+    assert "Required asset keys (type, make, model, serial) must not have empty values" in ret.stderr
     assert ret.returncode == 1
 
     # <TSV> has necessary columns but contains no assets
     table = prepared_tsvs / "error_empty_columns.tsv"
     ret = subprocess.run(['onyo', 'new', "--tsv", table],
                          capture_output=True, text=True)
-    assert not ret.stdout
-    assert "No new assets given." in ret.stderr
-    assert ret.returncode == 1
+    assert "No new assets created." in ret.stdout
+    assert not ret.stderr
+    assert ret.returncode == 0
 
     # verify that the repository is in a clean state
     assert repo.git.is_clean_worktree()

--- a/onyo/lib/inventory.py
+++ b/onyo/lib/inventory.py
@@ -678,4 +678,5 @@ class Inventory(object):
         if any(v is None or not str(v)
                for k, v in asset.items()
                if k in self.repo.get_asset_name_keys()):
-            raise ValueError("Required asset keys must not have empty values.")
+            raise ValueError(f"Required asset keys ({', '.join(self.repo.get_asset_name_keys())})"
+                             f" must not have empty values.")


### PR DESCRIPTION
(Forgot to add to PR #628)

Empty values for required keys (used in asset names) are currently forbidden. Re-enable the test accordingly and make the check report what keys actually are required.
Also change defined behavior on a TSV with no rows other than the header to report no assets created and return zero. The decisive thing here is to inform the user, but I think there's technically no error here - we were simply asked to do nothing.