### PR TITLE
BF: make sorting case sensitive

### DIFF
--- a/onyo/lib/command_utils.py
+++ b/onyo/lib/command_utils.py
@@ -96,10 +96,14 @@ def natural_sort(assets: list[dict],
     reverse
         Whether to sort in reverse order.
     """
+    import locale
     import natsort
 
+    # set the locale for all categories to the user’s default setting
+    locale.setlocale(locale.LC_ALL, '')
+
     for key in reversed(keys.keys()):
-        alg = natsort.ns.IGNORECASE | natsort.ns.INT
+        alg = natsort.ns.LOCALE | natsort.ns.INT
         if key == 'path':
             alg |= natsort.ns.PATH
         assets = sorted(assets,


### PR DESCRIPTION
Previously, sorting was case insensitive, so that the words would actually be grouped together. However, within a word, it was not sorted.

`GROUPLETTERS` does not do what we want, but using `LOCALE` does (at least with 'en_US.UTF-8').

For now, I am choosing to use whatever the user has configured on their OS. That makes sense to me, respecting their choice. If this ends up biting us in practice, then we'll simply hardcode it or make it a configurable option in `.onyo/config`.

fix #651