### PR TITLE
`get`: Better sorting and `--exclude`

### DIFF
--- a/onyo/cli/get.py
+++ b/onyo/cli/get.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from onyo.argparse_helpers import StoreSortOption
 from onyo.lib.onyo import OnyoRepo
 from onyo.lib.commands import onyo_get
-from onyo.lib.exceptions import InvalidArgumentError
 from onyo.lib.filters import Filter
 from onyo.lib.inventory import Inventory
 
@@ -91,19 +91,31 @@ args_get = {
 
     'sort_ascending': dict(
         args=('-s', '--sort-ascending'),
-        action='store_true',
-        default=False,
+        metavar='SORT_KEY',
+        action=StoreSortOption,
+        nargs='+',
         help=r"""
-            Sort output in ascending order (excludes ``--sort-descending``).
+            Sort output by **SORT-KEY** in ascending order.
+            Can be given multiple times. Sorting by multiple **SORT-KEY** will be done in order
+            (earlier given keys take precedence over subsequent keys).
+            This can be intermixed with ``-s/--sort-descending``.
+            Note, that if a **SORT-KEY** appears multiple times, the latest appearance will
+            overrule what ws specified before.
         """
     ),
 
     'sort_descending': dict(
         args=('-S', '--sort-descending'),
-        action='store_true',
-        default=False,
+        metavar='SORT_KEY',
+        action=StoreSortOption,
+        nargs='+',
         help=r"""
-            Sort output in descending order (excludes ``--sort-ascending``).
+            Sort output by **SORT-KEY** in descending order.
+            Can be given multiple times. Sorting by multiple **SORT-KEY** will be done in order
+            (earlier given keys take precedence over subsequent keys).
+            This can be intermixed with ``-s/--sort-ascending``.
+            Note, that if a **SORT-KEY** appears multiple times, the latest appearance will
+            overrule what ws specified before.
         """
     ),
 }
@@ -149,9 +161,6 @@ def get(args: argparse.Namespace) -> None:
 
     By default, the results are sorted by ``path``.
     """
-    if args.sort_ascending and args.sort_descending:
-        raise InvalidArgumentError('-s/--sort-ascending and -S/--sort-descending are mutually exclusive')
-    sort = 'descending' if args.sort_descending else 'ascending'
     includes = args.path if args.path else []
     includes += args.include if args.include else []
     includes = [Path(p).resolve() for p in includes] if includes else [Path.cwd()]
@@ -162,7 +171,7 @@ def get(args: argparse.Namespace) -> None:
     filters = [Filter(f).match for f in args.match] if args.match else None
 
     onyo_get(inventory=inventory,
-             sort=sort,
+             sort=args.sort,
              include=includes,
              exclude=excludes,
              depth=args.depth,

--- a/onyo/cli/tests/test_get.py
+++ b/onyo/cli/tests/test_get.py
@@ -508,6 +508,18 @@ def test_natural_sort(keys: dict[str, sort_t], expected: list[int]) -> None:
     sorted_assets = natural_sort(assets, keys=keys)
     assert expected == [data.get('id') for data in sorted_assets]
 
+    # explicitly check path sorting:
+    assets = [{'path': Path('folder/file (1).txt')},
+              {'path': Path('folder/file.txt')},
+              {'path': Path('folder (1)/file.txt')},
+              {'path': Path('folder (10)/file.txt')}]
+    sorted_assets = natural_sort(assets, {'path': SORT_ASCENDING})  # pyre-ignore[6]
+    expectation = ['folder/file.txt',
+                   'folder/file (1).txt',
+                   'folder (1)/file.txt',
+                   'folder (10)/file.txt']
+    assert expectation == [str(a.get('path')) for a in sorted_assets]
+
 
 @pytest.mark.parametrize('assets', [[
     {'num': 'num-20', 'str': 'abc', 'path': Path('a13bc_foo_bar.1')},

--- a/onyo/lib/command_utils.py
+++ b/onyo/lib/command_utils.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import re
 import shutil
 import sys
 from typing import TYPE_CHECKING
@@ -92,16 +91,15 @@ def natural_sort(assets: list[dict],
     reverse
         Whether to sort in reverse order.
     """
-
-    def sort_order(x, k):
-        return [int(s) if s.isdigit() else s.lower()
-                for s in re.split('([0-9]+)', str(x[k]))]
+    import natsort
 
     for key in reversed(keys.keys()):
