### PR TITLE
TMP: Workaround not implemented dict support

### DIFF
--- a/onyo/lib/inventory.py
+++ b/onyo/lib/inventory.py
@@ -629,8 +629,16 @@ class Inventory(object):
         config_str = self.repo.get_config("onyo.assets.name-format")
         if not config_str:
             raise ValueError("Missing config 'onyo.assets.name-format'.")
+
+        # Replace key references so that the same dot notation as in CLI works, while actual
+        # format-language features using the dot work as well.
+        # Example: config string: "{some.more:.3}"
+        #          results in : "{asset[some.more]:.3}"
+        for name in self.repo.get_asset_name_keys():
+            config_str = config_str.replace(f"{{{name}", f"{{asset[{name}]")
+
         try:
-            name = config_str.format(**asset)  # TODO: Only pass non-pseudo keys?! What if there is no config?
+            name = config_str.format(asset=asset)  # TODO: Only pass non-pseudo keys?! What if there is no config?
         except KeyError as e:
             raise ValueError(f"Asset missing value for required field {str(e)}.") from e
         return name

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -176,7 +176,7 @@ class OnyoRepo(object):
         import re
         # Regex for finding key references in a python format string
         # (see notes above):
-        search_regex = r"\{(\w+)"
+        search_regex = r"\{([\w\.]+)"  # TODO: temp. fix to include `.`. Revert with full dict support
         config_str = self.get_config("onyo.assets.name-format")
         return re.findall(search_regex, config_str) if config_str else []
 


### PR DESCRIPTION
This changes the parsing of key names used in the asset name config to include a literal dot in the key name. That way we can use the intended dot notation by putting a flattened dict into the yaml with literal keys like `disk.size: 250GB` and use it in asset names the same way (`"asset_name_{disk.size}"`). This temporary change would now report the literal key `disk.size` as required, rather than `disk`.

In addition this replaces any key reference in the config string by a proper python format-language reference
`asset[key_name_with_possible_dots]` because the format language does not allow arbitrary dictionary key names including dots, brackets and so on plus the dot has syntactical meaning. With this replacement, actual "dot features" can still be utilized.