### PR TITLE
New pseudo-key `onyo.path.name`

### DIFF
--- a/onyo/lib/items.py
+++ b/onyo/lib/items.py
@@ -204,6 +204,12 @@ class Item(DotNotationWrapper):
             return self['onyo.path.relative'] / onyo.lib.onyo.OnyoRepo.ANCHOR_FILE_NAME
         return None
 
+    def get_path_name(self):
+        """Initializer for the 'onyo.path.name' pseudo-key."""
+        if self['onyo.path.absolute']:
+            return self['onyo.path.absolute'].name
+        return None
+
     def is_asset(self) -> bool | None:
         """Initializer for the 'onyo.is.asset' pseudo-key."""
         if not self.repo or not self._path:

--- a/onyo/lib/pseudokeys.py
+++ b/onyo/lib/pseudokeys.py
@@ -58,6 +58,10 @@ PSEUDO_KEYS: Dict[str, PseudoKey] = {
                     "Different from 'onyo.path.relative' in case of an asset directory.",
         implementation=partial(delegate, attribute='get_path_file')
     ),
+    'onyo.path.name': PseudoKey(
+        description="Basename of the item's path.",
+        implementation=partial(delegate, attribute='get_path_name')
+    ),
     'onyo.is.asset': PseudoKey(
         description="Is the item an asset.",
         implementation=partial(delegate, attribute='is_asset')

--- a/onyo/lib/tests/test_item.py
+++ b/onyo/lib/tests/test_item.py
@@ -40,6 +40,7 @@ def test_item_init(onyorepo) -> None:
         # If a Path was given, at the very least the absolute path is available:
         if idx in [3, 4, 5, 6]:
             assert isinstance(item.get('onyo.path.absolute'), Path)
+            assert item.get('onyo.path.name') == item['onyo.path.absolute'].name
         else:
             # otherwise, this is unset
             assert item.get('onyo.path.absolute') is None
@@ -64,11 +65,13 @@ def test_item_init(onyorepo) -> None:
             assert item.get('onyo.path.relative') == onyorepo.test_annotation['assets'][0]['onyo.path.absolute'].relative_to(onyorepo.git.root)
             assert item.get('onyo.path.parent') == onyorepo.test_annotation['assets'][0]['onyo.path.absolute'].parent.relative_to(onyorepo.git.root)
             assert item.get('onyo.path.file') == item.get('onyo.path.relative')
+            assert item['onyo.is.empty'] is None
         elif idx == 6:
             assert item.get('onyo.path.absolute') == onyorepo.test_annotation['templates'][1]
             assert item.get('onyo.path.relative') == onyorepo.test_annotation['templates'][1].relative_to(onyorepo.git.root)
             assert item.get('onyo.path.parent') == onyorepo.test_annotation['templates'][1].parent.relative_to(onyorepo.git.root)
             assert item.get('onyo.path.file') == item.get('onyo.path.relative')
+            assert item['onyo.is.empty'] is None
         if item.repo is None:
             assert item['onyo.is.asset'] is None
             assert item['onyo.is.directory'] is None


### PR DESCRIPTION
This introduces `onyo.path.name` as a pseudo-key, providing the basename of an item's path for use in queries.

Sits on top of #750