### PR TITLE
`get`: Allow querying templates and directories

### DIFF
--- a/onyo/cli/get.py
+++ b/onyo/cli/get.py
@@ -54,7 +54,7 @@ args_get = {
         type=str,
         default=None,
         help=r"""
-            Criteria to match assets in the form ``KEY=VALUE``, where **VALUE**
+            Criteria to match in the form ``KEY=VALUE``, where **VALUE**
             is a python regular expression. Pseudo-keys such as ``path`` can
             also be used. Dictionary subkeys can be addressed using a period
             (e.g. ``model.name``, ``model.year``, etc.) One can match keys that
@@ -71,7 +71,7 @@ args_get = {
         metavar='INCLUDE',
         nargs='+',
         help=r"""
-            Assets or directories to query.
+            Paths to query.
         """
     ),
 
@@ -80,7 +80,7 @@ args_get = {
         metavar='EXCLUDE',
         nargs='+',
         help=r"""
-            Assets or directories to exclude from the query.
+            Paths to exclude from the query.
         """
     ),
 
@@ -113,6 +113,18 @@ args_get = {
             Note, that if a **SORT-KEY** appears multiple times, the latest appearance will
             overrule what was specified before.
             One can sort by keys that are not in the output.
+        """
+    ),
+
+    'types': dict(
+        args=('-t', '--types'),
+        metavar="TYPES",
+        nargs='+',
+        choices=('assets', 'directories', 'templates'),
+        default=["assets"],
+        help=r"""
+            Item types to query.
+            Equivalent to ``onyo.is.asset=True``, ``onyo.is.directory=True``, and ``onyo.is.template=True``.
         """
     ),
 }
@@ -182,7 +194,8 @@ def get(args: argparse.Namespace) -> None:
                        # doesn't work with the bound method `Filter.match`.
                        # Not clear, what's the problem.
                        match=filters,  # pyre-ignore[6]
-                       keys=args.keys)
+                       keys=args.keys,
+                       types=args.types)
 
     if not results:
         raise OnyoCLIExitCode("'onyo get' exits 1 when no results are found.", 1)

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -49,6 +49,7 @@ if TYPE_CHECKING:
         Dict,
         Generator,
         Iterable,
+        Literal,
     )
     from onyo.lib.consts import sort_t
     from onyo.lib.onyo import OnyoRepo
