### PR TITLE
Getting rid of YAML implicit typing (for now)

### DIFF
--- a/onyo/argparse_helpers.py
+++ b/onyo/argparse_helpers.py
@@ -72,26 +72,12 @@ class StoreMultipleKeyValuePairs(argparse.Action):
             parser.error(f"All keys given multiple times must be given the same number of times:\n"
                          f"{f'{linesep}'.join(['{}: {}'.format(k, c) for k, c in key_counts.items() if 1 < c])}")
 
-        def cvt(v: str) -> int | float | str | bool:
-            if v.lower() == "true":
-                return True
-            elif v.lower() == "false":
-                return False
-            try:
-                r = int(v)
-            except ValueError:
-                try:
-                    r = float(v)
-                except ValueError:
-                    r = v
-            return r
-
         results = []
         for i in range(key_max_count):
             d = dict()
             for k, values in key_lists.items():
                 v = values[0] if len(values) == 1 else values[i]
-                d[k] = cvt(v)
+                d[k] = v
             results.append(d)
         setattr(namespace, self.dest, results)
 
@@ -143,20 +129,6 @@ class StoreSingleKeyValuePairs(argparse.Action):
             if "=" not in kv:
                 parser.error(f"Invalid argument '{kv}'. Expected key-value pairs '<key>=<value>'.")
 
-        def cvt(v: str) -> int | float | str | bool:
-            if v.lower() == "true":
-                return True
-            elif v.lower() == "false":
-                return False
-            try:
-                r = int(v)
-            except ValueError:
-                try:
-                    r = float(v)
-                except ValueError:
-                    r = v
-            return r
-
         pairs = [p.split('=', maxsplit=1) for p in key_values]
         results = dict()
         for k, v in pairs:
@@ -164,7 +136,7 @@ class StoreSingleKeyValuePairs(argparse.Action):
                 parser.error(f"Duplicate key '{k}' found.\n"
                              f"Keys must not be given multiple times.")
 
-            results[k] = cvt(v)
+            results[k] = v
 
         setattr(namespace, self.dest, results)
 

