### PR TITLE
Rework error reporting on asset file content

### DIFF
--- a/onyo/lib/inventory.py
+++ b/onyo/lib/inventory.py
@@ -537,7 +537,12 @@ class Inventory(object):
         Generator of dict
            All matching assets in the inventory.
         """
-        return (self.get_asset(p) for p in self.repo.get_asset_paths(subtrees=paths, depth=depth))
+        for p in self.repo.get_asset_paths(subtrees=paths, depth=depth):
+            try:
+                yield self.get_asset(p)
+            except NotAnAssetError as e:
+                # report the error, but proceed
+                ui.error(e)
 
     def get_asset_from_template(self, template: Path | str | None) -> dict:
         # TODO: Possibly join with get_asset (path optional)

--- a/onyo/lib/ui.py
+++ b/onyo/lib/ui.py
@@ -76,6 +76,10 @@ class UI(object):
         self.stderr_console = Console(stderr=True, highlight=False)
         self.stdout_console = Console(stderr=False, highlight=False)
 
+        # count reported errors; this allows to assess whether errors occurred
+        # even when no exception bubbles up.
+        self.error_count: int = 0
+
     def set_debug(self,
                   debug: bool = False) -> None:
         r"""Toggle debug mode.
@@ -138,6 +142,7 @@ class UI(object):
             Specify the string at the end of prints.
             Per default, prints end with a line break.
         """
+        self.error_count += 1
         if not self.quiet:
             print(f"ERROR: {error}", file=sys.stderr, end=end)
         if isinstance(error, Exception):

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -561,6 +561,10 @@ def main() -> None:
             sys.exit(1)
         finally:
             os.chdir(old_cwd)
+        if ui.error_count > 0:
+            # We may have reported errors while being able to proceed (hence no exception bubbled up).
+            # That's fine, but still exit non-zero.
+            sys.exit(1)
     else:
         parser.print_help()
         sys.exit(1)


### PR DESCRIPTION
This changes how onyo deals with errors when reading an asset file.
- A technically valid YAML that does not yield a dictionary is considered an invalid asset. This could be the case for a text file, that is not (yet) included in `.onyoignore`.
- At the lower level do not return an empty asset, but actually raise, if there was an error.
- When trying to read several assets (likely for matching) report such errors but do skip such a file and proceed.
- Have `UI` count when an error message is issued. With that `main.py` can exit non-zero if errors we reported even if no exception bubbled up, b/c the reporting code could proceed despite the error.

Closes #582
Closes #587
Closes #436