### PR TITLE
BF/TYPE: simplify some type checks; fix shell completion bug

### DIFF
--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -741,7 +741,7 @@ def onyo_new(inventory: Inventory,
              template: Path | str | None = None,
              clone: Path | None = None,
              tsv: Path | None = None,
-             keys: list[Dict[str, str | int | float]] | None = None,
+             keys: list[Dict] | None = None,
              edit: bool = False,
              message: str | None = None) -> None:
     r"""Create new assets and add them to the inventory.
@@ -995,7 +995,7 @@ def onyo_rm(inventory: Inventory,
 
 @raise_on_inventory_state
 def onyo_set(inventory: Inventory,
-             keys: Dict[str, str | int | float],
+             keys: Dict,
              assets: list[Path],
              message: str | None = None) -> str | None:
     r"""Set key-value pairs of assets, and change asset names.

--- a/onyo/lib/tests/test_commands_new.py
+++ b/onyo/lib/tests/test_commands_new.py
@@ -66,7 +66,7 @@ def test_onyo_new_keys(inventory: Inventory) -> None:
     old_hexsha = inventory.repo.git.get_hexsha()
     onyo_new(inventory,
              directory=inventory.root / "empty",
-             keys=specs)  # pyre-ignore[6] How is that not fitting `List[Dict[str, int | float | str]]`?
+             keys=specs)
     # exactly one commit added
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
 
@@ -97,7 +97,7 @@ def test_onyo_new_keys(inventory: Inventory) -> None:
                   keys=specs)
     # w/o `directory` everything is fine:
     onyo_new(inventory,
-             keys=specs)  # pyre-ignore[6] How is that not fitting `List[Dict[str, int | float | str]]`?
+             keys=specs)
     # another commit added
     assert inventory.repo.git.get_hexsha('HEAD~2') == old_hexsha
 
@@ -132,7 +132,7 @@ def test_onyo_new_keys(inventory: Inventory) -> None:
               'template': 'laptop.example',
               'serial': '1234'}]
     onyo_new(inventory,
-             keys=specs)  # pyre-ignore[6] How is that not fitting `List[Dict[str, int | float | str]]`?
+             keys=specs)
     # another commit added
     assert inventory.repo.git.get_hexsha('HEAD~3') == old_hexsha
     expected_path = inventory.root / f"{specs[0]['type']}_{specs[0]['make']}_{specs[0]['model']}.{specs[0]['serial']}"
@@ -164,7 +164,7 @@ def test_onyo_new_creates_directories(inventory: Inventory) -> None:
 
     onyo_new(inventory,
              directory=new_directory,
-             keys=specs)  # pyre-ignore[6] How is that not fitting `List[Dict[str, int | float | str]]`?
+             keys=specs)
 
     # exactly one commit added
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
@@ -196,7 +196,7 @@ def test_onyo_new_edit(inventory: Inventory, monkeypatch) -> None:
               'type': 'TYPE',
               'serial': 'totally_random'}]
     onyo_new(inventory,
-             keys=specs,  # pyre-ignore[6] How is that not fitting `List[Dict[str, int | float | str]]`?
+             keys=specs,
              directory=directory,
              edit=True)
     expected_path = directory / "TYPE_MAKER_MODEL.totally_random"
@@ -231,7 +231,7 @@ def test_onyo_new_edit(inventory: Inventory, monkeypatch) -> None:
     monkeypatch.setenv('EDITOR', f"printf '{edit_str}' >>")
     specs = [{'template': 'empty'}]
     onyo_new(inventory,
-             keys=specs,  # pyre-ignore[6] How is that not fitting `List[Dict[str, int | float | str]]`?
+             keys=specs,
              directory=directory,
              edit=True)
     expected_content = '---\n' + edit_str

--- a/onyo/lib/tests/test_commands_set.py
+++ b/onyo/lib/tests/test_commands_set.py
@@ -176,7 +176,7 @@ def test_onyo_set_simple(inventory: Inventory) -> None:
     # set a value in an asset
     onyo_set(inventory,
              assets=[asset_path],
-             keys=key_value,  # pyre-ignore[6]
+             keys=key_value,
              message="some subject\n\nAnd a body")
 
     # check content
@@ -203,7 +203,7 @@ def test_onyo_set_already_set(inventory: Inventory) -> None:
     # set a value in an asset
     onyo_set(inventory,
              assets=[asset_path],
-             keys=key_value,  # pyre-ignore[6]
+             keys=key_value,
              message="some subject\n\nAnd a body")
 
     # check content is unchanged
@@ -230,7 +230,7 @@ def test_onyo_set_overwrite_existing_value(inventory: Inventory) -> None:
     # set a value in an asset
     onyo_set(inventory,
              assets=[asset_path],
-             keys=new_key_value,  # pyre-ignore[6]
+             keys=new_key_value,
              message="some subject\n\nAnd a body")
 
     # check content
