### PR TITLE
RF: `Item()`-ize `onyo_mkdir()` and `inventory.add_directory()`

### DIFF
--- a/onyo/conftest.py
+++ b/onyo/conftest.py
@@ -207,8 +207,8 @@ def inventory(repo) -> Generator:
              other=1,
              directory=repo.git.root / "somewhere" / "nested"),
         repo=repo))
-    inventory.add_directory(repo.git.root / 'empty')
-    inventory.add_directory(repo.git.root / 'different' / 'place')
+    inventory.add_directory(Item(repo.git.root / 'empty', repo=inventory.repo))
+    inventory.add_directory(Item(repo.git.root / 'different' / 'place', repo=inventory.repo))
     inventory.commit("First asset added")
     yield inventory
 

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -682,7 +682,7 @@ def onyo_mkdir(inventory: Inventory,
         raise ValueError("At least one directory path must be specified.")
 
     for d in deduplicate(dirs):  # pyre-ignore[16]
-        inventory.add_directory(d)
+        inventory.add_directory(Item(d, repo=inventory.repo))
 
     if inventory.operations_pending():
         # display changes
@@ -786,7 +786,7 @@ def onyo_mv(inventory: Inventory,
         implicit_move = True
         # destination Asset File needs to be converted into Asset Directory first
         if inventory.repo.is_asset_file(destination):
-            inventory.add_directory(destination)
+            inventory.add_directory(Item(destination, repo=inventory.repo))
 
         for s in sources:
             _move_asset_or_dir(inventory, s, destination)

--- a/onyo/lib/tests/test_commands_mv.py
+++ b/onyo/lib/tests/test_commands_mv.py
@@ -43,7 +43,7 @@ def test_onyo_mv_errors(inventory: Inventory) -> None:
                   destination=asset_path.parent / "new_asset_name")
 
     # target already exists
-    inventory.add_directory(asset_path.parent / dir_path.name)
+    inventory.add_directory(Item(asset_path.parent / dir_path.name, repo=inventory.repo))
     inventory.commit("add target dir")
     pytest.raises(ValueError,
                   onyo_mv,


### PR DESCRIPTION
This takes to approach of: minimal changes to make things work in areas of the code that are not ready to be flipped fully over to `Item()` yet.

This will lead to a bit of churn, but is the only rational way to convert the codebase incrementally rather than all at once.