### PR TITLE
NF: match `onyo get`'s exit codes to `grep`'s

### DIFF
--- a/onyo/cli/get.py
+++ b/onyo/cli/get.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -121,6 +122,13 @@ args_get = {
 }
 
 epilog_get = r"""
+.. rubric:: Exit Status
+
+The exit status is ``0`` if at least one result is found, ``1`` if there are no
+results, and ``2`` if an error occurred.
+
+These exit values match those of ``grep``.
+
 .. rubric:: Examples
 
 List all assets belonging to a user:
@@ -170,14 +178,17 @@ def get(args: argparse.Namespace) -> None:
 
     filters = [Filter(f).match for f in args.match] if args.match else None
 
-    onyo_get(inventory=inventory,
-             sort=args.sort,
-             include=includes,
-             exclude=excludes,
-             depth=args.depth,
-             machine_readable=args.machine_readable,
-             # Type annotation for callables as filters, somehow
-             # doesn't work with the bound method `Filter.match`.
-             # Not clear, what's the problem.
-             match=filters,  # pyre-ignore[6]
-             keys=args.keys)
+    results = onyo_get(inventory=inventory,
+                       sort=args.sort,
+                       include=includes,
+                       exclude=excludes,
+                       depth=args.depth,
+                       machine_readable=args.machine_readable,
+                       # Type annotation for callables as filters, somehow
+                       # doesn't work with the bound method `Filter.match`.
+                       # Not clear, what's the problem.
+                       match=filters,  # pyre-ignore[6]
+                       keys=args.keys)
+
+    if not results:
+        sys.exit(1)

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -535,6 +535,10 @@ def main() -> None:
     if subcmd_index:
         old_cwd = Path.cwd()
         os.chdir(args.opdir)
+        # normally exit 1 on error. `get` is a special case. Exit with 2 on
+        # error to mimic `grep`'s behavior.
+        error_returncode = 2 if args.cmd == 'get' else 1
+
         try:
             args.run(args)
         except InvalidArgumentError as e:
@@ -554,7 +558,7 @@ def main() -> None:
             # TODO: This may need to be nicer, but in any case: Turn any exception/error into a message and exit
             #       non-zero here, in order to have this generic last catcher.
             ui.error(e)
-            code = e.returncode if hasattr(e, 'returncode') else 1  # pyre-ignore
+            code = e.returncode if hasattr(e, 'returncode') else error_returncode  # pyre-ignore
             sys.exit(code)
         except KeyboardInterrupt:
             ui.error("User interrupted.")
@@ -564,7 +568,7 @@ def main() -> None:
         if ui.error_count > 0:
             # We may have reported errors while being able to proceed (hence no exception bubbled up).
             # That's fine, but still exit non-zero.
-            sys.exit(1)
+            sys.exit(error_returncode)
     else:
         parser.print_help()
         sys.exit(1)


### PR DESCRIPTION
Previously, `onyo get` returned `1` if there was an error and `0` if not.

This change exits `2` on error, exits `1` if no results are found, and `0` if there are results found.

I considered adding a `returncode` attribute to exceptions, matching what `CalledProcessError` does. But how the CLI exits has nothing to do with exceptions. So I did the check there and categorically modified the behavior of `onyo get`.

close #680