### PR TITLE
New pseudo-keys:  Part I

### DIFF
--- a/onyo/cli/get.py
+++ b/onyo/cli/get.py
@@ -160,11 +160,11 @@ def get(args: argparse.Namespace) -> None:
     In addition to keys in asset contents, **PSEUDO-KEYS** can be queried and
     matched.
 
-      * ``is_asset_directory``: is the asset an Asset Directory
-      * ``directory``: parent directory of the asset relative to repo root
-      * ``path``: path of the asset relative to repo root
+      * ``onyo.is.directory``: is the asset an Asset Directory
+      * ``onyo.path.parent`` (default alias: ``directory``): parent directory of the asset relative to repo root
+      * ``onyo.path.relative`` (default alias: ``path``): path of the asset relative to repo root
 
-    By default, the results are sorted by ``path``.
+    By default, the results are sorted by ``onyo.path.relative``.
     """
     includes = [Path(p).resolve() for p in args.include] if args.include else [Path.cwd()]
     excludes = [Path(p).resolve() for p in args.exclude] if args.exclude else None

--- a/onyo/cli/new.py
+++ b/onyo/cli/new.py
@@ -165,7 +165,7 @@ def new(args: argparse.Namespace) -> None:
 
       * ``directory``: directory to create the asset in relative to the root of
         the repository. This key cannot be used with the ``--directory`` flag.
-      * ``is_asset_directory``: whether to create the asset as an Asset
+      * ``onyo.is.directory``: whether to create the asset as an Asset
         Directory.  Default is ``false``.
       * ``template``: which template to use for the asset. This key cannot be
         used with the ``--clone`` or ``--template`` flags.

--- a/onyo/cli/set.py
+++ b/onyo/cli/set.py
@@ -76,7 +76,7 @@ Change an Asset File to an Asset Directory:
 
 .. code:: shell
 
-    $ onyo set --keys is_asset_directory=true --asset accounting/Bingo\ Bob/laptop_lenovo_T490s.abc123
+    $ onyo set --keys onyo.is.directory=true --asset accounting/Bingo\ Bob/laptop_lenovo_T490s.abc123
 """
 
 
@@ -89,7 +89,7 @@ def set(args: argparse.Namespace) -> None:
 
     In addition to keys in asset contents, some PSEUDO-KEYS can be set:
 
-      * ``is_asset_directory``: boolean to control whether the asset is an
+      * ``onyo.is.directory``: boolean to control whether the asset is an
         Asset Directory.
 
     The contents of all modified assets are checked for validity before

--- a/onyo/cli/tests/test_get.py
+++ b/onyo/cli/tests/test_get.py
@@ -133,7 +133,7 @@ def test_get_defaults(repo: OnyoRepo) -> None:
     r"""Test `onyo get` using default values"""
     cmd = ['onyo', 'get']
     ret = subprocess.run(cmd, capture_output=True, text=True)
-    keys = ['type', 'make', 'model.name', 'serial', 'path']
+    keys = ['type', 'make', 'model.name', 'serial', 'onyo.path.relative']
     assert 'laptop_apple_macbookpro.1' in ret.stdout
     assert 'laptop_dell_precision.2' in ret.stdout
     assert 'headphones_apple_pro.3' in ret.stdout
