### PR TITLE
BF: retire `onyo get --path` alias, and other cleanups

### DIFF
--- a/docs/source/concepts.rst
+++ b/docs/source/concepts.rst
@@ -80,7 +80,7 @@ repository.
     - ``onyo config onyo.history.interactive "tig --follow"``
     - ``onyo config onyo.history.non-interactive "git --no-pager log --follow"``
 
-  - default template to use with ``onyo new --path <asset>``
+  - default template to use with ``onyo new``
     The standard template can be updated with e.g.:
 
     - ``onyo config onyo.new.template empty``
@@ -95,11 +95,10 @@ repository.
 Template Files
 **************
 
-Templates can be used with the command ``onyo new --template <template>
---path <asset>`` and are stored in the folder ``.onyo/templates/``.
-Templates will be copied as a basis for a new asset file, and can then be
-edited. After saving the newly created asset, the file will be checked for
-valid YAML syntax.
+Templates can be used with the command ``onyo new --template <template>`` and
+are stored in the folder ``.onyo/templates/``.  Templates will be copied as a
+basis for a new asset file, and can then be edited. After saving the newly
+created asset, the file will be checked for valid YAML syntax.
 
 The default template that gets used when ``onyo new`` is called is
 ``.onyo/templates/empty``. It can be updated with

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -56,12 +56,12 @@ Templates
 This section describes some of the templates provided with ``onyo init`` in the
 directory ``.onyo/templates/``.
 
-``onyo new --keys <keys> --path <directory>`` (equivalent to
-``onyo new --keys <keys> --template empty --path <directory>``) as defined
+``onyo new --keys <keys> --directory <directory>`` (equivalent to
+``onyo new --keys <keys> --template empty --directory <directory>``) as defined
 by ``.onyo/templates/empty`` is an empty YAML file, and ``keys`` must
 additionally specify the keys used for asset names.
 
-``onyo new --edit --template laptop.example --path <directory>`` as defined by
+``onyo new --edit --template laptop.example --directory <directory>`` as defined by
 ``.onyo/templates/laptop.example`` contains a simple example for a laptop asset
 which already contains some fields, which are relevant for all assets of that
 device type.

