### PR TITLE
RF: `os.linesep` -> `\n`

### DIFF
--- a/onyo/argparse_helpers.py
+++ b/onyo/argparse_helpers.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import argparse
-import os
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -67,9 +66,11 @@ class StoreMultipleKeyValuePairs(argparse.Action):
 
         key_counts = {k: len(v) for k, v in key_lists.items()}
         key_max_count = max(key_counts.values())
+        # Python < 3.12 does not support backslashes in f-strings
+        linesep = '\n'
         if any([True for k, c in key_counts.items() if 1 < c < key_max_count]):
-            parser.error(f"All keys given multiple times must be given the same number of times:{os.linesep}"
-                         f"{f'{os.linesep}'.join(['{}: {}'.format(k, c) for k, c in key_counts.items() if 1 < c])}")
+            parser.error(f"All keys given multiple times must be given the same number of times:\n"
+                         f"{f'{linesep}'.join(['{}: {}'.format(k, c) for k, c in key_counts.items() if 1 < c])}")
 
         def cvt(v: str) -> int | float | str | bool:
             if v.lower() == "true":
@@ -160,7 +161,7 @@ class StoreSingleKeyValuePairs(argparse.Action):
         results = dict()
         for k, v in pairs:
             if k in results:
-                parser.error(f"Duplicate key '{k}' found.{os.linesep}"
+                parser.error(f"Duplicate key '{k}' found.\n"
                              f"Keys must not be given multiple times.")
 
             results[k] = cvt(v)

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import copy
 import logging
 import subprocess
-from os import linesep
 from pathlib import Path
 from typing import (
     ParamSpec,
@@ -936,7 +935,7 @@ def onyo_new(inventory: Inventory,
         if not edit:
             # If `edit` was given, per-asset diffs were already approved. Don't ask again.
             print_diff(inventory)
-        ui.print(linesep + inventory.operations_summary())
+        ui.print('\n' + inventory.operations_summary())
 
         if edit or ui.request_user_response("Create assets? (y/n) "):
             if not message:
@@ -1068,7 +1067,7 @@ def onyo_set(inventory: Inventory,
     if inventory.operations_pending():
         # display changes
         print_diff(inventory)
-        ui.print(linesep + inventory.operations_summary())
+        ui.print('\n' + inventory.operations_summary())
 
         if ui.request_user_response("Update assets? (y/n) "):
             if not message:
@@ -1226,7 +1225,7 @@ def onyo_unset(inventory: Inventory,
     if inventory.operations_pending():
         # display changes
         print_diff(inventory)
-        ui.print(linesep + inventory.operations_summary())
+        ui.print('\n' + inventory.operations_summary())
 
         if ui.request_user_response("Update assets? (y/n) "):
             if not message:

--- a/onyo/lib/inventory.py
+++ b/onyo/lib/inventory.py
@@ -144,10 +144,9 @@ class Inventory(object):
         # get user message + generate appendix from operations
         # does order matter for execution? Prob.
         # ^  Nope. Fail on conflicts.
-        from os import linesep
         paths_to_commit = []
         paths_to_stage = []
-        commit_msg = message + f"{linesep}{linesep}"
+        commit_msg = message + "\n\n"
 
         try:
             for operation in self.operations:
@@ -163,8 +162,7 @@ class Inventory(object):
             self.reset()
 
     def operations_summary(self) -> str:
-        from os import linesep
-        summary = f"--- Inventory Operations ---{linesep}"
+        summary = "--- Inventory Operations ---\n"
         operations_record = dict()
 
         for operation in self.operations:

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -184,6 +183,8 @@ class OnyoRepo(object):
         r"""Returns the editor, progressing through onyo, git, $EDITOR, and finally
         fallback to "nano".
         """
+        from os import environ
+
         # onyo config setting (from onyo and git config files)
         editor = self.get_config('onyo.core.editor')
 
@@ -195,7 +196,7 @@ class OnyoRepo(object):
         # $EDITOR environment variable
         if not editor:
             ui.log_debug("core.editor is not set.")
-            editor = os.environ.get('EDITOR')
+            editor = environ.get('EDITOR')
 
         # fallback to nano
         if not editor:
@@ -628,7 +629,7 @@ class OnyoRepo(object):
                 a = get_asset_content(path)
                 a['is_asset_directory'] = False
         except NotAnAssetError as e:
-            raise NotAnAssetError(f"{str(e)}{os.linesep}"
+            raise NotAnAssetError(f"{str(e)}\n"
                                   f"If {path} is not meant to be an asset, consider putting it into"
                                   f" '{self.IGNORE_FILE_NAME}'") from e
         # Add pseudo-keys:

--- a/onyo/lib/recorders.py
+++ b/onyo/lib/recorders.py
@@ -1,4 +1,3 @@
-from os import linesep
 from pathlib import Path
 
 from onyo.lib.onyo import OnyoRepo
@@ -27,7 +26,7 @@ from onyo.lib.onyo import OnyoRepo
 
 def record_item(repo: OnyoRepo, item: Path | dict) -> str:
     path = item if isinstance(item, Path) else item['path']
-    return f"- {path.relative_to(repo.git.root).as_posix()}{linesep}"
+    return f"- {path.relative_to(repo.git.root).as_posix()}\n"
 
 
 def record_move(repo: OnyoRepo, src: Path | dict, dst: Path) -> str:
@@ -36,7 +35,7 @@ def record_move(repo: OnyoRepo, src: Path | dict, dst: Path) -> str:
     src_path = src if isinstance(src, Path) else src['path']
     dst_path = (dst / src_path.name).relative_to(repo.git.root).as_posix()
     src_path = src_path.relative_to(repo.git.root).as_posix()
-    return f"- {src_path} -> {dst_path}{linesep}"
+    return f"- {src_path} -> {dst_path}\n"
 
 
 def record_rename(repo: OnyoRepo, src: Path | dict, dst: Path) -> str:
@@ -44,52 +43,52 @@ def record_rename(repo: OnyoRepo, src: Path | dict, dst: Path) -> str:
     src_path = src if isinstance(src, Path) else src['path']
     src_path = src_path.relative_to(repo.git.root).as_posix()
     dst_path = dst.relative_to(repo.git.root).as_posix()
-    return f"- {src_path} -> {dst_path}{linesep}"
+    return f"- {src_path} -> {dst_path}\n"
 
 
 def record_new_assets(repo: OnyoRepo, operands: tuple) -> dict[str, list[str]]:
-    return {f"New assets:{linesep}": [record_item(repo, operands[0])]}
+    return {"New assets:\n": [record_item(repo, operands[0])]}
 
 
 def record_new_directories(repo: OnyoRepo, operands: tuple) -> dict[str, list[str]]:
-    return {f"New directories:{linesep}": [record_item(repo, operands[0])]}
+    return {"New directories:\n": [record_item(repo, operands[0])]}
 
 
 def record_remove_assets(repo: OnyoRepo, operands: tuple) -> dict[str, list[str]]:
-    return {f"Removed assets:{linesep}": [record_item(repo, operands[0])]}
+    return {"Removed assets:\n": [record_item(repo, operands[0])]}
 
 
 def record_remove_directories(repo: OnyoRepo, operands: tuple) -> dict[str, list[str]]:
-    return {f"Removed directories:{linesep}": [record_item(repo, operands[0])]}
+    return {"Removed directories:\n": [record_item(repo, operands[0])]}
 
 
 def record_move_assets(repo: OnyoRepo, operands: tuple) -> dict[str, list[str]]:
-    records = {f"Moved assets:{linesep}": [record_move(repo, operands[0], operands[1])]}
+    records = {"Moved assets:\n": [record_move(repo, operands[0], operands[1])]}
     if repo.is_asset_dir(operands[0]):
         # In case of an asset dir, we need to record an operation for both aspects
-        records.update({f"Moved directories:{linesep}": [record_move(repo, operands[0], operands[1])]})
+        records.update({"Moved directories:\n": [record_move(repo, operands[0], operands[1])]})
     return records
 
 
 def record_move_directories(repo: OnyoRepo, operands: tuple) -> dict[str, list[str]]:
-    records = {f"Moved directories:{linesep}": [record_move(repo, operands[0], operands[1])]}
+    records = {"Moved directories:\n": [record_move(repo, operands[0], operands[1])]}
     if repo.is_asset_dir(operands[0]):
         # In case of an asset dir, we need to record an operation for both aspects
-        records.update({f"Moved assets:{linesep}": [record_move(repo, operands[0], operands[1])]})
+        records.update({"Moved assets:\n": [record_move(repo, operands[0], operands[1])]})
     return records
 
 
 def record_rename_directories(repo: OnyoRepo, operands: tuple) -> dict[str, list[str]]:
-    return {f"Renamed directories:{linesep}": [record_rename(repo, operands[0], operands[1])]}
+    return {"Renamed directories:\n": [record_rename(repo, operands[0], operands[1])]}
 
 
 def record_rename_assets(repo: OnyoRepo, operands: tuple) -> dict[str, list[str]]:
-    records = {f"Renamed assets:{linesep}": [record_rename(repo, operands[0], operands[1])]}
+    records = {"Renamed assets:\n": [record_rename(repo, operands[0], operands[1])]}
     if repo.is_asset_dir(operands[0]):
         # In case of an asset dir, we need to record an operation for both aspects
-        records.update({f"Renamed directories:{linesep}": [record_rename(repo, operands[0], operands[1])]})
+        records.update({"Renamed directories:\n": [record_rename(repo, operands[0], operands[1])]})
     return records
 
 
 def record_modify_assets(repo: OnyoRepo, operands: tuple) -> dict[str, list[str]]:
-    return {f"Modified assets:{linesep}": [record_item(repo, operands[0])]}
+    return {"Modified assets:\n": [record_item(repo, operands[0])]}

--- a/onyo/lib/tests/test_commands_new.py
+++ b/onyo/lib/tests/test_commands_new.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 from pathlib import Path
 
@@ -209,7 +208,7 @@ def test_onyo_new_edit(inventory: Inventory, monkeypatch) -> None:
     assert asset_content['key'] == 'value'
 
     # file already exists:
-    edit_str = f"model:{os.linesep}  name: MODEL{os.linesep}make: MAKER{os.linesep}type: TYPE{os.linesep}"
+    edit_str = "model:\n  name: MODEL\nmake: MAKER\ntype: TYPE\n"
     monkeypatch.setenv('EDITOR', f"printf '{edit_str}' >>")
     specs = [{'template': 'empty',
               'serial': 'totally_random'}]
@@ -217,7 +216,7 @@ def test_onyo_new_edit(inventory: Inventory, monkeypatch) -> None:
     pytest.raises(ValueError, onyo_new, inventory, keys=specs, directory=directory, edit=True)
 
     # asset already exists (but elsewhere - see fixture):
-    edit_str = f"model:{os.linesep}  name: MODEL{os.linesep}make: MAKER{os.linesep}type: TYPE{os.linesep}serial: SERIAL{os.linesep}"
+    edit_str = "model:\n  name: MODEL\nmake: MAKER\ntype: TYPE\nserial: SERIAL\n"
     monkeypatch.setenv('EDITOR', f"printf '{edit_str}' >>")
     specs = [{'template': 'empty'}]
     pytest.raises(ValueError, onyo_new, inventory, keys=specs, directory=directory, edit=True)
@@ -230,7 +229,7 @@ def test_onyo_new_edit(inventory: Inventory, monkeypatch) -> None:
 
     # content should be exactly as expected
     # (empty files used to serialize to '{}')
-    edit_str = f"model:\n  name: MODEL{os.linesep}make: MAKER{os.linesep}type: TYPE{os.linesep}serial: 8675309{os.linesep}"
+    edit_str = "model:\n  name: MODEL\nmake: MAKER\ntype: TYPE\nserial: 8675309\n"
     monkeypatch.setenv('EDITOR', f"printf '{edit_str}' >>")
     specs = [{'template': 'empty'}]
     onyo_new(inventory,

--- a/onyo/lib/tests/test_utils.py
+++ b/onyo/lib/tests/test_utils.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 from ruamel.yaml import YAML  # pyre-ignore[21]
 
@@ -11,29 +9,29 @@ def test_dict_to_asset_yaml() -> None:
     r"""Test Dict, CommentedMap, and empty dict."""
     # normal python dict
     d = {'type': 'TYPE', 'make': 'MAKE', 'model': 'MODEL', 'serial': 8675309}
-    d_expected_output = f"---{os.linesep}type: TYPE{os.linesep}make: MAKE{os.linesep}model: MODEL{os.linesep}serial: 8675309{os.linesep}"
+    d_expected_output = "---\ntype: TYPE\nmake: MAKE\nmodel: MODEL\nserial: 8675309\n"
     assert d_expected_output == dict_to_asset_yaml(d)
 
     # YAML with comments
-    yaml_string = f"---{os.linesep}" + \
-                  f"model: MODEL{os.linesep}" + \
-                  f"# You can be my Yoko Onyo{os.linesep}" + \
-                  f"make: MAKE{os.linesep}" + \
-                  f"type: TYPE{os.linesep}" + \
-                  f"# service tag for Dell{os.linesep}" + \
-                  f"serial: SERIAL{os.linesep}"
+    yaml_string = "---\n" + \
+                  "model: MODEL\n" + \
+                  "# You can be my Yoko Onyo\n" + \
+                  "make: MAKE\n" + \
+                  "type: TYPE\n" + \
+                  "# service tag for Dell\n" + \
+                  "serial: SERIAL\n"
     yaml = YAML(typ='rt', pure=True)
     yaml_dict_w_comments = yaml.load(yaml_string)
     assert yaml_string == dict_to_asset_yaml(yaml_dict_w_comments)
 
     # empty top-level dict should be stripped
     empty = {}
-    empty_expected_output = f"---{os.linesep}"
+    empty_expected_output = "---\n"
     assert empty_expected_output == dict_to_asset_yaml(empty)
 
     # empty nested dict should be retained
     d = {'type': 'TYPE', 'make': 'MAKE', 'model': 'MODEL', 'serial': 8675309, 'dict': {}}
-    d_expected_output = f"---{os.linesep}type: TYPE{os.linesep}make: MAKE{os.linesep}model: MODEL{os.linesep}serial: 8675309{os.linesep}dict: {{}}{os.linesep}"
+    d_expected_output = "---\ntype: TYPE\nmake: MAKE\nmodel: MODEL\nserial: 8675309\ndict: {}\n"
     assert d_expected_output == dict_to_asset_yaml(d)
 
 
@@ -41,5 +39,5 @@ def test_dict_to_asset_yaml() -> None:
 def test_redaction_dict_to_asset_yaml(rkey: str) -> None:
     r"""Reserved- and Pseudo-Keys should not be serialized."""
     d = {'type': 'TYPE', 'make': 'MAKE', 'model': 'MODEL', 'serial': 8675309, rkey: 'REDACT_ME'}
-    d_expected_output = f"---{os.linesep}type: TYPE{os.linesep}make: MAKE{os.linesep}model: MODEL{os.linesep}serial: 8675309{os.linesep}"
+    d_expected_output = "---\ntype: TYPE\nmake: MAKE\nmodel: MODEL\nserial: 8675309\n"
     assert d_expected_output == dict_to_asset_yaml(d)

--- a/onyo/lib/ui.py
+++ b/onyo/lib/ui.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import sys
 import traceback
 from typing import Any
@@ -128,7 +127,7 @@ class UI(object):
 
     def error(self,
               error: str | Exception,
-              end: str = os.linesep) -> None:
+              end: str = '\n') -> None:
         r"""Print an error message, if the `UI` is not set to quiet mode.
 
         Parameters

--- a/onyo/lib/utils.py
+++ b/onyo/lib/utils.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import copy
-import os
 from collections import UserDict
 from io import StringIO
 from pathlib import Path
@@ -220,7 +219,7 @@ def get_asset_content(asset_file: Path) -> dict[str, bool | float | int | str | 
         # Remove ruaml usage pointer (see github issue 436)
         if hasattr(e, 'note') and isinstance(e.note, str) and "suppress this check" in e.note:
             e.note = ""
-        raise NotAnAssetError(f"Invalid YAML in {asset_file}:{os.linesep}{str(e)}") from e
+        raise NotAnAssetError(f"Invalid YAML in {asset_file}:\n{str(e)}") from e
     if contents is None:
         return dict()
     if not isinstance(contents, (dict, CommentedMap)):


### PR DESCRIPTION
`os.linesep` is of no use to us, as git translates line endings to match the user's OS.

The codebase used both `linesep` and `\n`. It makes sense to choose the one that is 5-10 characters shorter, faster, and doesn't require an import.

This removes 9 out of 16 imports of `os`.