@@ -162,7 +162,7 @@ def test_get_all(
     """
     keys = keys if keys else repo.get_asset_name_keys()
     cmd = ['onyo', 'get', '--include', *paths, '--depth', depth]
-    cmd += ['--keys', *keys + ["path"]] if keys else []
+    cmd += ['--keys', *keys + ["onyo.path.relative"]] if keys else []
     cmd += ['--match', *matches] if matches else []
     cmd += [machine_readable] if machine_readable else []
     ret = subprocess.run(cmd, capture_output=True, text=True)
@@ -300,10 +300,10 @@ def test_get_filter_errors(repo: OnyoRepo, matches: list[str]) -> None:
                                                      'laptop_dell_precision.2',
                                                      'headphones_apple_pro.3']]])
 @pytest.mark.parametrize('keys', [
-    ['type', 'make', 'model.name', 'serial', 'path'],
-    ['unset', 'type', 'unset2', 'make', 'path'],
-    ['num', 'str', 'bool', 'path'],
-    ['TyPe', 'MAKE', 'moDEL', 'NuM', 'STR', 'path'],
+    ['type', 'make', 'model.name', 'serial', 'onyo.path.relative'],
+    ['unset', 'type', 'unset2', 'make', 'onyo.path.relative'],
+    ['num', 'str', 'bool', 'onyo.path.relative'],
+    ['TyPe', 'MAKE', 'moDEL', 'NuM', 'STR', 'onyo.path.relative'],
     []])
 def test_get_keys(
         repo: OnyoRepo, raw_assets: list[tuple[str, dict[str, Any]]],
@@ -311,7 +311,7 @@ def test_get_keys(
     r"""
     Test that `onyo get --keys x y z` retrieves the expected keys.
     """
-    from onyo.lib.consts import PSEUDO_KEYS
+    from onyo.lib.pseudokeys import PSEUDO_KEYS
     cmd = ['onyo', 'get', '-H']
     cmd += ['--keys', *keys, ] if keys else []
     ret = subprocess.run(cmd, capture_output=True, text=True)
@@ -319,7 +319,7 @@ def test_get_keys(
 
     # Asset name keys returned if no keys were specified
     if not keys:
-        keys = repo.get_asset_name_keys() + ["path"]
+        keys = repo.get_asset_name_keys() + ["onyo.path.relative"]
 
     # Get all the key values and make sure they match
     for line in output:

--- a/onyo/cli/tests/test_set.py
+++ b/onyo/cli/tests/test_set.py
@@ -441,7 +441,7 @@ def test_set_empty_dictlist(repo: OnyoRepo, asset: str) -> None:
     assert "new:" in ret.stdout
     assert "dict: {}" in ret.stdout
     assert "list: []" in ret.stdout
-    ret = subprocess.run(['onyo', 'get', '--keys', 'path', '--match', 'new.dict={}', 'new.list=[]'],
+    ret = subprocess.run(['onyo', 'get', '-H', '--keys', 'path', '--match', 'new.dict={}', 'new.list=[]'],
                          capture_output=True, text=True)
     assert ret.returncode == 0
     assert not ret.stderr
@@ -458,12 +458,12 @@ def test_set_empty_dictlist(repo: OnyoRepo, asset: str) -> None:
     assert "list: {}" in ret.stdout
 
     # we swapped the keys, so old matching criterion should NOT work:
-    ret = subprocess.run(['onyo', 'get', '--keys', 'path', '--match', 'new.dict={}', 'new.list=[]'],
+    ret = subprocess.run(['onyo', 'get', '-H', '--keys', 'path', '--match', 'new.dict={}', 'new.list=[]'],
                          capture_output=True, text=True)
     assert ret.returncode == 1
 
     # correct query
-    ret = subprocess.run(['onyo', 'get', '--keys', 'path', '--match', 'new.dict=[]', 'new.list={}'],
+    ret = subprocess.run(['onyo', 'get', '-H', '--keys', 'path', '--match', 'new.dict=[]', 'new.list={}'],
                          capture_output=True, text=True)
     assert ret.returncode == 0
     assert not ret.stderr

--- a/onyo/lib/command_utils.py
+++ b/onyo/lib/command_utils.py
@@ -72,13 +72,13 @@ def natural_sort(assets: list[dict | UserDict],
     """
     import locale
     import natsort
-
+    from onyo.lib.items import resolve_alias
     # set the locale for all categories to the user’s default setting
     locale.setlocale(locale.LC_ALL, '')
 
     for key in reversed(keys.keys()):
         alg = natsort.ns.LOCALE | natsort.ns.INT
-        if key == 'path':
+        if resolve_alias(key).startswith('onyo.path'):
             alg |= natsort.ns.PATH
         assets = sorted(assets,
                         key=natsort.natsort_keygen(key=lambda x: x.get(key), alg=alg),

--- a/onyo/lib/consts.py
+++ b/onyo/lib/consts.py
@@ -1,20 +1,16 @@
 from collections import UserDict
 from typing import TYPE_CHECKING
+
+from onyo.lib.pseudokeys import PSEUDOKEY_ALIASES
 if TYPE_CHECKING:
     from typing import Literal
     sort_t = Literal['ascending', 'descending']
 
 
-PSEUDO_KEYS = ['path']
-r"""Key names that are addressable but not in asset content.
-
-All ``PSEUDO_KEYS`` are reserved.
-
-See Also
---------
-RESERVED_KEYS
-"""
-RESERVED_KEYS = ['directory', 'is_asset_directory', 'template']
+RESERVED_KEYS = ['template', 'onyo'] + list(PSEUDOKEY_ALIASES.keys())
+# TODO: That's not right yet. We need all aliases and the "onyo." namespace
+# How do we deal with namespaces, though? We may want Item/DotNotationWrapper
+# to yield views based on namespaces.
 r"""Key names that are reserved and must not be part of asset content.
 
 These keys have functional meaning for Onyo. Thus they are reserved and cannot

--- a/onyo/lib/differs.py
+++ b/onyo/lib/differs.py
@@ -20,8 +20,8 @@ if TYPE_CHECKING:
 def diff_assets(asset_old: dict, asset_new: dict) -> Generator[str, None, None]:
     yield from unified_diff(dict_to_asset_yaml(asset_old).splitlines(keepends=False),
                             dict_to_asset_yaml(asset_new).splitlines(keepends=False),
-                            fromfile=str(asset_old.get('path', '')),
-                            tofile=str(asset_new.get('path', '')),
+                            fromfile=str(asset_old.get('onyo.path.absolute', '')),
+                            tofile=str(asset_new.get('onyo.path.absolute', '')),
                             lineterm="")
 
 
@@ -37,7 +37,7 @@ diff_renamed_asset = diff_assets  # This is the same, because a rename requires 
 
 def diff_moved_asset(asset_old: dict | Path, asset_new: Path) -> Generator[str, None, None]:
     # could be same. Just check isinstance?
-    yield from diff_path_change(asset_old if isinstance(asset_old, Path) else asset_old.get('path'),
+    yield from diff_path_change(asset_old if isinstance(asset_old, Path) else asset_old.get('onyo.path.absolute'),
                                 asset_new)
 
 
@@ -50,7 +50,7 @@ def differ_new_directories(repo: OnyoRepo, operands: tuple) -> Generator[str, No
 
 
 def differ_remove_assets(repo: OnyoRepo, operands: tuple) -> Generator[str, None, None]:
-    yield f"-{str(operands[0]) if isinstance(operands[0], Path) else operands[0].get('path')}"
+    yield f"-{str(operands[0]) if isinstance(operands[0], Path) else operands[0].get('onyo.path.absolute')}"
 
 
 def differ_remove_directories(repo: OnyoRepo, operands: tuple) -> Generator[str, None, None]:

--- a/onyo/lib/items.py
+++ b/onyo/lib/items.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import onyo.lib.onyo
+import onyo.lib.inventory
+import onyo.lib.pseudokeys
+from onyo.lib.utils import DotNotationWrapper
+
+
+if TYPE_CHECKING:
+    from typing import (
+        Any,
+        Mapping,
+        TypeVar,
+    )
+
+    _KT = TypeVar("_KT")  # Key type.
+    _VT = TypeVar("_VT")  # Value type.
+
+
+def resolve_alias(key: Any) -> Any:
+    """Return the target of a key alias."""
+    try:
+        return onyo.lib.pseudokeys.PSEUDOKEY_ALIASES[key]
+    except KeyError:
+        return key
+
+
+class Item(DotNotationWrapper):
+    """An Item an Inventory can potentially track.
+
+    The main purpose of this class is to attach pseudo-keys
+    and alias resolution to things that can be inventoried.
+    That's directories and YAML-files.
+
+    The initializer methods are referenced in the `PSEUDO_KEYS`
+    mapping. They are called, when a pseudo-key is first
+    accessed (see `self.__getitem__`). This allows to distinguish
+    a meaningful `None` (<unset>) from a not yet evaluated
+    pseudo-key.
+    """
+
+    def __init__(self,
+                 item: Mapping[_KT, _VT] | Path | None = None,
+                 repo: onyo.lib.onyo.OnyoRepo | None = None,
+                 **kwargs: _VT):
+        super().__init__()
+        self.repo: onyo.lib.onyo.OnyoRepo | None = repo
+        self.update(onyo.lib.pseudokeys.PSEUDO_KEYS)
+        self._path = None
+
+        if isinstance(item, Path):
+            assert item.is_absolute()  # currently no support for relative. This is how all existing code should work ATM.
+            self.update_from_path(item)
+        elif item is not None:
+            self.update(item)
+
+        if kwargs:
+            self.update(**kwargs)
+
+    def __setitem__(self, key, value):
+        key = resolve_alias(key)
+        super().__setitem__(key, value)
+
+    def __getitem__(self, key):
+        key = resolve_alias(key)
+        value = super().__getitem__(key)
+        if key in onyo.lib.pseudokeys.PSEUDO_KEYS and \
+                isinstance(value, onyo.lib.pseudokeys.PseudoKey):
+            # Value still is the pseudo-key definition.
+            # Actually load and set the response as the new value.
+            new_value = value.implementation(self)
+            self[key] = new_value
+            return new_value
+        return value
+
+    def __delitem__(self, key):
+        return super().__delitem__(resolve_alias(key))
+
+    def __contains__(self, key):
+        return super().__contains__(resolve_alias(key))
+
+    def get(self, key, default=None):
+        return super().get(resolve_alias(key), default=default)
+
+    def update_from_path(self, path: Path):
+        """Update internal dictionary from a YAML file."""
+        # TODO: Potentially account for being pointed to
+        #       a directory or an .onyoignore'd file.
+        from onyo.lib.utils import get_asset_content
+        self._path = path
+        if self['onyo.is.asset']:
+            loader = self.repo.get_asset_content if self.repo else get_asset_content
+            self.update(loader(path))
+
+    # TODO: git metadata:
+    # def fill_created(self, what: str | None):
+    #     # self.repo.git.xxx   (self.get('onyo.path.file'))
+    #     # fill in all created keys
+    #     # switch `what` -> return whatever part was requesting this
+    #     pass#raise NotImplementedError
+    #
+    # def fill_modified(self, what: str | None):
+    #     pass#raise NotImplementedError
+
+    def get_path_absolute(self):
+        """Initializer for the 'onyo.path.absolute' pseudo-key."""
+        if self.repo and self._path and self._path.name == self.repo.ASSET_DIR_FILE_NAME:
+            return self._path.parent
+        return self._path
+
+    def get_path_relative(self):
+        """Initializer for the 'onyo.path.relative' pseudo-key."""
+        if self.repo and self['onyo.path.absolute']:
+            return self['onyo.path.absolute'].relative_to(self.repo.git.root)
+        return None
+
+    def get_path_parent(self):
+        """Initializer for the 'onyo.path.parent' pseudo-key."""
+        if self.repo and self['onyo.path.absolute']:
+            return self['onyo.path.absolute'].parent.relative_to(self.repo.git.root)
+        return None
+
+    def get_path_file(self):
+        """Initializer for the 'onyo.path.file' pseudo-key."""
+        return self._path.relative_to(self.repo.git.root) if self.repo and self['onyo.is.asset'] else None
+
+    def is_asset(self) -> bool | None:
+        """Initializer for the 'onyo.is.asset' pseudo-key."""
+        if not self.repo or not self._path:
+            return None
+        return self.repo.is_asset_path(self._path)
+
+    def is_directory(self) -> bool | None:
+        """Initializer for the 'onyo.is.directory' pseudo-key."""
+        if not self.repo or not self._path:
+            return None
+        return self.repo.is_inventory_dir(self._path)
+
+    def is_template(self) -> bool | None:
+        """Initializer for the 'onyo.is.template' pseudo-key."""
+        if not self.repo or not self._path:
+            return None
+        return self.repo.git.root / self.repo.TEMPLATE_DIR in self._path.parents
+
+    def is_empty(self) -> bool | None:
+        """Initializer for the 'onyo.is.empty' pseudo-key."""
+        return None  # TODO: Unclear what exactly this needs to consider. Probably child items? Or just assets?
+
+# TODO/Notes for next PR(s):
+# - Bug/Missing feature: pseudo-keys that are supposed to be settable by commands, are not yet
+#   ensured to return bool/Path objects that the codebase acts upon when their values are coming in from
+#   CLI or (template-)files, since everything is stringified now.
+# - We need plain files/directories represented for --yaml
+# - Templates can be (asset-) dirs  -> a dir is an item. If it has the dot yaml file, it's an asset dir
+# - values in templates maybe to be evaluated matching expression or even plugin calls  #714
+# - Path attribute caching at git/onyo layers (is_file, etc.):
+#   We actually know that everything we get from
+#   git ls-tree is in fact a file or symlink. And we can derive
+#   dirs from that path list (.anchor). That may be a lot faster.
+#   Implement cache dict at GitRepo level.
+# - Probably/Maybe: Stop passing dicts and Path objects around. All things relevant at higher level are Items, right?
+# - suck in DotNotationWrapper instead of deriving!? Probably not, because we have asset/template specs that should
+#   behave with dot notation, but can't or even must not have pseudo-keys.
+# - What about `__eq__` (see the horrible is_equal_dict helper)?

--- a/onyo/lib/pseudokeys.py
+++ b/onyo/lib/pseudokeys.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import partial
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from typing import (
+        Callable,
+        Dict,
+    )
+    from onyo.lib.items import Item
+
+
+@dataclass()
+class PseudoKey:
+    """"Defines a pseudo-key implementation."""
+    description: str
+    """description of what that pseudo-key is delivering"""
+    implementation: Callable
+    """Called by an `Item` when a pseudo-keys value is still undefined.
+
+    This Callable is expected to have a single parameter of type `Item`.
+    """
+
+
+def delegate(self: Item, attribute: str, *args, **kwargs):
+    # This is to avoid circular imports ATM.
+    return self.__getattribute__(attribute)(*args, **kwargs)
+
+
+PSEUDO_KEYS: Dict[str, PseudoKey] = {
+    'onyo.path.absolute': PseudoKey(description="Absolute path of the item.",
+                                    implementation=partial(delegate, attribute='get_path_absolute')
+                                    ),
+    'onyo.path.relative': PseudoKey(description="Path of the item relative to the repository root.",
+                                    implementation=partial(delegate, attribute='get_path_relative')
+                                    ),
+    'onyo.path.parent': PseudoKey(description="Path of the directory the item is in, relative to the repository root.",
+                                  implementation=partial(delegate, attribute='get_path_parent')
+                                  ),
+    'onyo.path.file': PseudoKey(description="Path to the file containing an asset's YAML."
+                                            "Different from 'onyo.path.relative' in case of an asset directory.",
+                                implementation=partial(delegate, attribute='get_path_file')
+                                ),
+    'onyo.is.asset': PseudoKey(description="Is the item an asset.",
+                               implementation=partial(delegate, attribute='is_asset')
+                               ),
+    'onyo.is.directory': PseudoKey(description="Is the item a directory.",
+                                   implementation=partial(delegate, attribute='is_directory')
+                                   ),
+    'onyo.is.template': PseudoKey(description="Is the item a template.",
+                                  implementation=partial(delegate, attribute='is_template')
+                                  ),
+    'onyo.is.empty': PseudoKey(description="Is the directory empty. <unset> if the item is not a directory.",
+                               implementation=partial(delegate, attribute='is_empty')
+                               ),
+}
+r"""Pseudo-Keys are key names that are addressable but not written to disk in asset YAML.
+
+All ``PSEUDO_KEYS`` are reserved.
+
+See Also
+--------
+RESERVED_KEYS
+"""
+
+# 'onyo.git.created.time': PseudoKey(description="Datetime the inventory item was created.",
+#                                    implementation=partial(delegate,
+#                                                           attribute='fill_created',
+#                                                           what='time')
+#                                    # or onyo.git.created.time for an "return self.get(what)" in implementation?
+#                                    ),
+# 'onyo.git.created.commit': PseudoKey(description="Commit SHA of the commit the object was created in",
+#                                      implementation=partial(delegate,
+#                                                             attribute='fill_created',
+#                                                             what='SHA')
+#                                      ),
+
+# 'onyo.git.created.committer.name': None,
+                   # 'onyo.git.created.committer.email': None,
+                   # 'onyo.git.created.author.name': None,
+                   # 'onyo.git.created.author.email': None,
+                   # 'onyo.git.modified.time': None,
+                   # 'onyo.git.modified.commit': None,
+                   # 'onyo.git.modified.committer.name': None,
+                   # 'onyo.git.modified.committer.email': None,
+                   # 'onyo.git.modified.author.name': None,
+                   # 'onyo.git.modified.author.email': None,
+                   #
+                   #          },
+                   #  }
+                   # }
+
+# Hardcode aliases for now:
+# Introduction of proper aliases requires config cache first.
+PSEUDOKEY_ALIASES: Dict[str, str] = {
+    'path': 'onyo.path.relative',
+    'directory': 'onyo.path.parent',
+}

--- a/onyo/lib/recorders.py
+++ b/onyo/lib/recorders.py
@@ -25,14 +25,14 @@ from onyo.lib.onyo import OnyoRepo
 
 
 def record_item(repo: OnyoRepo, item: Path | dict) -> str:
-    path = item if isinstance(item, Path) else item['path']
+    path = item if isinstance(item, Path) else item['onyo.path.absolute']
     return f"- {path.relative_to(repo.git.root).as_posix()}\n"
 
 
 def record_move(repo: OnyoRepo, src: Path | dict, dst: Path) -> str:
     # This currently expects `dst` to be the dir to move src into,
     # rather than already containing src' name at the destination.
-    src_path = src if isinstance(src, Path) else src['path']
+    src_path = src if isinstance(src, Path) else src['onyo.path.absolute']
     dst_path = (dst / src_path.name).relative_to(repo.git.root).as_posix()
     src_path = src_path.relative_to(repo.git.root).as_posix()
     return f"- {src_path} -> {dst_path}\n"
@@ -40,7 +40,7 @@ def record_move(repo: OnyoRepo, src: Path | dict, dst: Path) -> str:
 
 def record_rename(repo: OnyoRepo, src: Path | dict, dst: Path) -> str:
     # In opposition to record_move, this expects the full target path in `dst`
-    src_path = src if isinstance(src, Path) else src['path']
+    src_path = src if isinstance(src, Path) else src['onyo.path.absolute']
     src_path = src_path.relative_to(repo.git.root).as_posix()
     dst_path = dst.relative_to(repo.git.root).as_posix()
     return f"- {src_path} -> {dst_path}\n"

--- a/onyo/lib/tests/test_commands_cat.py
+++ b/onyo/lib/tests/test_commands_cat.py
@@ -5,6 +5,7 @@ import pytest
 from onyo.lib.exceptions import InvalidAssetError
 from onyo.lib.inventory import Inventory
 from onyo.lib.onyo import OnyoRepo
+from onyo.lib.items import Item
 from ..commands import onyo_cat
 
 
@@ -97,7 +98,7 @@ def test_onyo_cat_multiple(inventory: Inventory,
     asset_path1 = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     # TODO: simplify with new fixtures
     # add a different second asset to the inventory
-    inventory.add_asset(dict(some_key="some_value",
+    inventory.add_asset(Item(some_key="some_value",
                              type="TYPE",
                              make="MAKER",
                              model=dict(name="MODEL"),
@@ -135,15 +136,15 @@ def test_onyo_cat_with_duplicate_path(inventory: Inventory,
 
 def test_onyo_cat_asset_dir(inventory: Inventory,
                             capsys) -> None:
-    inventory.add_asset(dict(some_key="some_value",
-                             type="TYPE",
-                             make="MAKER",
-                             model=dict(name="MODEL"),
-                             serial="SERIAL2",
-                             other=1,
-                             directory=inventory.root,
-                             is_asset_directory=True)
-                        )
+    asset = Item(some_key="some_value",
+                 type="TYPE",
+                 make="MAKER",
+                 model=dict(name="MODEL"),
+                 serial="SERIAL2",
+                 other=1,
+                 directory=inventory.root)
+    asset['onyo.is.directory'] = True
+    inventory.add_asset(asset)
     asset_dir = inventory.root / "TYPE_MAKER_MODEL.SERIAL2"
     inventory.commit("add an asset dir")
 

--- a/onyo/lib/tests/test_commands_mv.py
+++ b/onyo/lib/tests/test_commands_mv.py
@@ -2,6 +2,7 @@ import pytest
 
 from onyo.lib.inventory import Inventory
 from onyo.lib.onyo import OnyoRepo
+from onyo.lib.items import Item
 from . import check_commit_msg
 from ..commands import onyo_mv
 
@@ -224,7 +225,7 @@ def test_onyo_mv_and_rename(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_mv_into_asset(inventory: Inventory) -> None:
-    asset = dict(some_key="some_value",
+    asset = Item(some_key="some_value",
                  type="TYPE",
                  make="MAKE",
                  model=dict(name="MODEL"),
@@ -252,13 +253,13 @@ def test_onyo_mv_into_asset(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_mv_asset_dir(inventory: Inventory) -> None:
-    asset_dir = dict(some_key="some_value",
+    asset_dir = Item(some_key="some_value",
                      type="TYPE",
                      make="MAKE",
                      model=dict(name="MODEL"),
                      serial="SERIAL2",
-                     is_asset_directory=True,
                      directory=inventory.root)
+    asset_dir["onyo.is.directory"] = True
     asset_path = inventory.root / "TYPE_MAKE_MODEL.SERIAL2"
     inventory.add_asset(asset_dir)
     inventory.commit("Add an asset dir.")

--- a/onyo/lib/tests/test_commands_rm.py
+++ b/onyo/lib/tests/test_commands_rm.py
@@ -1,6 +1,7 @@
 import pytest
 
 from onyo.lib.exceptions import InvalidInventoryOperationError, InventoryOperationError
+from onyo.lib.items import Item
 from onyo.lib.inventory import Inventory
 from onyo.lib.onyo import OnyoRepo
 from . import check_commit_msg
@@ -211,15 +212,15 @@ def test_onyo_rm_subpath_and_contents(inventory: Inventory) -> None:
 def test_onyo_rm_asset_dir(inventory: Inventory) -> None:
     # As long as there no assets within, `rm` should remove the asset dir
     # with and without the `--recursive` flag being set
-    inventory.add_asset(dict(some_key="some_value",
-                             type="TYPE",
-                             make="MAKE",
-                             model=dict(name="MODEL"),
-                             serial="SERIAL2",
-                             other=1,
-                             directory=inventory.root,
-                             is_asset_directory=True)
-                        )
+    asset = Item(some_key="some_value",
+                 type="TYPE",
+                 make="MAKE",
+                 model=dict(name="MODEL"),
+                 serial="SERIAL2",
+                 other=1,
+                 directory=inventory.root)
+    asset["onyo.is.directory"] = True
+    inventory.add_asset(asset)
     asset_dir = inventory.root / "TYPE_MAKE_MODEL.SERIAL2"
     inventory.commit("add an asset dir")
 

--- a/onyo/lib/tests/test_commands_tree.py
+++ b/onyo/lib/tests/test_commands_tree.py
@@ -1,6 +1,7 @@
 import pytest
 
 from onyo.lib.inventory import Inventory
+from onyo.lib.items import Item
 from ..commands import onyo_tree
 
 
@@ -76,12 +77,13 @@ def test_onyo_tree_description(inventory: Inventory,
 def test_onyo_tree_dirs_only(inventory: Inventory,
                              capsys) -> None:
     r"""Display a tree w/o any files"""
-    inventory.add_asset(dict(type="atype",
-                             make="someone",
-                             model=dict(name="fancy"),
-                             serial="faux",
-                             directory=inventory.root,
-                             is_asset_directory=True))
+    asset = Item(type="atype",
+                 make="someone",
+                 model=dict(name="fancy"),
+                 serial="faux",
+                 directory=inventory.root)
+    asset["onyo.is.directory"] = True
+    inventory.add_asset(asset)
     inventory.commit("Add an asset dir to make sure it's not excluded.")
     onyo_tree(inventory,
               path=inventory.root,

--- a/onyo/lib/tests/test_inventory_operations.py
+++ b/onyo/lib/tests/test_inventory_operations.py
@@ -1,6 +1,7 @@
 import pytest
 
-from onyo.lib.consts import RESERVED_KEYS, PSEUDO_KEYS
+from onyo.lib.consts import RESERVED_KEYS
+from onyo.lib.pseudokeys import PSEUDO_KEYS
 from onyo.lib.exceptions import (
     InvalidInventoryOperationError,
     NoopError,
@@ -9,7 +10,7 @@ from onyo.lib.exceptions import (
 )
 from onyo.lib.inventory import Inventory, OPERATIONS_MAPPING
 from onyo.lib.onyo import OnyoRepo
-from onyo.lib.utils import DotNotationWrapper
+from onyo.lib.items import Item
 
 
 # TODO: - Inventory fixture(s)
@@ -44,15 +45,13 @@ def test_add_asset(repo: OnyoRepo) -> None:
     newdir1 = inventory.root / "somewhere"
     newdir2 = newdir1 / "new"
     asset_file = newdir2 / "test_I_mk1.123"
-    asset = DotNotationWrapper(
-        dict(some_key="some_value",
-             other='1',
-             directory=newdir2,
-             type="test",
-             make="I",
-             model=dict(name="mk1"),
-             serial="123")
-    )
+    asset = Item(some_key="some_value",
+                 other='1',
+                 directory=newdir2,
+                 type="test",
+                 make="I",
+                 model=dict(name="mk1"),
+                 serial="123")
     assert num_operations(inventory, 'new_assets') == 0
     assert num_operations(inventory, 'new_directories') == 0
 
@@ -80,9 +79,9 @@ def test_add_asset(repo: OnyoRepo) -> None:
     assert repo.is_inventory_dir(newdir2)
     assert repo.is_asset_path(asset_file)
     asset_from_disc = inventory.get_asset(asset_file)
-    assert asset_file == asset_from_disc.pop('path')
+    assert asset_file == asset_from_disc.get('onyo.path.absolute')
     for k, v in asset.items():
-        if k not in RESERVED_KEYS + PSEUDO_KEYS:
+        if k not in RESERVED_KEYS + list(PSEUDO_KEYS.keys()):
             assert asset_from_disc[k] == v
     # TODO: check commit message
 
@@ -103,7 +102,7 @@ def test_add_asset(repo: OnyoRepo) -> None:
     #                                   but an inventory operation.)
     existing_asset_file = repo.git.root / 'root_asset'
     existing_asset_file.touch()
-    asset = dict(some='whatever', path=existing_asset_file)
+    asset = {'some': 'whatever', 'onyo.path.absolute': existing_asset_file}
     pytest.raises(ValueError, inventory.add_asset, asset)
 
     # TODO: should also fail when adding an asset that is already pending? Or one that is also being removed, etc?
@@ -153,15 +152,15 @@ def test_move_asset(repo: OnyoRepo) -> None:
     newdir1 = repo.git.root / "somewhere"
     newdir2 = newdir1 / "new"
     asset_file = newdir2 / "test_I_mk1.123"
-    asset = DotNotationWrapper(
-        dict(some_key="some_value",
-             other='1',
-             directory=newdir2,
-             type="test",
-             make="I",
-             model=dict(name="mk1"),
-             serial="123")
-    )
+    asset = Item(
+        some_key="some_value",
+        other='1',
+        directory=newdir2,
+        type="test",
+        make="I",
+        model=dict(name="mk1"),
+        serial="123")
+
     inventory.add_asset(asset)
     inventory.commit("First asset added")
 
@@ -194,15 +193,14 @@ def test_rename_asset(repo: OnyoRepo) -> None:
     inventory = Inventory(repo)
     newdir1 = repo.git.root / "somewhere"
     newdir2 = newdir1 / "new"
-    asset = DotNotationWrapper(
-        dict(some_key="some_value",
-             type="TYPE",
-             make="MAKER",
-             model=dict(name="MODEL"),
-             serial="SERIAL",
-             other='1',
-             directory=newdir2)
-    )
+    asset = Item(
+        some_key="some_value",
+        type="TYPE",
+        make="MAKER",
+        model=dict(name="MODEL"),
+        serial="SERIAL",
+        other='1',
+        directory=newdir2)
     inventory.add_asset(asset)
     inventory.commit("First asset added")
 
@@ -221,15 +219,14 @@ def test_modify_asset(repo: OnyoRepo) -> None:
     newdir1 = repo.git.root / "somewhere"
     newdir2 = newdir1 / "new"
     asset_file = newdir2 / "TYPE_MAKER_MODEL.SERIAL"
-    asset = DotNotationWrapper(
-        dict(some_key="some_value",
-             type="TYPE",
-             make="MAKER",
-             model=dict(name="MODEL"),
-             serial="SERIAL",
-             other='1',
-             directory=newdir2)
-    )
+    asset = Item(
+        some_key="some_value",
+        type="TYPE",
+        make="MAKER",
+        model=dict(name="MODEL"),
+        serial="SERIAL",
+        other='1',
+        directory=newdir2)
     inventory.add_asset(asset)
     inventory.commit("First asset added")
 
@@ -247,9 +244,10 @@ def test_modify_asset(repo: OnyoRepo) -> None:
 
     new_asset.update(dict(model=dict(name="CORRECTED-MODEL")))  # implies rename w/ default name config
 
-    # illegal to define 'path' in `new_asset`:
+    # Asset path in `new_asset` must be None or identical to `asset`:
+    new_asset['onyo.path.absolute'] = newdir2 / "new_name"
     pytest.raises(ValueError, inventory.modify_asset, asset, new_asset)
-    new_asset.pop('path')
+    new_asset['onyo.path.absolute'] = None
     # raises on non-existing asset
     pytest.raises(ValueError, inventory.modify_asset, repo.git.root / "doesnotexist", new_asset)
     # raises on non-asset
@@ -272,9 +270,9 @@ def test_modify_asset(repo: OnyoRepo) -> None:
     assert asset_file.is_file()
     assert not new_asset_file.exists()
     asset_on_disc = inventory.get_asset(asset_file)
-    assert asset_file == asset_on_disc.pop('path')
+    assert asset_file == asset_on_disc.get('onyo.path.absolute')
     for k, v in asset.items():
-        if k not in RESERVED_KEYS + PSEUDO_KEYS:
+        if k not in RESERVED_KEYS + list(PSEUDO_KEYS.keys()):
             assert asset_on_disc[k] == v
 
     # TODO: diff
@@ -283,11 +281,15 @@ def test_modify_asset(repo: OnyoRepo) -> None:
     inventory.commit("Modify an asset")
     assert not asset_file.exists()
     assert repo.is_asset_path(new_asset_file)
-    expected_asset = {k: v for k, v in new_asset.items() if k not in RESERVED_KEYS}
-    expected_asset['path'] = new_asset_file
-    expected_asset['directory'] = new_asset_file.parent
-    expected_asset['is_asset_directory'] = False
-    assert inventory.get_asset(new_asset_file) == expected_asset
+
+    asset_on_disc = inventory.get_asset(new_asset_file)
+    for k, v in new_asset.items():
+        if k not in PSEUDO_KEYS:
+            assert asset_on_disc[k] == new_asset[k]
+
+    assert asset_on_disc['onyo.path.absolute'] == new_asset_file
+    assert asset_on_disc['onyo.path.parent'] == new_asset_file.parent.relative_to(inventory.root)
+    assert asset_on_disc['onyo.is.directory'] is False
 
 
 def test_add_directory(repo: OnyoRepo) -> None:
@@ -322,15 +324,14 @@ def test_remove_directory(repo: OnyoRepo) -> None:
     newdir2 = newdir1 / "new"
     emptydir = newdir1 / "empty"
     asset_file = newdir2 / "asset_file"
-    asset = DotNotationWrapper(
-        dict(some_key="some_value",
-             type="TYPE",
-             make="MAKER",
-             model=dict(name="MODEL"),
-             serial="SERIAL",
-             other='1',
-             directory=newdir2)
-    )
+    asset = Item(
+        some_key="some_value",
+        type="TYPE",
+        make="MAKER",
+        model=dict(name="MODEL"),
+        serial="SERIAL",
+        other='1',
+        directory=newdir2)
     inventory.add_asset(asset)
     inventory.add_directory(emptydir)
     inventory.commit("First asset added")
@@ -369,15 +370,14 @@ def test_move_directory(repo: OnyoRepo) -> None:
     newdir2 = newdir1 / "new"
     emptydir = newdir1 / "empty"
     asset_file = newdir2 / "asset_file"
-    asset = DotNotationWrapper(
-        dict(some_key="some_value",
-             type="TYPE",
-             make="MAKER",
-             model=dict(name="MODEL"),
-             serial="SERIAL",
-             other=1,
-             directory=newdir2)
-    )
+    asset = Item(
+        some_key="some_value",
+        type="TYPE",
+        make="MAKER",
+        model=dict(name="MODEL"),
+        serial="SERIAL",
+        other=1,
+        directory=newdir2)
     inventory.add_asset(asset)
     inventory.add_directory(emptydir)
     inventory.commit("First asset added")
@@ -410,15 +410,14 @@ def test_rename_directory(repo: OnyoRepo) -> None:
     newdir2 = newdir1 / "new"
     emptydir = newdir1 / "empty"
     asset_file = newdir2 / "asset_file"
-    asset = DotNotationWrapper(
-        dict(some_key="some_value",
-             type="TYPE",
-             make="MAKER",
-             model=dict(name="MODEL"),
-             serial="SERIAL",
-             other=1,
-             directory=newdir2)
-    )
+    asset = Item(
+        some_key="some_value",
+        type="TYPE",
+        make="MAKER",
+        model=dict(name="MODEL"),
+        serial="SERIAL",
+        other=1,
+        directory=newdir2)
     inventory.add_asset(asset)
     inventory.add_directory(emptydir)
     inventory.commit("First asset added")
@@ -452,16 +451,15 @@ def test_add_asset_dir(repo: OnyoRepo) -> None:
     inventory = Inventory(repo)
 
     asset_dir_path = inventory.root / "TYPE_MAKE_MODEL.SERIAL"
-    asset = DotNotationWrapper(
-        dict(some_key="some_value",
-             other=1,
-             type="TYPE",
-             make="MAKE",
-             model=dict(name="MODEL"),
-             serial="SERIAL",
-             is_asset_directory=True,
-             path=asset_dir_path)
-    )
+    asset = Item(
+        some_key="some_value",
+        other=1,
+        type="TYPE",
+        make="MAKE",
+        model=dict(name="MODEL"),
+        serial="SERIAL")
+    asset["onyo.path.absolute"] = asset_dir_path
+    asset["onyo.is.directory"] = True
     inventory.add_asset(asset)
     # operations to add new asset and a dir are registered:
     assert num_operations(inventory, 'new_assets') == 1
@@ -492,16 +490,14 @@ def test_add_asset_dir(repo: OnyoRepo) -> None:
     inventory.add_directory(dir_path)
     inventory.commit("New inventory dir")
 
-    asset = DotNotationWrapper(
-        dict(some_key="some_value",
-             other=1,
-             type="TYPE1",
-             make="MAKE1",
-             model=dict(name="MODEL1"),
-             serial="1X2",
-             is_asset_directory=True,
-             path=dir_path)
-    )
+    asset = Item(some_key="some_value",
+                 other=1,
+                 type="TYPE1",
+                 make="MAKE1",
+                 model=dict(name="MODEL1"),
+                 serial="1X2")
+    asset["onyo.path.absolute"] = dir_path
+    asset["onyo.is.directory"] = True
     expected_name = inventory.generate_asset_name(asset)
     expected_path = dir_path.parent / expected_name
     inventory.add_asset(asset)
@@ -538,15 +534,14 @@ def test_add_asset_dir(repo: OnyoRepo) -> None:
 
 def test_add_dir_asset(repo: OnyoRepo) -> None:
     inventory = Inventory(repo)
-    asset = DotNotationWrapper(
-        dict(some_key="some_value",
-             other=1,
-             type="TYPE1",
-             make="MAKE1",
-             model=dict(name="MODEL1"),
-             serial="1X2",
-             directory=inventory.root)
-    )
+    asset = Item(
+        some_key="some_value",
+        other=1,
+        type="TYPE1",
+        make="MAKE1",
+        model=dict(name="MODEL1"),
+        serial="1X2",
+        directory=inventory.root)
     inventory.add_asset(asset)
     inventory.commit("Add an asset.")
     asset_path = inventory.root / "TYPE1_MAKE1_MODEL1.1X2"
@@ -571,24 +566,21 @@ def test_add_dir_asset(repo: OnyoRepo) -> None:
 def test_remove_asset_dir_directory(repo: OnyoRepo) -> None:
     inventory = Inventory(repo)
     asset_dir_path = inventory.root / "TYPE_MAKE_MODEL.SERIAL"
-    asset = DotNotationWrapper(
-        dict(some_key="some_value",
-             other=1,
-             type="TYPE",
-             make="MAKE",
-             model=dict(name="MODEL"),
-             serial="SERIAL",
-             is_asset_directory=True,
-             path=asset_dir_path)
-    )
+    asset = Item(
+        some_key="some_value",
+        other=1,
+        type="TYPE",
+        make="MAKE",
+        model=dict(name="MODEL"),
+        serial="SERIAL")
+    asset["onyo.path.absolute"] = asset_dir_path
+    asset["onyo.is.directory"] = True
     inventory.add_asset(asset)
-    asset_within = DotNotationWrapper(
-        dict(type="a",
-             make="b",
-             model=dict(name="c"),
-             serial="1A",
-             directory=asset_dir_path)
-    )
+    asset_within = Item(type="a",
+                        make="b",
+                        model=dict(name="c"),
+                        serial="1A",
+                        directory=asset_dir_path)
     inventory.add_asset(asset_within)
     inventory.commit("Whatever")
 
@@ -614,24 +606,21 @@ def test_remove_asset_dir_directory(repo: OnyoRepo) -> None:
 def test_remove_asset_dir_asset(repo: OnyoRepo) -> None:
     inventory = Inventory(repo)
     asset_dir_path = inventory.root / "TYPE_MAKE_MODEL.SERIAL"
-    asset = DotNotationWrapper(
-        dict(some_key="some_value",
-             other=1,
-             type="TYPE",
-             make="MAKE",
-             model=dict(name="MODEL"),
-             serial="SERIAL",
-             is_asset_directory=True,
-             path=asset_dir_path)
-    )
+    asset = Item(
+            some_key="some_value",
+            other=1,
+            type="TYPE",
+            make="MAKE",
+            model=dict(name="MODEL"),
+            serial="SERIAL")
+    asset["onyo.path.absolute"] = asset_dir_path
+    asset["onyo.is.directory"] = True
     inventory.add_asset(asset)
-    asset_within = DotNotationWrapper(
-        dict(type="a",
-             make="b",
-             model=dict(name="c"),
-             serial="1A",
-             directory=asset_dir_path)
-    )
+    asset_within = Item(type="a",
+                        make="b",
+                        model=dict(name="c"),
+                        serial="1A",
+                        directory=asset_dir_path)
     inventory.add_asset(asset_within)
     inventory.commit("Whatever")
     inventory.remove_asset(asset)
@@ -663,16 +652,14 @@ def test_move_asset_dir(repo: OnyoRepo) -> None:
     inventory = Inventory(repo)
     asset_dir_path = inventory.root / "TYPE_MAKE_MODEL.SERIAL"
     dir_path = inventory.root / "destination"
-    asset = DotNotationWrapper(
-        dict(some_key="some_value",
-             other=1,
-             type="TYPE",
-             make="MAKE",
-             model=dict(name="MODEL"),
-             serial="SERIAL",
-             is_asset_directory=True,
-             path=asset_dir_path)
-    )
+    asset = Item(some_key="some_value",
+                 other=1,
+                 type="TYPE",
+                 make="MAKE",
+                 model=dict(name="MODEL"),
+                 serial="SERIAL")
+    asset["onyo.path.absolute"] = asset_dir_path
+    asset["onyo.is.directory"] = True
     inventory.add_asset(asset)
     inventory.add_directory(dir_path)
     inventory.commit("Whatever")
@@ -721,16 +708,14 @@ def test_rename_asset_dir(repo: OnyoRepo) -> None:
 
     inventory = Inventory(repo)
     asset_dir_path = inventory.root / "TYPE_MAKE_MODEL.SERIAL"
-    asset = DotNotationWrapper(
-        dict(some_key="some_value",
-             other=1,
-             type="TYPE",
-             make="MAKE",
-             model=dict(name="MODEL"),
-             serial="SERIAL",
-             is_asset_directory=True,
-             path=asset_dir_path)
-    )
+    asset = Item(some_key="some_value",
+                 other=1,
+                 type="TYPE",
+                 make="MAKE",
+                 model=dict(name="MODEL"),
+                 serial="SERIAL")
+    asset["onyo.path.absolute"] = asset_dir_path
+    asset["onyo.is.directory"] = True
     inventory.add_asset(asset)
     inventory.commit("Whatever")
 
@@ -775,27 +760,30 @@ def test_modify_asset_dir(repo: OnyoRepo) -> None:
     newdir1 = repo.git.root / "somewhere"
     newdir2 = newdir1 / "new"
     asset_path = newdir2 / "TYPE_MAKER_MODEL.SERIAL"
-    asset = DotNotationWrapper(
-        dict(some_key="some_value",
-             type="TYPE",
-             make="MAKER",
-             model=dict(name="MODEL"),
-             serial="SERIAL",
-             other=1,
-             is_asset_directory=True,
-             path=asset_path,
-             directory=asset_path.parent)
+    asset = Item(
+        {"some_key": "some_value",
+         "type": "TYPE",
+         "make": "MAKER",
+         "model": dict(name="MODEL"),
+         "serial": "SERIAL",
+         "other": 1,
+         "onyo": {"is": {"asset": True,
+                         "directory": True},
+                  "path": {"absolute": asset_path}}
+         }
     )
     inventory.add_asset(asset)
     inventory.commit("asset dir added")
+    asset = inventory.get_asset(asset_path)
     assert inventory.repo.is_asset_dir(asset_path)
+    assert asset['onyo.is.directory'] and asset['onyo.is.asset']
 
     asset_changes = dict(some_key="new_value",  # arbitrary content change
                          model=dict(name="CORRECTED-MODEL")  # implies rename w/ given name config
                          )
     new_asset = asset.copy()
     new_asset.update(asset_changes)
-    new_asset.pop('path')
+    new_asset['onyo.path.absolute'] = None
 
     inventory.modify_asset(asset, new_asset)
     # modify operation:
@@ -818,6 +806,10 @@ def test_modify_asset_dir(repo: OnyoRepo) -> None:
     assert inventory.repo.is_asset_dir(new_asset_path)
     assert inventory.repo.git.is_clean_worktree()
 
-    expected_asset = dict(**new_asset)
-    expected_asset['path'] = new_asset_path
-    assert inventory.get_asset(new_asset_path) == expected_asset
+    asset_on_disc = inventory.get_asset(new_asset_path)
+    for k, v in new_asset.items():
+        if k not in PSEUDO_KEYS:
+            assert asset_on_disc[k] == new_asset[k]
+
+    assert asset_on_disc['onyo.path.absolute'] == new_asset_path
+    assert asset_on_disc['onyo.path.parent'] == new_asset_path.parent.relative_to(inventory.root)

--- a/onyo/lib/tests/test_item.py
+++ b/onyo/lib/tests/test_item.py
@@ -1,0 +1,75 @@
+from pathlib import Path
+
+import pytest
+
+from ..items import Item
+from ..pseudokeys import PSEUDO_KEYS, PSEUDOKEY_ALIASES
+
+asset_dict = Item({
+    "type": "atype",
+    "make": "amake",
+    "model": {"name": "amodel"},
+    "serial": "001",
+    "path": Path("subdir") / "atype_amake_amodel.1"
+}
+)
+
+
+@pytest.mark.inventory_assets(asset_dict)
+def test_item_init(onyorepo) -> None:
+    # TODO: Values may need to change. Stringification!
+    #       But may be not for pseudo-keys? There are never written out.
+    #       However, they are meant to be specifiable in a (template-) YAML.
+    constructor_calls = [Item(),
+                         Item({'some': {'nested': '0_03'}}),
+                         Item(some={'nested': '0_03'}),
+                         Item(onyorepo.test_annotation['dirs'][0]),
+                         Item(onyorepo.test_annotation['dirs'][0], onyorepo),
+                         Item(onyorepo.test_annotation['assets'][0]['onyo.path.absolute'], onyorepo),
+                         ]
+
+    for item, idx in zip(constructor_calls, range(len(constructor_calls))):
+        # All pseudo-keys are accessible:
+        assert all(pk in item for pk in PSEUDO_KEYS)
+        # Given key-value pairs are accessible:
+        assert (item.get('some.nested') == '0_03') if idx in [1, 2] else item.get('some.nested') is None
+        # Non-existing keys raise proper error:
+        pytest.raises(KeyError, lambda: item['doesnotexist'])
+        # If a Path was given, at the very least the absolute path is available:
+        if idx in [3, 4, 5]:
+            assert isinstance(item.get('onyo.path.absolute'), Path)
+        else:
+            # otherwise, this is unset
+            assert item.get('onyo.path.absolute') is None
+        # If the repo was given, relative-to-root paths are available as well:
+        if idx in [4, 5]:
+            assert isinstance(item.get('onyo.path.relative'), Path)
+            assert isinstance(item.get('onyo.path.parent'), Path)
+        else:
+            # otherwise, relative-to-root paths are unset
+            assert item.get('onyo.path.relative') is None
+            assert item.get('onyo.path.parent') is None
+        # Check actual paths:
+        if idx == 4:
+            assert item.get('onyo.path.absolute') == onyorepo.test_annotation['dirs'][0]
+            assert item.get('onyo.path.relative') == onyorepo.test_annotation['dirs'][0].relative_to(onyorepo.git.root)
+            assert item.get('onyo.path.parent') == onyorepo.test_annotation['dirs'][0].parent.relative_to(onyorepo.git.root)
+            assert item.get('onyo.path.file') is None
+        elif idx == 5:
+            assert item.get('onyo.path.absolute') == onyorepo.test_annotation['assets'][0]['onyo.path.absolute']
+            assert item.get('onyo.path.relative') == onyorepo.test_annotation['assets'][0]['onyo.path.absolute'].relative_to(onyorepo.git.root)
+            assert item.get('onyo.path.parent') == onyorepo.test_annotation['assets'][0]['onyo.path.absolute'].parent.relative_to(onyorepo.git.root)
+            assert item.get('onyo.path.file') == item.get('onyo.path.relative')
+        if item.repo is None:
+            assert item['onyo.is.asset'] is None
+            assert item['onyo.is.directory'] is None
+            assert item['onyo.is.template'] is None
+            assert item['onyo.is.empty'] is None
+        else:
+            assert item['onyo.is.asset'] is (item['onyo.path.absolute'] in [a['onyo.path.absolute'] for a in onyorepo.test_annotation['assets']])
+            assert item['onyo.is.directory'] is (item['onyo.path.absolute'] in onyorepo.test_annotation['dirs'])
+            assert item['onyo.is.template'] is (onyorepo.git.root / onyorepo.TEMPLATE_DIR in item['onyo.path.absolute'].parents)
+
+        # Aliases
+        for k in PSEUDOKEY_ALIASES:
+            assert item[k] == item[PSEUDOKEY_ALIASES[k]]

--- a/onyo/lib/tests/test_onyo.py
+++ b/onyo/lib/tests/test_onyo.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 
 from onyo.lib.onyo import OnyoRepo, OnyoInvalidRepoError
+from onyo.lib.items import Item
 
 
 def test_OnyoRepo_instantiation_existing(onyorepo: OnyoRepo) -> None:
@@ -59,7 +60,7 @@ def test_OnyoRepo_incorrect_input_arguments_raise_error(onyorepo: OnyoRepo,
         OnyoRepo(tmp_path, init=True, find_root=True)
 
 
-@pytest.mark.inventory_assets(dict(type="asset",
+@pytest.mark.inventory_assets(Item(type="asset",
                                    make="for",
                                    model="test",
                                    serial=0,
@@ -71,7 +72,7 @@ def test_clear_cache(onyorepo) -> None:
     """
 
     # Use arbitrary asset here:
-    asset = onyorepo.test_annotation['assets'][0]['path']
+    asset = onyorepo.test_annotation['assets'][0]['onyo.path.absolute']
 
     # make sure asset is in the cache:
     assert asset in onyorepo.asset_paths
@@ -204,7 +205,7 @@ def test_Repo_validate_anchors(onyorepo) -> None:
                               (Path("subdir") / "subsub" / "untracked_som.txt", ""),
                               (Path("docs") / "regular", "whatever")
                               )
-@pytest.mark.inventory_assets(dict(type="atype",
+@pytest.mark.inventory_assets(Item(type="atype",
                                    make="amake",
                                    model="amodel",
                                    serial=1,
@@ -214,7 +215,7 @@ def test_onyo_ignore(onyorepo) -> None:
     # TODO: This test still has hardcoded stuff from the markers.
     #       Markers and fixture annotation not fit for this yet.
     for a in onyorepo.test_annotation['assets']:
-        assert not onyorepo.is_onyo_ignored(a['path'])
+        assert not onyorepo.is_onyo_ignored(a['onyo.path.absolute'])
     for d in onyorepo.test_annotation['dirs']:
         assert not onyorepo.is_onyo_ignored(d)
         assert not onyorepo.is_onyo_ignored(d / OnyoRepo.ANCHOR_FILE_NAME)

--- a/onyo/lib/tests/test_utils.py
+++ b/onyo/lib/tests/test_utils.py
@@ -1,8 +1,10 @@
 import pytest
 
-from onyo.lib.consts import PSEUDO_KEYS, RESERVED_KEYS
+from onyo.lib.consts import RESERVED_KEYS
+from onyo.lib.pseudokeys import PSEUDO_KEYS
 from onyo.lib.utils import (
     dict_to_asset_yaml,
+    DotNotationWrapper,
     get_asset_content,
 )
 
@@ -52,10 +54,11 @@ def test_dict_to_asset_yaml() -> None:
     assert d_expected_output == dict_to_asset_yaml(d)
 
 
-@pytest.mark.parametrize('rkey', PSEUDO_KEYS + RESERVED_KEYS)
+@pytest.mark.parametrize('rkey', list(PSEUDO_KEYS.keys()) + RESERVED_KEYS)
 def test_redaction_dict_to_asset_yaml(rkey: str) -> None:
     r"""Reserved- and Pseudo-Keys should not be serialized."""
-    d = {'type': 'TYPE', 'make': 'MAKE', 'model': 'MODEL', 'serial': '008675309', 'explicit': 123, rkey: 'REDACT_ME'}
+    d = DotNotationWrapper({'type': 'TYPE', 'make': 'MAKE', 'model': 'MODEL', 'serial': '008675309', 'explicit': 123})
+    d[rkey] = 'REDACT_ME'
     d_expected_output = "---\ntype: TYPE\nmake: MAKE\nmodel: MODEL\nserial: 008675309\nexplicit: !!int '123'\n"
     assert d_expected_output == dict_to_asset_yaml(d)
 

--- a/onyo/tests/benchmark.py
+++ b/onyo/tests/benchmark.py
@@ -126,7 +126,8 @@ class TestOnyoBenchmark:
 
         inventory = benchmark_inventory
         # get 50 random assets
-        assets = [a['path'].resolve() for a in random.sample(onyo_get(inventory), k=50)]
+        assets = [a["onyo.path.absolute"]
+                  for a in random.sample(onyo_get(inventory, keys=["onyo.path.absolute"]), k=50)]
         # set 50
         onyo_set(inventory, assets=assets, keys={'fifty': 'fifty'})
 
@@ -151,7 +152,8 @@ class TestOnyoBenchmark:
 
         inventory = benchmark_inventory
         # get 50 assets
-        assets = [str(a['path'].resolve()) for a in random.sample(onyo_get(inventory), k=50)]
+        assets = [str(a["onyo.path.absolute"])
+                  for a in random.sample(onyo_get(inventory, keys=["onyo.path.absolute"]), k=50)]
 
         def setup():
             """
@@ -183,7 +185,8 @@ class TestOnyoBenchmark:
         r"""Cat 1 asset in the repo."""
         inventory = benchmark_inventory
         # get 1 asset
-        assets = [a['path'].resolve() for a in random.sample(onyo_get(inventory), k=1)]
+        assets = [a["onyo.path.absolute"]
+                  for a in random.sample(onyo_get(inventory, keys=["onyo.path.absolute"]), k=1)]
 
         benchmark(onyo_cat, inventory, assets=assets)
 
@@ -198,7 +201,7 @@ class TestOnyoBenchmark:
         r"""Cat 1 asset from the CLI."""
         inventory = benchmark_inventory
         # get 1 asset
-        asset = random.sample(onyo_get(inventory), k=1)[0]['path'].resolve()
+        asset = random.sample(onyo_get(inventory, keys=["onyo.path.absolute"]), k=1)[0]['onyo.path.absolute']
 
         @benchmark
         def bench():


### PR DESCRIPTION
Sits on top of PR #707 and resolves its issue WRT `is_asset_directory` by removing that key altogether. This is now split into the new `onyo.is.asset` and `onyo.is.directory` pseudo-keys. Although for the most part `onyo.is.directory` is what is used instead.

This is the first PR of a series, aiming to implement #662, #688, #689.
It's introducing an `Item` class and a new `PSEUDO_KEYS` mapping, that add pseudo-keys to dict-likes.
The aim for this PR is:
- Make `path` and `directory` keys aliases and replace their internal usage (except for test code, where they are still used at times in their role as default aliases)
- Remove `is_asset_directory` key in favor of `onyo.is.directory` (and `onyo.is.asset`)
- Replace `DotNotationWrapper` by `Item` in most places. `DotNotationWrapper` remains valid in some places where we don't want any pseudo-keys yet (For example: Reading yaml from an edited temporary file - only becomes an `Item` when we tie it to the actual repo. We don't want pseudo-keys referring to the temp file)
- Don't break anything other than `is_asset_directory` while throwing this class in.
- It does not yet utilize `Item`'s ability to represent directories, templates, etc. - just assets in the first round.
- It does not yet implement git metadata keys, but builds on a mechanic that is meant to account for the need to lazy load pseudo-keys.
- It does not yet introduce a proper mechanic for namespaces nor streamline the usage of this class yet. I want to see what this really needs first.

The scope is limited, in order to address that topic in digestable chunks. Next up should be:
- git metadata
- actually use `Item` consistently for anything at high-level code, so this becomes the datastructure, that `Inventory` and command implementations deal with, instead of arbitrary dicts and paths.
- Build different validators (at least in terms of design). Anything is an Item, but what it's used for is what makes the difference. If I want to use an asset as a template, I simply treat it that way (and put it into a TemplateValidator). As opposed to the initial idea of the object itself determining what it is. There may be more to do in a similar fashion along this line of thought.
- consequently properly implement namespaces and allow `get` to query anything (dirs, templates)

During these further steps, we/I can figure out additional functions to ease various ways of dealing with these objects (we need to repeatedly strip or reset pseudo-keys and we have notions of "you-can't-set-these", leading to a bunch of code duplication - I want to iron that out as we get to see more access patterns)