--- a/onyo/cli/tests/test_set.py
+++ b/onyo/cli/tests/test_set.py
@@ -33,7 +33,7 @@ asset_specs = [DotNotationWrapper({'type': 'laptop',
 assets = []
 for i, d in enumerate(directories):
     for spec in asset_specs:
-        spec['serial'] = str(i)
+        spec['serial'] = "00_" + str(i)
         name = f"{spec['type']}_{spec['make']}_{spec['model.name']}.{spec['serial']}"
         content = dict_to_asset_yaml(spec)
         assets.append([f"{d}/{name}", content])

--- a/onyo/lib/tests/test_inventory_operations.py
+++ b/onyo/lib/tests/test_inventory_operations.py
@@ -46,7 +46,7 @@ def test_add_asset(repo: OnyoRepo) -> None:
     asset_file = newdir2 / "test_I_mk1.123"
     asset = DotNotationWrapper(
         dict(some_key="some_value",
-             other=1,
+             other='1',
              directory=newdir2,
              type="test",
              make="I",
@@ -155,7 +155,7 @@ def test_move_asset(repo: OnyoRepo) -> None:
     asset_file = newdir2 / "test_I_mk1.123"
     asset = DotNotationWrapper(
         dict(some_key="some_value",
-             other=1,
+             other='1',
              directory=newdir2,
              type="test",
              make="I",
@@ -200,7 +200,7 @@ def test_rename_asset(repo: OnyoRepo) -> None:
              make="MAKER",
              model=dict(name="MODEL"),
              serial="SERIAL",
-             other=1,
+             other='1',
              directory=newdir2)
     )
     inventory.add_asset(asset)
@@ -227,7 +227,7 @@ def test_modify_asset(repo: OnyoRepo) -> None:
              make="MAKER",
              model=dict(name="MODEL"),
              serial="SERIAL",
-             other=1,
+             other='1',
              directory=newdir2)
     )
     inventory.add_asset(asset)
@@ -328,7 +328,7 @@ def test_remove_directory(repo: OnyoRepo) -> None:
              make="MAKER",
              model=dict(name="MODEL"),
              serial="SERIAL",
-             other=1,
+             other='1',
              directory=newdir2)
     )
     inventory.add_asset(asset)

--- a/onyo/lib/tests/test_utils.py
+++ b/onyo/lib/tests/test_utils.py
@@ -1,28 +1,45 @@
 import pytest
-from ruamel.yaml import YAML  # pyre-ignore[21]
 
 from onyo.lib.consts import PSEUDO_KEYS, RESERVED_KEYS
-from onyo.lib.utils import dict_to_asset_yaml
+from onyo.lib.utils import (
+    dict_to_asset_yaml,
+    get_asset_content,
+)
+
+asset_file_content = """---
+# top-level comment
+type: a  # key comment
+make: b
+model:  # comment at intermediate node
+  name: c # comment in nested dict-key
+  # comment in nested dict
+  more: d
+  integer: 1
+  explicit: !!int '2'
+  float: 1.2
+  list:
+  - 1.2
+  - b
+  - 003_5
+# keys and values need to preserve leading zeroes and underscores:
+serial: 00012_3456
+003_5: true
+explicit_null: null
+tilde_null: ~ # what now
+implicit_null:
+emptystring: ''
+description: |
+  This is a long text
+  containing multiple lines.
+"""
 
 
 def test_dict_to_asset_yaml() -> None:
     r"""Test Dict, CommentedMap, and empty dict."""
     # normal python dict
-    d = {'type': 'TYPE', 'make': 'MAKE', 'model': 'MODEL', 'serial': 8675309}
-    d_expected_output = "---\ntype: TYPE\nmake: MAKE\nmodel: MODEL\nserial: 8675309\n"
+    d = {'type': 'TYPE', 'make': 'MAKE', 'model': 'MODEL', 'serial': '008675309', 'explicit': 123}
+    d_expected_output = "---\ntype: TYPE\nmake: MAKE\nmodel: MODEL\nserial: 008675309\nexplicit: !!int '123'\n"
     assert d_expected_output == dict_to_asset_yaml(d)
-
-    # YAML with comments
-    yaml_string = "---\n" + \
-                  "model: MODEL\n" + \
-                  "# You can be my Yoko Onyo\n" + \
-                  "make: MAKE\n" + \
-                  "type: TYPE\n" + \
-                  "# service tag for Dell\n" + \
-                  "serial: SERIAL\n"
-    yaml = YAML(typ='rt', pure=True)
-    yaml_dict_w_comments = yaml.load(yaml_string)
-    assert yaml_string == dict_to_asset_yaml(yaml_dict_w_comments)
 
     # empty top-level dict should be stripped
     empty = {}
@@ -30,14 +47,53 @@ def test_dict_to_asset_yaml() -> None:
     assert empty_expected_output == dict_to_asset_yaml(empty)
 
     # empty nested dict should be retained
-    d = {'type': 'TYPE', 'make': 'MAKE', 'model': 'MODEL', 'serial': 8675309, 'dict': {}}
-    d_expected_output = "---\ntype: TYPE\nmake: MAKE\nmodel: MODEL\nserial: 8675309\ndict: {}\n"
+    d = {'type': 'TYPE', 'make': 'MAKE', 'model': 'MODEL', 'serial': '008675309', 'explicit': 123, 'dict': {}}
+    d_expected_output = "---\ntype: TYPE\nmake: MAKE\nmodel: MODEL\nserial: 008675309\nexplicit: !!int '123'\ndict: {}\n"
     assert d_expected_output == dict_to_asset_yaml(d)
 
 
 @pytest.mark.parametrize('rkey', PSEUDO_KEYS + RESERVED_KEYS)
 def test_redaction_dict_to_asset_yaml(rkey: str) -> None:
     r"""Reserved- and Pseudo-Keys should not be serialized."""
-    d = {'type': 'TYPE', 'make': 'MAKE', 'model': 'MODEL', 'serial': 8675309, rkey: 'REDACT_ME'}
-    d_expected_output = "---\ntype: TYPE\nmake: MAKE\nmodel: MODEL\nserial: 8675309\n"
+    d = {'type': 'TYPE', 'make': 'MAKE', 'model': 'MODEL', 'serial': '008675309', 'explicit': 123, rkey: 'REDACT_ME'}
+    d_expected_output = "---\ntype: TYPE\nmake: MAKE\nmodel: MODEL\nserial: 008675309\nexplicit: !!int '123'\n"
     assert d_expected_output == dict_to_asset_yaml(d)
+
+
+def test_get_asset_content(tmp_path) -> None:
+    r"""Turn YAML into a dict representation w/ correct key-stringification."""
+
+    asset_file = tmp_path / "asset-file"
+    asset_file.write_text(asset_file_content)
+
+    asset_dict = get_asset_content(asset_file)
+    assert isinstance(asset_dict, dict)  # this includes ruamel's CommentedMap
+
+    def assert_all_keys_strings(d: dict) -> None:
+        for key in d.keys():
+            assert isinstance(key, str)
+            if isinstance(d[key], list):
+                # This does not yet consider lists/dicts within lists!
+                assert all(isinstance(i, str) for i in d[key])
+                continue
+            if isinstance(d[key], dict):
+                assert_all_keys_strings(d[key])
+                continue
+            if 'null' in key:
+                assert d[key] is None
+                continue
+            assert isinstance(d[key], int if key == 'explicit' else str)
+
+    assert_all_keys_strings(asset_dict)
+
+
+def test_roundtrip(tmp_path) -> None:
+    """Test roundtrip get_asset_content->dict_to_asset_yaml"""
+    asset_file = tmp_path / "asset-file"
+    asset_file.write_text(asset_file_content)
+
+    asset_dict = get_asset_content(asset_file)
+    # For now values ruamel does not roundtrip the representation. It's the `empty:` form:
+    write_back = asset_file_content.replace("~", " ")  # Space, b/c the comment position is retained.
+    write_back = write_back.replace(" Null", "").replace(" NULL", "").replace(" null", "")
+    assert dict_to_asset_yaml(asset_dict) == write_back

--- a/onyo/tests/demo/reference_git_log.txt
+++ b/onyo/tests/demo/reference_git_log.txt
@@ -1,4 +1,4 @@
-commit 8a0f7a9077ad854b4ca862be576fb5cadbb4b919
+commit 39a6548b8ea1f9bf864507377a79d345f7ef3653
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -8,7 +8,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     Removed directories:
     - management/Max Mustermann
 
-commit e1eedebaf4f9a94f7ce7c145d01c3bf14a3f4e0f
+commit 48dda31ef1e14269b1723c5a6e71756925ffbbf8
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -19,7 +19,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     - management/Max Mustermann/headphones_apple_airpods.7h8f04 -> warehouse/headphones_apple_airpods.7h8f04
     - management/Max Mustermann/laptop_apple_macbook.uef82b3 -> warehouse/laptop_apple_macbook.uef82b3
 
-commit 631daafe3361cbe8ac358edb7c617f3243cee8b4
+commit b5ea51f768de2d3097328e852e0adef6dd8a51e5
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -29,7 +29,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     Moved assets:
     - warehouse/laptop_lenovo_thinkpad.owh8e2 -> ethics/Theo Turtle/laptop_lenovo_thinkpad.owh8e2
 
-commit 2375bed6fbd9587899704c8fc01b70497dcae799
+commit f0fcfedeef1ab0849060e8b7bbbdcfbe2435f174
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -39,7 +39,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     New directories:
     - ethics/Theo Turtle
 
-commit 3abafd2eae6828f2b639a517020e193c8c929bee
+commit 74810fc84cc40083bfaeaabd0ea71ce79a2cd1fc
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -49,7 +49,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     New assets:
     - management/Alice Wonder/laptop_apple_macbook.83hd0
 
-commit f963b7b273be145ef31677a122669740b2b0ef65
+commit c794f05f9340afd0079ae7d91b1ed869c7d68e2e
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -59,7 +59,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     New directories:
     - management/Alice Wonder
 
-commit 0caf65831c383a28f859f25f5530a04d66e51601
+commit 0c16e95d73b7c519eea956643b317c109eb3a78c
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -69,7 +69,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     Moved directories:
     - ethics/Max Mustermann -> management/Max Mustermann
 
-commit 34a371619381df41e006c5145e0afd1d6710d80f
+commit 971b397dce814f48c1a834f33ad829dfe05eb802
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -79,7 +79,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     New directories:
     - management
 
-commit 8db46add9d843eaeb8001c79881b12feecba2efe
+commit f64526372088deb6073468fa1dab90faeae4f845
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -89,7 +89,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     Moved assets:
     - warehouse/laptop_apple_macbook.uef82b3 -> ethics/Max Mustermann/laptop_apple_macbook.uef82b3
 
-commit c6ea7a2dda0e8071eed218b8caa9678a26f8c540
+commit b63f859bf9c903b56b661c2135d145767c36d72d
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -99,7 +99,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     Moved assets:
     - ethics/Max Mustermann/laptop_apple_macbook.9r32he -> recycling/laptop_apple_macbook.9r32he
 
-commit 1534684351cb0961ee6cbd72fc1053b23ed755a0
+commit 924b1b1fd197b5cd0efe3bad1d3b27e98d772b5f
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -109,7 +109,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     Moved assets:
     - repair/laptop_lenovo_thinkpad.owh8e2 -> warehouse/laptop_lenovo_thinkpad.owh8e2
 
-commit b3d2328713701e4a1d085ec875ea460dd3965e3d
+commit 30ad29a4cc6f7f9f9e9de79a168eb410b81783d4
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -119,7 +119,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     Modified assets:
     - repair/laptop_lenovo_thinkpad.owh8e2
 
-commit 365c34cc90346d32e098d4b6fcbb34178d371d34
+commit d992d4519b28fbfe514475cdab36a146a047c168
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -131,7 +131,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     - warehouse/laptop_apple_macbook.oiw629 -> accounting/Bingo Bob/laptop_apple_macbook.oiw629
     - warehouse/monitor_dell_PH123.86JZho -> accounting/Bingo Bob/monitor_dell_PH123.86JZho
 
-commit 749538883e072d61d23c93332c3ac2c9be26dd61
+commit 1890e9029d8b7560b485ae83d1ed41b136704fc0
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -141,7 +141,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     New assets:
     - warehouse/headphones_apple_airpods.uzl8e1
 
-commit 10ad59f1435e0861111e664a89b77fce679cd0e9
+commit f0992980751f04c3b6a9477c544e072d131c2dfd
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -151,7 +151,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     New assets:
     - warehouse/laptop_apple_macbook.oiw629
 
-commit 9515653491aeff9f5d4f6ca07b88e254e220f66b
+commit a0ed7f880bf6b17d3edab562ef9ee34ee4df56d2
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -161,7 +161,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     New assets:
     - warehouse/monitor_dell_PH123.86JZho
 
-commit 1c656e760d4e7d74c641cfa80f1aea3ccfba4828
+commit e1a130baab3bdd8c7f5102b5303bec11ba394a05
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -172,7 +172,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     - accounting
     - accounting/Bingo Bob
 
-commit d2367322b7eaaa3cbd542d4b806ac291bafbd86f
+commit 9237c7b50365b5c860c73c325f7c42209f016486
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -184,7 +184,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     - warehouse/laptop_apple_macbook.9il2b4
     - warehouse/laptop_apple_macbook.uef82b3
 
-commit f1905b224518eb5f41e0a1880289d4abc773e573
+commit 6e038325e8b30e1518027c5410ba11631f74f869
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -195,7 +195,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     - ethics/Max Mustermann/laptop_apple_macbook.9r32he
     - warehouse/laptop_apple_macbook.9r5qlk
 
-commit c20d8ac7ba79dcf3a68d8516d634bd08f4717769
+commit 661255cc37a306741f32107cbfcb64a563808b91
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -214,7 +214,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     - warehouse/laptop_apple_macbookpro.1eic93
     - warehouse/laptop_lenovo_thinkpad.iu7h6d
 
-commit b3bee27701aeeeea35c4a0dc03e8f1f8bafb66e7
+commit 283ff37812cae2ff8f3e38434829393d3f3c1b4f
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -224,7 +224,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     Moved assets:
     - warehouse/laptop_microsoft_surface.oq782j -> ethics/Achilles Book/laptop_microsoft_surface.oq782j
 
-commit b3bd1f0ed0e140e6b94415f28267228d539a4730
+commit 75802147ff15222cf5b244e18323e731c0107ac0
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -234,7 +234,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     Moved assets:
     - ethics/Achilles Book/laptop_lenovo_thinkpad.owh8e2 -> repair/laptop_lenovo_thinkpad.owh8e2
 
-commit 7cd9c561cc0e0425f3851d526e641ae93fd55fbc
+commit f21a57245f39a68df2feda9b5e4a7f269de5fe40
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -244,7 +244,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     Moved assets:
     - warehouse/headphones_JBL_pro.e98t2p -> ethics/Achilles Book/headphones_JBL_pro.e98t2p
 
-commit b49291a2cb346d24d3ebf872533c97488fbd0123
+commit d47538bc6f715e2d436e842f8e7ca81aa8f290a2
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -254,7 +254,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     Moved assets:
     - warehouse/laptop_lenovo_thinkpad.owh8e2 -> ethics/Achilles Book/laptop_lenovo_thinkpad.owh8e2
 
-commit 194917e7b28925bad0d5a9f38384f50800b14cfd
+commit 9670adf05bc80c58175e10c4063705f6e366dd6b
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -264,7 +264,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     Moved assets:
     - warehouse/headphones_apple_airpods.7h8f04 -> ethics/Max Mustermann/headphones_apple_airpods.7h8f04
 
-commit aa57795119892fdf177fff98f0dac97f3568546d
+commit bc5908c384faf592fa5dc93a0a9cb2bf1ff26215
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -274,7 +274,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     Moved assets:
     - warehouse/laptop_apple_macbook.9r32he -> ethics/Max Mustermann/laptop_apple_macbook.9r32he
 
-commit dc93507e41a8cb3c61d2e94c65268c48db7b13f8
+commit 865d18f29172efc6b0dbcaf779709856e36e1932
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -286,7 +286,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     - ethics/Achilles Book
     - ethics/Max Mustermann
 
-commit 3523788a735be2c2620658a2bc0ff34a58fda7c5
+commit 085cb6aaada1aed9d3f8f911552d30a034c66d6f
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -296,7 +296,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     Removed assets:
     - warehouse/headphones_JBL_pro.ph9527
 
-commit fbfded9ae0350a02e248b66ca0b09bf435ae5fb1
+commit 849ed25bd17f219a0491245c5affb4ade4d28af6
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -306,7 +306,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     New assets:
     - warehouse/headphones_JBL_pro.ph9527
 
-commit 33f43902ee6eba6a7c94d1eb90eaf8a685fcdd94
+commit 217f37503f8fda399b47efe982297343c6b8467a
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -316,7 +316,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     New assets:
     - warehouse/headphones_JBL_pro.e98t2p
 
-commit 58bf0b2c5f943b4b23cf6bfe54cc7b8c23077f95
+commit 5faecaa58239d9d92a57a00430864dcd4a4eb201
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -326,7 +326,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     New assets:
     - warehouse/headphones_JBL_pro.325gtt
 
-commit fcf3e19795b5ebbc85439ba9e8ced9ca54259548
+commit 55281f6b33ec965914b00ec723f96aebbde7afca
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -336,7 +336,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     New assets:
     - warehouse/headphones_apple_airpods.7h8f04
 
-commit 7c6b894359596376e6fe4e6b4029bcf7e19711c1
+commit fa94ae78691591f44903eadb5f1d4dcc0c22c0aa
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -346,7 +346,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     New assets:
     - warehouse/laptop_microsoft_surface.oq782j
 
-commit eac4b7fa3000921812e156b7451b9b847d60a215
+commit 3041ccea3927c009b3bb0c86f35dd8e5e54196fb
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -356,7 +356,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     New assets:
     - warehouse/laptop_lenovo_thinkpad.iu7h6d
 
-commit af59dc06c296c52b2ab60601ebf8c8454e1cbc8f
+commit 5d1fac00b7c49d0ac0488ee7af21de151f481ec2
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -366,7 +366,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     New assets:
     - warehouse/laptop_lenovo_thinkpad.owh8e2
 
-commit 7526e0186b10d41424146650b5088a1075be2b7b
+commit 5d127ea63f47142837e0e321f66d03296e8547f8
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -376,7 +376,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     New assets:
     - warehouse/laptop_apple_macbook.9r5qlk
 
-commit 7327349f9be251212837047f58827d30ae0fa14c
+commit f25d3ecfff73d8d30526d41c95459e5b0d21a15a
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 
@@ -386,7 +386,7 @@ Date:   Sun Jan 1 00:00:00 2023 +0100
     New assets:
     - warehouse/laptop_apple_macbook.9r32he
 
-commit b82eacf921e379daac488a0eb7ac8ec272d15e7b
+commit 9b6041155866dfa04da053712dbe922f6fa17599
 Author: Yoko Onyo <yoko@onyo.org>
 Date:   Sun Jan 1 00:00:00 2023 +0100
 


### PR DESCRIPTION
See commit message.

This is essentially ready, but: It wouldn't be ready for a release or actual usage (which speaks to a lack of testing).
The reason is the `is_asset_directory` key, which is expected to be a boolean rather than a string.
But with this PR, users can't easily pass a boolean anymore.
However, the clean solution for that, would rely on a proper implementation of pseudo keys in general, so I'd prefer to solve the problem in that PR rather than here.

Closes #696
Closes #643
Closes #261