### PR TITLE
TMP: Workaround YAML representation issue

### DIFF
--- a/onyo/lib/inventory.py
+++ b/onyo/lib/inventory.py
@@ -637,8 +637,11 @@ class Inventory(object):
         for name in self.repo.get_asset_name_keys():
             config_str = config_str.replace(f"{{{name}", f"{{asset[{name}]")
 
+        # Workaround: dump proper representation rather that str() of values in `asset`.
+        # This should probably be integrated in an asset wrapper class instead.
+        from onyo.lib.utils import YAMLDumpWrapper
         try:
-            name = config_str.format(asset=asset)  # TODO: Only pass non-pseudo keys?! What if there is no config?
+            name = config_str.format(asset=YAMLDumpWrapper(asset))  # TODO: Only pass non-pseudo keys?! What if there is no config?
         except KeyError as e:
             raise ValueError(f"Asset missing value for required field {str(e)}.") from e
         return name

--- a/onyo/lib/utils.py
+++ b/onyo/lib/utils.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import copy
 import os
 from pathlib import Path
+from collections import UserDict
 from typing import TYPE_CHECKING
 
 from ruamel.yaml import CommentedMap, scanner, YAML  # pyre-ignore[21]
 from ruamel.yaml.error import YAMLError  # pyre-ignore[21]
+from ruamel.yaml.representer import RoundTripRepresenter  # pyre-ignore[21]
 
 from onyo.lib.consts import PSEUDO_KEYS, RESERVED_KEYS
 from onyo.lib.exceptions import NotAnAssetError
@@ -16,6 +18,7 @@ if TYPE_CHECKING:
     from typing import (
         Dict,
         Set,
+        Hashable,
     )
 
 
@@ -171,6 +174,23 @@ def write_asset_file(path: Path,
     path.open('w').write(dict_to_asset_yaml(asset))
 
 
+class YAMLDumpWrapper(UserDict):
+    r"""Wrapper class for asset dicts accessing ruamel's representation of data rather than the provided object.
+
+    This works around the issue that something like `serial: 001234` yields a `{'serial': 1234}` but is dumped as
+    `serial: 001234`, which messes up onyo's comparisons for whether there's a modification of an asset.
+    """
+    def __init__(self, d: dict):
+        super().__init__(d)
+
+    def __getitem__(self, item: Hashable):
+        if item not in self.keys():
+            raise KeyError(item)
+        if isinstance(self.data[item], (dict, list, Path)):
+            return self.data[item]
+        return RoundTripRepresenter().represent_data(self.data[item]).value
+
+
 def is_equal_assets_dict(a: Dict, b: Dict) -> bool:
     r"""Whether two asset dictionaries have the same content.
 
@@ -183,7 +203,8 @@ def is_equal_assets_dict(a: Dict, b: Dict) -> bool:
     # if there are more reasons to have such a class.
     if not isinstance(a, CommentedMap) and not isinstance(b, CommentedMap):
         return a == b
-    if dict(a) != dict(b):
+
+    if YAMLDumpWrapper(a) != YAMLDumpWrapper(b):
         # not accounting for comments yet
         return False
 


### PR DESCRIPTION
When reading from (edited) files, ruamel delivers a dict-like (`CommentedMap`). When accessed like a dict something like `serial: 00123` would show up as `{'serial': 123}`. However, under the hood ruamel retains the information how it was read (in roundtrip mode) and consequently dumps it as `serial: 00123`, which is what we want.

The issue is, that when using these dicts "normally", we end up looking at the "wrong" value - in this case an integer `123` - which messes up dumping into the asset name as well as dict comparisons when trying to find out whether there even was a modification.

This patch introduces a dict-like wrapper that delivers the representation ruamel would use for dumping rather than the "technical value" of that object.
The patch is considered temporary as it is incomplete (not using this mechanic for matching assets in `onyo get` for example) and should be integrated with similar efforts, most notably accounting for comments when comparing assets and implementing full nested dictionary support.