@@ -455,7 +456,9 @@ def onyo_get(inventory: Inventory,
              machine_readable: bool = False,
              match: list[Callable[[dict], bool]] | None = None,
              keys: list[str] | None = None,
-             sort: dict[str, sort_t] | None = None) -> list[dict]:
+             sort: dict[str, sort_t] | None = None,
+             types: list[Literal['assets', 'directories', 'templates']] | None = None,
+             ) -> list[dict]:
     r"""Query the key-values of assets.
 
     Parameters
@@ -490,6 +493,11 @@ def onyo_get(inventory: Inventory,
         use: :py:data:`onyo.lib.consts.SORT_ASCENDING` and
         :py:data:`onyo.lib.consts.SORT_DESCENDING`.
         Default: ``{'onyo.path.relative': SORT_ASCENDING}``
+    types
+        List of types of inventory items to consider. Valid types are
+        'assets', 'directories', and 'templates'.
+        Equivalent to ``onyo.is.asset=True``, ``onyo.is.directory=True``, and ``onyo.is.template=True``.
+        Defaults to ['assets'].
 
     Raises
     ------
@@ -515,10 +523,11 @@ def onyo_get(inventory: Inventory,
         raise ValueError(f"Allowed sorting modes: {', '.join(allowed_sorting)}")
 
     selected_keys = selected_keys or inventory.repo.get_asset_name_keys() + ['onyo.path.relative']
-    results = list(inventory.get_assets_by_query(include=include,
-                                                 exclude=exclude,
-                                                 depth=depth,
-                                                 match=match))  # pyre-ignore[6]
+    results = list(inventory.get_items_by_query(include=include,
+                                                exclude=exclude,
+                                                depth=depth,
+                                                match=match,  # pyre-ignore[6]
+                                                types=types))
 
     # sort results before filtering/replacing, so all keys can be sorted
     results = natural_sort(

--- a/onyo/lib/items.py
+++ b/onyo/lib/items.py
@@ -103,16 +103,20 @@ class Item(DotNotationWrapper):
         #       a directory or an .onyoignore'd file.
         from onyo.lib.utils import get_asset_content
         self._path = path
-        if self['onyo.is.asset']:
-            loader = self.repo.get_asset_content if self.repo else get_asset_content
-            map_from_file = loader(path)
-            self.update(map_from_file)
-            if hasattr(map_from_file, 'copy_attributes'):
-                # We got a (subclass of) ruamel.yaml.CommentBase.
-                # Copy the attributes re comments, format, etc. for roundtrip.
-                # Note, that this is replacing - there's no straightforward way to merge w/
-                # existing comments etc.
-                map_from_file.copy_attributes(self.data)  # pyre-ignore[16]
+        if self['onyo.is.asset'] and self.repo:
+            loader = self.repo.get_asset_content
+        elif self['onyo.is.asset'] or self['onyo.is.template']:
+            loader = get_asset_content
+        else:
+            return
+        map_from_file = loader(path)
+        self.update(map_from_file)
+        if hasattr(map_from_file, 'copy_attributes'):
+            # We got a (subclass of) ruamel.yaml.CommentBase.
+            # Copy the attributes re comments, format, etc. for roundtrip.
+            # Note, that this is replacing - there's no straightforward way to merge w/
+            # existing comments etc.
+            map_from_file.copy_attributes(self.data)  # pyre-ignore[16]
 
     def fill_created(self, what: str | None):
         """Initializer for the 'onyo.was.created' pseudo-keys.
@@ -128,6 +132,10 @@ class Item(DotNotationWrapper):
         and we'd have to trace back moves and renames in order to know what path or file name we are looking
         to match against these operations.
         """
+        if self['onyo.is.template']:
+            # Templates aren't actually tracked in the inventory (only in git).
+            # Hence, there are no operations records to be used.
+            return None
         if self.repo and self['onyo.path.absolute']:
             for commit in self.repo.get_history(self['onyo.path.file']):  # pyre-ignore[16]
                 if 'operations' in commit:
@@ -146,6 +154,10 @@ class Item(DotNotationWrapper):
         ----------
         See ``fill_created``.
         """
+        if self['onyo.is.template']:
+            # Templates aren't actually tracked in the inventory (only in git).
+            # Hence, there are no operations records to be used.
+            return None
         if self.repo and self['onyo.path.absolute']:
             for commit in self.repo.get_history(self['onyo.path.file']):  # pyre-ignore[16]
                 if 'operations' in commit:
@@ -169,24 +181,26 @@ class Item(DotNotationWrapper):
     def get_path_relative(self):
         """Initializer for the 'onyo.path.relative' pseudo-key."""
         if self.repo and self['onyo.path.absolute']:
-            return self['onyo.path.absolute'].relative_to(self.repo.git.root)
+            try:
+                return self['onyo.path.absolute'].relative_to(self.repo.git.root)
+            except ValueError:
+                pass  # return None (translates to '<unset>') if relative_to() fails b/c path is outside repo.
         return None
 
     def get_path_parent(self):
         """Initializer for the 'onyo.path.parent' pseudo-key."""
-        if self.repo and self['onyo.path.absolute']:
-            return self['onyo.path.absolute'].parent.relative_to(self.repo.git.root)
+        if self.repo and self['onyo.path.relative']:
+            return self['onyo.path.relative'].parent
         return None
 
     def get_path_file(self):
         """Initializer for the 'onyo.path.file' pseudo-key."""
-        if self.repo and self['onyo.path.absolute']:
-            if self['onyo.is.asset'] and not self['onyo.is.directory']:
+        if self.repo and self['onyo.path.relative']:
+            if not self['onyo.is.directory']:
                 return self['onyo.path.relative']
