### PR TITLE
BF: Empty assets should not serialize to literal '{}'

### DIFF
--- a/onyo/lib/utils.py
+++ b/onyo/lib/utils.py
@@ -64,6 +64,12 @@ def dict_to_asset_yaml(d: Dict[str, bool | float | int | str | Path]) -> str:
         if k in content.keys():
             del content[k]
 
+    # Empty dicts are serialized to '{}', and I was unable to find any input
+    # ('', None, etc) that would serialize to nothing. Hardcoding, though ugly,
+    # seems to be the only option.
+    if not content:
+        return '---\n'
+
     from io import StringIO
     yaml = YAML(typ='rt')
     yaml.explicit_start = True


### PR DESCRIPTION
New empty assets would have a literal "{}" as their content (and diffs would also include the "{}").

This removes the spurious `{}`.

My first approach was to pass `None` or `''` to `yaml.dump()`, but both serialized to non-empty strings. So the only option is to explicitly return what an empty file should be.

I was unsure where to put the tests, but I settled on `edit` partly by choice and partly by accident. This bug was already inadvertently documented in those tests. And I do think that editing with `printf` is a relatively easy and intuitive place to verify that the content is precisely what we expect.

close #663