### PR TITLE
Itemize add_asset, remove_asset, remove_directory

### DIFF
--- a/onyo/lib/executors.py
+++ b/onyo/lib/executors.py
@@ -77,7 +77,7 @@ def exec_remove_assets(repo: OnyoRepo, operands: tuple) -> tuple[list[Path], lis
 
 def exec_remove_directories(repo: OnyoRepo, operands: tuple) -> tuple[list[Path], list[Path]]:
     paths = []
-    p = operands[0]
+    p = operands[0]['onyo.path.absolute']
     is_asset_dir = (p / OnyoRepo.ASSET_DIR_FILE_NAME).exists()  # required after dir was removed, therefore store
     anchor = p / repo.ANCHOR_FILE_NAME
     anchor.unlink()

--- a/onyo/lib/tests/test_commands_rm.py
+++ b/onyo/lib/tests/test_commands_rm.py
@@ -1,6 +1,9 @@
 import pytest
 
-from onyo.lib.exceptions import InvalidInventoryOperationError, InventoryOperationError
+from onyo.lib.exceptions import (
+    InvalidArgumentError,
+    InvalidInventoryOperationError,
+)
 from onyo.lib.items import Item
 from onyo.lib.inventory import Inventory
 from onyo.lib.onyo import OnyoRepo
@@ -12,32 +15,32 @@ from ..commands import onyo_rm
 def test_onyo_rm_errors(inventory: Inventory) -> None:
     r"""`onyo_rm` must raise the correct error in different illegal or impossible calls."""
     # delete non-existing asset
-    pytest.raises(InvalidInventoryOperationError,
+    pytest.raises(InvalidArgumentError,
                   onyo_rm,
                   inventory,
                   paths=inventory.root / "TYPE_MAKER_MODEL.SERIAL")
 
     # delete non-existing directory
-    pytest.raises(InvalidInventoryOperationError,
+    pytest.raises(InvalidArgumentError,
                   onyo_rm,
                   inventory,
                   paths=inventory.root / "somewhere" / "non-existing")
 
     # delete .anchor
-    pytest.raises(InvalidInventoryOperationError,
+    pytest.raises(InvalidArgumentError,
                   onyo_rm,
                   inventory,
                   paths=inventory.root / OnyoRepo.ANCHOR_FILE_NAME)
 
     # delete outside onyo repository
-    pytest.raises(InventoryOperationError,
+    pytest.raises(InvalidArgumentError,
                   onyo_rm,
                   inventory,
                   paths=inventory.root / "..")
 
     # deleting an existing file which is neither an asset nor a directory is illegal
     assert (inventory.root / ".onyo" / "templates" / "laptop.example").is_file()
-    pytest.raises(InvalidInventoryOperationError,
+    pytest.raises(InvalidArgumentError,
                   onyo_rm,
                   inventory,
                   paths=inventory.root / ".onyo" / "templates" / "laptop.example")
@@ -69,7 +72,7 @@ def test_onyo_rm_errors_before_rm(inventory: Inventory) -> None:
     old_hexsha = inventory.repo.git.get_hexsha()
 
     # one of multiple paths to delete does not exist
-    pytest.raises(InvalidInventoryOperationError,
+    pytest.raises(InvalidArgumentError,
                   onyo_rm,
                   inventory,
                   paths=[asset_path, inventory.root / "not-existent", destination_path])


### PR DESCRIPTION
This ensures that the above mentioned `Inventory` methods are always passed `Item`s by their callers.
In the process two more aspects are addressed:

- Register both `remove_*` operations with an `Item` as operand.
- Change `onyo_rm` and `Inventory.remove_directory()` to not remove any non-inventory files regardless of `recursive`. What's `.onyoignore`'d is ignored by onyo. Period.