### PR TITLE
TST: add benchmarking and Faker support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 onyo/_version.py
 docs/source/onyo.*.rst
+.benchmarks/
 .coverage
+.pyre/
+.pytest_cache/
 build/
 __pycache__
 *egg-info
-.pyre

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,18 @@ flake8
 pyre check
 ```
 
+### Benchmarks
+
+Benchmarks use pytest-benchmark.
+```bash
+pytest -p no:randomly -p no:cov --benchmark-autosave --benchmark-time-unit=s --benchmark-max-time=5 --benchmark-min-rounds=5 --benchmark-sort=name --benchmark-group-by=func --benchmark-columns=min,max,mean,stddev,median,rounds -vv onyo/tests/benchmark.py
+```
+To compare to previous runs:
+```
+pytest-benchmark compare .benchmarks/[...] [...]
+```
+
+
 ### Building documentation
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,9 +62,9 @@ REPO_ROOT=$PWD pytest -vv --cov
 
 ### Linting and type checking
 
-Linting uses both flake8 and Pyre.
+Linting uses both ruff and Pyre.
 ```bash
-flake8
+ruff check
 pyre check
 ```
 
@@ -91,7 +91,7 @@ Navigate to <file:///<repo_dir>/docs/build/html/index.html>
 ## Code Conventions
 
 Onyo follows a set of development and coding conventions throughout its code
-base. For linting and type checking, Onyo uses flake8 and Pyre. The following
+base. For linting and type checking, Onyo uses ruff and Pyre. The following
 sections describe conventions followed in this project, additionally to the
 [PEP 8 Style Guide](https://peps.python.org/pep-0008/).
 

--- a/onyo/conftest.py
+++ b/onyo/conftest.py
@@ -252,7 +252,17 @@ def helpers() -> Type[Helpers]:
 
 
 @pytest.fixture(scope='function', autouse=True)
-def set_ui(request) -> None:
+def set_ui_function(request) -> None:
+    r"""Set up onyo.lib.ui according to a dict provided by the 'ui' marker"""
+    from onyo.lib.ui import ui
+    m = request.node.get_closest_marker('ui')
+    if m:
+        ui.set_yes(m.args[0].get('yes', False))
+        ui.set_quiet(m.args[0].get('quiet', False))
+        ui.set_debug(m.args[0].get('debug', False))
+
+@pytest.fixture(scope='class', autouse=True)
+def set_ui_class(request) -> None:
     r"""Set up onyo.lib.ui according to a dict provided by the 'ui' marker"""
     from onyo.lib.ui import ui
     m = request.node.get_closest_marker('ui')

--- a/onyo/conftest.py
+++ b/onyo/conftest.py
@@ -280,7 +280,7 @@ class OnyoProvider(python.Provider):
                          num: int = 1,
                          override: dict | None = None) -> Generator[dict, None, None]:
         r"""
-        Yield asset directories suitable for populating realistic assets.
+        Yield asset dictionaries suitable for populating realistic assets.
         """
         if override is None:
             override = {}

--- a/onyo/conftest.py
+++ b/onyo/conftest.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import os
 import subprocess
 from collections.abc import Iterable
+from contextlib import contextmanager
 from itertools import chain, combinations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
 from _pytest.mark.structures import MarkDecorator
+from faker.providers import python
 
 from onyo.lib.git import GitRepo
 from onyo.lib.inventory import Inventory
@@ -258,3 +260,189 @@ def set_ui(request) -> None:
         ui.set_yes(m.args[0].get('yes', False))
         ui.set_quiet(m.args[0].get('quiet', False))
         ui.set_debug(m.args[0].get('debug', False))
+
+
+class OnyoProvider(python.Provider):
+    r"""
+    Faker Provider for Onyo.
+    """
+    def onyo_asset_dicts(self,
+                         num: int = 1,
+                         override: dict | None = None) -> Generator[dict, None, None]:
+        r"""
+        Yield asset directories suitable for populating realistic assets.
+        """
+        if override is None:
+            override = {}
+
+        for _ in range(num):
+            yield {
+                'type': next(self.onyo_types()),
+                'make': next(self.onyo_manufacturers()),
+                'model': { 'name': self.numerify(text='Wizbang %##!') },
+                'serial': self.pystr(min_chars=15),
+                'keyboard': next(self.onyo_keyboards()),
+                'display': {
+                    'size': self.numerify(text='%#'),
+                    'resolution': self.numerify(text='%##! x %##!'),
+                    'hz': self.numerify(text='%#!'),
+                },
+                'RAM': self.numerify(text='%#!!G'),
+                'CPU': {
+                    'vendor': next(self.onyo_cpu_vendors()),
+                    'cores': self.numerify(text='%#!'),
+                    'arch': next(self.onyo_cpu_archs()),
+                    'model': self.numerify(text='Speedy % %%##Z'),
+                },
+                'disk': { 'size': self.numerify(text='%#!T') },
+            } | override
+
+
+    def onyo_cpu_archs(self,
+                       num: int = 1) -> Generator[str, None, None]:
+        r"""
+        Yield CPU architectures.
+        """
+        cpu_archs = (
+            'aarch64',
+            'amd64',
+            'ppc64',
+            'x86',
+        )
+        yield self.random_element(elements=cpu_archs)
+
+
+    def onyo_cpu_vendors(self,
+                         num: int = 1) -> Generator[str, None, None]:
+        r"""
+        Yield CPU vendors.
+        """
+        cpu_vendors = (
+            'amd',
+            'apple',
+            'intel',
+            'ibm',
+        )
+        yield self.random_element(elements=cpu_vendors)
+
+
+    def onyo_directories(self,
+                         num: int = 1) -> Generator[str, None, None]:
+        r"""
+        Yield directory names.
+
+        Useful for ``onyo.path.directory``.
+        """
+        locations = (
+            'repair',
+            'shelf',
+            'warehouse',
+            'group',
+            'group/Accounting',
+            'group/Creative',
+            'group/HR',
+            'group/IT',
+            'group/Operations',
+            'group/Purchasing',
+            'group/Sales',
+        )
+        for _ in range(num):
+            yield self.random_element(elements=locations)
+
+
+    def onyo_keyboards(self,
+                       num: int = 1) -> Generator[str, None, None]:
+        r"""
+        Yield keyboard layout names.
+        """
+        keyboards = (
+            'azerty',
+            'qwerty',
+            'qwertz',
+            'qzerty',
+            'qüerty',
+            'ąžerty',
+        )
+        yield self.random_element(elements=keyboards)
+
+
+    def onyo_manufacturers(self,
+                           num: int = 1) -> Generator[str, None, None]:
+        r"""
+        Yield manufacturers.
+        """
+        manufacturers = (
+            'apple',
+            'asus',
+            'cisco',
+            'dell',
+            'eizo',
+            'framework',
+            'hp',
+            'lenovo',
+            'samsung',
+            'sun',
+            'toshiba',
+            'zebra',
+        )
+        yield self.random_element(elements=manufacturers)
+
+
+    def onyo_types(self,
+                   num: int = 1) -> Generator[str, None, None]:
+        r"""
+        Yield asset types.
+        """
+        types = (
+            'desktop',
+            'display',
+            'laptop',
+            'pdu',
+            'server',
+            'switch',
+            'ups',
+        )
+        yield self.random_element(elements=types)
+
+
+@pytest.fixture(scope="session")
+def fixture_fake() -> Generator:
+    r"""
+    Yield a faker object with the Onyo Provider loaded.
+
+    Onyo-specific functions are all prefixed with ``onyo_``.
+    """
+    from faker import Faker
+
+    _fake = Faker()
+    _fake.add_provider(OnyoProvider)
+    yield _fake
+
+
+@contextmanager
+def _context_for_fixture(val_to_yield_after_setup):
+    yield val_to_yield_after_setup
+
+
+@pytest.fixture(scope='function', name='fake')
+def fake_function_scope(fixture_fake):
+    with _context_for_fixture(fixture_fake) as result:
+        yield result
+
+
+@pytest.fixture(scope='class')
+def fake_class_scope(fixture_fake):
+    with _context_for_fixture(fixture_fake) as result:
+        yield result
+
+
+@pytest.fixture(scope='module')
+def fake_module_scope(fixture_fake):
+    with _context_for_fixture(fixture_fake) as result:
+        yield result
+
+
+@pytest.fixture(scope='session')
+def fake_session_scope(fixture_fake):
+    with _context_for_fixture(fixture_fake) as result:
+        yield result

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -148,7 +148,7 @@ def fsck(repo: OnyoRepo,
 
 @raise_on_inventory_state
 def onyo_cat(inventory: Inventory,
-             paths: list[Path]) -> None:
+             assets: list[Path]) -> None:
     r"""Print the contents of assets.
 
     The same asset can be given multiple times.
@@ -160,7 +160,7 @@ def onyo_cat(inventory: Inventory,
     ----------
     inventory
         The inventory containing the assets to print.
-    paths
+    assets
         Paths of assets to print the contents of.
 
     Raises
@@ -176,18 +176,18 @@ def onyo_cat(inventory: Inventory,
     from onyo.lib.onyo import OnyoRepo
     from onyo.lib.utils import validate_yaml
 
-    if not paths:
+    if not assets:
         raise ValueError("At least one asset must be specified.")
 
-    non_asset_paths = [str(p) for p in paths if not inventory.repo.is_asset_path(p)]
+    non_asset_paths = [str(a) for a in assets if not inventory.repo.is_asset_path(a)]
     if non_asset_paths:
         raise ValueError("The following paths are not assets:\n%s" %
                          "\n".join(non_asset_paths))
 
-    files = list(p / OnyoRepo.ASSET_DIR_FILE_NAME
-                 if inventory.repo.is_asset_dir(p)
-                 else p
-                 for p in paths)
+    files = list(a / OnyoRepo.ASSET_DIR_FILE_NAME
+                 if inventory.repo.is_asset_dir(a)
+                 else a
+                 for a in assets)
     # open file and print to stdout
     for f in files:
         asset_text = f.read_text()

--- a/onyo/lib/git.py
+++ b/onyo/lib/git.py
@@ -343,7 +343,7 @@ class GitRepo(object):
         if short:
             cmd.append('--short')
         try:
-            return self._git(cmd)
+            return self._git(cmd).strip()
         except subprocess.CalledProcessError:
             if commitish is None:
                 return None

--- a/onyo/lib/tests/test_commands_cat.py
+++ b/onyo/lib/tests/test_commands_cat.py
@@ -18,51 +18,51 @@ def test_onyo_cat_errors(inventory: Inventory) -> None:
     pytest.raises(ValueError,
                   onyo_cat,
                   inventory,
-                  paths=[])
+                  assets=[])
 
     # cat on dir
     pytest.raises(ValueError,
                   onyo_cat,
                   inventory,
-                  paths=[dir_path])
+                  assets=[dir_path])
 
     # cat on non-existing file
     pytest.raises(ValueError,
                   onyo_cat,
                   inventory,
-                  paths=[dir_path / "does_not_exi.st"])
+                  assets=[dir_path / "does_not_exi.st"])
 
     # cat on untracked file
     pytest.raises(ValueError,
                   onyo_cat,
                   inventory,
-                  paths=[inventory.root / "untracked" / "file"])
+                  assets=[inventory.root / "untracked" / "file"])
 
     # cat on path outside onyo repository
     pytest.raises(ValueError,
                   onyo_cat,
                   inventory,
-                  paths=[inventory.root / ".."])
+                  assets=[inventory.root / ".."])
 
     # one of multiple is non-existing
     pytest.raises(ValueError,
                   onyo_cat,
                   inventory,
-                  paths=[asset_path,
-                         inventory.root / "doesnotexist",
-                         asset_path])
+                  assets=[asset_path,
+                          inventory.root / "doesnotexist",
+                          asset_path])
 
     # cat on .anchor
     pytest.raises(ValueError,
                   onyo_cat,
                   inventory,
-                  paths=[dir_path / OnyoRepo.ANCHOR_FILE_NAME])
+                  assets=[dir_path / OnyoRepo.ANCHOR_FILE_NAME])
 
     # cat on a template file
     pytest.raises(ValueError,
                   onyo_cat,
                   inventory,
-                  paths=[inventory.repo.dot_onyo / "templates" / "laptop.example"])
+                  assets=[inventory.repo.dot_onyo / "templates" / "laptop.example"])
 
     # cat on a file that is in the inventory, but has invalid YAML contents
     invalid_path = inventory.root / "in_va_l.id"
@@ -73,7 +73,7 @@ def test_onyo_cat_errors(inventory: Inventory) -> None:
     pytest.raises(InvalidAssetError,
                   onyo_cat,
                   inventory,
-                  paths=[invalid_path])
+                  assets=[invalid_path])
 
 
 @pytest.mark.ui({'yes': True})
@@ -84,7 +84,7 @@ def test_onyo_cat_single(inventory: Inventory,
 
     # cat single asset
     onyo_cat(inventory,
-             paths=[asset_path])
+             assets=[asset_path])
 
     # verify asset contents are in output
     assert Path.read_text(asset_path) in capsys.readouterr().out
@@ -110,8 +110,8 @@ def test_onyo_cat_multiple(inventory: Inventory,
 
     # cat multiple assets at once
     onyo_cat(inventory,
-             paths=[asset_path1,
-                    asset_path2])
+             assets=[asset_path1,
+                     asset_path2])
 
     # verify the output contains both assets
     out = capsys.readouterr().out
@@ -127,9 +127,9 @@ def test_onyo_cat_with_duplicate_path(inventory: Inventory,
 
     # cat single asset
     onyo_cat(inventory,
-             paths=[asset_path, asset_path, asset_path])
+             assets=[asset_path, asset_path, asset_path])
 
-    # verify output contains the asset contents once for each time the asset is in `paths`
+    # verify output contains the asset contents once for each time the asset is in `assets`
     assert capsys.readouterr().out.count(Path.read_text(asset_path)) == 3
 
 

--- a/onyo/lib/tests/test_git.py
+++ b/onyo/lib/tests/test_git.py
@@ -237,6 +237,8 @@ def test_GitRepo_get_subtrees(gitrepo) -> None:
 
 
 def test_GitRepo_get_hexsha(gitrepo) -> None:
+    import string
+
     # empty repo yields no hexsha:
     assert gitrepo.get_hexsha() is None
     # unknown commit-ish raises ValueError:
@@ -249,8 +251,10 @@ def test_GitRepo_get_hexsha(gitrepo) -> None:
     # There actually is a commit now:
     sha = gitrepo.get_hexsha()
     assert isinstance(sha, str)
-    # TODO: Add proper length assumption
-    #       -> also: short
+    # full sha is always returned
+    assert len(sha) == 40
+    # only hex characters used
+    assert all(c in string.hexdigits for c in sha)
 
     # Default is HEAD
     assert sha == gitrepo.get_hexsha('HEAD')

--- a/onyo/tests/benchmark.py
+++ b/onyo/tests/benchmark.py
@@ -1,0 +1,208 @@
+import random
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from onyo.lib.commands import (
+        onyo_cat,
+        onyo_get,
+        onyo_new,
+        onyo_set,
+    )
+from onyo.lib.inventory import Inventory
+from onyo.lib.onyo import OnyoRepo
+from onyo.lib.utils import DotNotationWrapper
+
+
+@pytest.mark.ui({'yes': True, 'quiet': True})
+@pytest.mark.parametrize('num', [100, 1000])
+class TestOnyoBenchmark:
+    @pytest.fixture(scope='function')
+    def benchmark_inventory(self,
+                            num: int,
+                            request,
+                            tmp_path: Path,
+                            fake,
+                            monkeypatch):
+
+        repo_path = tmp_path
+
+        if not getattr(request.cls, '_class_repo_path', False):
+            request.cls._class_repo_path = {}
+        if not getattr(request.cls, '_class_old_hexsha', False):
+            request.cls._class_old_hexsha = {}
+
+        class_repo_path = request.cls._class_repo_path.get(num, False)
+        if class_repo_path:
+            # clone existing repo
+            subprocess.run(['git', 'clone', str(class_repo_path), str(repo_path)])
+
+            repo = OnyoRepo(repo_path)
+            inventory = Inventory(repo=repo)
+        else:
+            # initialize new repo
+            repo = OnyoRepo(repo_path, init=True)
+            repo.set_config("onyo.assets.name-format", "{type}_{make}_{model.name}.{serial}")
+            repo.git.commit(repo.git.root / repo.ONYO_CONFIG, message="Asset name config w/ dot")
+            inventory = Inventory(repo=repo)
+
+            # populate the repo
+            assets = [DotNotationWrapper(a) for a in fake.onyo_asset_dicts(num=num)]
+            directories = fake.onyo_directories(num=num)
+            assets = [a | {'directory': d} for a, d in zip(assets, directories)]
+            onyo_new(inventory, keys=assets)  # pyre-ignore[6]
+
+            # store location of repo dir
+            request.cls._class_repo_path[num] = repo_path
+            # store pre-benchmark sha
+            request.cls._class_old_hexsha[num] = inventory.repo.git.get_hexsha()
+
+        # cd into the repo dir
+        monkeypatch.chdir(repo_path)
+
+        # reset to a known state (no leftovers from other benchmark runs)
+        subprocess.run(['git', 'reset', '--hard', request.cls._class_old_hexsha[num]])
+
+        # yield
+        yield inventory
+
+
+    def test_cli_onyo_new_fifty(self,
+                                num: int,
+                                benchmark_inventory: Inventory,
+                                benchmark,
+                                fake) -> None:
+        r"""Create 50 assets in the repo."""
+        inventory = benchmark_inventory
+        # fifty additional assets
+        fifty_assets = [DotNotationWrapper(a) for a in fake.onyo_asset_dicts(num=50)]
+        fifty_assets_as_keys = [f'{k}={v}' for a in fifty_assets for k, v in a.items()]
+
+        def setup():
+            """
+            Benchmark in a consistent-state repo.
+
+            The benchmarked function is run multiple times, but without re-running
+            the entire test function. This can create conflicts, etc.
+            """
+            inventory.repo.git._git(["reset", "--hard", self._class_old_hexsha[num]])
+            # gc the repo
+            inventory.repo.git._git(["gc", "--aggressive", "--quiet", "--prune=now"])
+
+        benchmark.pedantic(subprocess.run,
+                           args=[['onyo', '--yes', 'new', '--keys', *fifty_assets_as_keys]],
+                           kwargs={'capture_output': True, 'check': True},
+                           rounds=5,  # does not honor CLI flag values
+                           setup=setup)
+
+        # sanity checks
+        assert len(onyo_get(inventory)) == (num + 50)
+
+
+    def test_cli_onyo_get_all(self,
+                              num: int,
+                              benchmark_inventory: Inventory,
+                              benchmark) -> None:
+        r"""Get all assets in the repo."""
+        inventory = benchmark_inventory
+
+        # Per default, this will return all keys in the asset name + path and
+        # sort by path.
+        @benchmark
+        def bench():
+            subprocess.run(["onyo", "get"], capture_output=True, check=True)
+
+        # sanity checks
+        assert len(onyo_get(inventory)) == num
+
+
+    def test_cli_onyo_get_fifty(self,
+                                num: int,
+                                benchmark_inventory: Inventory,
+                                benchmark) -> None:
+        r"""Get 50 assets from the repo."""
+        from onyo.lib.filters import Filter
+
+        inventory = benchmark_inventory
+        # get 50 random assets
+        assets = [a['path'].resolve() for a in random.sample(onyo_get(inventory), k=50)]
+        # set 50
+        onyo_set(inventory, assets=assets, keys={'fifty': 'fifty'})
+
+        # Per default, this will return all keys in the asset name + path and
+        # sort by path.
+        @benchmark
+        def bench():
+            subprocess.run(["onyo", "get", '--match', 'fifty=fifty'], capture_output=True, check=True)
+
+        # sanity checks
+        assert len(onyo_get(inventory)) == num
+        filters = [Filter('fifty=fifty').match]
+        assert len(onyo_get(inventory, match=filters)) == 50  # pyre-ignore[6]
+
+
+    def test_cli_onyo_set_fifty(self,
+                                num: int,
+                                benchmark_inventory: Inventory,
+                                benchmark) -> None:
+        r"""Set 50 assets in the repo."""
+        from onyo.lib.filters import Filter
+
+        inventory = benchmark_inventory
+        # get 50 assets
+        assets = [str(a['path'].resolve()) for a in random.sample(onyo_get(inventory), k=50)]
+
+        def setup():
+            """
+            Benchmark in a consistent-state repo.
+
+            The benchmarked function is run multiple times, but without re-running
+            the entire test function. This can create conflicts, etc.
+            """
+            inventory.repo.git._git(["reset", "--hard", self._class_old_hexsha[num]])
+            # gc the repo
+            inventory.repo.git._git(["gc", "--aggressive", "--quiet", "--prune=now"])
+
+        benchmark.pedantic(subprocess.run,
+                           args=[['onyo', '--yes', 'set', '--keys', 'fifty=fifty', '--asset', *assets]],
+                           kwargs={'capture_output': True, 'check': True},
+                           rounds=5,  # does not honor CLI flag values
+                           setup=setup)
+
+        # sanity checks
+        assert len(onyo_get(inventory)) == num
+        filters = [Filter('fifty=fifty').match]
+        assert len(onyo_get(inventory, match=filters)) == 50  # pyre-ignore[6]
+
+
+    def test_api_onyo_cat_one(self,
+                              num: int,
+                              benchmark_inventory: Inventory,
+                              benchmark) -> None:
+        r"""Cat 1 asset in the repo."""
+        inventory = benchmark_inventory
+        # get 1 asset
+        assets = [a['path'].resolve() for a in random.sample(onyo_get(inventory), k=1)]
+
+        benchmark(onyo_cat, inventory, assets=assets)
+
+        # sanity checks
+        assert len(onyo_get(inventory)) == num
+
+
+    def test_cli_onyo_cat_one(self,
+                              num: int,
+                              benchmark_inventory: Inventory,
+                              benchmark) -> None:
+        r"""Cat 1 asset from the CLI."""
+        inventory = benchmark_inventory
+        # get 1 asset
+        asset = random.sample(onyo_get(inventory), k=1)[0]['path'].resolve()
+
+        @benchmark
+        def bench():
+            subprocess.run(["onyo", "cat", str(asset)], capture_output=True, check=True)
+
+        # sanity checks
+        assert len(onyo_get(inventory)) == num

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ tests = [
     'Faker',
     'pyre-check',
     'pytest',
+    'pytest-benchmark',
     'pytest-cov',
     'pytest-randomly',
     'ruff',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 tests = [
+    'Faker',
     'pyre-check',
     'pytest',
     'pytest-cov',


### PR DESCRIPTION
The core motivation for this PR is to add some benchmarks ~~and test out CodSpeed to see if it's a reasonable fit for us~~.

~~If not, the benchmarks are still useful, but we'll go back to vanilla pytest-benchmark. Codspeed is mostly compatible, until it isn't. For example, it does not support `pendantic`, which is a loss.~~

Generating large, representative repos led me to finally add Faker support. I hope/plan to use this for more tests that require populated repos, rather than our current verbose, hard-coded mess.

This PR also:
- fixes a bug in `git.get_hexsha()`
- fixes a documentation bug WRT flake8->ruff
- normalizes `onyo_cat()`'s arguments to match other onyo functions.

Fixes:
- #224 
- #254

I encountered numerous bugs around pytest fixture scoping, parametrization, indirect parametrization, and referring to the parent class.

As a result, I hack a class-level cache through a function-scoped fixture. I would like to to this differently, with a class-level fixture populating and function-level fixture cloning, but this was not to be.

I also setup Faker with fixtures for each scope. We may not use this, in which case we can remove it. But I wanted to include it for now so we have a history of it in the repo, and it may in fact turn out to be of use.