-            if self['onyo.is.asset'] and self['onyo.is.directory']:
+            if self['onyo.is.asset'] or self['onyo.is.template']:
                 return self['onyo.path.relative'] / onyo.lib.onyo.OnyoRepo.ASSET_DIR_FILE_NAME
-            if self['onyo.is.directory'] and not self['onyo.is.asset']:
-                return self['onyo.path.relative'] / onyo.lib.onyo.OnyoRepo.ANCHOR_FILE_NAME
+            return self['onyo.path.relative'] / onyo.lib.onyo.OnyoRepo.ANCHOR_FILE_NAME
         return None
 
     def is_asset(self) -> bool | None:

--- a/onyo/lib/tests/test_commands_get.py
+++ b/onyo/lib/tests/test_commands_get.py
@@ -584,3 +584,27 @@ def test_onyo_get_unset_values(inventory: Inventory,
                       for p in [asset1_path, asset2_path]]
     assert expected_lines[0] in output.splitlines()
     assert expected_lines[1] in output.splitlines()
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_get_items(inventory: Inventory, capsys) -> None:
+    """`get` can also query dirs and templates"""
+
+    onyo_get(inventory,
+             keys=["onyo.path.relative"],
+             machine_readable=True,
+             types=['templates'])
+    output = capsys.readouterr().out
+    assert len(output.splitlines()) == 2
+    assert str(OnyoRepo.TEMPLATE_DIR / "empty") in output
+    assert str(OnyoRepo.TEMPLATE_DIR / "laptop.example") in output
+
+    onyo_get(inventory,
+             keys=["onyo.path.relative"],
+             machine_readable=True,
+             include=[inventory.root / "somewhere"],
+             types=['directories'])
+    output_lines = capsys.readouterr().out.splitlines(keepends=True)
+    assert len(output_lines) == 2
+    assert "somewhere\n" in output_lines
+    assert "somewhere/nested\n" in output_lines

--- a/onyo/lib/tests/test_inventory.py
+++ b/onyo/lib/tests/test_inventory.py
@@ -1,0 +1,47 @@
+import pytest
+from pathlib import Path
+
+from onyo.lib.inventory import Inventory
+from onyo.lib.onyo import OnyoRepo
+from onyo.lib.items import Item
+
+
+@pytest.mark.ui({'yes': True})
+def test_get_items_types(inventory: Inventory, capsys) -> None:
+
+    assets = [a for a in inventory.get_items(types=['assets'])]
+    assert len(assets) == 1
+    asset = assets[0]
+    assert isinstance(asset, Item)
+    assert asset["onyo.path.relative"] == Path("somewhere") / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+    assert asset["onyo.is.asset"] is True
+    assert asset["onyo.is.directory"] is False
+    assert asset["onyo.is.template"] is False
+
+    fixture_dirs = [Path("."),
+                    Path("empty"),
+                    Path("somewhere"),
+                    Path("somewhere") / "nested",
+                    Path("different"),
+                    Path("different") / "place"]
+    dirs = [d for d in inventory.get_items(types=['directories'])]
+    assert len(dirs) == len(fixture_dirs)
+    assert all(d["onyo.path.relative"] in fixture_dirs for d in dirs)
+    assert all(p in [d["onyo.path.relative"] for d in dirs] for p in fixture_dirs)
+    for d in dirs:
+        assert isinstance(d, Item)
+        assert d["onyo.is.directory"] is True
+        assert d["onyo.is.asset"] is False
+        assert d["onyo.is.template"] is False
+
+    fixture_templates = [OnyoRepo.TEMPLATE_DIR / "empty",
+                         OnyoRepo.TEMPLATE_DIR / "laptop.example"]
+    templates = [t for t in inventory.get_items(types=['templates'])]
+    assert len(templates) == len(fixture_templates)
+    assert all(t["onyo.path.relative"] in fixture_templates for t in templates)
+    assert all(p in [t["onyo.path.relative"] for t in templates] for p in fixture_templates)
+    for t in templates:
+        assert isinstance(t, Item)
+        assert t["onyo.is.asset"] is False
+        assert t["onyo.is.directory"] is False
+        assert t["onyo.is.template"] is True

