### PR TITLE
Rename asset name config

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -39,8 +39,9 @@ Options
 ``onyo.new.template``
     The default template to use with ``onyo new``. (default: "empty")
 
-``onyo.assets.filename``
+``onyo.assets.name-format``
     The name scheme for asset files and asset directories in the repository.
+    Python format string that will be filled in by an asset's content.
     (default: "{type}_{make}_{model}.{serial}")
 
 ``onyo.repo.version``

--- a/onyo/cli/config.py
+++ b/onyo/cli/config.py
@@ -54,7 +54,7 @@ def config(args: argparse.Namespace) -> None:
 
     Onyo configuration options:
 
-      * ``onyo.assets.filename``: The format for asset names on the
+      * ``onyo.assets.name-format``: The format for asset names on the
         filesystem. (default: "{type}_{make}_{model}.{serial}")
       * ``onyo.core.editor``: The editor to use for subcommands such as ``edit``
         and ``new``. If unset, it will fallback to the environmental variable

--- a/onyo/cli/get.py
+++ b/onyo/cli/get.py
@@ -118,7 +118,7 @@ def get(args: argparse.Namespace) -> None:
     Return values of the requested **KEY**\ s for matching assets.
 
     If no **KEY**\ s are given, the path and all keys in the asset name are
-    printed (see ``onyo.assets.filename``). If no **PATH**\ s are given, the
+    printed (see ``onyo.assets.name-format``). If no **PATH**\ s are given, the
     current working directory is used.
 
     In addition to keys in asset contents, **PSEUDO-KEYS** can be queried and

--- a/onyo/cli/new.py
+++ b/onyo/cli/new.py
@@ -148,7 +148,7 @@ def new(args: argparse.Namespace) -> None:
       4) ``--edit`` (i.e. manual user input)
 
     The **KEY**\ s that comprise the asset filename are required (configured by
-    ``onyo.assets.filename``).
+    ``onyo.assets.name-format``).
 
     The contents of all new assets are checked for validity before committing.
 

--- a/onyo/cli/set.py
+++ b/onyo/cli/set.py
@@ -22,7 +22,7 @@ args_set = {
         action='store_true',
         help=r"""
             Allow setting **KEY**\ s that are part of the asset name.
-            (see the ``onyo.assets.filename`` configuration option)
+            (see the ``onyo.assets.name-format`` configuration option)
         """
     ),
 

--- a/onyo/cli/unset.py
+++ b/onyo/cli/unset.py
@@ -57,7 +57,7 @@ def unset(args: argparse.Namespace) -> None:
     r"""
     Remove **KEY**\ s from assets.
 
-    Keys that are used in asset names (see the ``onyo.assets.filename``
+    Keys that are used in asset names (see the ``onyo.assets.name-format``
     configuration option) cannot be unset.
 
     The contents of all modified assets are checked for validity before

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -767,8 +767,8 @@ def onyo_new(inventory: Inventory,
 
     keys
         List of dictionaries with key/value pairs that will be set in the newly
-        created assets. The keys used in the ``onyo.assets.filename`` config
-        ``.onyo/config`` (e.g. ``filename = "{type}_{make}_{model}.{serial}"``)
+        created assets. The keys used in the ``onyo.assets.name-format`` config
+        ``.onyo/config`` (e.g. ``name-format = "{type}_{make}_{model}.{serial}"``)
         are used in the asset name and therefore a required.
 
     edit

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -205,6 +205,15 @@ def onyo_config(inventory: Inventory,
     from onyo.lib.command_utils import allowed_config_args
 
     allowed_config_args(config_args)
+    # repo version shim
+    try:
+        v2_cfg = config_args.index("onyo.assets.name-format")
+    except ValueError:
+        # not found is fine
+        v2_cfg = None
+    if v2_cfg is not None and inventory.repo.version == '1':
+        config_args = config_args[:v2_cfg] + ['onyo.assets.filename'] + config_args[v2_cfg + 1:]
+    # end repo version shim
     subprocess.run(["git", 'config', '-f', str(inventory.repo.ONYO_CONFIG)] +
                    config_args, cwd=inventory.repo.git.root, check=True)
 

--- a/onyo/lib/consts.py
+++ b/onyo/lib/consts.py
@@ -17,3 +17,10 @@ be part of asset content.
 UNSET_VALUE = '<unset>'
 r"""String to represent keys that are not set.
 """
+
+KNOWN_REPO_VERSIONS = ['1', '2']
+r"""Onyo repository versions that this version of onyo knows.
+
+Needed to realize when onyo runs on a repo that was created by a newer version.
+(Or a user messed it up).
+"""

--- a/onyo/lib/inventory.py
+++ b/onyo/lib/inventory.py
@@ -388,7 +388,7 @@ class Inventory(object):
         )
         if name and name != generated_name:
             raise ValueError(f"Renaming asset {path.name} to {name} is invalid."
-                             f"Config 'onyo.assets.filename' suggests '{generated_name}' as its name.")
+                             f"Config 'onyo.assets.name-format' suggests '{generated_name}' as its name.")
         if not name:
             name = generated_name
         if path.name == name:
@@ -607,9 +607,9 @@ class Inventory(object):
                 raise ValueError(f"Asset name '{path.name}' already exists in inventory.")
 
     def generate_asset_name(self, asset: dict) -> str:
-        config_str = self.repo.get_config("onyo.assets.filename")
+        config_str = self.repo.get_config("onyo.assets.name-format")
         if not config_str:
-            raise ValueError("Missing config 'onyo.assets.filename'.")
+            raise ValueError("Missing config 'onyo.assets.name-format'.")
         try:
             name = config_str.format(**asset)  # TODO: Only pass non-pseudo keys?! What if there is no config?
         except KeyError as e:

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -134,7 +134,7 @@ class OnyoRepo(object):
         r"""Get a list of keys required for generating asset names
 
         This is extracting names of used keys from the
