### PR TITLE
Itemize rename_asset and modify_asset

### DIFF
--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -245,9 +245,9 @@ def onyo_config(inventory: Inventory,
 
 
 def _edit_asset(inventory: Inventory,
-                asset: dict | UserDict,
+                asset: Item,
                 operation: Callable,
-                editor: str | None) -> dict | UserDict:
+                editor: str | None) -> Item:
     r"""Edit an ``asset`` (as a temporary file) with ``editor``.
 
     A helper for ``onyo_edit()`` and ``onyo_new(edit=True)``.
@@ -339,7 +339,7 @@ def _edit_asset(inventory: Inventory,
                 case 'edit':
                     continue
                 case 'skip':
-                    return dict()
+                    return Item()
                 case 'abort':
                     # Error message was already passed to ui. Raise a different exception instead.
                     # TODO: Own exception class for that purpose? Can we have no message at all?
@@ -375,7 +375,7 @@ def _edit_asset(inventory: Inventory,
             case 'edit':
                 continue
             case 'skip':
-                return dict()
+                return Item()
             case 'abort':
                 raise KeyboardInterrupt
             case _:
@@ -426,7 +426,7 @@ def onyo_edit(inventory: Inventory,
     editor = inventory.repo.get_editor()
     for path in paths:
         asset = inventory.get_item(path)
-        _edit_asset(inventory, asset, partial(inventory.modify_asset, path), editor)
+        _edit_asset(inventory, asset, partial(inventory.modify_asset, asset), editor)
 
     if inventory.operations_pending():
         # display changes

--- a/onyo/lib/tests/test_inventory_operations.py
+++ b/onyo/lib/tests/test_inventory_operations.py
@@ -289,9 +289,9 @@ def test_modify_asset(repo: OnyoRepo) -> None:
     pytest.raises(ValueError, inventory.modify_asset, asset, new_asset)
     new_asset['onyo.path.absolute'] = None
     # raises on non-existing asset
-    pytest.raises(ValueError, inventory.modify_asset, repo.git.root / "doesnotexist", new_asset)
+    pytest.raises(ValueError, inventory.modify_asset, Item(repo.git.root / "doesnotexist", repo=inventory.repo), new_asset)
     # raises on non-asset
-    pytest.raises(ValueError, inventory.modify_asset, newdir1, new_asset)
+    pytest.raises(ValueError, inventory.modify_asset, Item(newdir1, repo=inventory.repo), new_asset)
 
     inventory.modify_asset(asset, new_asset)
     # modify operation:
@@ -966,8 +966,10 @@ def test_rename_asset_dir(repo: OnyoRepo) -> None:
     inventory.add_asset(asset)
     inventory.commit("Whatever")
 
+    asset_dir = inventory.get_item(asset_dir_path)
+
     # renaming the asset dir as a dir needs to fail
-    pytest.raises(NotADirError, inventory.rename_directory, Item(asset_dir_path, repo=repo), "newname")
+    pytest.raises(NotADirError, inventory.rename_directory, asset_dir, "newname")
 
     # renaming as an asset by changing the naming config
     inventory.repo.set_config("onyo.assets.name-format", "{serial}_{other}", "onyo")
@@ -975,7 +977,7 @@ def test_rename_asset_dir(repo: OnyoRepo) -> None:
                           "Change asset name config")
     new_asset_dir_path = asset_dir_path.parent / "SERIAL_1"
 
-    inventory.rename_asset(asset_dir_path)
+    inventory.rename_asset(asset_dir)
     # no change on disc:
     assert inventory.repo.is_inventory_dir(asset_dir_path)
     assert inventory.repo.is_asset_path(asset_dir_path)


### PR DESCRIPTION
This is making sure `Inventory.modify_asset()`, `Inventory.rename_asset()`, and their callers pass `Item`s around rather than paths.