--- a/onyo/lib/tests/test_item.py
+++ b/onyo/lib/tests/test_item.py
@@ -27,6 +27,7 @@ def test_item_init(onyorepo) -> None:
                          Item(onyorepo.test_annotation['dirs'][0]),
                          Item(onyorepo.test_annotation['dirs'][0], onyorepo),
                          Item(onyorepo.test_annotation['assets'][0]['onyo.path.absolute'], onyorepo),
+                         Item(onyorepo.test_annotation['templates'][1], onyorepo),
                          ]
 
     for item, idx in zip(constructor_calls, range(len(constructor_calls))):
@@ -37,13 +38,13 @@ def test_item_init(onyorepo) -> None:
         # Non-existing keys raise proper error:
         pytest.raises(KeyError, lambda: item['doesnotexist'])
         # If a Path was given, at the very least the absolute path is available:
-        if idx in [3, 4, 5]:
+        if idx in [3, 4, 5, 6]:
             assert isinstance(item.get('onyo.path.absolute'), Path)
         else:
             # otherwise, this is unset
             assert item.get('onyo.path.absolute') is None
         # If the repo was given, relative-to-root paths are available as well:
-        if idx in [4, 5]:
+        if idx in [4, 5, 6]:
             assert isinstance(item.get('onyo.path.relative'), Path)
             assert isinstance(item.get('onyo.path.parent'), Path)
         else:
@@ -63,6 +64,11 @@ def test_item_init(onyorepo) -> None:
             assert item.get('onyo.path.relative') == onyorepo.test_annotation['assets'][0]['onyo.path.absolute'].relative_to(onyorepo.git.root)
             assert item.get('onyo.path.parent') == onyorepo.test_annotation['assets'][0]['onyo.path.absolute'].parent.relative_to(onyorepo.git.root)
             assert item.get('onyo.path.file') == item.get('onyo.path.relative')
+        elif idx == 6:
+            assert item.get('onyo.path.absolute') == onyorepo.test_annotation['templates'][1]
+            assert item.get('onyo.path.relative') == onyorepo.test_annotation['templates'][1].relative_to(onyorepo.git.root)
+            assert item.get('onyo.path.parent') == onyorepo.test_annotation['templates'][1].parent.relative_to(onyorepo.git.root)
+            assert item.get('onyo.path.file') == item.get('onyo.path.relative')
         if item.repo is None:
             assert item['onyo.is.asset'] is None
             assert item['onyo.is.directory'] is None
@@ -76,3 +82,7 @@ def test_item_init(onyorepo) -> None:
         # Aliases
         for k in PSEUDOKEY_ALIASES:
             assert item[k] == item[PSEUDOKEY_ALIASES[k]]
+
+        # content is read from file:
+        if idx in [5, 6]:
+            assert all(k in item.keys() for k in ['type', 'make', 'model.name'])

--- a/onyo/shell_completion/zsh
+++ b/onyo/shell_completion/zsh
@@ -118,6 +118,7 @@ _onyo() {
                     '(-e --exclude)'{-e,--exclude}'[assets and/or directories to exclude from the query]:*-*:PATH:_files -W "$(_onyo_dir)"'
                     '(-s --sort-ascending -S --sort-descending)'{-s,--sort-ascending}'[sort output in ascending order]'
                     '(-S --sort-descending -s --sort-ascending)'{-S,--sort-descending}'[sort output in descending order]'
+                    '(-t --types)'{-t,--types}'[item types to query]:*-*:TYPES:(assets directories templates)'
                 )
                 ;;
             history)


### PR DESCRIPTION
This introduces the `--types` switch to `get`, allowing to specify what
types of items to consider for matching.

Closes https://github.com/psyinfra/onyo/issues/673
Closes https://github.com/psyinfra/onyo/issues/674
Closes https://github.com/psyinfra/onyo/issues/675
Closes https://github.com/psyinfra/onyo/issues/676

In the process fixed the `Item` class to account for templates and to have pseudokeys evaluate to `<unset>` for relative paths in `onyo.path.*` whenever they would point outside the repository.