--- a/onyo/cli/get.py
+++ b/onyo/cli/get.py
@@ -85,15 +85,6 @@ args_get = {
         """
     ),
 
-    'path': dict(
-        args=('-p', '--path'),
-        metavar='PATH',
-        nargs='+',
-        help=r"""
-            Deprecated. Alias for ``--include``.
-        """
-    ),
-
     'sort_ascending': dict(
         args=('-s', '--sort-ascending'),
         metavar='SORT_KEY',
@@ -141,13 +132,13 @@ List all assets belonging to a user:
 
 .. code:: shell
 
-    $ onyo get --path accounting/Bingo\ Bob
+    $ onyo get --include accounting/Bingo\ Bob
 
 List all laptops in the warehouse:
 
 .. code:: shell
 
-    $ onyo get --match type=laptop --path warehouse/
+    $ onyo get --match type=laptop --include warehouse/
 
 Get the path of all laptops of a specific make and model, and print in machine
 parsable format (suitable for piping):
@@ -175,9 +166,7 @@ def get(args: argparse.Namespace) -> None:
 
     By default, the results are sorted by ``path``.
     """
-    includes = args.path if args.path else []
-    includes += args.include if args.include else []
-    includes = [Path(p).resolve() for p in includes] if includes else [Path.cwd()]
+    includes = [Path(p).resolve() for p in args.include] if args.include else [Path.cwd()]
     excludes = [Path(p).resolve() for p in args.exclude] if args.exclude else None
 
     inventory = Inventory(repo=OnyoRepo(Path.cwd(), find_root=True))

--- a/onyo/cli/tests/test_get.py
+++ b/onyo/cli/tests/test_get.py
@@ -161,7 +161,7 @@ def test_get_all(
     occurs.
     """
     keys = keys if keys else repo.get_asset_name_keys()
-    cmd = ['onyo', 'get', '--path', *paths, '--depth', depth]
+    cmd = ['onyo', 'get', '--include', *paths, '--depth', depth]
     cmd += ['--keys', *keys + ["path"]] if keys else []
     cmd += ['--match', *matches] if matches else []
     cmd += [machine_readable] if machine_readable else []
@@ -406,14 +406,14 @@ def test_get_path_at_depth(
         repo: OnyoRepo, paths: str, depth: str | None,
         expected: int) -> None:
     r"""
-    Test that `onyo get --path x --depth y` retrieves the expected assets by
+    Test that `onyo get --include x --depth y` retrieves the expected assets by
     ensuring that `depth` is assessed relative to the given paths.
 
     A portion of the parameters tests the usage of path with the default
     value of depth, when no depth is specified.
     """
     cmd = ['onyo', 'get', '-H']
-    cmd += ['--path', *paths] if paths else []
+    cmd += ['--include', *paths] if paths else []
     cmd += ['--depth', depth] if depth else []
     ret = subprocess.run(cmd, capture_output=True, text=True)
     output = [output.split('\t') for output in ret.stdout.split('\n')][:-1]
@@ -445,10 +445,10 @@ def test_get_path_at_depth(
     'def/ghi'])
 def test_get_path_error(repo: OnyoRepo, path: str) -> None:
     r"""
-    Test that `onyo get --path x --depth y` returns an exception if an invalid
+    Test that `onyo get --include x --depth y` returns an exception if an invalid
     path is being used
     """
-    cmd = ['onyo', 'get', '--path', path, '-H']
+    cmd = ['onyo', 'get', '--include', path, '-H']
     ret = subprocess.run(cmd, capture_output=True, text=True)
     assert f"The following paths are not part of the inventory:\n{repo.git.root / path}" in ret.stderr
     assert ret.returncode == 2

--- a/onyo/cli/unset.py
+++ b/onyo/cli/unset.py
@@ -51,7 +51,7 @@ Remove a key from an asset:
 
 .. code:: shell
 
-    $ onyo unset --keys USB_A --path accounting/Bingo\ Bob/laptop_apple_macbook.oiw629
+    $ onyo unset --keys USB_A --asset accounting/Bingo\ Bob/laptop_apple_macbook.oiw629
 
 Remove a key from all laptops:
 

--- a/onyo/shell_completion/zsh/_onyo
+++ b/onyo/shell_completion/zsh/_onyo
@@ -110,13 +110,15 @@ _onyo() {
             get)
                 args+=(
                     '(- : *)'{-h,--help}'[show this help message and exit]'
-                    '(-H --machine-readable)'{-H,--machine-readable}'[display assets separated by new lines and keys by tabs]'
+                    '(-d --depth)'{-d,--depth}'[descend up to DEPTH levels into directories]:DEPTH: '
                     '(-k --keys)'{-k,--keys}'[key values to return]:*-*:KEYS: '
+                    '(-H --machine-readable)'{-H,--machine-readable}'[display assets separated by new lines and keys by tabs]'
+                    '(-M --match)'{-M,--match}'[criteria to match assets in the form '\''KEY=VALUE'\'', where VALUE is a python regular expression]:*-*:MATCH: '
+                    '(-i --include)'{-i,--include}'[assets or directories to include in the query]:*-*:PATH:_files -W "$(_onyo_dir)"'
+                    '(-e --exclude)'{-e,--exclude}'[assets or directories to exclude from the query]:*-*:PATH:_files -W "$(_onyo_dir)"'
                     '(-p --path)'{-p,--path}'[assets or directories to search through]:*-*:PATH:_files -W "$(_onyo_dir)"'
                     '(-s --sort-ascending -S --sort-descending)'{-s,--sort-ascending}'[sort output in ascending order]'
                     '(-S --sort-descending -s --sort-ascending)'{-S,--sort-descending}'[sort output in descending order]'
-                    '(-d --depth)'{-d,--depth}'[descend up to DEPTH levels into directories]:DEPTH: '
-                    '(-M --match)'{-M,--match}'[criteria to match assets in the form '\''KEY=VALUE'\'', where VALUE is a python regular expression]:*-*:MATCH: '
                 )
                 ;;
             history)

--- a/onyo/shell_completion/zsh/_onyo
+++ b/onyo/shell_completion/zsh/_onyo
@@ -116,7 +116,6 @@ _onyo() {
                     '(-M --match)'{-M,--match}'[criteria to match assets in the form '\''KEY=VALUE'\'', where VALUE is a python regular expression]:*-*:MATCH: '
                     '(-i --include)'{-i,--include}'[assets or directories to include in the query]:*-*:PATH:_files -W "$(_onyo_dir)"'
                     '(-e --exclude)'{-e,--exclude}'[assets or directories to exclude from the query]:*-*:PATH:_files -W "$(_onyo_dir)"'
-                    '(-p --path)'{-p,--path}'[assets or directories to search through]:*-*:PATH:_files -W "$(_onyo_dir)"'
                     '(-s --sort-ascending -S --sort-descending)'{-s,--sort-ascending}'[sort output in ascending order]'
                     '(-S --sort-descending -s --sort-ascending)'{-S,--sort-descending}'[sort output in descending order]'
                 )

--- a/onyo/tests/test_usecases.py
+++ b/onyo/tests/test_usecases.py
@@ -53,7 +53,7 @@ def test_workflow_cli(repo: OnyoRepo) -> None:
     assert ret.returncode == 0
 
     # 2b. Check the warehouse for a display
-    cmd = ['onyo', 'get', '--path', 'warehouse', '--machine-readable', '--match', 'type=monitor', "display=22.0"]
+    cmd = ['onyo', 'get', '--include', 'warehouse', '--machine-readable', '--match', 'type=monitor', "display=22.0"]
     ret = subprocess.run(cmd, capture_output=True, text=True)
     assert ret.returncode == 0
     monitor = Path(ret.stdout.splitlines()[0].split('\t')[-1])
@@ -94,7 +94,7 @@ def test_workflow_cli(repo: OnyoRepo) -> None:
 
     # 4. Member switches workgroup
     # 4a. Member left display behind -> assign to their former group
-    cmd = ['onyo', 'get', '--machine-readable', '--path', str(member), '--match', 'type=monitor']
+    cmd = ['onyo', 'get', '--machine-readable', '--include', str(member), '--match', 'type=monitor']
     ret = subprocess.run(cmd, capture_output=True, text=True)
     assert ret.returncode == 0
     display = Path(ret.stdout.splitlines()[0].split('\t')[-1])
@@ -128,7 +128,7 @@ def test_workflow_cli(repo: OnyoRepo) -> None:
 
     # 7. Member leaves institute
     # 7a. Retire laptop
-    cmd = ['onyo', 'get', '--machine-readable', '--path', str(member), '--match', "type=laptop"]
+    cmd = ['onyo', 'get', '--machine-readable', '--include', str(member), '--match', "type=laptop"]
     ret = subprocess.run(cmd, capture_output=True, text=True)
     assert ret.returncode == 0
     laptop = Path(ret.stdout.splitlines()[0].split('\t')[-1])
@@ -143,7 +143,7 @@ def test_workflow_cli(repo: OnyoRepo) -> None:
 
     #  QUERIES
     # 1. What is available in the warehouse?
-    cmd = ['onyo', 'get', '--machine-readable', '--path', 'warehouse']
+    cmd = ['onyo', 'get', '--machine-readable', '--include', 'warehouse']
     ret = subprocess.run(cmd, capture_output=True, text=True)
     assert ret.returncode == 0
     # warehouse was prefilled with 6 assets. We previously took one display out.
@@ -172,7 +172,7 @@ def test_workflow_cli(repo: OnyoRepo) -> None:
     assert len(ret.stdout.splitlines()) == 3
 
     # 5. Find all lenovo laptops used in a workgroup
-    cmd = ['onyo', 'get', '--machine-readable', '--path', 'somegroup', '--match', 'make=lenovo']
+    cmd = ['onyo', 'get', '--machine-readable', '--include', 'somegroup', '--match', 'make=lenovo']
     ret = subprocess.run(cmd, capture_output=True, text=True)
     assert ret.returncode == 0
     # 'somegroup' got an apple and a lenovo from the start;


### PR DESCRIPTION
This PR
- fixes some outdated docs (in general, I'm leaving RTD alone for now, as it's so out of date)
- drops `onyo get --path`; it was an alias for `onyo get --include`
  - it made the CLI feel inconsistent, and was confusing
- adds `--include` and `--exclude` to `onyo get`'s tab completion (somehow overlooked)