-        ``onyo.assets.filename`` config, which is supposed to be
+        ``onyo.assets.name-format`` config, which is supposed to be
         a python format string.
 
         Notes
@@ -165,7 +165,7 @@ class OnyoRepo(object):
         # Regex for finding key references in a python format string
         # (see notes above):
         search_regex = r"\{(\w+)"
-        config_str = self.get_config("onyo.assets.filename")
+        config_str = self.get_config("onyo.assets.name-format")
         return re.findall(search_regex, config_str) if config_str else []
 
     def get_editor(self) -> str:

--- a/onyo/lib/tests/test_inventory_operations.py
+++ b/onyo/lib/tests/test_inventory_operations.py
@@ -706,7 +706,7 @@ def test_rename_asset_dir(repo: OnyoRepo) -> None:
     pytest.raises(NotADirError, inventory.rename_directory, asset_dir_path, "newname")
 
     # renaming as an asset by changing the naming config
-    inventory.repo.set_config("onyo.assets.filename", "{serial}_{other}", "onyo")
+    inventory.repo.set_config("onyo.assets.name-format", "{serial}_{other}", "onyo")
     inventory.repo.commit(inventory.root / OnyoRepo.ONYO_CONFIG,
                           "Change asset name config")
     new_asset_dir_path = asset_dir_path.parent / "SERIAL_1"

--- a/onyo/lib/tests/test_onyo.py
+++ b/onyo/lib/tests/test_onyo.py
@@ -28,8 +28,8 @@ def test_OnyoRepo_instantiation_non_existing(tmp_path: Path) -> None:
         new_repo.dot_onyo / new_repo.TEMPLATE_DIR.name / OnyoRepo.ANCHOR_FILE_NAME,
         new_repo.dot_onyo / 'validation' / OnyoRepo.ANCHOR_FILE_NAME,
     ]])