-        assets = sorted(
-            assets,
-            key=lambda x: sort_order(x, key),
-            reverse=keys[key] == SORT_DESCENDING)
+        alg = natsort.ns.IGNORECASE | natsort.ns.INT
+        if key == 'path':
+            alg |= natsort.ns.PATH
+        assets = sorted(assets,
+                        key=natsort.natsort_keygen(key=lambda x: x.get(key), alg=alg),
+                        reverse=keys[key] == SORT_DESCENDING)
 
     return assets
 

--- a/onyo/lib/command_utils.py
+++ b/onyo/lib/command_utils.py
@@ -6,12 +6,17 @@ import shutil
 import sys
 from typing import TYPE_CHECKING
 
-from .consts import UNSET_VALUE
-
+from .consts import (
+    SORT_DESCENDING,
+    UNSET_VALUE,
+)
 if TYPE_CHECKING:
-    from typing import Generator
+    from typing import (
+        Generator,
+    )
 
     from .onyo import OnyoRepo
+    from .consts import sort_t
 
 log: logging.Logger = logging.getLogger('onyo.command_utils')
 
@@ -75,8 +80,7 @@ def fill_unset(assets: Generator[dict, None, None] | filter,
 
 
 def natural_sort(assets: list[dict],
-                 keys: list[str] | None = None,
-                 reverse: bool = False) -> list[dict]:
+                 keys: dict[str, sort_t]) -> list[dict]:
     r"""Sort an asset list by a list of ``keys``.
 
     Parameters
@@ -84,21 +88,20 @@ def natural_sort(assets: list[dict],
     assets
         Assets to sort.
     keys
-        Keys to sort ``assets`` by. Default: ``['path']``.
+        Keys to sort ``assets`` by.
     reverse
         Whether to sort in reverse order.
     """
-    keys = keys or ['path']
 
     def sort_order(x, k):
         return [int(s) if s.isdigit() else s.lower()
                 for s in re.split('([0-9]+)', str(x[k]))]
 
