### PR TITLE
Fixing asset comparison to account for comments

### DIFF
--- a/onyo/cli/tests/test_edit.py
+++ b/onyo/cli/tests/test_edit.py
@@ -374,10 +374,9 @@ def test_edit_with_dot_dot(repo: OnyoRepo, asset: str) -> None:
 
     # check edit with a path containing a ".." that leads outside the onyo repo
     # and then inside again
-    # Note: Strange. That path isn't used with `edit` at all.
     path = Path(f"../{repo.git.root.name}/{asset}")
     assert path.is_file()
-    ret = subprocess.run(['onyo', '--yes', 'edit', asset],
+    ret = subprocess.run(['onyo', '--yes', 'edit', str(path)],
                          capture_output=True, text=True)
     assert ret.returncode == 0
     assert "+key: dot_dot" in ret.stdout

--- a/onyo/lib/inventory.py
+++ b/onyo/lib/inventory.py
@@ -47,7 +47,10 @@ from onyo.lib.recorders import (
     record_rename_assets,
     record_rename_directories,
 )
-from onyo.lib.utils import deduplicate
+from onyo.lib.utils import (
+    deduplicate,
+    is_equal_assets_dict,
+)
 from onyo.lib.ui import ui
 
 if TYPE_CHECKING:
@@ -422,7 +425,7 @@ class Inventory(object):
         # We keep the old path - if it needs to change, this will be done by a rename operation down the road
         new_asset['path'] = path
 
-        if asset == new_asset:
+        if is_equal_assets_dict(asset, new_asset):
             raise NoopError
 
         # If a change in is_asset_directory is implied, do this first:


### PR DESCRIPTION
`modify_asset` raises a `NoopError` when there's nothing to do.
However, this was based on a dict comparison, leading to the assessment
that there isn't anything to do, if comments were the only thing
modified.
This commit adds a comparison helper, that accounts for `ruamel`'s
comment annotation. Builtin by `ruamel` operator overwrites (`__eq__`,
`__neq__`, `__contains__`) don't work for us, b/c a `CommentToken`'s
start- and end markers may end up being `FileMark` objects. And these
contain the path to a file this was read from. Hence, comparing across
files doesn't work as we need it to, b/c assets are edited in a temp
location, so that the edited asset object is connected to a different
file path. This led to edits that change nothing but comments being
ignored by `onyo edit` and therefore nothing was committed.

Closes #586


Second commit is a miniscule fix of a test I stumbled upon. Not actually related to the topic above.