### PR TITLE
`mkdir`: No duplicate creation of parent dirs

### DIFF
--- a/onyo/lib/inventory.py
+++ b/onyo/lib/inventory.py
@@ -339,7 +339,9 @@ class Inventory(object):
         operations.append(self._add_operation('new_directories', (path,)))
         operations.extend([self._add_operation('new_directories', (p,))
                            for p in path.parents
-                           if self.root in p.parents and not self.repo.is_inventory_dir(p)])
+                           if self.root in p.parents and
+                           not self.repo.is_inventory_dir(p) and
+                           p not in self._get_pending_dirs()])
         return operations
 
     def remove_asset(self, asset: dict | Path) -> list[InventoryOperation]:

--- a/onyo/onyo_arguments.py
+++ b/onyo/onyo_arguments.py
@@ -1,13 +1,28 @@
+import sys
 from pathlib import Path
 
 from onyo._version import __version__
+from onyo.lib.ui import ui
+
+
+def get_cwd() -> Path:
+    # This avoids dumping a traceback to the user,
+    # if CWD doesn't exist.
+    # A bit hacky, b/c this would happen early on where
+    # we are not a general exception handler yet.
+    try:
+        return Path.cwd()
+    except FileNotFoundError as e:
+        ui.error(e)
+        sys.exit(1)
+
 
 args_onyo = {
     'opdir': dict(
         args=('-C', '--onyopath'),
         metavar='DIR',
         required=False,
-        default=Path.cwd(),
+        default=get_cwd(),
         help=r"""
             Run Onyo from **DIR** instead of the current working directory.
         """


### PR DESCRIPTION
This lets `add_directory` skip issuing an operation for parent dir
creation, if that's already in the operation queue.
Therefore, creating several dirs underneath the same to-be-created
parent don't execute, diff, and record that operation several times.

In addition, stumbled upon a minor bug, where we'd dump a full traceback when `CWD` happens to be gone.

Closes #538