### PR TITLE
NF/DOC: `onyo cat` improved documentation and enhance error codes

### DIFF
--- a/onyo/cli/cat.py
+++ b/onyo/cli/cat.py
@@ -4,6 +4,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from onyo.lib.commands import onyo_cat
+from onyo.lib.exceptions import (
+    InvalidAssetError,
+    OnyoCLIExitCode,
+)
 from onyo.lib.inventory import Inventory
 from onyo.lib.onyo import OnyoRepo
 
@@ -21,6 +25,11 @@ args_cat = {
 }
 
 epilog_cat = r"""
+.. rubric:: Exit Status
+
+The exit status is ``0`` if the asset contents are valid, ``1`` if the
+contents are invalid, and ``2`` if an error occurred.
+
 .. rubric:: Examples
 
 Display the contents of an asset (file or directory):
@@ -47,11 +56,17 @@ def cat(args: argparse.Namespace) -> None:
     r"""
     Print the contents of **ASSET**\ s to the terminal.
 
-    If any of the paths are invalid, then no contents are printed and an error
-    is returned.
+    If any of the paths are not assets, no content is printed and an error is
+    returned.
+
+    Assets with invalid content are printed with an error message. See **Exit
+    Status** for more information about return codes.
     """
     paths = [Path(p).resolve() for p in args.asset]
 
     inventory = Inventory(repo=OnyoRepo(Path.cwd(), find_root=True))
-    onyo_cat(inventory,
-             paths)
+    try:
+        onyo_cat(inventory,
+                 paths)
+    except InvalidAssetError as e:
+        raise OnyoCLIExitCode("'onyo cat' exits 1 when invalid asset content is found.", 1) from e

--- a/onyo/cli/get.py
+++ b/onyo/cli/get.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
-import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from onyo.argparse_helpers import StoreSortOption
-from onyo.lib.onyo import OnyoRepo
 from onyo.lib.commands import onyo_get
+from onyo.lib.exceptions import OnyoCLIExitCode
 from onyo.lib.filters import Filter
 from onyo.lib.inventory import Inventory
+from onyo.lib.onyo import OnyoRepo
 
 if TYPE_CHECKING:
     import argparse
@@ -197,4 +197,4 @@ def get(args: argparse.Namespace) -> None:
                        keys=args.keys)
 
     if not results:
-        sys.exit(1)
+        raise OnyoCLIExitCode("'onyo get' exits 1 when no results are found.", 1)

--- a/onyo/cli/tests/test_cat.py
+++ b/onyo/cli/tests/test_cat.py
@@ -39,8 +39,7 @@ contents: List[List[str]] = [[x, content_str] for x in assets]
 @pytest.mark.parametrize('asset', assets)
 def test_cat(repo: OnyoRepo, asset: str) -> None:
     r"""
-    Test that a single file is cat successfully, and that stdout matches file
-    content.
+    Single file is cat successfully, and stdout matches file content.
     """
     ret = subprocess.run(["onyo", "cat", asset], capture_output=True, text=True)
     assert ret.returncode == 0
@@ -51,8 +50,7 @@ def test_cat(repo: OnyoRepo, asset: str) -> None:
 @pytest.mark.repo_contents(*contents)
 def test_cat_multiple_inputs(repo: OnyoRepo) -> None:
     r"""
-    Test that multiple files are cat successfully, and that stdout matches file
-    content.
+    Multiple files are cat successfully, and stdout matches file content.
     """
     ret = subprocess.run(["onyo", "cat", *assets], capture_output=True, text=True)
     assert ret.returncode == 0
@@ -68,10 +66,10 @@ def test_cat_multiple_inputs(repo: OnyoRepo) -> None:
                          )
 def test_cat_non_existing_path(repo: OnyoRepo, variant: str) -> None:
     r"""
-    Test that cat fails for a path that doesn't exist.
+    Error (2) on path that doesn't exist.
     """
     ret = subprocess.run(['onyo', 'cat', variant], capture_output=True, text=True)
-    assert ret.returncode == 1
+    assert ret.returncode == 2
     assert not ret.stdout
     assert ret.stderr
 
@@ -84,10 +82,10 @@ def test_cat_non_existing_path(repo: OnyoRepo, variant: str) -> None:
 )
 def test_cat_multiple_paths_missing(repo: OnyoRepo, variant: list[str]) -> None:
     r"""
-    Test that cat fails with multiple paths if at least one doesn't exist.
+    Errors (2) with multiple paths when at least one doesn't exist.
     """
     ret = subprocess.run(['onyo', 'cat', *variant], capture_output=True, text=True)
-    assert ret.returncode == 1
+    assert ret.returncode == 2
     assert not ret.stdout
     assert ret.stderr
 
@@ -96,10 +94,10 @@ def test_cat_multiple_paths_missing(repo: OnyoRepo, variant: list[str]) -> None:
 @pytest.mark.parametrize('directory', directories)
 def test_cat_error_with_directory(repo: OnyoRepo, directory: str) -> None:
     r"""
