### PR TITLE
TST: add Python 3.13; bump various Action versions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,12 +12,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.11', '3.12']
+        python-version: ['3.11', '3.12', '3.13']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: git config
@@ -40,4 +40,4 @@ jobs:
         export REPO_ROOT=$PWD
         pytest -vv --cov
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4


### PR DESCRIPTION
This adds the newly release Python 3.13 to the test matrix.

It also bumps the versions of various Actions. None of  them should bring in breaking changes.