### PR TITLE
More flexible user questions

### DIFF
--- a/onyo/cli/tests/test_edit.py
+++ b/onyo/cli/tests/test_edit.py
@@ -130,6 +130,15 @@ def test_edit_with_user_response(repo: OnyoRepo) -> None:
     """
     os.environ['EDITOR'] = "printf 'key: user_response' >>"
 
+    # abort command
+    input_string = 'a'
+    ret = subprocess.run(['onyo', 'edit', *repo.asset_paths],
+                         input=input_string, capture_output=True, text=True)
+    assert "Accept changes" in ret.stdout
+    assert "Save changes?" not in ret.stdout  # we don't get to the final confirmation
+    assert "interrupted" in ret.stderr
+    assert ret.returncode == 1
+
     # test edit for a list of assets all at once
     input_string = '\n'.join(
         'y' for i in range(len(repo.asset_paths) + 1))  # confirm per asset + summary

--- a/onyo/cli/tests/test_new.py
+++ b/onyo/cli/tests/test_new.py
@@ -389,6 +389,24 @@ def test_new_with_flags_edit_keys_template(repo: OnyoRepo, directory: str) -> No
     asset = Path(f"{directory}/laptop_apple_macbookpro.0")
     key_values = asset_spec + ["mode=keys"]
 
+    # skip asset when asked for confirmation of the edited changes:
+    ret = subprocess.run(['onyo', 'new', '--edit',
+                          '--template', template, '--directory', directory, '--keys'] + key_values,
+                         input='s',
+                         capture_output=True, text=True)
+    assert 'No new assets created.' in ret.stdout
+    assert not ret.stderr
+    assert ret.returncode == 0
+
+    # abort command when asked for confirmation of the edited changes:
+    ret = subprocess.run(['onyo', 'new', '--edit',
+                          '--template', template, '--directory', directory, '--keys'] + key_values,
+                         input='a',
+                         capture_output=True, text=True)
+    assert "Accept changes?" in ret.stdout
+    assert "interrupted" in ret.stderr
+    assert ret.returncode == 1
+
     # create asset with --edit, --template and --keys
     ret = subprocess.run(['onyo', '--yes', 'new', '--edit',
                           '--template', template, '--directory', directory, '--keys'] + key_values,


### PR DESCRIPTION
This allows to pose questions to the user in a more flexible way and make use of that by asking 3- and 4-way questions when editing assets (either via `onyo edit` or `onyo new --edit`).

`UI.request_user_response`  now takes a definition of a default answer and a list of specifications of possible answers.
The default is assumed when the user simply hits enter (empty response) or when `--yes` is set. Consequently this is rendering the name `yes` worse, but that may need to change anyway. We already established, that it's actually setting a non-interactive mode.

With that, we can now better deal with (bulk-) editing. See #553.

Closes #553