-    Test that cat fails if path provided not a file.
+    Error (2) if path provided is a plain directory.
     """
     ret = subprocess.run(['onyo', 'cat', directory], capture_output=True, text=True)
-    assert ret.returncode == 1
+    assert ret.returncode == 2
     assert not ret.stdout
     assert ret.stderr
 
@@ -108,7 +106,7 @@ def test_cat_error_with_directory(repo: OnyoRepo, directory: str) -> None:
 @pytest.mark.parametrize('asset', assets)
 def test_same_target(repo: OnyoRepo, asset: str) -> None:
     r"""
-    Test that cat succeeds if the same path is provided more than once.
+    Succeed if the same path is provided more than once.
     """
     ret = subprocess.run(['onyo', 'cat', asset, asset], capture_output=True, text=True)
     assert ret.returncode == 0
@@ -122,10 +120,9 @@ def test_same_target(repo: OnyoRepo, asset: str) -> None:
                                       "---\nRAM:\nSize:\nUSB:"]])
 def test_no_trailing_newline(repo: OnyoRepo, variant: list[str]) -> None:
     r"""
-    Test that `onyo cat` outputs the file content exactly, and doesn't add any
-    newlines or other characters.
+    The output matches the file content /exactly/, without spurious newlines,
+    formatting, or other characters.
     """
-    # test
     ret = subprocess.run(['onyo', 'cat', variant[0]], capture_output=True, text=True)
     assert ret.returncode == 0
     assert not ret.stderr
@@ -135,8 +132,7 @@ def test_no_trailing_newline(repo: OnyoRepo, variant: list[str]) -> None:
 @pytest.mark.repo_files(*assets)
 def test_no_trailing_newline_with_many_empty_assets(repo: OnyoRepo) -> None:
     r"""
-    Test that `onyo cat ASSET ASSET [...]` does not print empty lines when given
-    a list of empty files.
+    No empty lines when given a list of empty files.
 
     Because `onyo cat` uses `print(path.read_text(), end='')` this test
     verifies that empty assets do not print empty new lines.
@@ -152,8 +148,7 @@ def test_no_trailing_newline_with_many_empty_assets(repo: OnyoRepo) -> None:
                          [["bad_yaml_file.test", "I: \nam:bad:\nbad:yaml\n"]])
 def test_invalid_yaml(repo: OnyoRepo, variant: list[str]) -> None:
     r"""
-    Test that `onyo cat` returns non-zero for a file with invalid yaml content,
-    but does print the content plus an error message.
+    Invalid content prints to stdout, error message to stderr, and exit 1.
     """
 
     # check that yaml is invalid

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -25,13 +25,14 @@ from onyo.lib.consts import (
     SORT_DESCENDING,
 )
 from onyo.lib.exceptions import (
+    InvalidAssetError,
+    InventoryDirNotEmpty,
     NotADirError,
     NotAnAssetError,
     NoopError,
     OnyoInvalidRepoError,
     OnyoRepoError,
     PendingInventoryOperationError,
-    InventoryDirNotEmpty,
 )
 from onyo.lib.inventory import Inventory, OPERATIONS_MAPPING
 from onyo.lib.ui import ui