-    new_repo.git.is_clean_worktree()
-    new_repo.is_valid_onyo_repo()
+    assert new_repo.git.is_clean_worktree()
+    new_repo.validate_onyo_repo()
     # a newly initialized repository has just one commit; requesting older ones is not possible
     assert new_repo.git.get_hexsha()
     pytest.raises(ValueError,

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -6,6 +6,7 @@ import sys
 import textwrap
 from argparse import ArgumentParser, PARSER, RawTextHelpFormatter
 from pathlib import Path
+from subprocess import CalledProcessError
 from typing import TYPE_CHECKING
 
 import rich
@@ -542,6 +543,13 @@ def main() -> None:
             # Same style of reporting as any other argparse error:
             subcmds._name_parser_map[args.cmd].print_usage(file=sys.stderr)
             parser.error(str(e))
+        except CalledProcessError as e:
+            # CalledProcessError itself is not informative to the user.
+            # As far as there was something useful in that process' stdout/stderr
+            # we usually let it through. If not, it should result in a dedicated exception,
+            # that we can treat here accordingly.
+            ui.log_debug(str(e))
+            sys.exit(e.returncode)
         except Exception as e:
             # TODO: This may need to be nicer, but in any case: Turn any exception/error into a message and exit
             #       non-zero here, in order to have this generic last catcher.

--- a/onyo/skel/config
+++ b/onyo/skel/config
@@ -4,6 +4,6 @@
 [onyo "new"]
 	template = empty
 [onyo "assets"]
-	filename = "{type}_{make}_{model}.{serial}"
+	name-format = "{type}_{make}_{model}.{serial}"
 [onyo "repo"]
-	version = 1
+	version = 2

--- a/onyo/tests/demo/reference_git_log.txt
+++ b/onyo/tests/demo/reference_git_log.txt
@@ -1,4 +1,4 @@
-commit 5544b04e1bc8a92dd1f3d423daf4d0ca7dbdcd39
+commit ccc6a95c7f04ec3ab73ca0807dd6f96283c47d6d
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -8,7 +8,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     Removed directories:
     - management/Max Mustermann
 
-commit 0d396bc90c7719c4ce71eb50b02d421d780623de
+commit e540ce4099832aa874604962565b2fb4977b57e3
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -19,7 +19,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     - management/Max Mustermann/headphones_apple_airpods.7h8f04 -> warehouse/headphones_apple_airpods.7h8f04
     - management/Max Mustermann/laptop_apple_macbook.uef82b3 -> warehouse/laptop_apple_macbook.uef82b3
 
-commit 0c734323f1f12ab26444ad36035229a6da0482ee
+commit 6dc64ba76d0354d571d584e2598ceb17a4a61068
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -29,7 +29,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     Moved assets:
     - warehouse/laptop_lenovo_thinkpad.owh8e2 -> ethics/Theo Turtle/laptop_lenovo_thinkpad.owh8e2
 
-commit b252ba602359be75565c581a8d25c88dd3ebf3fd
+commit 6a59d579d1519a75166a4f15a54c6d0b85805521
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -39,7 +39,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     New directories:
     - ethics/Theo Turtle
 
-commit e7d26e067582d76e01244ece6a082b2c2e78040a
+commit ae6d0846a8321cf63c7afa7dcb64eb74931bf59f
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -49,7 +49,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     New assets:
     - management/Alice Wonder/laptop_apple_macbook.83hd0
 
-commit 45b01b9cd6b31cc03fe6ffc35c5c2f50037c3f3d
+commit d97e21a03a18a64425dd16ca8c7a80cc92dae836
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -59,7 +59,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     New directories:
     - management/Alice Wonder
 
-commit e89cafb9cfdd2bb878fea471075669f8c9eca796
+commit 7251c12cbafb8f157e7826558cc7042719466716
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -69,7 +69,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     Moved directories:
     - ethics/Max Mustermann -> management/Max Mustermann
 
-commit deb5b0ffca556fe50a5abe4a6555a367b97255c6
+commit 967d55298320bff7165f7b1a898aa43f4c3007ac
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -79,7 +79,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     New directories:
     - management
 
-commit a0d575e2a8884cb6a794b428510fb4114bd77a9a
+commit af214824bc9666bddafdec454e15bec0e42b90e0
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -89,7 +89,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     Moved assets:
     - warehouse/laptop_apple_macbook.uef82b3 -> ethics/Max Mustermann/laptop_apple_macbook.uef82b3
 
-commit 4748d6600162cd4e087556de6662580c9a08317a
+commit fd90d143771e3ac4c32b6bd284edc67d5441227d
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -99,7 +99,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     Moved assets:
     - ethics/Max Mustermann/laptop_apple_macbook.9r32he -> recycling/laptop_apple_macbook.9r32he
 
-commit 84b134df91b07ecd50d0f20d85330721316475fe
+commit 1b5c779fd729d155a9ee1be56dbe8f58535b079a
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -109,7 +109,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     Moved assets:
     - repair/laptop_lenovo_thinkpad.owh8e2 -> warehouse/laptop_lenovo_thinkpad.owh8e2
 
-commit 471ab4ab63debf63818860f7351ef03bbd4ffad3
+commit f12ba458d4634da7efc3a85c0b333e4ab07a3814
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -119,7 +119,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     Modified assets:
     - repair/laptop_lenovo_thinkpad.owh8e2
 
-commit 01b8899e7e17f8b535d61a528fefae5d4256b2b2
+commit ca7ffc303cd94f1156e8992737fc273e5127f680
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -131,7 +131,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     - warehouse/laptop_apple_macbook.oiw629 -> accounting/Bingo Bob/laptop_apple_macbook.oiw629
     - warehouse/monitor_dell_PH123.86JZho -> accounting/Bingo Bob/monitor_dell_PH123.86JZho
 
-commit 361e10fd2d561ff83c7fe5deb753212d4e1a1ef7
+commit bc8af3cfce77c1d80ff5dc4e35b4fb9891f92a0a
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -141,7 +141,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     New assets:
     - warehouse/headphones_apple_airpods.uzl8e1
 
-commit 7eaf4a40f915e47b69fd73f98eecad2c33981816
+commit de9a3a347dbf9a6e6215699b40725905b9831e72
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -151,7 +151,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     New assets:
     - warehouse/laptop_apple_macbook.oiw629
 
-commit 591dabe63b23f879d5a72acb0285915d27302394
+commit 913236a737cb04265fce4bf12cf5e46dfa8037ee
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -161,7 +161,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     New assets:
     - warehouse/monitor_dell_PH123.86JZho
 
-commit c27a5bf855c277ceeafbb2237b39a0acf6f292eb
+commit 87c3d7be626ddbe955da7884508a0e998d980e36
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -172,7 +172,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     - accounting
     - accounting/Bingo Bob
 
-commit 7ade322dc12e2ff944b978f05e467f4c4b0d8b8a
+commit 1a401436b11ad4b425fc8cac53703f7c89a70cf5
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -184,7 +184,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     - warehouse/laptop_apple_macbook.9il2b4
     - warehouse/laptop_apple_macbook.uef82b3
 
-commit bb66af6269c8e47482f308172b5470378baa41a1
+commit 3d58ad1ff5ff2f4dd1d6ea31c171afe7a5c8f833
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -195,7 +195,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     - ethics/Max Mustermann/laptop_apple_macbook.9r32he
     - warehouse/laptop_apple_macbook.9r5qlk
 
-commit 5f3e3c5a0011c302d101a25fd0f93d40be2478db
+commit db4fe42ccadb60b88675b8b8eea5f2c3ce21debe
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -214,7 +214,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     - warehouse/laptop_apple_macbookpro.1eic93
     - warehouse/laptop_lenovo_thinkpad.iu7h6d
 
-commit 2d6088ae97fe51beae3c55eee4bdef52912ab882
+commit e1cd0a7c7dcb375cf577ecee964bda02250dea98
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -224,7 +224,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     Moved assets:
     - warehouse/laptop_microsoft_surface.oq782j -> ethics/Achilles Book/laptop_microsoft_surface.oq782j
 
-commit 96f870eaccb59a703a4df7b5f7cb66aa33f07eef
+commit c4bf25e038f2936d9104ac97e702fe864fd565ec
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -234,7 +234,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     Moved assets:
     - ethics/Achilles Book/laptop_lenovo_thinkpad.owh8e2 -> repair/laptop_lenovo_thinkpad.owh8e2
 
-commit 5d1824a8a304a37a56e42027f1ef7a6484b0abfb
+commit 30b9475ae62f3b92088389bbbb0fdbdd3871c949
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -244,7 +244,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     Moved assets:
     - warehouse/headphones_JBL_pro.e98t2p -> ethics/Achilles Book/headphones_JBL_pro.e98t2p
 
-commit 34ce272e91f81519c2a501a6fe3fce36b66f97db
+commit 8f10999874ba2f7d0f76dff0648ada9b45c2fa8e
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -254,7 +254,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     Moved assets:
     - warehouse/laptop_lenovo_thinkpad.owh8e2 -> ethics/Achilles Book/laptop_lenovo_thinkpad.owh8e2
 
-commit d74c2ddeef0d92e0e6889e930461039ec7ad23f6
+commit 616e3cc59a33ee9555e15bc90b3ff9156c3bf1c9
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -264,7 +264,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     Moved assets:
     - warehouse/headphones_apple_airpods.7h8f04 -> ethics/Max Mustermann/headphones_apple_airpods.7h8f04
 
-commit 1eca4f65baa8d9b467dca2835ec43a783c18bde5
+commit a181c902c3a5dd57c199cb1e6baf2c19640d20e4
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -274,7 +274,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     Moved assets:
     - warehouse/laptop_apple_macbook.9r32he -> ethics/Max Mustermann/laptop_apple_macbook.9r32he
 
-commit cd948af99e7367937e9c195089ed9e3ef85fca7b
+commit 97e5808610a11c256c1afb4d63f92f765953c0a7
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -286,7 +286,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     - ethics/Achilles Book
     - ethics/Max Mustermann
 
-commit fcac89d2c4ddda930dc79d063869d695efe0e171
+commit 9b50f203321babe23f853ef322aae232488fadc7
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -296,7 +296,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     Removed assets:
     - warehouse/headphones_JBL_pro.ph9527
 
-commit 36a5b922e8c692a86cdebc2d80a8cacfd7f6e5cd
+commit adf15bce35ec9f4778fe0b8c613d61796218bb38
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -306,7 +306,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     New assets:
     - warehouse/headphones_JBL_pro.ph9527
 
-commit faece574edcec4baf2382fde1a2f7a88f7fc88ba
+commit 182f77cf24e6bb4f3dbceeec9c7b2dc56f43391f
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -316,7 +316,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     New assets:
     - warehouse/headphones_JBL_pro.e98t2p
 
-commit fcf129c86ce28447f7804c950459d26372eca8e1
+commit 4d557e3bbef4c89107379de19471d5f63a2e370a
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -326,7 +326,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     New assets:
     - warehouse/headphones_JBL_pro.325gtt
 
-commit 17cf119543fd16c45080968e56cb59d49f52b6c9
+commit b4a34aa353404d3a73dd994525fda4a90399357b
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -336,7 +336,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     New assets:
     - warehouse/headphones_apple_airpods.7h8f04
 
-commit 44c802766f0d660404a744f2f39ce9ac81221121
+commit b6ea9bec7c7fef12f71d5bb857782c231eee6ea4
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -346,7 +346,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     New assets:
     - warehouse/laptop_microsoft_surface.oq782j
 
-commit c84f868361bebf2149d0afb85d1851d6ae1b8241
+commit d4d85d73f0bc3701866ffce6534a04e2b88eb96f
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -356,7 +356,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     New assets:
     - warehouse/laptop_lenovo_thinkpad.iu7h6d
 
-commit a4a512c0571f02dbe0e2bada7b20dccd121b514b
+commit 5da8dbe4c10162236c98b6a2b1b2a1155e98d73c
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -366,7 +366,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     New assets:
     - warehouse/laptop_lenovo_thinkpad.owh8e2
 
-commit 7bc2e81aacd208381ad312c51cbfa8b7e2b02f08
+commit 16c3b322909c18c2b6c9685bc42ce502bde23bf1
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -376,7 +376,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     New assets:
     - warehouse/laptop_apple_macbook.9r5qlk
 
-commit cca69f0aac5544c7dc371e4d2bb33bd187a0638b
+commit 8ad9e12c05caf2678ff6b606ddd294c4546d6ec0
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -386,7 +386,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     New assets:
     - warehouse/laptop_apple_macbook.9r32he
 
-commit b820118e4b2e40d28eddc674e8666bd0a7363435
+commit c4e28743d8e3da0790289c2f932c3d91601e98a2
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -403,7 +403,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     - admin
     - admin/Karl Krebs
 
-commit 819a60148f6cdfd586d8817e68a35c6e19537618
+commit 10bdb44cfce9a0dd6189a6878783d50b29f8b3cb
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -413,7 +413,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     New directories:
     - repair
 
-commit c83d1055363012409b5f42ef88d8f238c6339bfb
+commit c39d41995e85743fb7ef768b77d9b117c63c8ead
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -423,7 +423,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     New directories:
     - recycling
 
-commit e6445ca7e8eaf32161d1e78052f5ca2727c4a852
+commit 75557b02fe3e8d725523ab3fd55257c0e46bd0db
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -433,7 +433,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     New directories:
     - warehouse
 
-commit 4b65a191efe10d81ef303d87fc1a9d7c2fbaa9fc
+commit e0630fb7ddeffc82ff9afa498c10be62a47916d8
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 


### PR DESCRIPTION
This PR renames the config that defines the asset naming scheme. Since this is a functional change of what's recorded in a repository and what to do with it, this becomes repository version 2 now.
Closes #572

I used the occasion to also introduce a first handling of different repository versions.
Onyo now fails on repositories with an unknown version.
Closes #441 

In addition, there's a bit of a shim in three places in order to translate the changed config name when running on a version 1 repo.
We'd want a way to actually (auto-)migrate repositories as well, but this is out of scope for this PR.
(See issue #633)