### PR TITLE
NF: print Inventory Operations after diff

### DIFF
--- a/onyo/cli/tests/test_new.py
+++ b/onyo/cli/tests/test_new.py
@@ -35,7 +35,7 @@ def test_new(repo: OnyoRepo, directory: str) -> None:
                          capture_output=True, text=True)
 
     # verify correct output
-    assert "The following will be created:" in ret.stdout
+    assert "New assets:" in ret.stdout
     assert file_ in ret.stdout
     assert not ret.stderr
     assert ret.returncode == 0
@@ -57,7 +57,7 @@ def test_new_interactive(repo: OnyoRepo) -> None:
                          input='y', capture_output=True, text=True)
 
     # verify correct output
-    assert "The following will be created:" in ret.stdout
+    assert "New assets:" in ret.stdout
     assert "Create assets? (y/n) " in ret.stdout
     assert file_ in ret.stdout
     assert not ret.stderr
@@ -80,7 +80,7 @@ def test_new_top_level(repo: OnyoRepo) -> None:
                          capture_output=True, text=True)
 
     # verify correct output
-    assert "The following will be created:" in ret.stdout
+    assert "New assets:" in ret.stdout
     assert file_ in ret.stdout
     assert not ret.stderr
     assert ret.returncode == 0
@@ -109,7 +109,7 @@ def test_new_sub_dir_absolute_path(repo: OnyoRepo) -> None:
                          capture_output=True, text=True)
 
     # verify correct output
-    assert "The following will be created:" in ret.stdout
+    assert "New assets:" in ret.stdout
     assert str(file_) in ret.stdout
     assert not ret.stderr
     assert ret.returncode == 0
@@ -140,7 +140,7 @@ def test_new_sub_dir_relative_path(repo: OnyoRepo) -> None:
                          capture_output=True, text=True)
 
     # verify correct output
-    assert "The following will be created:" in ret.stdout
+    assert "New assets:" in ret.stdout
     assert "just another path/laptop_apple_macbookpro.0" in ret.stdout
     assert not ret.stderr
     assert ret.returncode == 0
@@ -163,7 +163,7 @@ def test_folder_creation_with_new(repo: OnyoRepo, directory: str) -> None:
                          capture_output=True, text=True)
 
     # verify correct output
-    assert "The following will be created:" in ret.stdout
+    assert "New assets:" in ret.stdout
     assert asset in ret.stdout
     assert not ret.stderr
     assert ret.returncode == 0
@@ -193,8 +193,9 @@ def test_with_faux_serial_number(repo: OnyoRepo) -> None:
     ret = subprocess.run(cmd, capture_output=True, text=True)
 
     # verify correct output
-    assert "The following will be created:" in ret.stdout
-    assert ret.stdout.count(filename_prefix) == len(assets)
+    assert "New assets:" in ret.stdout
+    # file names are printed twice (diff and operations summary)
+    assert ret.stdout.count(filename_prefix) == len(assets) * 2
     assert not ret.stderr
     assert ret.returncode == 0
 
@@ -217,7 +218,7 @@ def test_new_assets_in_multiple_directories_at_once(repo: OnyoRepo) -> None:
                          capture_output=True, text=True)
 
     # verify correct output
-    assert "The following will be created:" in ret.stdout
+    assert "New assets:" in ret.stdout
     for asset in assets:
         assert asset in ret.stdout
     assert not ret.stderr
@@ -242,7 +243,7 @@ def test_yes_flag(repo: OnyoRepo, directory: str) -> None:
                          capture_output=True, text=True)
 
     # verify correct output
-    assert "The following will be created:" in ret.stdout
+    assert "New assets:" in ret.stdout
     assert asset in ret.stdout
     assert not ret.stderr
     assert ret.returncode == 0
@@ -273,7 +274,7 @@ def test_keys_flag(repo: OnyoRepo, directory: str) -> None:
         capture_output=True, text=True)
 
     # verify output
-    assert "The following will be created:" in ret.stdout
+    assert "New assets:" in ret.stdout
     assert asset in ret.stdout
     assert not ret.stderr
     assert ret.returncode == 0
@@ -337,7 +338,7 @@ def test_discard_changes(repo: OnyoRepo, directory: str) -> None:
                          input='n', capture_output=True, text=True)
 
     # verify correct output
-    assert "The following will be created:" in ret.stdout
+    assert "New assets:" in ret.stdout
     assert "Create assets? (y/n) " in ret.stdout
     assert asset in ret.stdout
     assert 'No new assets created.' in ret.stdout
@@ -449,7 +450,7 @@ def test_new_with_keys_overwrite_template(repo: OnyoRepo, directory: str) -> Non
                          capture_output=True, text=True)
 
     # verify output
-    assert "The following will be created:" in ret.stdout
+    assert "New assets:" in ret.stdout
     assert str(asset) in ret.stdout
     assert not ret.stderr
     assert ret.returncode == 0
