### PR TITLE
BF: show Inventory Operations for onyo edit

### DIFF
--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -434,6 +434,9 @@ def onyo_edit(inventory: Inventory,
         _edit_asset(inventory, asset, partial(inventory.modify_asset, path), editor)
 
     if inventory.operations_pending():
+        # display changes
+        ui.print('\n' + inventory.operations_summary())
+
         if ui.request_user_response("Save changes? No discards all changes. (y/n) "):
             if auto_message:
                 operation_paths = sorted(deduplicate([  # pyre-ignore[6]


### PR DESCRIPTION
A diff is shown after each edit, so we skip showing the diff /again/ because it is confusing and unnecessary.

This continues to suppress the second diff, but does print the Inventory Operations, which is a useful summary.

close #736