@@ -167,7 +168,7 @@ def onyo_cat(inventory: Inventory,
     ValueError
         If a provided asset is not an asset, or if ``paths`` is empty.
 
-    OnyoInvalidRepoError
+    InvalidAssetError
         If ``paths`` contains an invalid asset (e.g. content is invalid YAML).
     """
 
@@ -200,7 +201,7 @@ def onyo_cat(inventory: Inventory,
     # TODO: "Full" asset validation. Address when fsck is reworked
     assets_valid = validate_yaml(deduplicate(files))
     if not assets_valid:
-        raise OnyoInvalidRepoError("Invalid assets")
+        raise InvalidAssetError("Invalid assets")
 
 
 @raise_on_inventory_state

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -151,10 +151,10 @@ def onyo_cat(inventory: Inventory,
              paths: list[Path]) -> None:
     r"""Print the contents of assets.
 
-    The same path can be given multiple times.
+    The same asset can be given multiple times.
 
     If any path is not an asset, nothing is printed.
-    If any asset content is invalid, the content of all assets is still printed.
+    If any asset content is invalid, the contents of all assets are still printed.
 
     Parameters
     ----------
@@ -166,10 +166,10 @@ def onyo_cat(inventory: Inventory,
     Raises
     ------
     ValueError
-        If a provided asset is not an asset, or if ``paths`` is empty.
+        The path is not an asset, or ``paths`` is empty.
 
     InvalidAssetError
-        If ``paths`` contains an invalid asset (e.g. content is invalid YAML).
+        An invalid asset is encountered.
     """
 
     from rich.syntax import Syntax

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -433,7 +433,7 @@ def onyo_edit(inventory: Inventory,
     if inventory.operations_pending():
         if ui.request_user_response("Save changes? No discards all changes. (y/n) "):
             if auto_message:
-                operation_paths = sorted(deduplicate([
+                operation_paths = sorted(deduplicate([  # pyre-ignore[6]
                     op.operands[0].get("path").relative_to(inventory.root)
                     for op in inventory.operations
                     if op.operator == OPERATIONS_MAPPING['modify_assets']]))
@@ -714,7 +714,7 @@ def onyo_mkdir(inventory: Inventory,
 
         if ui.request_user_response("Save changes? No discards all changes. (y/n) "):
             if auto_message:
-                operation_paths = sorted(deduplicate([
+                operation_paths = sorted(deduplicate([  # pyre-ignore[6]
                     op.operands[0].relative_to(inventory.root)
                     for op in inventory.operations
                     if op.operator == OPERATIONS_MAPPING['new_directories']]))
@@ -841,7 +841,7 @@ def onyo_mv(inventory: Inventory,
 
         if ui.request_user_response("Save changes? No discards all changes. (y/n) "):
             if auto_message:
-                operation_paths = sorted(deduplicate([
+                operation_paths = sorted(deduplicate([  # pyre-ignore[6]
                     op.operands[0].relative_to(inventory.root)
                     for op in inventory.operations
                     if op.operator == OPERATIONS_MAPPING['rename_assets'] or
@@ -1053,7 +1053,7 @@ def onyo_new(inventory: Inventory,
 
         if edit or ui.request_user_response("Create assets? (y/n) "):
             if auto_message:
-                operation_paths = sorted(deduplicate([
+                operation_paths = sorted(deduplicate([  # pyre-ignore[6]
                     op.operands[0].get("path").relative_to(inventory.root)
                     for op in inventory.operations
                     if op.operator == OPERATIONS_MAPPING['new_assets']]))
@@ -1118,7 +1118,7 @@ def onyo_rm(inventory: Inventory,
 
         if ui.request_user_response("Save changes? No discards all changes. (y/n) "):
             if auto_message:
-                operation_paths = sorted(deduplicate([
+                operation_paths = sorted(deduplicate([  # pyre-ignore[6]
                     op.operands[0].relative_to(inventory.root)
                     for op in inventory.operations
                     if op.operator == OPERATIONS_MAPPING['remove_assets'] or
@@ -1199,7 +1199,7 @@ def onyo_set(inventory: Inventory,
 
         if ui.request_user_response("Update assets? (y/n) "):
             if auto_message:
-                operation_paths = sorted(deduplicate([
+                operation_paths = sorted(deduplicate([  # pyre-ignore[6]
                     op.operands[0].get("path").relative_to(inventory.root)
                     for op in inventory.operations
                     if op.operator == OPERATIONS_MAPPING['modify_assets']]))
@@ -1363,7 +1363,7 @@ def onyo_unset(inventory: Inventory,
 
         if ui.request_user_response("Update assets? (y/n) "):
             if auto_message:
-                operation_paths = sorted(deduplicate([
+                operation_paths = sorted(deduplicate([  # pyre-ignore[6]
                     op.operands[0].get("path").relative_to(inventory.root)
                     for op in inventory.operations
                     if op.operator == OPERATIONS_MAPPING[

--- a/onyo/lib/exceptions.py
+++ b/onyo/lib/exceptions.py
@@ -34,6 +34,10 @@ class InvalidArgumentError(Exception):
     r"""Raised a (CLI-) command is invalidly called beyond what's covered by argparse."""
 
 
+class InvalidAssetError(Exception):
+    r"""Raised if an asset is invalid."""
+
+
 class InventoryOperationError(Exception):
     r"""Raised if an inventory operation cannot be executed."""
 

--- a/onyo/lib/exceptions.py
+++ b/onyo/lib/exceptions.py
@@ -5,6 +5,15 @@ class UIInputError(Exception):
     r"""Raised if UI failed when trying to read input"""
 
 
+class OnyoCLIExitCode(Exception):
+    r"""Raised if the onyo CLI should exit with a specific value."""
+    def __init__(self,
+                 message: str,
+                 returncode: int):
+        self.message = message
+        self.returncode = returncode
+
+
 class OnyoRepoError(Exception):
     r"""Raised if something is wrong with an Onyo repository."""
 

--- a/onyo/lib/tests/test_commands_cat.py
+++ b/onyo/lib/tests/test_commands_cat.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from onyo.lib.exceptions import OnyoInvalidRepoError
+from onyo.lib.exceptions import InvalidAssetError
 from onyo.lib.inventory import Inventory
 from onyo.lib.onyo import OnyoRepo
 from ..commands import onyo_cat
@@ -70,7 +70,7 @@ def test_onyo_cat_errors(inventory: Inventory) -> None:
     invalid_path.write_text("key: value\ninvalid")
     inventory.repo.git._git(["add", str(invalid_path)])
     inventory.commit("Invalid file added")
-    pytest.raises(OnyoInvalidRepoError,
+    pytest.raises(InvalidAssetError,
                   onyo_cat,
                   inventory,
                   paths=[invalid_path])

--- a/onyo/lib/ui.py
+++ b/onyo/lib/ui.py
@@ -126,32 +126,46 @@ class UI(object):
         """
         self.yes = yes
 
+    def format_traceback(self,
+                         e: Exception) -> str:
+        r"""Format an Exception's traceback suitable for logging.
+
+        Parameters
+        ----------
+        e
+            Exception to extract the traceback from.
+        """
+
+        tb = traceback.TracebackException.from_exception(
+            e, lookup_lines=True, capture_locals=False
+        )
+        if e.__traceback__:
+            traceback.clear_frames(e.__traceback__)
+        return ''.join(tb.format())
+
     def error(self,
               error: str | Exception,
               end: str = '\n') -> None:
-        r"""Print an error message, if the `UI` is not set to quiet mode.
+        r"""Print an error message.
+
+        Nothing will be printed when ``UI`` is set to quiet mode.
+
+        When provided, Exceptions will print tracebacks in debug mode.
 
         Parameters
         ----------
         error
-            Prints the string, or the message of an error.
-            If debug mode is activated, displays the full traceback of an
-            exception.
-
+            Error message to print. Exceptions will have their message printed
+            and traceback added to the debug log.
         end
-            Specify the string at the end of prints.
-            Per default, prints end with a line break.
+            String to end the message with. Defaults to "\n".
         """
+
         self.error_count += 1
         if not self.quiet:
             print(f"ERROR: {error}", file=sys.stderr, end=end)
         if isinstance(error, Exception):
-            tb = traceback.TracebackException.from_exception(
-                error, lookup_lines=True, capture_locals=False
-            )
-            if error.__traceback__:
-                traceback.clear_frames(error.__traceback__)
-            self.logger.debug(''.join(tb.format()))
+            self.log_debug(self.format_traceback(error))
 
     def log(self,
             message: str,

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -14,6 +14,7 @@ import rich
 from onyo import cli
 from onyo.lib.exceptions import (
     InvalidArgumentError,
+    OnyoCLIExitCode,
     UIInputError,
 )
 from onyo.lib.ui import ui
@@ -556,6 +557,9 @@ def main() -> None:
             # we usually let it through. If not, it should result in a dedicated exception,
             # that we can treat here accordingly.
             ui.log_debug(str(e))
+            sys.exit(e.returncode)
+        except OnyoCLIExitCode as e:
+            ui.log_debug(ui.format_traceback(e))
             sys.exit(e.returncode)
         except UIInputError as e:
             ui.error(e)

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -541,7 +541,11 @@ def main() -> None:
         os.chdir(args.opdir)
         # normally exit 1 on error. `get` is a special case. Exit with 2 on
         # error to mimic `grep`'s behavior.
-        error_returncode = 2 if args.cmd == 'get' else 1
+        cmd_error_codes = {
+            'cat': 2,
+            'get': 2,
+        }
+        error_returncode = cmd_error_codes.get(args.cmd, 1)
 
         try:
             args.run(args)

--- a/onyo/onyo_arguments.py
+++ b/onyo/onyo_arguments.py
@@ -6,10 +6,8 @@ from onyo.lib.ui import ui
 
 
 def get_cwd() -> Path:
-    # This avoids dumping a traceback to the user,
-    # if CWD doesn't exist.
-    # A bit hacky, b/c this would happen early on where
-    # we are not a general exception handler yet.
+    # HACK: avoid dumping a traceback to the user, if CWD doesn't exist.
+    # Needed early on, before we have a general exception handler.
     try:
         return Path.cwd()
     except FileNotFoundError as e:


### PR DESCRIPTION
This continues my journey to bring more features to the most irrelevant parts of `onyo`. ;-)

Really, this was an accident. I was looking at #493 and chose to work on `cat`'s docstrings. There was ambiguity about error cases and invalid content, and I wanted to clarify it.

Previously, `onyo cat` would exit `0` on success and `1` on error (no print content) or invalid asset content (but still print content).

I really like `onyo get`'s new ability to differentiate between producing valid output that is problematic (exit `1`) vs an error (exit `2`). And so I chose to bring that to `onyo cat`. Invalid asset content will continue to print and exit `1`. Errors will now exit `2`.

I also introduce a new exception (`InvalidAssetError`), as I felt `OnyoInvalidRepoError` was misleading and was being abused.