@@ -486,7 +487,7 @@ def test_with_special_characters(
                          capture_output=True, text=True)
 
     # verify correct output
-    assert "The following will be created:" in ret.stdout
+    assert "New assets:" in ret.stdout
     assert asset in ret.stdout
     assert not ret.stderr
     assert ret.returncode == 0
@@ -579,7 +580,7 @@ def test_tsv(repo: OnyoRepo) -> None:
     ret = subprocess.run(['onyo', '--yes', 'new', "--tsv", table_path],
                          capture_output=True, text=True)
     assert not ret.stderr
-    assert "The following will be created:" in ret.stdout
+    assert "New assets:" in ret.stdout
     assert ret.returncode == 0
 
     # verify that the new assets exist and the repository is in a clean state
@@ -599,7 +600,7 @@ def test_tsv_with_value_columns(repo: OnyoRepo) -> None:
     ret = subprocess.run(['onyo', '--yes', 'new', '--tsv', table_path],
                          capture_output=True, text=True)
 
-    assert "The following will be created:" in ret.stdout
+    assert "New assets:" in ret.stdout
     assert not ret.stderr
     assert ret.returncode == 0
 

--- a/onyo/cli/tests/test_rm.py
+++ b/onyo/cli/tests/test_rm.py
@@ -36,7 +36,7 @@ def test_rm(repo: OnyoRepo, asset: str) -> None:
     ret = subprocess.run(['onyo', '--yes', 'rm', asset],
                          capture_output=True, text=True)
     assert ret.returncode == 0
-    assert "The following will be deleted:" in ret.stdout
+    assert "Removed assets:" in ret.stdout
     assert not ret.stderr
 
     # verify deleting was successful and the repository is in a clean state
@@ -53,7 +53,7 @@ def test_rm_multiple_inputs(repo: OnyoRepo) -> None:
     ret = subprocess.run(['onyo', '--yes', 'rm', *assets],
                          capture_output=True, text=True)
     assert ret.returncode == 0
-    assert "The following will be deleted:" in ret.stdout
+    assert "Removed assets:" in ret.stdout
     assert not ret.stderr
 
     # verify deleting was successful and the repository is in a clean state
@@ -72,7 +72,7 @@ def test_rm_single_dirs_with_files(repo: OnyoRepo, directory: str) -> None:
     ret = subprocess.run(['onyo', '--yes', 'rm', '--recursive', directory],
                          capture_output=True, text=True)
     assert ret.returncode == 0
-    assert "The following will be deleted:" in ret.stdout
+    assert "Removed directories:" in ret.stdout
     assert not ret.stderr
 
     # verify deleting was successful and the repository is in a clean state
@@ -89,7 +89,7 @@ def test_rm_multiple_directories(repo: OnyoRepo) -> None:
     ret = subprocess.run(['onyo', '--yes', 'rm', '--recursive', *directories[1:]],
                          capture_output=True, text=True)
     assert ret.returncode == 0
-    assert "The following will be deleted:" in ret.stdout
+    assert "Removed directories:" in ret.stdout
     assert not ret.stderr
 
     # verify deleting was successful and the repository is in a clean state
@@ -107,7 +107,7 @@ def test_rm_empty_directories(repo: OnyoRepo) -> None:
     ret = subprocess.run(['onyo', '--yes', 'rm', *directories[1:]],
                          capture_output=True, text=True)
     assert ret.returncode == 0
-    assert "The following will be deleted:" in ret.stdout
+    assert "Removed directories:" in ret.stdout
     assert not ret.stderr
 
     # verify deleting was successful and the repository is in a clean state

--- a/onyo/cli/tests/test_set.py
+++ b/onyo/cli/tests/test_set.py
@@ -56,7 +56,7 @@ def test_set(repo: OnyoRepo,
                          capture_output=True, text=True)
 
     # verify output
-    assert "The following assets will be changed:" in ret.stdout
+    assert "Modified assets:" in ret.stdout
     assert str(Path(asset)) in ret.stdout
     assert not ret.stderr
     assert ret.returncode == 0
@@ -78,7 +78,7 @@ def test_set_interactive(repo: OnyoRepo,
                          input='y', capture_output=True, text=True)
 
     # verify output
-    assert "The following assets will be changed:" in ret.stdout
+    assert "Modified assets:" in ret.stdout
     assert "Update assets? (y/n) " in ret.stdout
     assert str(Path(asset)) in ret.stdout
     assert not ret.stderr
@@ -102,7 +102,7 @@ def test_set_multiple_assets(repo: OnyoRepo,
                          capture_output=True, text=True)
 
     # verify output
-    assert "The following assets will be changed:" in ret.stdout
+    assert "Modified assets:" in ret.stdout
     assert not ret.stderr
     assert ret.returncode == 0
 
