### PR TITLE
Colorize diff output

### DIFF
--- a/onyo/lib/command_utils.py
+++ b/onyo/lib/command_utils.py
@@ -9,6 +9,11 @@ from .consts import (
     SORT_DESCENDING,
     UNSET_VALUE,
 )
+from .inventory import (
+    Inventory,
+    InventoryOperation,
+)
+from .ui import ui
 if TYPE_CHECKING:
     from typing import (
         Generator,
@@ -143,3 +148,19 @@ def get_history_cmd(interactive: bool,
                          f"The program '{history_program}' was not found. Exiting.")
 
     return history_cmd
+
+
+def print_diff(diffable: Inventory | InventoryOperation) -> None:
+    # This isn't nice yet. We need to consolidate `UI` to deal with that.
+    # However, that requires figuring how to deal with issues, when
+    # capturing output in tests and rich not realizing that.
+    for line in diffable.diff():
+        if line.startswith('+'):
+            style = "green"
+        elif line.startswith('-'):
+            style = "red"
+        elif line.startswith('@'):
+            style = "bold"
+        else:
+            style = ""
+        ui.rich_print(line, style=style)

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -14,7 +14,11 @@ from functools import wraps
 from rich import box
 from rich.table import Table  # pyre-ignore[21] for some reason pyre doesn't find Table
 
-from onyo.lib.command_utils import fill_unset, natural_sort
+from onyo.lib.command_utils import (
+    fill_unset,
+    natural_sort,
+    print_diff,
+)
 from onyo.lib.consts import (
     PSEUDO_KEYS,
     RESERVED_KEYS,
@@ -347,8 +351,7 @@ def _edit_asset(inventory: Inventory,
         if operations:
             ui.print("Effective changes:")
             for op in operations:
-                for line in op.diff():
-                    ui.print(line)
+                print_diff(op)
         response = ui.request_user_response(
             "Accept changes? (y)es / continue (e)diting / (s)kip asset / (a)bort command",
             default='yes',
@@ -589,8 +592,7 @@ def onyo_mkdir(inventory: Inventory,
         inventory.add_directory(d)
     if inventory.operations_pending():
         ui.print('The following directories will be created:')
-        for line in inventory.diff():
-            ui.print(line)
+        print_diff(inventory)
         if ui.request_user_response("Save changes? No discards all changes. (y/n) "):
             if not message:
                 operation_paths = sorted(deduplicate([
@@ -709,8 +711,7 @@ def onyo_mv(inventory: Inventory,
 
     if inventory.operations_pending():
         ui.print("The following will be {}:".format("moved" if subject == "mv" else "renamed"))
-        for line in inventory.diff():
-            ui.print(line)
+        print_diff(inventory)
         if ui.request_user_response("Save changes? No discards all changes. (y/n) "):
             if not message:
                 operation_paths = sorted(deduplicate([
@@ -914,8 +915,7 @@ def onyo_new(inventory: Inventory,
             # Note: If `edit` was given, the diffs where already confirmed per asset.
             #       Don't ask again.
             ui.print("The following will be created:")
-            for line in inventory.diff():
-                ui.print(line)
+            print_diff(inventory)
         if edit or ui.request_user_response("Create assets? (y/n) "):
             if not message:
                 operation_paths = sorted(deduplicate([
@@ -971,8 +971,7 @@ def onyo_rm(inventory: Inventory,
 
     if inventory.operations_pending():
         ui.print('The following will be deleted:')
-        for line in inventory.diff():
-            ui.print(line)
+        print_diff(inventory)
         if ui.request_user_response("Save changes? No discards all changes. (y/n) "):
             if not message:
                 operation_paths = sorted(deduplicate([
@@ -1053,9 +1052,7 @@ def onyo_set(inventory: Inventory,
     if inventory.operations_pending():
         # display changes
         ui.print("The following assets will be changed:")
-        for line in inventory.diff():
-            ui.print(line)
-
+        print_diff(inventory)
         if ui.request_user_response("Update assets? (y/n) "):
             if not message:
                 operation_paths = sorted(deduplicate([
@@ -1204,8 +1201,7 @@ def onyo_unset(inventory: Inventory,
     if inventory.operations_pending():
         # display changes
         ui.print("The following assets will be changed:")
-        for line in inventory.diff():
-            ui.print(line)
+        print_diff(inventory)
 
         if ui.request_user_response("Update assets? (y/n) "):
             if not message:

--- a/onyo/lib/ui.py
+++ b/onyo/lib/ui.py
@@ -73,8 +73,8 @@ class UI(object):
         else:
             self.logger.setLevel(logging.INFO)
 
-        self.stderr_console = Console(stderr=True, highlight=False)
-        self.stdout_console = Console(stderr=False, highlight=False)
+        self.stderr_console = Console(stderr=True, highlight=False, soft_wrap=True)
+        self.stdout_console = Console(stderr=False, highlight=False, soft_wrap=True)
 
         # count reported errors; this allows to assess whether errors occurred
         # even when no exception bubbles up.
@@ -252,9 +252,10 @@ class UI(object):
         The stderr option should consequently be replaced by `print`'s
         standard `file` option.
         """
-        stderr = kwargs.pop('stderr') if 'stderr' in kwargs.keys() else False
-        console = self.stderr_console if stderr else self.stdout_console
-        console.print(*args, **kwargs)
+        if not self.quiet:
+            stderr = kwargs.pop('stderr') if 'stderr' in kwargs.keys() else False
+            console = self.stderr_console if stderr else self.stdout_console
+            console.print(*args, **kwargs)
 
 
 # create a shared UI object to import by classes/commands


### PR DESCRIPTION
This colorizes diffs in a git-like fashion.
Generally, that topic requires a more general solution, but this part is easy enough to have w/o making all issues relating to the use of `rich` a blocker.

Closes #581