### PR TITLE
NF: `onyo cat` use syntax highlighting for YAML

### DIFF
--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -171,6 +171,7 @@ def onyo_cat(inventory: Inventory,
         If ``paths`` contains an invalid asset (e.g. content is invalid YAML).
     """
 
+    from rich.syntax import Syntax
     from onyo.lib.onyo import OnyoRepo
     from onyo.lib.utils import validate_yaml
 
@@ -188,7 +189,13 @@ def onyo_cat(inventory: Inventory,
                  for p in paths)
     # open file and print to stdout
     for f in files:
-        ui.print(f.read_text(), end='')
+        asset_text = f.read_text()
+        highlighted_text = Syntax('', 'yaml').highlight(asset_text)
+        # detect and strip when Syntax() ends with a newline that isn't in the input.
+        if not asset_text or asset_text[-1] != '\n':
+            highlighted_text = highlighted_text[0:-1]
+
+        ui.rich_print(highlighted_text, end='')
 
     # TODO: "Full" asset validation. Address when fsck is reworked
     assets_valid = validate_yaml(deduplicate(files))

--- a/onyo/lib/ui.py
+++ b/onyo/lib/ui.py
@@ -60,7 +60,7 @@ class UI(object):
             Activate the yes mode to suppress all interactive requests to the
             user, and instead answers them with yes.
         """
-        # set the the attributes of the UI object
+        # set the attributes of the UI object
         self.quiet = quiet
         self.yes = yes
         self.logger = logging.getLogger('onyo')


### PR DESCRIPTION
This allows `onyo cat` to provide more value over using just `cat`.

Rich automatically detects if the TTY is interactive or not, so piping, etc is unaffected.

Works towards #55