@@ -159,7 +159,7 @@ def test_set_discard_changes_single_assets(repo: OnyoRepo,
                          capture_output=True, text=True)
 
     # verify output for just dot, should be all in onyo root, but not recursive
-    assert "The following assets will be changed:" in ret.stdout
+    assert "Modified assets:" in ret.stdout
     assert str(Path(asset)) in ret.stdout
     assert "No assets updated." in ret.stdout
     assert not ret.stderr
@@ -207,7 +207,7 @@ def test_add_new_key_to_existing_content(repo: OnyoRepo,
                          capture_output=True, text=True)
 
     # verify output
-    assert "The following assets will be changed:" in ret.stdout
+    assert "Modified assets:" in ret.stdout
     assert str(Path(asset)) in ret.stdout
     assert set_1.replace("=", ": ") in ret.stdout
     assert set_1.replace("=", ": ") in Path.read_text(Path(asset))
@@ -220,7 +220,7 @@ def test_add_new_key_to_existing_content(repo: OnyoRepo,
                          capture_output=True, text=True)
 
     # verify output
-    assert "The following assets will be changed:" in ret.stdout
+    assert "Modified assets:" in ret.stdout
     assert str(Path(asset)) in ret.stdout
     assert set_2.replace("=", ": ") in ret.stdout
     assert not ret.stderr
@@ -250,7 +250,7 @@ def test_set_overwrite_key(repo: OnyoRepo,
                          capture_output=True, text=True)
 
     # verify output
-    assert "The following assets will be changed:" in ret.stdout
+    assert "Modified assets:" in ret.stdout
     assert str(Path(asset)) in ret.stdout
     assert set_value.replace("=", ": ") in ret.stdout
     assert set_value.replace("=", ": ") in Path.read_text(Path(asset))
@@ -263,7 +263,7 @@ def test_set_overwrite_key(repo: OnyoRepo,
                          capture_output=True, text=True)
 
     # verify output
-    assert "The following assets will be changed:" in ret.stdout
+    assert "Modified assets:" in ret.stdout
     assert str(Path(asset)) in ret.stdout
     assert f"-{set_value}".replace("=", ": ") in ret.stdout
     assert f"+{set_value_2}".replace("=", ": ") in ret.stdout
@@ -289,7 +289,7 @@ def test_setting_new_values_if_some_values_already_set(repo: OnyoRepo,
                          capture_output=True, text=True)
 
     # verify output
-    assert "The following assets will be changed:" in ret.stdout
+    assert "Modified assets:" in ret.stdout
     assert str(Path(asset)) in ret.stdout
     assert set_values.replace("=", ": ") in Path.read_text(Path(asset))
     assert not ret.stderr
@@ -302,7 +302,7 @@ def test_setting_new_values_if_some_values_already_set(repo: OnyoRepo,
                          capture_output=True, text=True)
 
     # verify output
-    assert "The following assets will be changed:" in ret.stdout
+    assert "Modified assets:" in ret.stdout
     assert str(Path(asset)) in ret.stdout
     assert not ret.stderr
     assert ret.returncode == 0
@@ -337,7 +337,7 @@ def test_values_already_set(repo: OnyoRepo,
                          capture_output=True, text=True)
 
     # verify output
-    assert "The following assets will be changed:" in ret.stdout
+    assert "Modified assets:" in ret.stdout
     assert str(Path(asset)) in ret.stdout
     for value in set_values:
         assert value.replace("=", ": ") in Path.read_text(Path(asset))

--- a/onyo/cli/tests/test_unset.py
+++ b/onyo/cli/tests/test_unset.py
@@ -124,7 +124,7 @@ def test_unset(repo: OnyoRepo,
                          capture_output=True, text=True)
 
     # verify output
-    assert "The following assets will be changed:" in ret.stdout
+    assert "Modified assets:" in ret.stdout
     assert asset in ret.stdout
     assert f"-{key}" in ret.stdout
     assert not ret.stderr
@@ -146,7 +146,7 @@ def test_unset_interactive(repo: OnyoRepo,
                          capture_output=True, text=True)
 
     # verify output
-    assert "The following assets will be changed:" in ret.stdout
+    assert "Modified assets:" in ret.stdout
     assert "Update assets? (y/n) " in ret.stdout
     assert asset in ret.stdout
     assert f"-{key}" in ret.stdout
@@ -189,7 +189,7 @@ def test_unset_multiple_assets(repo: OnyoRepo,
                          capture_output=True, text=True)
 
     # verify output
-    assert "The following assets will be changed:" in ret.stdout
+    assert "Modified assets:" in ret.stdout
     for asset in [a.relative_to(repo.git.root) for a in assets]:
         assert str(asset) in ret.stdout
     assert not ret.stderr

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import logging
 import subprocess
