### PR TITLE
Make `core.editor` first fallback

### DIFF
--- a/docs/source/concepts.rst
+++ b/docs/source/concepts.rst
@@ -77,13 +77,15 @@ repository.
   - tools used by ``onyo history``.
     The values can be updated with e.g.:
 
-    - ``onyo config history.interactive "tig --follow"``
-    - ``onyo config history.non-interactive "git --no-pager log --follow"``
+    - ``onyo config onyo.history.interactive "tig --follow"``
+    - ``onyo config onyo.history.non-interactive "git --no-pager log --follow"``
 
   - default template to use with ``onyo new --path <asset>``
     The standard template can be updated with e.g.:
 
-    - ``onyo config template.default empty``
+    - ``onyo config onyo.new.template empty``
+
+  - see also: :doc:`configuration`.
 
 - ``.onyo/templates/`` contains:
 
@@ -101,7 +103,7 @@ valid YAML syntax.
 
 The default template that gets used when ``onyo new`` is called is
 ``.onyo/templates/empty``. It can be updated with
-``onyo config template.default empty``.
+``onyo config onyo.new.template empty``.
 
 For examples, see the section "Templates" in :doc:`examples`.
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -25,7 +25,8 @@ Options
 
 ``onyo.core.editor``
     The editor to use for commands such as ``edit`` and ``new``. If unset, it
-    will fallback to the environmental variable ``EDITOR`` and lastly ``nano``.
+    will fallback to ``core.editor`` configuration of ``git`` it self, then to
+    the environmental variable ``EDITOR`` and lastly ``nano``.
     (default: unset)
 
 ``onyo.history.interactive``

--- a/onyo/cli/config.py
+++ b/onyo/cli/config.py
@@ -57,8 +57,9 @@ def config(args: argparse.Namespace) -> None:
       * ``onyo.assets.filename``: The format for asset names on the
         filesystem. (default: "{type}_{make}_{model}.{serial}")
       * ``onyo.core.editor``: The editor to use for subcommands such as ``edit``
-        and ``new``. If unset, it will fallback to the environmental variable
-        ``EDITOR`` and lastly ``nano``. (default: unset)
+        and ``new``. If unset, it will fallback to ``core.editor`` of  ``git``,
+        then the environmental variable ``EDITOR`` and lastly ``nano``.
+        (default: unset)
       * ``onyo.history.interactive``: The interactive command to use for
         ``onyo history``. (default: "tig --follow")
       * ``onyo.history.non-interactive``: The non-interactive command for

--- a/onyo/cli/edit.py
+++ b/onyo/cli/edit.py
@@ -44,6 +44,7 @@ def edit(args: argparse.Namespace) -> None:
     The editor is selected by (in order):
 
       * ``onyo.core.editor`` configuration option
+      * ``core.editor`` configuration option (git)
       * ``EDITOR`` environment variable
       * ``nano`` (as a final fallback)
 

--- a/onyo/cli/tests/test_edit.py
+++ b/onyo/cli/tests/test_edit.py
@@ -17,15 +17,25 @@ assets = [['laptop_apple_macbookpro.0', "type: laptop\nmake: apple\nmodel: macbo
 
 
 @pytest.mark.parametrize('variant', ['local', 'onyo'])
-def test_get_editor_git(repo: OnyoRepo, variant: str) -> None:
+def test_get_editor_onyo(repo: OnyoRepo, variant: str) -> None:
     r"""
-    Get the editor from git or onyo configs.
+    Get the editor from onyo configuration.
     """
     repo.set_config('onyo.core.editor', variant, location=variant)
 
     # test
     editor = repo.get_editor()
     assert editor == variant
+
+
+def test_get_editor_git(repo: OnyoRepo) -> None:
+    r"""
+    Get the editor from git configuration
+    """
+    repo.set_config('core.editor', 'git-edit', location='local')
+    assert "git-edit" in (repo.git.root / '.git' / 'config').read_text()
+    editor = repo.get_editor()
+    assert editor == "git-edit"
 
 
 def test_get_editor_envvar(repo: OnyoRepo) -> None:

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -169,15 +169,20 @@ class OnyoRepo(object):
         return re.findall(search_regex, config_str) if config_str else []
 
     def get_editor(self) -> str:
-        r"""Returns the editor, progressing through git, onyo, $EDITOR, and finally
+        r"""Returns the editor, progressing through onyo, git, $EDITOR, and finally
         fallback to "nano".
         """
-        # onyo config and git config
+        # onyo config setting (from onyo and git config files)
         editor = self.get_config('onyo.core.editor')
+
+        # git config
+        if not editor:
+            ui.log_debug("onyo.core.editor is not set.")
+            editor = self.get_config('core.editor')
 
         # $EDITOR environment variable
         if not editor:
-            ui.log_debug("onyo.core.editor is not set.")
+            ui.log_debug("core.editor is not set.")
             editor = os.environ.get('EDITOR')
 
         # fallback to nano


### PR DESCRIPTION
This changes the editor used by onyo to first fall back to git's editor before considering `$EDITOR` or `nano`.

Closes #347
Closes #536