### PR TITLE
TST: flake8 -> ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,8 +1,0 @@
-[flake8]
-ignore =
-    # E501: Line too long (82 > 79 characters)
-    E501,
-    # W504: Line break occurred after a binary operator
-    W504,
-exclude =
-    build/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,9 +29,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e ".[tests]"
         sudo apt-get install -y zsh
-    - name: flake8 linting
+    - name: ruff linting
       run: |
-        flake8
+        ruff check
     - name: Pyre type-checking
       run: |
         pyre --noninteractive check

--- a/onyo/lib/tests/test_commands_mkdir.py
+++ b/onyo/lib/tests/test_commands_mkdir.py
@@ -83,7 +83,7 @@ def test_onyo_mkdir_errors_before_mkdir(inventory: Inventory) -> None:
     # no new directory/anchor was created
     assert not dir_path_new.is_dir()
     assert not (dir_path_new / OnyoRepo.ANCHOR_FILE_NAME).is_file()
-    assert not (dir_path_new / OnyoRepo.ANCHOR_FILE_NAME) in inventory.repo.git.files
+    assert not (dir_path_new / OnyoRepo.ANCHOR_FILE_NAME) in inventory.repo.git.files  # noqa: E713
     # no commit was added
     assert inventory.repo.git.get_hexsha() == old_hexsha
     assert inventory.repo.git.is_clean_worktree()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,11 +31,11 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 tests = [
-    'flake8',
     'pyre-check',
     'pytest',
     'pytest-cov',
-    'pytest-randomly'
+    'pytest-randomly',
+    'ruff',
 ]
 docs = [
     'sphinx',
@@ -58,3 +58,13 @@ version_file = "onyo/_version.py"
 
 [tool.setuptools.packages]
 find = {}  # Scanning implicit namespaces is active by default
+
+[tool.ruff]
+exclude = ["build/"]
+# E501: Line too long (82 > 79 characters)
+lint.ignore = ["E501"]
+lint.select = [
+    "E",
+    "F",
+    "W",
+]


### PR DESCRIPTION
[ruff](https://docs.astral.sh/ruff/) is a drop-in replacement for just about all Python linters.

It's blazingly fast (not an overstatement), and supports [far more rules](https://docs.astral.sh/ruff/rules/) than flake8.

This is a naive migration from flake8. More checks can be enabled as we see fit.

There is a github action for `ruff`. I didn't se the advantage of using it.