@@ -264,7 +264,7 @@ def test_onyo_set_some_values_already_set(inventory: Inventory) -> None:
     # set a value in an asset
     onyo_set(inventory,
              assets=[asset_path],
-             keys=new_key_values,  # pyre-ignore[6]
+             keys=new_key_values,
              message="some subject\n\nAnd a body")
 
     # check content
@@ -292,7 +292,7 @@ def test_onyo_set_multiple(inventory: Inventory) -> None:
     onyo_set(inventory,
              assets=[asset_path1,
                      asset_path2],
-             keys=key_value,  # pyre-ignore[6]
+             keys=key_value,
              message="some subject\n\nAnd a body")
 
     # check contents
@@ -317,7 +317,7 @@ def test_onyo_set_allows_duplicates(inventory: Inventory) -> None:
     # call `onyo_set()` with `paths` containing duplicates
     onyo_set(inventory,
              assets=[asset_path, asset_path, asset_path],
-             keys=key_value,  # pyre-ignore[6]
+             keys=key_value,
              message="some subject\n\nAnd a body")
 
     # check content

--- a/onyo/lib/utils.py
+++ b/onyo/lib/utils.py
@@ -18,7 +18,6 @@ from onyo.lib.ui import ui
 
 if TYPE_CHECKING:
     from typing import (
-        Any,
         Dict,
         Set,
         Hashable,
@@ -44,7 +43,7 @@ def deduplicate(sequence: list | None) -> list | None:
     return [x for x in sequence if not (x in seen or seen.add(x))]
 
 
-def dict_to_asset_yaml(d: Dict[str, Any]) -> str:
+def dict_to_asset_yaml(d: Dict) -> str:
     r"""Convert a dictionary to a YAML string, stripped of reserved-keys.
 
     Dictionaries that contain a map of comments (ruamel, etc) will have those
@@ -169,7 +168,7 @@ def validate_yaml(asset_files: list[Path] | None) -> bool:
 
 
 def write_asset_file(path: Path,
-                     asset: Dict[str, bool | float | int | str | Path]) -> None:
+                     asset: Dict) -> None:
     r"""Write content to an asset file.
 
     All ``RESERVED_KEYS`` will be stripped from the content before writing.

--- a/onyo/shell_completion/zsh/_onyo
+++ b/onyo/shell_completion/zsh/_onyo
@@ -13,6 +13,35 @@ _onyo() {
     local -a fullwords
     fullwords=("${words[@]}")
 
+    # load _git, so that _git-config is available for onyo config completion
+    whence -v _git-config > /dev/null || _git
+
+    _onyo_dir() {
+        #setopt local_options xtrace
+        local REPO=$PWD
+
+        # check if -C or --onyopath is used
+        for i in {1..$#fullwords} ; do
+            if [[ "$fullwords[$i]" == "-C" ]] || [[ "$fullwords[$i]" == "--onyopath" ]] ; then
+                # Hack to unescape any '\ ' from path.
+                # Sadly, printf %b does not work here, since it only interprets
+                # format controls, not escaping.
+                ONYOPATH=$(printf '%b' "$fullwords[$i+1]" | sed 's/\\ / /g')
+                REPO=$(realpath "$ONYOPATH")
+
+                [[ -d "$REPO" ]] || printf '"%s" is not a valid directory!\n' "$REPO" >&2
+                break
+            fi
+        done
+
+        printf "$REPO"
+    }
+
+    _template_dir() {
+        ONYO_DIR=$(_onyo_dir)
+        printf "${ONYO_DIR}/.onyo/templates"
+    }
+
     local -a args subcommands
     args=( )
     toplevel_flags=(
@@ -176,35 +205,6 @@ _onyo() {
         _arguments -s -S $args && ret=0
         ;;
     esac
-
-    # load _git, so that _git-config is available for onyo config completion
-    whence -v _git-config > /dev/null || _git
-
-    _onyo_dir() {
-        #setopt local_options xtrace
-        local REPO=$PWD
-
-        # check if -C or --onyopath is used
-        for i in {1..$#fullwords} ; do
-            if [[ "$fullwords[$i]" == "-C" ]] || [[ "$fullwords[$i]" == "--onyopath" ]] ; then
-                # Hack to unescape any '\ ' from path.
-                # Sadly, printf %b does not work here, since it only interprets
-                # format controls, not escaping.
-                ONYOPATH=$(printf '%b' "$fullwords[$i+1]" | sed 's/\\ / /g')
-                REPO=$(realpath "$ONYOPATH")
-
-                [[ -d "$REPO" ]] || printf '"%s" is not a valid directory!\n' "$REPO" >&2
-                break
-            fi
-        done
-
-        printf "$REPO"
-    }
-
-    _template_dir() {
-        ONYO_DIR=$(_onyo_dir)
-        printf "${ONYO_DIR}/.onyo/templates"
-    }
 
     return ret
 }


### PR DESCRIPTION
This PR has two unrelated fixes

- simplifies some unnecessary (and actively annoyingly) specific type annotations (#665)
- silences a one-time user error when first using shell completion (#585)