+from os import linesep
 from pathlib import Path
 from typing import (
     ParamSpec,
@@ -591,8 +592,9 @@ def onyo_mkdir(inventory: Inventory,
         # explicit duplicates would make auto-generating message subject more complicated ATM
         inventory.add_directory(d)
     if inventory.operations_pending():
-        ui.print('The following directories will be created:')
-        print_diff(inventory)
+        # display changes
+        ui.print(inventory.operations_summary())
+
         if ui.request_user_response("Save changes? No discards all changes. (y/n) "):
             if not message:
                 operation_paths = sorted(deduplicate([
@@ -710,8 +712,9 @@ def onyo_mv(inventory: Inventory,
         raise ValueError("Can only move into an existing directory/asset, or rename a single directory.")
 
     if inventory.operations_pending():
-        ui.print("The following will be {}:".format("moved" if subject == "mv" else "renamed"))
-        print_diff(inventory)
+        # display changes
+        ui.print(inventory.operations_summary())
+
         if ui.request_user_response("Save changes? No discards all changes. (y/n) "):
             if not message:
                 operation_paths = sorted(deduplicate([
@@ -911,11 +914,12 @@ def onyo_new(inventory: Inventory,
             inventory.add_asset(asset)
 
     if inventory.operations_pending():
+        # display changes
         if not edit:
-            # Note: If `edit` was given, the diffs where already confirmed per asset.
-            #       Don't ask again.
-            ui.print("The following will be created:")
+            # If `edit` was given, per-asset diffs were already approved. Don't ask again.
             print_diff(inventory)
+        ui.print(linesep + inventory.operations_summary())
+
         if edit or ui.request_user_response("Create assets? (y/n) "):
             if not message:
                 operation_paths = sorted(deduplicate([
@@ -970,8 +974,9 @@ def onyo_rm(inventory: Inventory,
                 raise InventoryDirNotEmpty(f"{str(e)}\nDid you forget '--recursive'?") from e
 
     if inventory.operations_pending():
-        ui.print('The following will be deleted:')
-        print_diff(inventory)
+        # display changes
+        ui.print(inventory.operations_summary())
+
         if ui.request_user_response("Save changes? No discards all changes. (y/n) "):
             if not message:
                 operation_paths = sorted(deduplicate([
@@ -1044,8 +1049,9 @@ def onyo_set(inventory: Inventory,
 
     if inventory.operations_pending():
         # display changes
-        ui.print("The following assets will be changed:")
         print_diff(inventory)
+        ui.print(linesep + inventory.operations_summary())
+
         if ui.request_user_response("Update assets? (y/n) "):
             if not message:
                 operation_paths = sorted(deduplicate([
@@ -1193,8 +1199,8 @@ def onyo_unset(inventory: Inventory,
 
     if inventory.operations_pending():
         # display changes
-        ui.print("The following assets will be changed:")
         print_diff(inventory)
+        ui.print(linesep + inventory.operations_summary())
 
         if ui.request_user_response("Update assets? (y/n) "):
             if not message:

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -329,7 +329,7 @@ def _edit_asset(inventory: Inventory,
             if queue_length < len(inventory.operations):
                 inventory.operations = inventory.operations[:queue_length]
             ui.error(e)
-            response = ui.request_user_response("Continue (e)diting asset, (s)kip asset or (a)bort command)?",
+            response = ui.request_user_response("Continue (e)diting asset, (s)kip asset or (a)bort command)? ",
                                                 default='a',  # non-interactive has to fail
                                                 answers=[('edit', ['e', 'E', 'edit']),
                                                          ('skip', ['s', 'S', 'skip']),
@@ -354,7 +354,7 @@ def _edit_asset(inventory: Inventory,
             for op in operations:
                 print_diff(op)
         response = ui.request_user_response(
-            "Accept changes? (y)es / continue (e)diting / (s)kip asset / (a)bort command",
+            "Accept changes? (y)es / continue (e)diting / (s)kip asset / (a)bort command ",
             default='yes',
             answers=[('accept', ['y', 'Y', 'yes']),
                      ('edit', ['e', 'E', 'edit']),

--- a/onyo/lib/ui.py
+++ b/onyo/lib/ui.py
@@ -227,7 +227,7 @@ class UI(object):
         #       and possible ways to respond are indicated.
         answers = answers or [(True, ['y', 'Y', 'yes']),
                               (False, ['n', 'N', 'no'])]
-        question += f"[Default: {default}]"
+        question += f"[Default: {default}] "
         while True:
             if self.yes:
                 answer = default


### PR DESCRIPTION
This PR implements #656 

After the diff, and before the user prompt, the Inventory Operations is printed. This is the exact same summary that is included in the commit message.

A small, unrelated fix is also included, that adds spaces between user prompts and the response. This annoyed me greatly during my interactive tests. :-) 