### PR TITLE
Allow querying OnyoRepo for paths of all kinds of items

### DIFF
--- a/onyo/cli/tests/test_unset.py
+++ b/onyo/cli/tests/test_unset.py
@@ -200,7 +200,7 @@ def test_unset_key_does_not_exist(repo: OnyoRepo,
 def test_unset_multiple_assets(repo: OnyoRepo,
                                key: str) -> None:
     r"""Test that `onyo unset --keys KEY --asset ASSET [ASSET2 ...]` removes keys from of assets."""
-    assets = repo.get_asset_paths()
+    assets = repo.get_item_paths(types=['assets'])
 
     # test unsetting keys for multiple assets:
     ret = subprocess.run(['onyo', '--yes', 'unset', '--keys', key, '--asset', *assets],

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -424,7 +424,7 @@ def onyo_edit(inventory: Inventory,
 
     editor = inventory.repo.get_editor()
     for path in paths:
-        asset = inventory.get_asset(path)
+        asset = inventory.get_item(path)
         _edit_asset(inventory, asset, partial(inventory.modify_asset, path), editor)
 
     if inventory.operations_pending():
@@ -1017,7 +1017,7 @@ def onyo_new(inventory: Inventory,
         spec['directory'] = directory
         # 2. start from template
         if clone:
-            asset = inventory.get_asset(clone)
+            asset = inventory.get_item(clone)
         else:
             t = spec.pop('template', None) or template
             asset = inventory.get_asset_from_template(Path(t) if t else None)
@@ -1169,7 +1169,7 @@ def onyo_set(inventory: Inventory,
         raise ValueError("The following paths aren't assets:\n%s" %
                          "\n".join(non_asset_paths))
 
-    for asset in [inventory.get_asset(a) for a in assets]:
+    for asset in [inventory.get_item(a) for a in assets]:
         new_content = Item(asset, inventory.repo)
         new_content.update(keys)
         try:
@@ -1332,7 +1332,7 @@ def onyo_unset(inventory: Inventory,
         raise ValueError(f"Can't unset reserved keys ({', '.join(RESERVED_KEYS)}) "
                          f"or keys in 'onyo.' namespace (pseudo keys)")
 
-    for asset in [inventory.get_asset(a) for a in assets]:
+    for asset in [inventory.get_item(a) for a in assets]:
         new_content = Item(asset, inventory.repo)
         for key in keys:
             try:

--- a/onyo/lib/inventory.py
+++ b/onyo/lib/inventory.py
@@ -426,7 +426,7 @@ class Inventory(object):
         #             registered modify operations. It's easier to not force compliance here, but simply let
         #             modify_asset generate the name and pass it.
         generated_name = self.generate_asset_name(
-            self.get_asset(path)
+            self.get_item(path)
             if isinstance(asset, Path) else asset
         )
         if name and name != generated_name:
@@ -449,7 +449,7 @@ class Inventory(object):
         path = asset if isinstance(asset, Path) else Path(asset.get('onyo.path.absolute'))
         if not self.repo.is_asset_path(path):
             raise ValueError(f"No such asset: {path}")
-        asset = self.get_asset(path) if isinstance(asset, Path) else asset
+        asset = self.get_item(path) if isinstance(asset, Path) else asset
 
         # A path change must not be specified w/ modify_asset. A move is a different operation and
         # a renaming has to be derived from content:
@@ -556,8 +556,8 @@ class Inventory(object):
     # non-operation methods
     #
 
-    def get_asset(self, path: Path) -> UserDict:
-        # read and return Asset
+    def get_item(self, path: Path) -> Item:
+        r"""Get an inventory ``Item`` from ``path``."""
         return Item(path, self.repo)
 
     def get_assets(self,
@@ -585,9 +585,9 @@ class Inventory(object):
         Generator of dict
            All matching assets in the inventory.
         """
-        for p in self.repo.get_asset_paths(include=include, exclude=exclude, depth=depth):
+        for p in self.repo.get_item_paths(include=include, exclude=exclude, depth=depth, types=['assets']):
             try:
-                yield self.get_asset(p)
+                yield self.get_item(p)
             except NotAnAssetError as e:
                 # report the error, but proceed
                 ui.error(e)

--- a/onyo/lib/items.py
+++ b/onyo/lib/items.py
@@ -211,7 +211,7 @@ class Item(DotNotationWrapper):
         """Initializer for the 'onyo.is.empty' pseudo-key."""
         if self['onyo.is.directory'] and self.repo and self._path:
             # TODO: This likely can be faster when redoing/enhancing caching of repo paths.
-            return not any(p.parent == self._path for p in self.repo.get_asset_paths())
+            return not any(p.parent == self._path for p in self.repo.asset_paths)
         return None
 
 # TODO/Notes for next PR(s):

--- a/onyo/lib/tests/test_commands_get.py
+++ b/onyo/lib/tests/test_commands_get.py
@@ -385,7 +385,7 @@ def test_onyo_get_depth_zero(inventory: Inventory,
 
     # verify output contains all assets and "onyo.path.relative" as default key
     output = capsys.readouterr().out
-    for asset in inventory.repo.get_asset_paths():
+    for asset in inventory.repo.asset_paths:
         assert asset.name in output
 
 
@@ -400,7 +400,7 @@ def test_onyo_get_default_inventory_root(inventory: Inventory,
 
     # verify output contains all assets and "onyo.path.relative" as default key
     output = capsys.readouterr().out
-    for asset in inventory.repo.get_asset_paths():
+    for asset in inventory.repo.asset_paths:
         assert asset.name in output
 
 

--- a/onyo/lib/tests/test_commands_new.py
+++ b/onyo/lib/tests/test_commands_new.py
@@ -76,7 +76,7 @@ def test_onyo_new_keys(inventory: Inventory) -> None:
         p = inventory.root / "empty" / f"{s['type']}_{s['make']}_{s['model.name']}.{s['serial']}"
         assert inventory.repo.is_asset_path(p)
         assert p in inventory.repo.git.files
-        new_asset = inventory.get_asset(p)
+        new_asset = inventory.get_item(p)
         assert new_asset.get("onyo.path.absolute") == p
         assert all(new_asset[k] == s[k] for k in s.keys())
 
@@ -114,7 +114,7 @@ def test_onyo_new_keys(inventory: Inventory) -> None:
         assert files[0].name.startswith(f"{s['type']}_{s['make']}_{s['model.name']}.")
         assert inventory.repo.is_asset_path(files[0])
         assert files[0] in inventory.repo.git.files
-        new_asset = inventory.get_asset(files[0])
+        new_asset = inventory.get_item(files[0])
         assert new_asset.get("onyo.path.absolute") == files[0]
         assert new_asset.get("onyo.path.parent") == files[0].parent.relative_to(inventory.root)
         # content equals spec:
@@ -141,7 +141,7 @@ def test_onyo_new_keys(inventory: Inventory) -> None:
     expected_path = inventory.root / f"{specs[0]['type']}_{specs[0]['make']}_{specs[0]['model.name']}.{specs[0]['serial']}"
     assert inventory.repo.is_asset_path(expected_path)
     assert expected_path in inventory.repo.git.files
-    asset_content = inventory.get_asset(expected_path)
+    asset_content = inventory.get_item(expected_path)
     # check for template keys:
     # (Note: key must be there - no `KeyError`; but content is `None`)
     for k in ['RAM', 'Size', 'USB']:
@@ -182,7 +182,7 @@ def test_onyo_new_creates_directories(inventory: Inventory) -> None:
         p = new_directory / inventory.generate_asset_name(s)
         assert inventory.repo.is_asset_path(p)
         assert p in inventory.repo.git.files
-        new_asset = inventory.get_asset(p)
+        new_asset = inventory.get_item(p)
         assert new_asset.get("onyo.path.absolute") == p
         assert all(new_asset[k] == s[k] for k in s.keys())
     assert inventory.repo.git.is_clean_worktree()
@@ -205,7 +205,7 @@ def test_onyo_new_edit(inventory: Inventory, monkeypatch) -> None:
     expected_path = directory / "TYPE_MAKER_MODEL.totally_random"
     assert inventory.repo.is_asset_path(expected_path)
     assert expected_path in inventory.repo.git.files
-    asset_content = inventory.get_asset(expected_path)
+    asset_content = inventory.get_item(expected_path)
     assert asset_content['key'] == 'value'
     assert 'key: value  #w/ comment' in expected_path.read_text()
     assert 'None' not in list(inventory.get_history(expected_path, n=1))[0]['message']
@@ -247,7 +247,7 @@ def test_onyo_new_edit(inventory: Inventory, monkeypatch) -> None:
 @pytest.mark.ui({'yes': True})
 def test_onyo_new_clones(inventory: Inventory) -> None:
     existing_asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
-    existing_asset = inventory.get_asset(existing_asset_path)
+    existing_asset = inventory.get_item(existing_asset_path)
     asset_dir = inventory.root / "somewhere"
     old_hexsha = inventory.repo.git.get_hexsha()
 
@@ -265,7 +265,7 @@ def test_onyo_new_clones(inventory: Inventory) -> None:
     # first new asset:
     new_asset_path1 = asset_dir / f"{existing_asset_path.name.split('.')[0]}.ANOTHER"
     assert inventory.repo.is_asset_path(new_asset_path1)
-    new_asset = inventory.get_asset(new_asset_path1)
+    new_asset = inventory.get_item(new_asset_path1)
     # equals existing asset except for path-pseudo-keys and serial:
     # Actually: history differs as well. onyo.is. doesn't, though
     for k, v in existing_asset.items():
@@ -278,7 +278,7 @@ def test_onyo_new_clones(inventory: Inventory) -> None:
     # second new asset
     new_asset_path2 = asset_dir / f"{existing_asset_path.name.split('.')[0]}.whatever"
     assert inventory.repo.is_asset_path(new_asset_path2)
-    new_asset = inventory.get_asset(new_asset_path2)
+    new_asset = inventory.get_item(new_asset_path2)
     # equals existing asset except for path-pseudo-keys and serial:
     assert all(v == new_asset[k] for k, v in existing_asset.items()
                if k != "serial" and not k.startswith('onyo.path') and not k.startswith('onyo.was.'))

--- a/onyo/lib/tests/test_commands_set.py
+++ b/onyo/lib/tests/test_commands_set.py
@@ -342,7 +342,7 @@ def test_onyo_set_asset_dir(inventory: Inventory) -> None:
              keys={'other': 2})
     assert inventory.repo.git.is_clean_worktree()
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
-    assert inventory.get_asset(asset_dir)['other'] == 2
+    assert inventory.get_item(asset_dir)['other'] == 2
 
     # turn asset dir into asset file:
     onyo_set(inventory,
@@ -352,7 +352,7 @@ def test_onyo_set_asset_dir(inventory: Inventory) -> None:
     assert inventory.repo.git.get_hexsha('HEAD~2') == old_hexsha
     assert inventory.repo.is_asset_path(asset_dir)
     assert asset_dir.is_file()
-    assert inventory.get_asset(asset_dir)["some_key"] == "some_value"
+    assert inventory.get_item(asset_dir)["some_key"] == "some_value"
 
     # turn it back into an asset dir
     onyo_set(inventory,
@@ -361,7 +361,7 @@ def test_onyo_set_asset_dir(inventory: Inventory) -> None:
     assert inventory.repo.git.is_clean_worktree()
     assert inventory.repo.git.get_hexsha('HEAD~3') == old_hexsha
     assert inventory.repo.is_asset_dir(asset_dir)
-    assert inventory.get_asset(asset_dir)["some_key"] == "some_value"
+    assert inventory.get_item(asset_dir)["some_key"] == "some_value"
 
 
 @pytest.mark.ui({'yes': True})
@@ -370,10 +370,10 @@ def test_set_empty_dictlist(inventory: Inventory) -> None:
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     onyo_set(inventory, assets=[asset_path], keys={"new_key": dict()})
     assert inventory.repo.git.is_clean_worktree()
-    assert inventory.get_asset(asset_path)["new_key"] == dict()
+    assert inventory.get_item(asset_path)["new_key"] == dict()
     onyo_set(inventory, assets=[asset_path], keys={"new_key": list()})
     assert inventory.repo.git.is_clean_worktree()
-    assert inventory.get_asset(asset_path)["new_key"] == list()
+    assert inventory.get_item(asset_path)["new_key"] == list()
 
 
 @pytest.mark.ui({'yes': True})

--- a/onyo/lib/tests/test_commands_tree.py
+++ b/onyo/lib/tests/test_commands_tree.py
@@ -48,7 +48,7 @@ def test_onyo_tree(inventory: Inventory,
     # root node is path
     assert tree_output.startswith(f"{directory_path}\n")
     # assets and paths are in output
-    for path in inventory.repo.get_asset_paths(include=[directory_path]):
+    for path in inventory.repo.get_item_paths(include=[directory_path], types=['assets']):
         assert all([part in tree_output for part in path.parts])
     assert inventory.repo.git.is_clean_worktree()
 

--- a/onyo/lib/tests/test_commands_unset.py
+++ b/onyo/lib/tests/test_commands_unset.py
@@ -293,8 +293,8 @@ def test_onyo_unset_asset_dir(inventory: Inventory) -> None:
                keys=['other', 'some_key'])
     assert inventory.repo.git.is_clean_worktree()
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
-    assert 'other' not in inventory.get_asset(asset_dir)
-    assert 'some_key' not in inventory.get_asset(asset_dir)
+    assert 'other' not in inventory.get_item(asset_dir)
+    assert 'some_key' not in inventory.get_item(asset_dir)
 
 
 @pytest.mark.ui({'yes': True})
@@ -317,7 +317,7 @@ def test_onyo_unset_empty(inventory: Inventory) -> None:
     inventory.commit("add asset w/ empty values")
     old_hexsha = inventory.repo.git.get_hexsha()
     asset_path = inventory.root / "TYPE_MAKE_MODEL.SERIAL2"
-    asset_written = inventory.get_asset(asset_path)
+    asset_written = inventory.get_item(asset_path)
 
     assert all(asset_written[k] == v for k, v in test_pairs.items())
 
@@ -326,5 +326,5 @@ def test_onyo_unset_empty(inventory: Inventory) -> None:
                keys=test_pairs.keys())
     assert inventory.repo.git.is_clean_worktree()
     assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
-    asset_written = inventory.get_asset(asset_path)
+    asset_written = inventory.get_item(asset_path)
     assert all(k not in asset_written.keys() for k in test_pairs.keys())

--- a/onyo/lib/tests/test_inventory_operations.py
+++ b/onyo/lib/tests/test_inventory_operations.py
@@ -78,7 +78,7 @@ def test_add_asset(repo: OnyoRepo) -> None:
     assert repo.is_inventory_dir(newdir1)
     assert repo.is_inventory_dir(newdir2)
     assert repo.is_asset_path(asset_file)
-    asset_from_disc = inventory.get_asset(asset_file)
+    asset_from_disc = inventory.get_item(asset_file)
     assert asset_file == asset_from_disc.get('onyo.path.absolute')
     # All pseudo-keys are set, except `onyo.is.empty` which is only set for directories:
     assert all(asset_from_disc[k] is not None for k in PSEUDO_KEYS.keys() if k != 'onyo.is.empty')
@@ -142,7 +142,7 @@ def test_remove_asset(inventory: Inventory) -> None:
     asset_file = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     assert asset_file.exists()
 
-    asset = inventory.get_asset(asset_file)
+    asset = inventory.get_item(asset_file)
     inventory.remove_asset(asset)
     # operation registered:
     assert num_operations(inventory, 'remove_assets') == 1
@@ -223,7 +223,7 @@ def test_move_asset(repo: OnyoRepo) -> None:
             )]
         else:
             assert v == []
-    asset_from_disc = inventory.get_asset(moved_asset_path)
+    asset_from_disc = inventory.get_item(moved_asset_path)
 
     # history pseudo-keys: The move is not an asset modification:
     assert asset_from_disc['onyo.was.created.hexsha'] == asset_from_disc['onyo.was.modified.hexsha'] == inventory.repo.git.get_hexsha('HEAD~1')
@@ -309,7 +309,7 @@ def test_modify_asset(repo: OnyoRepo) -> None:
     # nothing done on disc yet:
     assert asset_file.is_file()
     assert not new_asset_file.exists()
-    asset_on_disc = inventory.get_asset(asset_file)
+    asset_on_disc = inventory.get_item(asset_file)
     assert asset_file == asset_on_disc.get('onyo.path.absolute')
     for k, v in asset.items():
         if k not in RESERVED_KEYS + list(PSEUDO_KEYS.keys()):
@@ -322,7 +322,7 @@ def test_modify_asset(repo: OnyoRepo) -> None:
     assert not asset_file.exists()
     assert repo.is_asset_path(new_asset_file)
 
-    asset_on_disc = inventory.get_asset(new_asset_file)
+    asset_on_disc = inventory.get_item(new_asset_file)
     for k, v in new_asset.items():
         if k not in PSEUDO_KEYS:
             assert asset_on_disc[k] == new_asset[k]
@@ -617,7 +617,7 @@ def test_add_asset_dir(repo: OnyoRepo) -> None:
             assert v == []
 
     # pseudo-keys
-    asset_from_disk = inventory.get_asset(asset_dir_path)
+    asset_from_disk = inventory.get_item(asset_dir_path)
     assert asset_from_disk['onyo.path.relative'] == asset_dir_path.relative_to(inventory.root)
     assert asset_from_disk['onyo.path.file'] == asset_from_disk['onyo.path.relative'] / OnyoRepo.ASSET_DIR_FILE_NAME
     assert asset_from_disk['onyo.is.asset'] is True
@@ -682,7 +682,7 @@ def test_add_asset_dir(repo: OnyoRepo) -> None:
             assert v == []
 
     # pseudo-keys
-    asset_from_disk = inventory.get_asset(expected_path)
+    asset_from_disk = inventory.get_item(expected_path)
     assert asset_from_disk['onyo.path.relative'] == expected_path.relative_to(inventory.root)
     assert asset_from_disk['onyo.path.file'] == asset_from_disk['onyo.path.relative'] / OnyoRepo.ASSET_DIR_FILE_NAME
     assert asset_from_disk['onyo.is.asset'] is True
@@ -732,7 +732,7 @@ def test_add_dir_asset(repo: OnyoRepo) -> None:
             assert v == []
 
     # pseudo-keys
-    asset_from_disk = inventory.get_asset(asset_path)
+    asset_from_disk = inventory.get_item(asset_path)
     assert asset_from_disk['onyo.path.relative'] == asset_path.relative_to(inventory.root)
     assert asset_from_disk['onyo.path.file'] == asset_from_disk['onyo.path.relative'] / OnyoRepo.ASSET_DIR_FILE_NAME
     assert asset_from_disk['onyo.is.asset'] is True
@@ -793,7 +793,7 @@ def test_remove_asset_dir_directory(repo: OnyoRepo) -> None:
             assert v == []
 
     # pseudo-keys
-    asset_from_disk = inventory.get_asset(asset_dir_path)
+    asset_from_disk = inventory.get_item(asset_dir_path)
     assert asset_from_disk['onyo.path.relative'] == asset_dir_path.relative_to(inventory.root)
     assert asset_from_disk['onyo.path.file'] == asset_from_disk['onyo.path.relative']
     assert asset_from_disk['onyo.is.asset'] is True
@@ -853,7 +853,7 @@ def test_remove_asset_dir_asset(repo: OnyoRepo) -> None:
             assert v == []
 
     # pseudo-keys
-    asset_from_disk = inventory.get_asset(asset_dir_path)
+    asset_from_disk = inventory.get_item(asset_dir_path)
     assert asset_from_disk['onyo.path.relative'] == asset_dir_path.relative_to(inventory.root)
     assert asset_from_disk['onyo.path.file'] == asset_from_disk['onyo.path.relative'] / OnyoRepo.ANCHOR_FILE_NAME
     assert asset_from_disk['onyo.is.asset'] is False
@@ -938,7 +938,7 @@ def test_move_asset_dir(repo: OnyoRepo) -> None:
             assert v == []
 
     # pseudo-keys
-    asset_from_disk = inventory.get_asset(asset_dir_path)
+    asset_from_disk = inventory.get_item(asset_dir_path)
     assert asset_from_disk['onyo.path.relative'] == asset_dir_path.relative_to(inventory.root)
     assert asset_from_disk['onyo.path.file'] == asset_from_disk['onyo.path.relative'] / OnyoRepo.ASSET_DIR_FILE_NAME
     assert asset_from_disk['onyo.is.asset'] is True
@@ -1006,7 +1006,7 @@ def test_rename_asset_dir(repo: OnyoRepo) -> None:
             assert v == []
 
     # pseudo-keys
-    asset_from_disk = inventory.get_asset(new_asset_dir_path)
+    asset_from_disk = inventory.get_item(new_asset_dir_path)
     assert asset_from_disk['onyo.path.relative'] == new_asset_dir_path.relative_to(inventory.root)
     assert asset_from_disk['onyo.path.file'] == asset_from_disk['onyo.path.relative'] / OnyoRepo.ASSET_DIR_FILE_NAME
     assert asset_from_disk['onyo.is.asset'] is True
@@ -1037,7 +1037,7 @@ def test_modify_asset_dir(repo: OnyoRepo) -> None:
     )
     inventory.add_asset(asset)
     inventory.commit("asset dir added")
-    asset = inventory.get_asset(asset_path)
+    asset = inventory.get_item(asset_path)
     assert inventory.repo.is_asset_dir(asset_path)
     assert asset['onyo.is.directory'] and asset['onyo.is.asset']
 
@@ -1060,7 +1060,7 @@ def test_modify_asset_dir(repo: OnyoRepo) -> None:
     # nothing done on disc yet:
     assert inventory.repo.is_asset_dir(asset_path)
     assert not new_asset_path.exists()
-    asset_on_disc = inventory.get_asset(asset_path)
+    asset_on_disc = inventory.get_item(asset_path)
     for k1, v1 in asset_on_disc.items():
         assert asset[k1] == v1
     for k2, v2 in asset.items():
@@ -1073,7 +1073,7 @@ def test_modify_asset_dir(repo: OnyoRepo) -> None:
     assert inventory.repo.is_asset_dir(new_asset_path)
     assert inventory.repo.git.is_clean_worktree()
 
-    asset_on_disc = inventory.get_asset(new_asset_path)
+    asset_on_disc = inventory.get_item(new_asset_path)
     for k, v in new_asset.items():
         if k not in PSEUDO_KEYS:
             assert asset_on_disc[k] == new_asset[k]
@@ -1094,7 +1094,7 @@ def test_modify_asset_dir(repo: OnyoRepo) -> None:
             assert v == []
 
     # pseudo-keys
-    asset_from_disk = inventory.get_asset(new_asset_path)
+    asset_from_disk = inventory.get_item(new_asset_path)
     assert asset_from_disk['onyo.path.relative'] == new_asset_path.relative_to(inventory.root)
     assert asset_from_disk['onyo.path.file'] == asset_from_disk['onyo.path.relative'] / OnyoRepo.ASSET_DIR_FILE_NAME
     assert asset_from_disk['onyo.is.asset'] is True

--- a/onyo/lib/tests/test_onyo.py
+++ b/onyo/lib/tests/test_onyo.py
@@ -253,3 +253,44 @@ def test_onyo_auto_message(onyorepo, caplog) -> None:
     assert onyorepo.auto_message
     assert caplog.text.startswith("WARNING")
     assert "Invalid config value" in caplog.text
+
+
+@pytest.mark.gitrepo_contents((Path('.gitignore'), "idea/"),
+                              (Path("subdir") / ".gitignore", "i_*"),
+                              (Path(OnyoRepo.IGNORE_FILE_NAME), "*.pdf\ndocs/"),
+                              (Path("subdir") / OnyoRepo.IGNORE_FILE_NAME, "untracked*\n"),
+                              (Path("idea") / "something", "blubb"),
+                              (Path("some.pdf"), "bla"),
+                              (Path("subdir") / "another.pdf", "content"),
+                              (Path("subdir") / "i_untracked", ""),
+                              (Path("subdir") / "subsub" / "untracked_som.txt", ""),
+                              (Path("docs") / "regular", "whatever")
+                              )
+@pytest.mark.inventory_assets(Item(type="atype",
+                                   make="amake",
+                                   model="amodel",
+                                   serial=1,
+                                   path=Path("subdir") / "atype_amake_amodel.1"))
+@pytest.mark.inventory_dirs(Path('a/test/directory/structure/'),
+                            Path('another/dir/'))
+@pytest.mark.inventory_templates((Path(OnyoRepo.TEMPLATE_DIR) / "t_dir" / "atemplate", "--\nkey: value\n"))
+def test_get_item_paths(onyorepo) -> None:
+    assert set(onyorepo.get_item_paths(types=['assets'])) == set(a['onyo.path.absolute'] for a in onyorepo.test_annotation['assets'])
+    assert set(onyorepo.get_item_paths(types=['templates'])) == set(onyorepo.test_annotation['templates'])
+    assert set(onyorepo.get_item_paths(types=['directories'])) == set(onyorepo.test_annotation['dirs'] + [onyorepo.git.root])
+
+    # listing several types is equivalent to summing of separate calls:
+    assert set(onyorepo.get_item_paths(types=['assets', 'templates'])) == set(
+        [a['onyo.path.absolute'] for a in onyorepo.test_annotation['assets']] + onyorepo.test_annotation['templates']
+    )
+    assert set(onyorepo.get_item_paths(types=['templates', 'directories'])) == set(
+        onyorepo.test_annotation['templates'] + onyorepo.test_annotation['dirs']
+    )
+
+    # Explicitly double-check onyoignored stuff:
+    ignored_path = onyorepo.git.root / "subdir" / "subsub" / "untracked_som.txt"
+    assert ignored_path not in onyorepo.get_item_paths(types=['assets', 'directories', 'templates'])
+    assert all(onyorepo.git.root / "docs" not in p.parents
+               for p in onyorepo.get_item_paths(types=['assets', 'directories', 'templates']))
+
+    # TODO: Test include/exclude/depth. This is currently only done at higher level (onyo get command).

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,6 +7,7 @@ markers =
     gitrepo_contents: Tuples (`Path`, `str`) of files to be committed in the "gitrepo" fixture
     inventory_assets: dicts specifying assets to create; for use with the "onyorepo" fixture
     inventory_dirs: paths specifying (empty) inventory dirs; for use with the "onyorepo" fixture
+    inventory_templates: Tuples (`Path`, `str`) of templates to be committed in the "onyorepo" fixture
 
 addopts =
     --strict-markers


### PR DESCRIPTION
- This enables `OnyoRepo` to be queried for paths of different types of items (Assets, Dirs, Templates) in preparation of the respective query modes for `onyo get` (see #673).
- In the process `Inventory.get_asset()` and `OnyoRepo.get_asset_paths()` are renamed b/c they account for all items, not just assets.
- Enhances the `onyorepo` fixture to take an `inventory_templates` marker