-    for key in reversed(keys):
+    for key in reversed(keys.keys()):
         assets = sorted(
             assets,
             key=lambda x: sort_order(x, key),
-            reverse=reverse)
+            reverse=keys[key] == SORT_DESCENDING)
 
     return assets
 

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -428,7 +428,8 @@ def onyo_edit(inventory: Inventory,
 
 @raise_on_inventory_state
 def onyo_get(inventory: Inventory,
-             paths: list[Path] | None = None,
+             include: list[Path] | None = None,
+             exclude: list[Path] | Path | None = None,
              depth: int = 0,
              machine_readable: bool = False,
              match: list[Callable[[dict], bool]] | None = None,
@@ -440,10 +441,15 @@ def onyo_get(inventory: Inventory,
     ----------
     inventory
       The inventory to query.
-    paths
+    include
       Limits the query to assets underneath these paths.
       Paths can be assets and directories.
       If no paths are specified, the inventory root is used as default.
+    exclude
+      Paths to exclude, meaning that assets underneath any of these are not
+      being returned. Defaults to `None`. Note, that `depth` only applies to
+      `include`, not to `exclude`. `depth` and `exclude` are different ways
+      of limiting the results.
     depth
       Number of levels to descend into. Must be greater or equal 0.
       If 0, descend recursively without limit.
@@ -459,8 +465,7 @@ def onyo_get(inventory: Inventory,
       this list.
     keys
       Defines what key-value pairs of an asset a result is composed of.
-      If no `keys` are given the keys then the asset name keys and
-      `path` are used.
+      If no `keys` are given then the asset name keys and `path` are used.
       Keys may be repeated.
     sort
       How to sort the results by `keys`. Possible values are
@@ -481,11 +486,11 @@ def onyo_get(inventory: Inventory,
     selected_keys = keys.copy() if keys else None
 
     # TODO: JSON output? Is this done somewhere?
-    paths = paths or [inventory.root]
+    include = include or [inventory.root]
 
     # validate path arguments
     invalid_paths = set(p
-                        for p in paths  # pyre-ignore[16]  `paths` not Optional anymore here
+                        for p in include  # pyre-ignore[16]  `paths` not Optional anymore here
                         if not (inventory.repo.is_inventory_dir(p) or inventory.repo.is_asset_path(p)))
     if invalid_paths:
         err_str = '\n'.join([str(x) for x in invalid_paths])
@@ -496,7 +501,8 @@ def onyo_get(inventory: Inventory,
         raise ValueError(f"Allowed sorting modes: {', '.join(allowed_sorting)}")
 
     selected_keys = selected_keys or inventory.repo.get_asset_name_keys() + ['path']
-    results = inventory.get_assets_by_query(paths=paths,
+    results = inventory.get_assets_by_query(include=include,
+                                            exclude=exclude,
                                             depth=depth,
                                             match=match)
     results = list(fill_unset(results, selected_keys))

--- a/onyo/lib/consts.py
+++ b/onyo/lib/consts.py
@@ -1,3 +1,9 @@
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from typing import Literal
+    sort_t = Literal['ascending', 'descending']
+
+
 PSEUDO_KEYS = ['path']
 r"""Key names that are addressable but not in asset content.
 
@@ -24,3 +30,6 @@ r"""Onyo repository versions that this version of onyo knows.
 Needed to realize when onyo runs on a repo that was created by a newer version.
 (Or a user messed it up).
 """
+
+SORT_ASCENDING = 'ascending'
+SORT_DESCENDING = 'descending'

--- a/onyo/lib/tests/test_commands_get.py
+++ b/onyo/lib/tests/test_commands_get.py
@@ -212,13 +212,13 @@ def test_onyo_get_sorting(inventory: Inventory,
 
     # call `onyo_get()` with sort=ascending
     onyo_get(inventory,
-             sort="ascending",
+             sort={get_key: "ascending", "path": "ascending"},
              keys=[get_key, "path"])
     ascending_output = capsys.readouterr().out
 
     # call `onyo_get()` with sort=descending
     onyo_get(inventory,
-             sort="descending",
+             sort={get_key: "descending", "path": "descending"},
              keys=[get_key, "path"])
     descending_output = capsys.readouterr().out
 
@@ -235,7 +235,7 @@ def test_onyo_get_sorting(inventory: Inventory,
     pytest.raises(ValueError,
                   onyo_get,
                   inventory,
-                  sort="ILLEGAL",
+                  sort={get_key: "ILLEGAL"},
                   keys=[get_key, "path"])
 
 

--- a/onyo/lib/tests/test_commands_tree.py
+++ b/onyo/lib/tests/test_commands_tree.py
@@ -54,7 +54,7 @@ def test_onyo_tree_single(inventory: Inventory,
 
     # verify assets and paths are in output
     tree_output = capsys.readouterr().out
-    for path in inventory.repo.get_asset_paths(subtrees=[directory_path]):
+    for path in inventory.repo.get_asset_paths(include=[directory_path]):
         assert all([part in tree_output for part in path.parts])
     assert inventory.repo.git.is_clean_worktree()
 
@@ -71,7 +71,7 @@ def test_onyo_tree_multiple_paths(inventory: Inventory,
 
     # verify assets and paths are in output
     tree_output = capsys.readouterr().out
-    for path in inventory.repo.get_asset_paths(subtrees=[dir_path, inventory.root]):
+    for path in inventory.repo.get_asset_paths(include=[dir_path, inventory.root]):
         assert all([part in tree_output for part in path.parts])
     assert inventory.repo.git.is_clean_worktree()
 
@@ -88,7 +88,7 @@ def test_onyo_tree_relative_single(inventory: Inventory,
 
     # verify assets and paths are in output
     tree_output = capsys.readouterr().out
-    for path in inventory.repo.get_asset_paths(subtrees=[directory_path]):
+    for path in inventory.repo.get_asset_paths(include=[directory_path]):
         assert all([part in tree_output for part in path.relative_to(inventory.root).parts])
     assert inventory.repo.git.is_clean_worktree()
 
@@ -125,7 +125,7 @@ def test_onyo_tree_with_same_dir_twice(inventory: Inventory,
 
     # verify assets and paths are in output
     tree_output = capsys.readouterr().out
-    for path in inventory.repo.get_asset_paths(subtrees=[directory_path]):
+    for path in inventory.repo.get_asset_paths(include=[directory_path]):
         assert all([part in tree_output for part in path.parts])
     assert tree_output.count(str(directory_path)) == 2
     assert inventory.repo.git.is_clean_worktree()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ classifiers = [
 dependencies = [
     "ruamel.yaml",
     "rich",
+    "natsort",
+    "fastnumbers"  # not strictly neccessary, but makes natsort's number parsing faster
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
This addresses several issues with `get`, mostly on sorting.
See commit messages and closed issues for details.

In short:
- `get` now has `--exclude` and `--include` arguments, that take paths. Assets underneath these (or directly specified) are exclude or included in the query respectively. The previous `--path` argument is consequently an alias for `--include`.
- Sorting has changed. We have `-s` and `-S` for ascending and descending order. However, they now take a key to sort by as argument and can be given multiple times. Sorting by multiple keys is done in order of appearance, where ascending and descending is specified per key so that it can be a mix.
- Lastly, onyo now depends on `natsort` (and `fastnumbers`) rather than bothering to try and reinvent the wheel. This package already considers a lot of special cases and performance issues.

Closes #518
Closes #507
Closes #505