### PR TITLE
DOC/TST/RF: one last giga uplift of docstrings

### DIFF
--- a/onyo/argparse_helpers.py
+++ b/onyo/argparse_helpers.py
@@ -15,22 +15,6 @@ class StoreMultipleKeyValuePairs(argparse.Action):
     StoreSingleKeyValuePairs
     """
 
-    def __init__(self,
-                 option_strings: Sequence[str],
-                 dest: str,
-                 nargs: int | str | None = None,
-                 **kwargs) -> None:
-        r"""
-        Parameters
-        ----------
-        option_strings
-        dest
-        nargs
-        **kwargs
-        """
-        self._nargs = nargs
-        super().__init__(option_strings, dest, nargs=nargs, **kwargs)
-
     def __call__(self,
                  parser: argparse.ArgumentParser,
                  namespace: argparse.Namespace,
@@ -89,22 +73,6 @@ class StoreSingleKeyValuePairs(argparse.Action):
     --------
     StoreMultipleKeyValuePairs
     """
-
-    def __init__(self,
-                 option_strings: Sequence[str],
-                 dest: str,
-                 nargs: int | str | None = None,
-                 **kwargs) -> None:
-        r"""
-        Parameters
-        ----------
-        option_strings
-        dest
-        nargs
-        **kwargs
-        """
-        self._nargs = nargs
-        super().__init__(option_strings, dest, nargs=nargs, **kwargs)
 
     def __call__(self,
                  parser: argparse.ArgumentParser,

--- a/onyo/argparse_helpers.py
+++ b/onyo/argparse_helpers.py
@@ -8,12 +8,7 @@ if TYPE_CHECKING:
 
 
 class StoreMultipleKeyValuePairs(argparse.Action):
-    r"""Store a list of dictionaries of key-value pairs.
-
-    See Also
-    --------
-    StoreSingleKeyValuePairs
-    """
+    r"""Store a list of dictionaries of key-value pairs."""
 
     def __call__(self,
                  parser: argparse.ArgumentParser,
@@ -22,22 +17,25 @@ class StoreMultipleKeyValuePairs(argparse.Action):
                  option_string: str | None = None) -> None:
         r"""Turn a list of 'KEY=VALUE' pairs into a list of dictionaries.
 
-        Each KEY can be defined either 1 or N times (where N is the number of
+        Each key can be defined either 1 or N times (where N is the number of
         dictionaries to be created).
 
-        A KEY that is declared once will apply to all dictionaries.
+        A key that is declared once will apply to all dictionaries.
 
-        All KEYs appearing N times must appear the same number of times. If not,
+        All keys appearing N times must appear the same number of times. If not,
         a message will print to standard error and the program will exit with
         status code 2.
 
         Parameters
         ----------
         parser
+            ArgumentParser object that contains this action.
         namespace
+            Namespace object returned by :py:meth:`argparse.ArgumentParser.parse_args`.
         key_values
             List of strings containing key-value pairs.
         option_string
+            Option string used to invoke this action.
         """
 
         for kv in key_values:
@@ -63,16 +61,12 @@ class StoreMultipleKeyValuePairs(argparse.Action):
                 v = values[0] if len(values) == 1 else values[i]
                 d[k] = v
             results.append(d)
+
         setattr(namespace, self.dest, results)
 
 
 class StoreSingleKeyValuePairs(argparse.Action):
-    r"""Store a dictionary of key-value pairs.
-
-    See Also
-    --------
-    StoreMultipleKeyValuePairs
-    """
+    r"""Store a dictionary of key-value pairs."""
 
     def __call__(self,
                  parser: argparse.ArgumentParser,
@@ -87,10 +81,13 @@ class StoreSingleKeyValuePairs(argparse.Action):
         Parameters
         ----------
         parser
+            ArgumentParser object that contains this action.
         namespace
+            Namespace object returned by :py:meth:`argparse.ArgumentParser.parse_args`.
         key_values
             List of strings containing key-value pairs.
         option_string
+            Option string used to invoke this action.
         """
 
         for kv in key_values:
@@ -110,40 +107,73 @@ class StoreSingleKeyValuePairs(argparse.Action):
 
 
 class StoreSortOption(argparse.Action):
+    r"""Store keys-to-sort and retain their order across multiple invoking options.
+
+    The results destination is hardcoded to ``sort``. This allows multiple
+    argparse options to use this action and retain the order of arguments passed
+    at the CLI across option flags.
+    """
 
     def __init__(self,
                  option_strings: Sequence[str],
-                 dest: str,
+                 dest: str | None = None,
                  **kwargs) -> None:
-        r"""
+        r"""Instantiate a ``StoreSortOption``.
+
+        The ``dest`` attribute is ignored and is hardcoded to ``'sort'``.
+
+        The ``default`` attribute is incompatible with this Action, as it's not
+        possible to know when to use/vs discard the default across multiple
+        options.
+
         Parameters
         ----------
         option_strings
+            List of option strings to associate with this action.
+            Passed to :py:meth:`argparse.Action`
         dest
+            This attribute is ignored and is hardcoded to ``'sort'``.
         **kwargs
+            Passed to :py:meth:`argparse.Action`
+
+        Raises
+        ------
+        ValueError
+            The ``default`` attribute is used.
         """
-        # This is a hack.
-        # We want sorting options where -s and -S take keys (to sort by) while
-        # capitalization determines whether it's ascending or descending order.
-        # Both are supposed to be intermixable.
-        # For a proper specification and help for both options, they need to be
-        # defined separately. But if we want to keep order in the intermixed case,
-        # they need to be stored into the same object to maintain order.
-        # Our way of specifying `dest` as the key in a dict defining the options
-        # per command, prevents that, though.
-        # With this hack we ignore the generated `dest` and set it to a fixed 'sort'.
+
         if 'default' in kwargs.keys():
-            # We can't deal with defaults while accounting for two different
-            # arguments, b/c we don't know when to discard the default.
             raise ValueError("'default' must not be used with `StoreSortOption`")
+
         for option in option_strings:
             if option.startswith('--sort-'):
-                self._sorting = option[7:]
+                self._sorting = option.removeprefix('--sort-')
+
         super().__init__(option_strings, "sort", **kwargs)
 
-    def __call__(self, parser, namespace, values, option_string=None):
-        partial_dict = {k: self._sorting for k in values}
+    def __call__(self,
+                 parser: argparse.ArgumentParser,
+                 namespace: argparse.Namespace,
+                 keys: list[str],
+                 option_string: str | None = None) -> None:
+        r"""Store keys in a dictionary with the associated sort direction.
+
+        Parameters
+        ----------
+        parser
+            ArgumentParser object that contains this action.
+        namespace
+            Namespace object returned by :py:meth:`argparse.ArgumentParser.parse_args`.
+        keys
+            List of strings containing keys to sort.
+        option_string
+            Option string used to invoke this action.
+        """
+
+        partial_dict = {k: self._sorting for k in keys}
+
         items = getattr(namespace, self.dest, None)
         items = dict() if items is None else items
         items.update(partial_dict)
+
         setattr(namespace, self.dest, items)

--- a/onyo/argparse_helpers.py
+++ b/onyo/argparse_helpers.py
@@ -4,7 +4,10 @@ import argparse
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Sequence
+    from typing import (
+        Literal,
+        Sequence,
+    )
 
 
 class StoreMultipleKeyValuePairs(argparse.Action):
@@ -117,8 +120,9 @@ class StoreSortOption(argparse.Action):
     def __init__(self,
                  option_strings: Sequence[str],
                  dest: str | None = None,
+                 sort_direction: Literal['ascending', 'descending'] = 'ascending',
                  **kwargs) -> None:
-        r"""Instantiate a ``StoreSortOption``.
+        r"""Instantiate a ``StoreSortOption`` with its sort direction.
 
         The ``dest`` attribute is ignored and is hardcoded to ``'sort'``.
 
@@ -133,6 +137,8 @@ class StoreSortOption(argparse.Action):
             Passed to :py:meth:`argparse.Action`
         dest
             This attribute is ignored and is hardcoded to ``'sort'``.
+        sort_direction
+            Sort direction.
         **kwargs
             Passed to :py:meth:`argparse.Action`
 
@@ -145,9 +151,7 @@ class StoreSortOption(argparse.Action):
         if 'default' in kwargs.keys():
             raise ValueError("'default' must not be used with `StoreSortOption`")
 
-        for option in option_strings:
-            if option.startswith('--sort-'):
-                self._sorting = option.removeprefix('--sort-')
+        self._sorting = sort_direction
 
         super().__init__(option_strings, "sort", **kwargs)
 

--- a/onyo/cli/get.py
+++ b/onyo/cli/get.py
@@ -85,6 +85,7 @@ args_get = {
 
     'sort_ascending': dict(
         args=('-s', '--sort-ascending'),
+        sort_direction='ascending',
         metavar='SORT_KEY',
         action=StoreSortOption,
         nargs='+',
@@ -98,6 +99,7 @@ args_get = {
 
     'sort_descending': dict(
         args=('-S', '--sort-descending'),
+        sort_direction='descending',
         metavar='SORT_KEY',
         action=StoreSortOption,
         nargs='+',

--- a/onyo/cli/tests/test_cat.py
+++ b/onyo/cli/tests/test_cat.py
@@ -38,9 +38,8 @@ contents: List[List[str]] = [[x, content_str] for x in assets]
 @pytest.mark.repo_contents(*contents)
 @pytest.mark.parametrize('asset', assets)
 def test_cat(repo: OnyoRepo, asset: str) -> None:
-    r"""
-    Single file is cat successfully, and stdout matches file content.
-    """
+    r"""``cat`` a single file."""
+
     ret = subprocess.run(["onyo", "cat", asset], capture_output=True, text=True)
     assert ret.returncode == 0
     assert not ret.stderr
@@ -49,9 +48,8 @@ def test_cat(repo: OnyoRepo, asset: str) -> None:
 
 @pytest.mark.repo_contents(*contents)
 def test_cat_multiple_inputs(repo: OnyoRepo) -> None:
-    r"""
-    Multiple files are cat successfully, and stdout matches file content.
-    """
+    r"""``cat`` multiple files."""
+
     ret = subprocess.run(["onyo", "cat", *assets], capture_output=True, text=True)
     assert ret.returncode == 0
     assert not ret.stderr
@@ -65,9 +63,8 @@ def test_cat_multiple_inputs(repo: OnyoRepo) -> None:
                                      ]
                          )
 def test_cat_non_existing_path(repo: OnyoRepo, variant: str) -> None:
-    r"""
-    Error (2) on path that doesn't exist.
-    """
+    r"""Error (2) when the path does not exist."""
+
     ret = subprocess.run(['onyo', 'cat', variant], capture_output=True, text=True)
     assert ret.returncode == 2
     assert not ret.stdout
@@ -81,9 +78,8 @@ def test_cat_non_existing_path(repo: OnyoRepo, variant: str) -> None:
     ['one_that_exists.test', 'dir/two_that_exists.test', 'does_not_exist.test']]
 )
 def test_cat_multiple_paths_missing(repo: OnyoRepo, variant: list[str]) -> None:
-    r"""
-    Errors (2) with multiple paths when at least one doesn't exist.
-    """
+    r"""Error (2) with multiple paths when at least one doesn't exist."""
+
     ret = subprocess.run(['onyo', 'cat', *variant], capture_output=True, text=True)
     assert ret.returncode == 2
     assert not ret.stdout
@@ -93,9 +89,8 @@ def test_cat_multiple_paths_missing(repo: OnyoRepo, variant: list[str]) -> None:
 @pytest.mark.repo_contents(*contents)
 @pytest.mark.parametrize('directory', directories)
 def test_cat_error_with_directory(repo: OnyoRepo, directory: str) -> None:
-    r"""
-    Error (2) if path provided is a plain directory.
-    """
+    r"""Error (2) if path provided is a plain directory."""
+
     ret = subprocess.run(['onyo', 'cat', directory], capture_output=True, text=True)
     assert ret.returncode == 2
     assert not ret.stdout
@@ -105,9 +100,8 @@ def test_cat_error_with_directory(repo: OnyoRepo, directory: str) -> None:
 @pytest.mark.repo_contents(*contents)
 @pytest.mark.parametrize('asset', assets)
 def test_same_target(repo: OnyoRepo, asset: str) -> None:
-    r"""
-    Succeed if the same path is provided more than once.
-    """
+    r"""Provide same path more than once."""
+
     ret = subprocess.run(['onyo', 'cat', asset, asset], capture_output=True, text=True)
     assert ret.returncode == 0
     assert not ret.stderr
@@ -119,10 +113,11 @@ def test_same_target(repo: OnyoRepo, asset: str) -> None:
 @pytest.mark.parametrize('variant', [["no_trailing_newline.test",
                                       "---\nRAM:\nSize:\nUSB:"]])
 def test_no_trailing_newline(repo: OnyoRepo, variant: list[str]) -> None:
-    r"""
-    The output matches the file content /exactly/, without spurious newlines,
-    formatting, or other characters.
+    r"""Output matches the file content /exactly/.
+
+    Without spurious newlines, formatting, or other characters.
     """
+
     ret = subprocess.run(['onyo', 'cat', variant[0]], capture_output=True, text=True)
     assert ret.returncode == 0
     assert not ret.stderr
@@ -131,12 +126,12 @@ def test_no_trailing_newline(repo: OnyoRepo, variant: list[str]) -> None:
 
 @pytest.mark.repo_files(*assets)
 def test_no_trailing_newline_with_many_empty_assets(repo: OnyoRepo) -> None:
-    r"""
-    No empty lines when given a list of empty files.
+    r"""No empty lines when given a list of empty files.
 
-    Because `onyo cat` uses `print(path.read_text(), end='')` this test
+    Because ``onyo cat`` uses ``print(path.read_text(), end='')``, this test
     verifies that empty assets do not print empty new lines.
     """
+
     ret = subprocess.run(['onyo', 'cat', *assets], capture_output=True, text=True)
     assert ret.returncode == 0
     assert not ret.stderr
@@ -147,9 +142,7 @@ def test_no_trailing_newline_with_many_empty_assets(repo: OnyoRepo) -> None:
 @pytest.mark.parametrize('variant',
                          [["bad_yaml_file.test", "I: \nam:bad:\nbad:yaml\n"]])
 def test_invalid_yaml(repo: OnyoRepo, variant: list[str]) -> None:
-    r"""
-    Invalid content prints to stdout, error message to stderr, and exit 1.
-    """
+    r"""Invalid content prints to stdout, error message to stderr, and exit 1."""
 
     # check that yaml is invalid
     with pytest.raises(OnyoInvalidRepoError):

--- a/onyo/cli/tests/test_config.py
+++ b/onyo/cli/tests/test_config.py
@@ -16,9 +16,8 @@ def test_config_set(repo: OnyoRepo) -> None:
 
 
 def test_config_already_set(repo: OnyoRepo) -> None:
-    r"""`onyo config` does not error if a legal value is
-    already set and no changes are made.
-    """
+    r"""Do not error if a legal value is already set and no changes are made."""
+
     assert 'onyo "history"' in Path('.onyo/config').read_text()
     assert 'interactive = tig --follow' in Path('.onyo/config').read_text()
     ret = subprocess.run(["onyo", "config", "onyo.history.interactive", "tig --follow"],
@@ -46,7 +45,7 @@ def test_config_get_onyo(repo: OnyoRepo) -> None:
 
 
 def test_config_get_pristine(repo: OnyoRepo) -> None:
-    r"""Onyo should not alter git config's output (newline, etc)"""
+    r"""Do not alter git config's output (newline, etc)."""
 
     ret = subprocess.run(["onyo", "config", "onyo.test.get-pristine",
                           "get-pristine-test"],
@@ -107,9 +106,8 @@ def test_config_unset(repo: OnyoRepo) -> None:
 
 
 def test_config_help(repo: OnyoRepo) -> None:
-    r"""
-    `onyo config --help` is shown and not `git config --help`.
-    """
+    r"""Show ``onyo config --help`` rather than ``git config --help``."""
+
     for flag in ['-h', '--help']:
         ret = subprocess.run(["onyo", "config", flag],
                              capture_output=True, text=True)
@@ -120,9 +118,8 @@ def test_config_help(repo: OnyoRepo) -> None:
 
 
 def test_config_forbidden_flags(repo: OnyoRepo) -> None:
-    r"""
-    Flags that change the source of values are not allowed.
-    """
+    r"""Disallow option flags change the source of values."""
+
     for flag in ['--system', '--global', '--local', '--worktree', '--file',
                  '--blob']:
         ret = subprocess.run(["onyo", "config", flag],
@@ -133,11 +130,12 @@ def test_config_forbidden_flags(repo: OnyoRepo) -> None:
 
 
 def test_config_bubble_retcode(repo: OnyoRepo) -> None:
-    r"""
-    Bubble up git-config's retcodes.
+    r"""Bubble up git-config's retcodes.
+
     According to the git config manpage, attempting to unset an option which
     does not exist exits with "5".
     """
+
     assert 'onyo.test.not-exist' not in Path('.onyo/config').read_text()
 
     ret = subprocess.run(["onyo", "config", "--unset", "onyo.test.not-exist"],
@@ -147,9 +145,8 @@ def test_config_bubble_retcode(repo: OnyoRepo) -> None:
 
 
 def test_config_bubble_stderr(repo: OnyoRepo) -> None:
-    r"""
-    Bubble up git-config printing to stderr.
-    """
+    r"""Bubble up git-config's printing to stderr."""
+
     ret = subprocess.run(["onyo", "config", "--invalid-flag-oopsies",
                           "such-an-oops"],
                          capture_output=True, text=True)

--- a/onyo/cli/tests/test_edit.py
+++ b/onyo/cli/tests/test_edit.py
@@ -19,9 +19,8 @@ assets = [['laptop_apple_macbookpro.0',
 
 @pytest.mark.parametrize('variant', ['local', 'onyo'])
 def test_get_editor_onyo(repo: OnyoRepo, variant: str) -> None:
-    r"""
-    Get the editor from onyo configuration.
-    """
+    r"""Get the editor from onyo configuration."""
+
     repo.set_config('onyo.core.editor', variant, location=variant)  # pyre-ignore[6]
 
     # test
@@ -30,9 +29,8 @@ def test_get_editor_onyo(repo: OnyoRepo, variant: str) -> None:
 
 
 def test_get_editor_git(repo: OnyoRepo) -> None:
-    r"""
-    Get the editor from git configuration
-    """
+    r"""Get the editor from git configuration."""
+
     repo.set_config('core.editor', 'git-edit', location='local')
     assert "git-edit" in (repo.git.root / '.git' / 'config').read_text()
     editor = repo.get_editor()
@@ -40,9 +38,8 @@ def test_get_editor_git(repo: OnyoRepo) -> None:
 
 
 def test_get_editor_envvar(repo: OnyoRepo) -> None:
-    r"""
-    Get the editor from $EDITOR.
-    """
+    r"""Get the editor from $EDITOR."""
+
     # verify that onyo.core.editor is not set
     assert not repo.get_config('onyo.core.editor')
 
@@ -52,9 +49,8 @@ def test_get_editor_envvar(repo: OnyoRepo) -> None:
 
 
 def test_get_editor_fallback(repo: OnyoRepo) -> None:
-    r"""
-    When no editor is set, nano is the fallback.
-    """
+    r"""Fallback to ``nano`` when no editor is set."""
+
     # verify that onyo.core.editor is not set
     assert not repo.get_config('onyo.core.editor')
     try:
@@ -67,9 +63,8 @@ def test_get_editor_fallback(repo: OnyoRepo) -> None:
 
 
 def test_get_editor_precedence(repo: OnyoRepo) -> None:
-    r"""
-    The order of precedence should be git > onyo > $EDITOR.
-    """
+    r"""The order of editor precedence is git > onyo > $EDITOR."""
+
     # set locations
     repo.set_config('onyo.core.editor', 'local', location='local')
     # Use onyo-config to also commit and not end up with a modified worktree here:
@@ -93,10 +88,8 @@ def test_get_editor_precedence(repo: OnyoRepo) -> None:
 @pytest.mark.repo_contents(*assets)
 @pytest.mark.parametrize('asset', [a[0] for a in assets])
 def test_edit_single_asset(repo: OnyoRepo, asset: str) -> None:
-    r"""
-    Test that for different paths it is possible to call `onyo edit` on a single
-    asset file.
-    """
+    r"""``edit`` a single asset file."""
+
     edit_str = "key: single_asset\nnested:\n  some: value"
     os.environ['EDITOR'] = f"printf '{edit_str}' >>"
 
@@ -130,10 +123,8 @@ def test_edit_single_asset(repo: OnyoRepo, asset: str) -> None:
 
 @pytest.mark.repo_contents(*assets)
 def test_edit_multiple_assets(repo: OnyoRepo) -> None:
-    r"""
-    Test that it is possible to call `onyo edit` with a list of multiple assets
-    containing different file names at once.
-    """
+    r"""``edit`` multiple assets at once."""
+
     os.environ['EDITOR'] = "printf 'key: multiple_assets' >>"
     repo_assets = repo.asset_paths
 
@@ -152,10 +143,8 @@ def test_edit_multiple_assets(repo: OnyoRepo) -> None:
 
 @pytest.mark.repo_contents(*assets)
 def test_edit_with_user_response(repo: OnyoRepo) -> None:
-    r"""
-    Test that without the --yes flag, `onyo edit` requests a user response
-    before saving changes.
-    """
+    r"""``edit`` (without `--yes``) requests a user response before saving changes."""
+
     os.environ['EDITOR'] = "printf 'key: user_response' >>"
 
     # abort command
@@ -182,9 +171,8 @@ def test_edit_with_user_response(repo: OnyoRepo) -> None:
 
 @pytest.mark.repo_contents(*assets)
 def test_quiet_flag(repo: OnyoRepo) -> None:
-    r"""
-    Test that `onyo edit --yes --quiet` does not print anything.
-    """
+    r"""``onyo edit --yes --quiet`` does not print anything."""
+
     os.environ['EDITOR'] = "printf 'key: quiet' >>"
 
     # edit a list of assets all at once
@@ -204,9 +192,8 @@ def test_quiet_flag(repo: OnyoRepo) -> None:
 
 @pytest.mark.repo_contents(*assets)
 def test_quiet_errors_without_yes_flag(repo: OnyoRepo) -> None:
-    r"""
-    Test that `onyo edit --quiet` does error without --yes flag.
-    """
+    r"""``onyo edit --quiet`` errors without ``--yes``."""
+
     os.environ['EDITOR'] = "printf 'key: quiet' >>"
 
     # edit a list of assets all at once
@@ -223,10 +210,8 @@ def test_quiet_errors_without_yes_flag(repo: OnyoRepo) -> None:
 @pytest.mark.repo_contents(*assets)
 @pytest.mark.parametrize('asset', [a[0] for a in assets])
 def test_edit_discard(repo: OnyoRepo, asset: str) -> None:
-    r"""
-    Test that if an asset got correctly changed, but the user answers to the
-    "Save changes?" dialog with 'n', that the changes get discarded.
-    """
+    r"""Throw away changes when the user answers "no" to the prompt."""
+
     os.environ['EDITOR'] = "printf 'key: discard' >>"
 
     # change asset with `onyo edit` but don't save it
@@ -255,9 +240,8 @@ def test_edit_discard(repo: OnyoRepo, asset: str) -> None:
     '.git/index'
 ])
 def test_edit_protected(repo: OnyoRepo, no_asset: str) -> None:
-    r"""
-    Test the error behavior when called on protected files.
-    """
+    r"""Error when passed protected files."""
+
     os.environ['EDITOR'] = "printf 'key: NOT_USED' >>"
 
     ret = subprocess.run(['onyo', 'edit', no_asset],
@@ -277,10 +261,8 @@ def test_edit_protected(repo: OnyoRepo, no_asset: str) -> None:
     "very/very/very/deep/non_existing_asset.0"
 ])
 def test_edit_non_existing_file(repo: OnyoRepo, no_asset: str) -> None:
-    r"""
-    Test the error behavior when called on non-existing files, that Onyo does
-    not create the files, and the repository stays valid.
-    """
+    r"""Error when passed non-exitsing files."""
+
     os.environ['EDITOR'] = "printf 'key: DOES_NOT_EXIST' >>"
 
     ret = subprocess.run(['onyo', 'edit', no_asset],
@@ -295,10 +277,8 @@ def test_edit_non_existing_file(repo: OnyoRepo, no_asset: str) -> None:
 @pytest.mark.repo_contents(*assets)
 @pytest.mark.parametrize('asset', [a[0] for a in assets])
 def test_continue_edit_no(repo: OnyoRepo, asset: str) -> None:
-    r"""
-    Test that Onyo detects yaml-errors, and responds correctly if the user
-    answers the "abort command?" dialog with 'a' to discard the changes
-    """
+    r"""Error on YAML errors;, and abort cleanly when instructed by user."""
+
     os.environ['EDITOR'] = "printf 'key: YAML: ERROR' >>"
 
     # Change the asset to invalid yaml, and respond 'y' to "cancel edit" dialog
@@ -327,8 +307,8 @@ def test_continue_edit_no(repo: OnyoRepo, asset: str) -> None:
 
 @pytest.mark.repo_contents(*assets)
 def test_edit_without_changes(repo: OnyoRepo) -> None:
-    r"""
-    Test that onyo does not fail when no changes were made.
+    r"""Do not error when no changes are made.
+
     This still requires a confirmation after editing an asset.
     """
     os.environ['EDITOR'] = "cat"
@@ -344,10 +324,8 @@ def test_edit_without_changes(repo: OnyoRepo) -> None:
 @pytest.mark.repo_contents(*assets)
 @pytest.mark.parametrize('asset', [a[0] for a in assets])
 def test_edit_with_dot_dot(repo: OnyoRepo, asset: str) -> None:
-    r"""
-    Check that in an onyo repository it is possible to call `onyo edit` on an
-    asset path that contains ".." leading outside and back into the repository.
-    """
+    r"""``edit`` a relative path that exits the repo with ``../`` and re-enters."""
+
     os.environ['EDITOR'] = "printf 'key: dot_dot' >>"
 
     # check edit with a path containing a ".." that leads outside the onyo repo

--- a/onyo/cli/tests/test_get.py
+++ b/onyo/cli/tests/test_get.py
@@ -119,7 +119,8 @@ asset_contents = [
 
 def convert_contents(
         raw_assets: list[tuple[str, dict[str, Any]]]) -> Generator:
-    r"""Convert content dictionary to a plain-text string"""
+    r"""Convert content dictionary to a plain-text string."""
+
     from onyo.lib.utils import dict_to_asset_yaml
     for file, raw_contents in raw_assets:
         yield [file, dict_to_asset_yaml(raw_contents)]
@@ -130,7 +131,8 @@ def convert_contents(
                                                           'one/laptop_dell_precision.2',
                                                           'one/two/headphones_apple_pro.3']]))
 def test_get_defaults(repo: OnyoRepo) -> None:
-    r"""Test `onyo get` using default values"""
+    r"""Test ``onyo get`` using default values."""
+
     cmd = ['onyo', 'get']
     ret = subprocess.run(cmd, capture_output=True, text=True)
     keys = ['type', 'make', 'model.name', 'serial', 'onyo.path.relative']
@@ -153,13 +155,14 @@ def test_get_defaults(repo: OnyoRepo) -> None:
     [], ['make', 'serial'], ['num', 'str', 'bool']])
 @pytest.mark.parametrize('paths', [['.'], ['one/two', 'abc/def']])
 @pytest.mark.parametrize('machine_readable', ['-H', None])
-def test_get_all(
-        repo: OnyoRepo, matches: list[str], depth: str, keys: list[str],
-        paths: list[str], machine_readable: str | None) -> None:
-    r"""
-    Test `onyo get` with a combination of valid arguments to ensure no error
-    occurs.
-    """
+def test_get_all(repo: OnyoRepo,
+                 matches: list[str],
+                 depth: str,
+                 keys: list[str],
+                 paths: list[str],
+                 machine_readable: str | None) -> None:
+    r"""Test ``onyo get`` with a combination of valid arguments to ensure no error occurs."""
+
     keys = keys if keys else repo.get_asset_name_keys()
     cmd = ['onyo', 'get', '--include', *paths, '--depth', depth]
     cmd += ['--keys', *keys + ["onyo.path.relative"]] if keys else []
@@ -205,12 +208,11 @@ def test_get_all(
     (['str=foo', 'unset=bar'], 0),
     (['str=foo=bar'], 1),
     ([], 4)])
-def test_get_filter(
-        repo: OnyoRepo, matches: list[str], expected: int) -> None:
-    r"""
-    Test that `onyo get --match KEY=VALUE` retrieves the expected
-    files.
-    """
+def test_get_filter(repo: OnyoRepo,
+                    matches: list[str],
+                    expected: int) -> None:
+    r"""``onyo get --match KEY=VALUE`` retrieves the expected files."""
+
     keys = repo.get_asset_name_keys() + ['num', 'str', 'bool', 'unset']
     cmd = ['onyo', 'get', '--keys', *keys, '-H']
     cmd += ['--match', *matches] if matches else []
@@ -243,12 +245,11 @@ def test_get_filter(
     (['num=8.*'], 2),
     (['str=foo.*'], 1),
     ([r'num=9\d*|\d{1,}'], 3)])
-def test_get_filter_regex(
-        repo: OnyoRepo, matches: list[str], expected: int) -> None:
-    r"""
-    Test that `onyo get --match KEY=VALUE` retrieves the expected
-    files using a regular expression as value
-    """
+def test_get_filter_regex(repo: OnyoRepo,
+                          matches: list[str],
+                          expected: int) -> None:
+    r"""``onyo get --match KEY=VALUE`` retrieves the expected files matching a regex."""
+
     keys = repo.get_asset_name_keys() + ['num', 'str', 'bool', 'unset']
     cmd = ['onyo', 'get', '--match', *matches, '--keys', *keys, '-H']
     ret = subprocess.run(cmd, capture_output=True, text=True)
@@ -278,11 +279,10 @@ def test_get_filter_regex(
 @pytest.mark.parametrize('matches', [
     ['num'],
     ['']])
-def test_get_filter_errors(repo: OnyoRepo, matches: list[str]) -> None:
-    r"""
-    Test that `onyo get --match KEY=VALUE` returns an error if
-    missing a value.
-    """
+def test_get_filter_errors(repo: OnyoRepo,
+                           matches: list[str]) -> None:
+    r"""``onyo get --match KEY=VALUE`` returns an error if missing a value."""
+
     cmd = ['onyo', 'get', '--match', *matches, '-H']
     ret = subprocess.run(cmd, capture_output=True, text=True)
 
@@ -305,12 +305,11 @@ def test_get_filter_errors(repo: OnyoRepo, matches: list[str]) -> None:
     ['num', 'str', 'bool', 'onyo.path.relative'],
     ['TyPe', 'MAKE', 'moDEL', 'NuM', 'STR', 'onyo.path.relative'],
     []])
-def test_get_keys(
-        repo: OnyoRepo, raw_assets: list[tuple[str, dict[str, Any]]],
-        keys: list) -> None:
-    r"""
-    Test that `onyo get --keys x y z` retrieves the expected keys.
-    """
+def test_get_keys(repo: OnyoRepo,
+                  raw_assets: list[tuple[str, dict[str, Any]]],
+                  keys: list) -> None:
+    r"""Test that ``onyo get --keys x y z`` retrieves the expected keys."""
+
     from onyo.lib.pseudokeys import PSEUDO_KEYS
     cmd = ['onyo', 'get', '-H']
     cmd += ['--keys', *keys, ] if keys else []
@@ -344,10 +343,11 @@ def test_get_keys(
                                                           'one/two/three/four/headphones_apple_pro.5']]))
 @pytest.mark.parametrize('depth,expected', [
     ('0', 5), ('1', 1), ('2', 2), ('3', 3), ('4', 4), ('999', 5)])
-def test_get_depth(repo: OnyoRepo, depth: str, expected: int) -> None:
-    r"""
-    Test that `onyo get --depth x` retrieves the expected assets.
-    """
+def test_get_depth(repo: OnyoRepo,
+                   depth: str,
+                   expected: int) -> None:
+    r"""Test that ``onyo get --depth x`` retrieves the expected assets."""
+
     cmd = ['onyo', 'get', '--depth', depth, '-H']
     ret = subprocess.run(cmd, capture_output=True, text=True)
     output = [output.split('\t') for output in ret.stdout.split('\n')][:-1]
@@ -370,10 +370,8 @@ def test_get_depth(repo: OnyoRepo, depth: str, expected: int) -> None:
                                                           'one/two/three/headphones_apple_pro.4',
                                                           'one/two/three/four/headphones_apple_pro.5']]))
 def test_get_depth_error(repo: OnyoRepo) -> None:
-    r"""
-    Test that `onyo get --depth x` when a negative integer is used returns the
-    expected exception
-    """
+    r"""``onyo get --depth x`` must be a non-negative integer."""
+
     cmd = ['onyo', 'get', '--depth', '-1', '-H']
     ret = subprocess.run(cmd, capture_output=True, text=True)
     assert ret.stderr
@@ -402,16 +400,16 @@ def test_get_depth_error(repo: OnyoRepo) -> None:
     (['.', './one', './one/two/three/four'], None, 6),
     (['./one/two/three/four', './another/dir'], None, 2),
     ([], None, 6)])
-def test_get_path_at_depth(
-        repo: OnyoRepo, paths: str, depth: str | None,
-        expected: int) -> None:
-    r"""
-    Test that `onyo get --include x --depth y` retrieves the expected assets by
-    ensuring that `depth` is assessed relative to the given paths.
+def test_get_path_at_depth(repo: OnyoRepo,
+                           paths: str,
+                           depth: str | None,
+                           expected: int) -> None:
+    r"""``--depth`` is relative to the given paths.
 
-    A portion of the parameters tests the usage of path with the default
-    value of depth, when no depth is specified.
+    A portion of the parameters tests the usage of path with the default value
+    of depth, when no depth is specified.
     """
+
     cmd = ['onyo', 'get', '-H']
     cmd += ['--include', *paths] if paths else []
     cmd += ['--depth', depth] if depth else []
@@ -443,11 +441,10 @@ def test_get_path_at_depth(
     '/path/that/does/not/exist/and/does/not/start/with/dot',
     'path/that/does/not/exist/and/does/not/start/with/dot/slash',
     'def/ghi'])
-def test_get_path_error(repo: OnyoRepo, path: str) -> None:
-    r"""
-    Test that `onyo get --include x --depth y` returns an exception if an invalid
-    path is being used
-    """
+def test_get_path_error(repo: OnyoRepo,
+                        path: str) -> None:
+    r"""Error if an invalid path is passed to `--include``."""
+
     cmd = ['onyo', 'get', '--include', path, '-H']
     ret = subprocess.run(cmd, capture_output=True, text=True)
     assert f"The following paths are not part of the inventory:\n{repo.git.root / path}" in ret.stderr
@@ -465,13 +462,11 @@ def test_get_path_error(repo: OnyoRepo, path: str) -> None:
     (['-S', 'make',
       '-s', 'type'], [2, 1, 3, 4])
 ])
-def test_get_sort(
-        repo: OnyoRepo, sort: list[str],
-        expected_order: list[int]) -> None:
-    r"""
-    Test the `-s` (ascending) and `-S` (descending)
-    sorting options for `onyo get`.
-    """
+def test_get_sort(repo: OnyoRepo,
+                  sort: list[str],
+                  expected_order: list[int]) -> None:
+    r"""Test ``-s`` (ascending) and ``-S`` (descending) sorting options."""
+
     # Note: This test has fewer test cases than `test_natural_sort`
     #       below. This is b/c here we are testing CLI and rely on
     #       reading assets from a repository. That implies we
@@ -504,8 +499,10 @@ def test_get_sort(
     ({'make': SORT_DESCENDING,
       'type': SORT_ASCENDING}, [2, 1, 3, 4])
 ])
-def test_natural_sort(keys: dict[str, sort_t], expected: list[int]) -> None:
-    r"""Test implementation of natural sorting algorithm"""
+def test_natural_sort(keys: dict[str, sort_t],
+                      expected: list[int]) -> None:
+    r"""Test implementation of natural sorting algorithm."""
+
     assets = [DotNotationWrapper(t[1]) for t in asset_contents
               if t[0] in ['a13bc_foo_bar.1',
                           'a2cd_foo_bar.2',

--- a/onyo/cli/tests/test_history.py
+++ b/onyo/cli/tests/test_history.py
@@ -32,10 +32,8 @@ assets: List[str] = [f"{d}/{f}.{i}" for f in files for i, d in enumerate(directo
 @pytest.mark.repo_files(*assets)
 @pytest.mark.parametrize('asset', assets)
 def test_history_noninteractive(repo: OnyoRepo, asset: str) -> None:
-    r"""
-    The default non-interactive history command runs and prints to stdout but
-    not stderr.
-    """
+    r"""Default non-interactive history prints to stdout and not stderr."""
+
     ret = subprocess.run(['onyo', 'history', '-I', asset],
                          capture_output=True, text=True)
     assert ret.returncode == 0
@@ -48,9 +46,8 @@ def test_history_noninteractive(repo: OnyoRepo, asset: str) -> None:
 @pytest.mark.parametrize('asset', ['does_not_exist.test',
                                    'subdir/does_not_exist.test'])
 def test_history_noninteractive_not_exist(repo: OnyoRepo, asset: str) -> None:
-    r"""
-    Non-existing assets print to stderr and return an error code.
-    """
+    r"""Non-existing assets print to stderr and return an error code."""
+
     ret = subprocess.run(['onyo', 'history', '-I', asset],
                          capture_output=True, text=True)
     assert ret.returncode != 0
@@ -66,9 +63,8 @@ def test_history_noninteractive_not_exist(repo: OnyoRepo, asset: str) -> None:
                           ['does_not_exist.test', 'file_does_exist.test']]
                          )
 def test_history_noninteractive_too_many_args(repo: OnyoRepo, variant: list[str]) -> None:
-    r"""
-    Multiple input arguments are not allowed.
-    """
+    r"""Multiple input arguments are not allowed."""
+
     ret = subprocess.run(['onyo', 'history', '-I', *variant],
                          capture_output=True, text=True)
     assert ret.returncode != 0
@@ -79,8 +75,7 @@ def test_history_noninteractive_too_many_args(repo: OnyoRepo, variant: list[str]
 
 @pytest.mark.repo_files(assets[0])
 def test_history_interactive_fallback(repo: OnyoRepo) -> None:
-    r"""
-    Without --non-interactive works.
+    r"""``--non-interactive`` works.
 
     Interactive mode cannot be tested directly, as onyo detects whether it's
     connected to a TTY.
@@ -95,9 +90,8 @@ def test_history_interactive_fallback(repo: OnyoRepo) -> None:
 
 @pytest.mark.repo_files(assets[0])
 def test_history_config_unset(repo: OnyoRepo) -> None:
-    r"""
-    Error when no tool is configured.
-    """
+    r"""Error when no tool is configured."""
+
     # unset config for history tool
     repo.set_config('onyo.history.non-interactive', '')
     repo.commit(paths=repo.dot_onyo / 'config',
@@ -117,9 +111,8 @@ def test_history_config_unset(repo: OnyoRepo) -> None:
 
 @pytest.mark.repo_files(assets[0])
 def test_history_config_invalid(repo: OnyoRepo) -> None:
-    r"""
-    Error when the history tool does not exist.
-    """
+    r"""Error when the history tool does not exist."""
+
     # set to invalid
     repo.set_config('onyo.history.non-interactive', 'does-not-exist-in-path')
     repo.commit(paths=repo.dot_onyo / 'config',
@@ -137,9 +130,8 @@ def test_history_config_invalid(repo: OnyoRepo) -> None:
 @pytest.mark.repo_files(*assets)
 @pytest.mark.parametrize('asset', assets)
 def test_history_fake_noninteractive_stdout(repo: OnyoRepo, asset: str) -> None:
-    r"""
-    History tool can be reconfigured.
-    """
+    r"""The history tool can be reconfigured."""
+
     repo.set_config('onyo.history.non-interactive', '/usr/bin/env printf')
     repo.commit(paths=repo.dot_onyo / 'config',
                 message="Update config: 'onyo.history.non-interactive'")
@@ -156,9 +148,8 @@ def test_history_fake_noninteractive_stdout(repo: OnyoRepo, asset: str) -> None:
 @pytest.mark.repo_files(*assets)
 @pytest.mark.parametrize('asset', assets)
 def test_history_fake_noninteractive_stderr(repo: OnyoRepo, asset: str) -> None:
-    r"""
-    The configured tool controls printing to stdout vs stderr.
-    """
+    r"""The configured tool controls printing to stdout vs stderr."""
+
     # configure to simply print to stdout
     repo.set_config('onyo.history.non-interactive', '/usr/bin/env printf >&1')
     repo.commit(paths=repo.dot_onyo / 'config',
@@ -193,9 +184,8 @@ def test_history_fake_noninteractive_stderr(repo: OnyoRepo, asset: str) -> None:
                           {'cmd': 'git config --invalid-flag', 'retval': 129},
                           ])
 def test_history_fake_noninteractive_bubble_exit_code(repo: OnyoRepo, variant: dict) -> None:
-    r"""
-    Bubble up exit codes unaltered from history tool.
-    """
+    r"""Bubble up exit codes unaltered from history tool."""
+
     repo.set_config('onyo.history.non-interactive', variant['cmd'])
     repo.commit(paths=repo.dot_onyo / 'config',
                 message="Update config: 'onyo.history.non-interactive'")

--- a/onyo/cli/tests/test_init.py
+++ b/onyo/cli/tests/test_init.py
@@ -6,9 +6,8 @@ from onyo.lib.onyo import OnyoRepo
 
 
 def fully_populated_dot_onyo(directory: Path) -> bool:
-    r"""
-    Assert whether a .onyo dir is fully populated.
-    """
+    r"""Assert whether a .onyo dir is fully populated."""
+
     dot_onyo = directory / '.onyo'
 
     if not dot_onyo.is_dir() or \
@@ -25,10 +24,8 @@ def fully_populated_dot_onyo(directory: Path) -> bool:
 
 
 def test_init_cwd(tmp_path: Path) -> None:
-    r"""
-    Test that `onyo init` without a path argument uses the cwd to initialize a
-    new onyo repository.
-    """
+    r"""``onyo init`` without a path inits CWD."""
+
     os.chdir(tmp_path)
     ret = subprocess.run(["onyo", "init"], capture_output=True, text=True)
 
@@ -42,10 +39,8 @@ def test_init_cwd(tmp_path: Path) -> None:
 
 
 def test_init_with_path(tmp_path: Path) -> None:
-    r"""
-    Test that `onyo init PATH` uses a provided path to initialize a new onyo
-    repository.
-    """
+    r"""``onyo init PATH`` inits the passed path."""
+
     repo_path = tmp_path.resolve()
     ret = subprocess.run(["onyo", "init", repo_path], capture_output=True, text=True)
 
@@ -59,10 +54,8 @@ def test_init_with_path(tmp_path: Path) -> None:
 
 
 def test_init_error_on_existing_repository(tmp_path: Path) -> None:
-    r"""
-    Test that `onyo init PATH` errors correctly, when called on an existing
-    repository.
-    """
+    r"""Error when passed an existing repository."""
+
     repo_path = tmp_path.resolve()
     ret = subprocess.run(["onyo", "init", repo_path], capture_output=True, text=True)
     ret = subprocess.run(["onyo", "init", repo_path], capture_output=True, text=True)

--- a/onyo/cli/tests/test_mkdir.py
+++ b/onyo/cli/tests/test_mkdir.py
@@ -17,10 +17,8 @@ directories = ['simple',
 
 @pytest.mark.parametrize('directory', directories)
 def test_mkdir(repo: OnyoRepo, directory: str) -> None:
-    r"""
-    Test that `onyo mkdir <dir>` creates new directories correctly for different
-    depths and directory names.
-    """
+    r"""Create new directories correctly for different depths and directory names."""
+
     ret = subprocess.run(['onyo', '--yes', 'mkdir', directory], capture_output=True, text=True)
 
     # verify output
@@ -40,10 +38,8 @@ def test_mkdir(repo: OnyoRepo, directory: str) -> None:
 
 
 def test_mkdir_multiple_inputs(repo: OnyoRepo) -> None:
-    r"""
-    Test that `onyo mkdir <dirs>` creates new directories all in one call when
-    given a list of inputs.
-    """
+    r"""Create new directories all in one call when given a list of inputs."""
+
     ret = subprocess.run(['onyo', '--yes', 'mkdir', *directories], capture_output=True, text=True)
 
     assert not ret.stderr
@@ -63,10 +59,8 @@ def test_mkdir_multiple_inputs(repo: OnyoRepo) -> None:
 
 
 def test_mkdir_no_response(repo: OnyoRepo) -> None:
-    r"""
-    Test that `onyo mkdir <dirs>` creates no new directories when user responds
-    with "no".
-    """
+    r"""Do not create directories when the user responds "no" to prompt."""
+
     ret = subprocess.run(['onyo', 'mkdir', *directories], input='n',
                          capture_output=True, text=True)
 
@@ -85,10 +79,8 @@ def test_mkdir_no_response(repo: OnyoRepo) -> None:
 
 
 def test_mkdir_quiet_flag(repo: OnyoRepo) -> None:
-    r"""
-    Test that `onyo mkdir --yes --quiet <dirs>` creates new directories without
-    printing output.
-    """
+    r"""Do not print output when passed ``--quiet``."""
+
     ret = subprocess.run(['onyo', '--yes', '--quiet', 'mkdir', *directories],
                          capture_output=True, text=True)
 
@@ -112,10 +104,8 @@ def test_mkdir_quiet_flag(repo: OnyoRepo) -> None:
 @pytest.mark.repo_dirs(*directories)
 @pytest.mark.parametrize('directory', directories)
 def test_dir_exists(repo: OnyoRepo, directory: str) -> None:
-    r"""
-    Test the correct behavior when `onyo mkdir <path>` is called on an
-    existing directory.
-    """
+    r"""Do not error when passed an existing directory."""
+
     ret = subprocess.run(['onyo', 'mkdir', directory], capture_output=True, text=True)
 
     # verify output
@@ -152,9 +142,8 @@ protected_paths = [".anchor",
 @pytest.mark.repo_dirs("simple")
 @pytest.mark.parametrize('protected_path', protected_paths)
 def test_dir_protected(repo: OnyoRepo, protected_path: str) -> None:
-    r"""
-    Test the correct error behavior of `onyo mkdir <path>` on protected paths.
-    """
+    r"""Error when passed protected paths."""
+
     ret = subprocess.run(["onyo", "mkdir", protected_path], capture_output=True, text=True)
 
     # verify output
@@ -169,9 +158,8 @@ def test_dir_protected(repo: OnyoRepo, protected_path: str) -> None:
 
 @pytest.mark.repo_dirs("simple")
 def test_mkdir_relative_path(repo: OnyoRepo) -> None:
-    r"""
-    Test `onyo mkdir <path>` with a relative path given as input.
-    """
+    r"""Create relative paths."""
+
     ret = subprocess.run(["onyo", "--yes", "mkdir", "simple/../relative"], capture_output=True, text=True)
 
     # verify output

--- a/onyo/cli/tests/test_new.py
+++ b/onyo/cli/tests/test_new.py
@@ -25,10 +25,10 @@ asset_spec = ['type=laptop', 'make=apple', 'model.name=macbookpro', 'serial=0']
 
 @pytest.mark.repo_dirs(*directories)
 @pytest.mark.parametrize('directory', directories)
-def test_new(repo: OnyoRepo, directory: str) -> None:
-    r"""
-    Test that `onyo new` can create an asset in different directories.
-    """
+def test_new(repo: OnyoRepo,
+             directory: str) -> None:
+    r"""Create an asset in a directory."""
+
     file_ = f'{directory}/laptop_apple_macbookpro.0'
     ret = subprocess.run(['onyo', '--yes', 'new', '--directory', directory, '--keys'] + asset_spec,
                          capture_output=True, text=True)
@@ -47,10 +47,8 @@ def test_new(repo: OnyoRepo, directory: str) -> None:
 
 @pytest.mark.repo_dirs(*directories)
 def test_new_interactive(repo: OnyoRepo) -> None:
-    r"""
-    Test that `onyo new` can create an asset in different directories when given
-    'y' as input in the dialog, instead of using the flag '--yes'.
-    """
+    r"""Create an asset when user responds "y" interactively."""
+
     file_ = f'{directories[0]}/laptop_apple_macbookpro.0'
     ret = subprocess.run(['onyo', 'new', '--directory', directories[0], '--keys'] + asset_spec,
                          input='y', capture_output=True, text=True)
@@ -69,11 +67,12 @@ def test_new_interactive(repo: OnyoRepo) -> None:
 
 
 def test_new_top_level(repo: OnyoRepo) -> None:
-    r"""
-    Test that `onyo new` can create an asset on the top level of
-    the repository. This relies on CWD being the default for `--directory`
-    and on the `repo` fixture CD'ing into the repo's root dir.
+    r"""Create an asset in the repo root.
+
+    This relies on CWD being the default for ``--directory`` and the ``repo``
+    fixture ``cd``ing into the repo's root dir.
     """
+
     file_ = 'laptop_apple_macbookpro.0'
     ret = subprocess.run(['onyo', '--yes', 'new', '--keys'] + asset_spec,
                          capture_output=True, text=True)
@@ -92,10 +91,8 @@ def test_new_top_level(repo: OnyoRepo) -> None:
 
 @pytest.mark.repo_dirs(*directories)
 def test_new_sub_dir_absolute_path(repo: OnyoRepo) -> None:
-    r"""
-    Test that `onyo new --directory <path>` can create an asset in sub-directories of
-    the repository while the cwd is inside a different sub-directory.
-    """
+    r"""Create an asset outside of the CWD with absolute path."""
+
     # Change cwd to sub-directory
     cwd = repo.git.root / 'spe\"cial\\char\'acteஞrs'
     os.chdir(cwd)
@@ -120,11 +117,8 @@ def test_new_sub_dir_absolute_path(repo: OnyoRepo) -> None:
 
 @pytest.mark.repo_dirs(*directories)
 def test_new_sub_dir_relative_path(repo: OnyoRepo) -> None:
-    r"""
-    Test that `onyo new --directory <path>` can create an asset in sub-directories of
-    the repository while the cwd is inside a different sub-directory with a
-    relative path.
-    """
+    r"""Create an asset outside of the CWD with relative path."""
+
     # Change cwd to sub-directory
     cwd = repo.git.root / 'r/e/c/u/r/s/i/v/e'
     os.chdir(cwd)
@@ -152,11 +146,8 @@ def test_new_sub_dir_relative_path(repo: OnyoRepo) -> None:
 @pytest.mark.repo_dirs('overlap')  # to test sub-dir creation for existing dir
 @pytest.mark.parametrize('directory', directories)
 def test_folder_creation_with_new(repo: OnyoRepo, directory: str) -> None:
-    r"""
-    Test that `onyo new` can create new folders for assets.
-    Tests that folders are created when a sub-folder already exist, too, through
-    existing dir 'overlap'.
-    """
+    r"""Automatically create parent directories."""
+
     asset = f"{directory}/laptop_apple_macbookpro.0"
     ret = subprocess.run(['onyo', '--yes', 'new', '--directory', directory, '--keys'] + asset_spec,
                          capture_output=True, text=True)
@@ -176,12 +167,8 @@ def test_folder_creation_with_new(repo: OnyoRepo, directory: str) -> None:
 
 
 def test_with_faux_serial_number(repo: OnyoRepo) -> None:
-    r"""
-    Test that `onyo new` can create multiple assets with faux serial numbers in
-    multiple directories at once. To specify several assets, at least one key-value-pair
-    has to be given multiple times. This test also needs to use the 'directory'
-    (reserved) key instead of `--directory` in order to specify the directory per asset.
-    """
+    r"""Create multiple assets with faux serials in multiple directories."""
+
     filename_prefix = "laptop_apple_macbookpro.faux"  # created asset files are expected to be this plus a random suffix
 
     num = 10
@@ -204,10 +191,8 @@ def test_with_faux_serial_number(repo: OnyoRepo) -> None:
 
 
 def test_new_assets_in_multiple_directories_at_once(repo: OnyoRepo) -> None:
-    r"""
-    Test that `onyo new` cat create new assets in multiple different
-    directories in one call.
-    """
+    r"""Create assets in multiple different directories."""
+
     assets = [f'{directory}/laptop_apple_macbookpro.{i}'
               for i, directory in enumerate(directories)]
     keys = ['--keys', 'type=laptop', 'make=apple', 'model.name=macbookpro']
@@ -233,10 +218,10 @@ def test_new_assets_in_multiple_directories_at_once(repo: OnyoRepo) -> None:
 
 
 @pytest.mark.parametrize('directory', directories)
-def test_yes_flag(repo: OnyoRepo, directory: str) -> None:
-    r"""
-    Test that `onyo new --yes` creates assets in different directories.
-    """
+def test_yes_flag(repo: OnyoRepo,
+                  directory: str) -> None:
+    r"""``onyo new --yes`` creates assets in different directories."""
+
     asset = f'{directory}/laptop_apple_macbookpro.0'
     ret = subprocess.run(['onyo', '--yes', 'new', '--directory', directory, '--keys'] + asset_spec,
                          capture_output=True, text=True)
@@ -259,10 +244,10 @@ def test_yes_flag(repo: OnyoRepo, directory: str) -> None:
 
 
 @pytest.mark.parametrize('directory', directories)
-def test_keys_flag(repo: OnyoRepo, directory: str) -> None:
-    r"""
-    Test that `onyo new --keys KEY=VALUE` creates assets with contents added.
-    """
+def test_keys_flag(repo: OnyoRepo,
+                   directory: str) -> None:
+    r"""``onyo new --keys KEY=VALUE`` creates assets with contents added."""
+
     # set `key=value` for --keys, and asset name
     asset = f"{directory}/laptop_apple_macbookpro.0"
     key_values = "mode=keys_flag"
@@ -285,10 +270,8 @@ def test_keys_flag(repo: OnyoRepo, directory: str) -> None:
 
 
 def test_error_keys_flag_mismatch_count(repo: OnyoRepo) -> None:
-    r"""
-    Test that `onyo new --keys KEY=VALUE` requires that repeated keys are given
-    the same number of times.
-    """
+    r"""Error when repeated keys passed to ``--keys`` are not given the same number of times."""
+
     key_values = asset_spec + ['serial=1', 'mode=0', 'mode=1', 'mode=2']
 
     # create asset with --keys
@@ -307,10 +290,10 @@ def test_error_keys_flag_mismatch_count(repo: OnyoRepo) -> None:
 
 
 @pytest.mark.parametrize('directory', directories)
-def test_discard_changes(repo: OnyoRepo, directory: str) -> None:
-    r"""
-    Test that `onyo new` can discard new assets and the repository stays clean.
-    """
+def test_discard_changes(repo: OnyoRepo,
+                         directory: str) -> None:
+    r"""Discard and don't modify when user responds with "n"."""
+
     asset = f'{directory}/laptop_apple_macbookpro.0'
     ret = subprocess.run(['onyo', 'new', '--directory', directory, '--keys'] + asset_spec,
                          input='n', capture_output=True, text=True)
@@ -339,11 +322,10 @@ def test_discard_changes(repo: OnyoRepo, directory: str) -> None:
     '.git/hooks',
     '.git/info'
 ])
-def test_new_protected_folder(repo: OnyoRepo, protected_folder: str) -> None:
-    r"""
-    Test that `onyo new` when called on protected folders errors correctly
-    instead of creating an asset.
-    """
+def test_new_protected_folder(repo: OnyoRepo,
+                              protected_folder: str) -> None:
+    r"""Error when called on protected directories."""
+
     asset = f"{protected_folder}/laptop_apple_macbookpro.0"
     ret = subprocess.run(['onyo', 'new', '--directory', protected_folder, '--keys'] + asset_spec,
                          capture_output=True, text=True)
@@ -357,11 +339,10 @@ def test_new_protected_folder(repo: OnyoRepo, protected_folder: str) -> None:
 
 
 @pytest.mark.parametrize('directory', directories)
-def test_new_with_flags_edit_keys_template(repo: OnyoRepo, directory: str) -> None:
-    r"""
-    Test `onyo new --edit --keys KEY=VALUE --template <TEMPLATE>` works when
-    called and all flags get executed together and modify the output correctly.
-    """
+def test_new_with_flags_edit_keys_template(repo: OnyoRepo,
+                                           directory: str) -> None:
+    r"""All flags waterfall correctly."""
+
     # set editor, template, key=value and asset
     os.environ['EDITOR'] = "printf 'key: value' >>"
     template = repo.git.root / repo.TEMPLATE_DIR / "laptop.example"
@@ -412,11 +393,10 @@ def test_new_with_flags_edit_keys_template(repo: OnyoRepo, directory: str) -> No
 
 
 @pytest.mark.parametrize('directory', directories)
-def test_new_with_keys_overwrite_template(repo: OnyoRepo, directory: str) -> None:
-    r"""
-    Test `onyo new --keys <KEY=VALUE> --template <TEMPLATE>` does overwrite the
-    contents of <TEMPLATE> with <KEY=VALUE>
-    """
+def test_new_with_keys_overwrite_template(repo: OnyoRepo,
+                                          directory: str) -> None:
+    r"""Overwrite keys in a template."""
+
     # set asset, --template and --keys
     template = "laptop.example"
     asset = Path(f"{directory}/laptop_apple_macbookpro.0")
@@ -453,11 +433,11 @@ def test_new_with_keys_overwrite_template(repo: OnyoRepo, directory: str) -> Non
     ['escapes', 'in', 'asset', 'na\\me'],
     ['lap\"top', 'appஞle', 'mac\\book\'pro', '0']
 ])
-def test_with_special_characters(
-        repo: OnyoRepo, directory: str, variant: str) -> None:
-    r"""
-    Test `onyo new` with names containing special characters.
-    """
+def test_with_special_characters(repo: OnyoRepo,
+                                 directory: str,
+                                 variant: str) -> None:
+    r"""Test special characters."""
+
     asset = f'{directory}/{variant[0]}_{variant[1]}_{variant[2]}.{variant[3]}'
     keys = [f"type={variant[0]}", f"make={variant[1]}",
             f"model.name={variant[2]}", f"serial={variant[3]}"]
@@ -477,7 +457,8 @@ def test_with_special_characters(
 
 @pytest.mark.repo_files('laptop_apple_macbookpro.0')
 @pytest.mark.parametrize('directory', directories)
-def test_identical_asset_exists(repo: OnyoRepo, directory: str) -> None:
+def test_identical_asset_exists(repo: OnyoRepo,
+                                directory: str) -> None:
     r"""Allow an asset identical to an existing one, but in a different directory."""
 
     asset = f"{directory}/laptop_apple_macbookpro.0"
@@ -496,8 +477,8 @@ def test_identical_asset_exists(repo: OnyoRepo, directory: str) -> None:
 
 
 @pytest.mark.parametrize('directory', directories)
-def test_two_identical_assets_in_input(
-        repo: OnyoRepo, directory: str) -> None:
+def test_two_identical_assets_in_input(repo: OnyoRepo,
+                                       directory: str) -> None:
     r"""Create two identical assets in two different target directories."""
 
     asset = "laptop_apple_macbookpro.0"
@@ -516,9 +497,9 @@ def test_two_identical_assets_in_input(
 
 
 @pytest.mark.parametrize('directory', directories)
-def test_error_two_identical_assets_in_input(
-        repo: OnyoRepo, directory: str) -> None:
-    r"""Error when two assets would result in identical name and location."""
+def test_error_two_identical_assets_in_input(repo: OnyoRepo,
+                                             directory: str) -> None:
+    r"""Error when two assets result in identical name and location."""
 
     asset = "laptop_apple_macbookpro.0"
     ret = subprocess.run(['onyo', 'new', '--keys'] + asset_spec + [f"directory={directory}", f"directory={directory}"],
@@ -535,10 +516,8 @@ def test_error_two_identical_assets_in_input(
 
 
 def test_error_template_does_not_exist(repo: OnyoRepo) -> None:
-    r"""
-    Test that `onyo new --template` errors when it is called with a non-existing
-    template name.
-    """
+    r"""Error when called with a non-existing template name."""
+
     no_template = "no_template"
     ret = subprocess.run(['onyo', 'new', '--template', no_template, '--keys'] + asset_spec,
                          capture_output=True, text=True)
@@ -554,11 +533,8 @@ def test_error_template_does_not_exist(repo: OnyoRepo) -> None:
 
 
 def test_conflicting_and_missing_arguments(repo: OnyoRepo) -> None:
-    r"""
-    Onyo should inform the user with specific error messages when arguments are
-    either missing or conflicting:
-    - error if `onyo new` without key/values or template/clone
-    """
+    r"""Inform the user when arguments are missing or conflicting."""
+
     # error if `onyo new` gets neither temaplte, clone, edit, or keys
     ret = subprocess.run(['onyo', 'new'], capture_output=True, text=True)
     assert not ret.stdout

--- a/onyo/cli/tests/test_rm.py
+++ b/onyo/cli/tests/test_rm.py
@@ -28,11 +28,10 @@ assets: List[str] = [f"{d}/{f}.{i}" for f in files for i, d in enumerate(directo
 
 @pytest.mark.repo_files(*assets)
 @pytest.mark.parametrize('asset', assets)
-def test_rm(repo: OnyoRepo, asset: str) -> None:
-    r"""
-    Test that `onyo rm ASSET` deletes assets and leaves the repository in a
-    clean state.
-    """
+def test_rm(repo: OnyoRepo,
+            asset: str) -> None:
+    r"""Delete an asset."""
+
     ret = subprocess.run(['onyo', '--yes', 'rm', asset],
                          capture_output=True, text=True)
     assert ret.returncode == 0
@@ -46,10 +45,8 @@ def test_rm(repo: OnyoRepo, asset: str) -> None:
 
 @pytest.mark.repo_files(*assets)
 def test_rm_multiple_inputs(repo: OnyoRepo) -> None:
-    r"""
-    Test that `onyo rm ASSET` deletes a list of assets all at once and leaves
-    the repository in a clean state.
-    """
+    r"""Delete a list of assets all at once."""
+
     ret = subprocess.run(['onyo', '--yes', 'rm', *assets],
                          capture_output=True, text=True)
     assert ret.returncode == 0
@@ -65,10 +62,8 @@ def test_rm_multiple_inputs(repo: OnyoRepo) -> None:
 @pytest.mark.repo_files(*assets)
 @pytest.mark.parametrize('directory', directories[1:])  # do not use "." as dir
 def test_rm_single_dirs_with_files(repo: OnyoRepo, directory: str) -> None:
-    r"""
-    Test that `onyo rm DIRECTORY` deletes directories successfully and leaves
-    the repository in a clean state.
-    """
+    r"""Delete a directory."""
+
     ret = subprocess.run(['onyo', '--yes', 'rm', '--recursive', directory],
                          capture_output=True, text=True)
     assert ret.returncode == 0
@@ -82,10 +77,8 @@ def test_rm_single_dirs_with_files(repo: OnyoRepo, directory: str) -> None:
 
 @pytest.mark.repo_files(*assets)
 def test_rm_multiple_directories(repo: OnyoRepo) -> None:
-    r"""
-    Test that `onyo rm DIRECTORY` deletes a list of directories all at once and
-    leaves the repository in a clean state.
-    """
+    r"""Delete a list of directories all at once."""
+
     ret = subprocess.run(['onyo', '--yes', 'rm', '--recursive', *directories[1:]],
                          capture_output=True, text=True)
     assert ret.returncode == 0
@@ -100,10 +93,8 @@ def test_rm_multiple_directories(repo: OnyoRepo) -> None:
 
 @pytest.mark.repo_dirs(*directories[1:])  # skip "." for directory creation
 def test_rm_empty_directories(repo: OnyoRepo) -> None:
-    r"""
-    Test that `onyo rm DIRECTORY` deletes empty directories and leaves the
-    repository in a clean state.
-    """
+    r"""Delete empty directories."""
+
     ret = subprocess.run(['onyo', '--yes', 'rm', *directories[1:]],
                          capture_output=True, text=True)
     assert ret.returncode == 0
@@ -118,9 +109,11 @@ def test_rm_empty_directories(repo: OnyoRepo) -> None:
 
 @pytest.mark.repo_files(*assets)
 def test_rm_interactive_missing_y(repo: OnyoRepo) -> None:
-    r"""
-    Default mode is interactive. It requires a "y" to approve.
+    r"""Default mode is interactive.
+
+    The user must respond with "y" to approve.
     """
+
     ret = subprocess.run(['onyo', 'rm', *assets], capture_output=True, text=True)
     assert ret.returncode == 1
     assert "Save changes? No discards all changes. (y/n) " in ret.stdout
@@ -134,10 +127,8 @@ def test_rm_interactive_missing_y(repo: OnyoRepo) -> None:
 
 @pytest.mark.repo_files(*assets)
 def test_rm_interactive_abort(repo: OnyoRepo) -> None:
-    r"""
-    Test that `onyo rm ASSET` does not delete any asset, when the user provides
-    "n" as response in interactive mode.
-    """
+    r"""Do not delete anything when the user responds with "n"."""
+
     ret = subprocess.run(['onyo', 'rm', *assets], input='n', capture_output=True, text=True)
     assert ret.returncode == 0
     assert "Save changes? No discards all changes. (y/n) " in ret.stdout
@@ -152,10 +143,8 @@ def test_rm_interactive_abort(repo: OnyoRepo) -> None:
 @pytest.mark.repo_files(*assets)
 @pytest.mark.parametrize('asset', assets)
 def test_rm_interactive(repo: OnyoRepo, asset: str) -> None:
-    r"""
-    Test that `onyo rm ASSET` deletes ASSET successfully, when the user provides
-    "y" as the response in interactive mode.
-    """
+    r"""Delete when the user responds with "y"."""
+
     ret = subprocess.run(['onyo', 'rm', asset], input='y', capture_output=True, text=True)
     assert ret.returncode == 0
     assert "Save changes? No discards all changes. (y/n) " in ret.stdout

--- a/onyo/cli/tests/test_set.py
+++ b/onyo/cli/tests/test_set.py
@@ -57,7 +57,8 @@ non_existing_assets: List[List[str]] = [
 def test_set(repo: OnyoRepo,
              asset: str,
              set_values: list[str]) -> None:
-    r"""Test that `onyo set KEY=VALUE --asset <asset>` updates contents of assets."""
+    r"""``onyo set KEY=VALUE --asset <asset>`` updates the contents of assets."""
+
     ret = subprocess.run(['onyo', '--yes', 'set', '--keys', *set_values, '--asset', asset],
                          capture_output=True, text=True)
 
@@ -85,7 +86,8 @@ def test_set(repo: OnyoRepo,
 def test_set_interactive(repo: OnyoRepo,
                          asset: str,
                          set_values: list[str]) -> None:
-    r"""Test that `onyo set KEY=VALUE --asset <asset>` updates contents of assets."""
+    r"""``onyo set KEY=VALUE --asset <asset>`` updates contents of assets."""
+
     ret = subprocess.run(['onyo', 'set', '--keys', *set_values, '--asset', asset],
                          input='y', capture_output=True, text=True)
 
@@ -112,9 +114,8 @@ def test_set_interactive(repo: OnyoRepo,
 @pytest.mark.parametrize('set_values', values)
 def test_set_multiple_assets(repo: OnyoRepo,
                              set_values: list[str]) -> None:
-    r"""Test that `onyo set KEY=VALUE --asset <asset>` can update the contents of multiple
-    assets in a single call.
-    """
+    r"""Update the contents of multiple assets in a single call."""
+
     ret = subprocess.run(['onyo', '--yes', 'set', '--keys', *set_values,
                           '--asset', *asset_paths],
                          capture_output=True, text=True)
@@ -142,11 +143,8 @@ def test_set_multiple_assets(repo: OnyoRepo,
 @pytest.mark.parametrize('no_assets', non_existing_assets)
 def test_set_error_non_existing_assets(repo: OnyoRepo,
                                        no_assets: list[str]) -> None:
-    r"""Test that `onyo set KEY=VALUE --asset <asset>` errors correctly for:
-    - non-existing assets on root
-    - non-existing assets in directories
-    - one non-existing asset in a list of existing ones
-    """
+    r"""Error when passed a non-existing asset."""
+
     ret = subprocess.run(['onyo', 'set', '--keys', 'key=value',
                           '--asset', *no_assets], capture_output=True, text=True)
 
@@ -161,8 +159,8 @@ def test_set_error_non_existing_assets(repo: OnyoRepo,
 @pytest.mark.parametrize('set_values', values)
 def test_set_without_path(repo: OnyoRepo,
                           set_values: list[str]) -> None:
-    r"""Test that `onyo set KEY=VALUE` without a given path fails.
-    """
+    r"""Error when not passed a path."""
+
     ret = subprocess.run(['onyo', '--yes', 'set', '--keys', *set_values],
                          capture_output=True, text=True)
 
@@ -177,7 +175,8 @@ def test_set_without_path(repo: OnyoRepo,
 def test_set_discard_changes_single_assets(repo: OnyoRepo,
                                            asset: str,
                                            set_values: list[str]) -> None:
-    r"""Test that `onyo set` discards changes for assets successfully."""
+    r"""Don't modify when the user responds "n"."""
+
     ret = subprocess.run(['onyo', 'set', '--keys', *set_values, '--asset', asset],
                          input='n',
                          capture_output=True, text=True)
@@ -208,9 +207,8 @@ def test_set_discard_changes_single_assets(repo: OnyoRepo,
 @pytest.mark.parametrize('asset', [asset_paths[0]])
 def test_add_new_key_to_existing_content(repo: OnyoRepo,
                                          asset: str) -> None:
-    r"""Test that `onyo set KEY=VALUE --asset <asset>` can be called two times with
-    different `KEY`, and adds it without overwriting existing values.
-    """
+    r"""Call ``set` two times with different keys, and don't alter unrelated values."""
+
     set_1 = "change=one"
     ret = subprocess.run(['onyo', '--yes', 'set', '--keys', set_1, '--asset', asset],
                          capture_output=True, text=True)
@@ -250,10 +248,8 @@ def test_add_new_key_to_existing_content(repo: OnyoRepo,
 @pytest.mark.parametrize('asset', [asset_paths[0]])
 def test_set_overwrite_key(repo: OnyoRepo,
                            asset: str) -> None:
-    r"""
-    Test that `onyo set KEY=VALUE --asset <asset>` can be called two times with
-    different VALUE for the same KEY, and overwrites existing values correctly.
-    """
+    r"""Set the same key twice in different runs."""
+
     set_value = "value=original"
     ret = subprocess.run(['onyo', '--yes', 'set', '--keys', set_value, '--asset', asset],
                          capture_output=True, text=True)
@@ -290,9 +286,8 @@ def test_set_overwrite_key(repo: OnyoRepo,
 @pytest.mark.parametrize('asset', [asset_paths[0]])
 def test_setting_new_values_if_some_values_already_set(repo: OnyoRepo,
                                                        asset: str) -> None:
-    r"""Test that `onyo set KEY=VALUE --asset <asset>` updates contents of assets and adds
-    the correct output if called multiple times, and that the output is correct.
-    """
+    r"""The correct output is generated when called multiple times."""
+
     set_values = "change=one"
     ret = subprocess.run(['onyo', '--yes', 'set', '--keys', set_values, '--asset', asset],
                          capture_output=True, text=True)
@@ -334,12 +329,7 @@ def test_setting_new_values_if_some_values_already_set(repo: OnyoRepo,
 def test_values_already_set(repo: OnyoRepo,
                             asset: str,
                             set_values: list[str]) -> None:
-    r"""Test that `onyo set KEY=VALUE --asset <asset>` updates
-    contents of assets once, and if called again with
-    same valid values the command does display the correct
-    info message without error, and the repository stays
-    in a clean state.
-    """
+    r"""The same call twice results in 1) changes and 2) no changes."""
 
     ret = subprocess.run(['onyo', '--yes', 'set', '--keys', *set_values,
                           '--asset', asset],
@@ -375,10 +365,7 @@ def test_values_already_set(repo: OnyoRepo,
 
 @pytest.mark.repo_contents(*assets)
 def test_update_many_faux_serial_numbers(repo: OnyoRepo) -> None:
-    r"""Test that `onyo set serial=faux --asset <asset>`
-    can successfully update many assets with new faux
-    serial numbers in one call.
-    """
+    r"""Generate faux serials for many assets in one call."""
 
     pytest.skip("TODO: faux serials not yet considered outside new. Needs to move (modify_asset)")
     # remember old assets before renaming
@@ -414,7 +401,7 @@ def test_update_many_faux_serial_numbers(repo: OnyoRepo) -> None:
 def test_duplicate_keys(repo: OnyoRepo,
                         asset: str,
                         set_values: list[str]) -> None:
-    r"""Test that `onyo set` fails, if the same key is given multiple times."""
+    r"""Error if the same key is passed multiple times."""
 
     ret = subprocess.run(['onyo', '--yes', 'set', '--keys',
                           *set_values, 'dup.key=1', 'dup.key=2', '--asset', asset],
@@ -433,6 +420,7 @@ def test_duplicate_keys(repo: OnyoRepo,
 @pytest.mark.parametrize('asset', [asset_paths[0]])
 def test_set_empty_dictlist(repo: OnyoRepo, asset: str) -> None:
     r"""Test special symbols {}, <dict>, [], <list> to set empty dicts/lists."""
+
     ret = subprocess.run(['onyo', '--yes', 'set', '--keys',
                           'new.dict={}', 'new.list=[]', '--asset', asset],
                          capture_output=True, text=True)

--- a/onyo/cli/tests/test_tree.py
+++ b/onyo/cli/tests/test_tree.py
@@ -28,9 +28,8 @@ assets: List[str] = [f"{d}/{f}.{i}" for f in files
 
 @pytest.mark.repo_files(*assets)
 def test_tree(repo: OnyoRepo) -> None:
-    r"""
-    Test that `onyo tree` works without input paths.
-    """
+    r"""``onyo tree`` works when passed no arguments."""
+
     ret = subprocess.run(['onyo', 'tree'], capture_output=True, text=True)
 
     # verify output
@@ -46,9 +45,8 @@ def test_tree(repo: OnyoRepo) -> None:
 @pytest.mark.repo_files(*assets)
 @pytest.mark.parametrize('directory', directories)
 def test_tree_with_directory(repo: OnyoRepo, directory: str) -> None:
-    r"""
-    Test that `onyo tree DIRECTORY` displays directories correctly.
-    """
+    r"""Pass a single directory."""
+
     ret = subprocess.run(['onyo', 'tree', directory], capture_output=True, text=True)
 
     # verify output
@@ -67,10 +65,8 @@ def test_tree_with_directory(repo: OnyoRepo, directory: str) -> None:
 
 @pytest.mark.repo_files(*assets)
 def test_tree_multiple_inputs(repo: OnyoRepo) -> None:
-    r"""
-    Test that `onyo tree <dirs>` displays all directories when given a list of
-    paths in one call.
-    """
+    r"""Pass multiple directories in one call."""
+
     ret = subprocess.run(['onyo', 'tree', *directories],
                          capture_output=True, text=True)
 
@@ -87,10 +83,8 @@ def test_tree_multiple_inputs(repo: OnyoRepo) -> None:
 @pytest.mark.parametrize('directory', ["does_not_exist"] + [
     d + "/subdir" for d in directories])
 def test_tree_error_dir_does_not_exist(repo: OnyoRepo, directory: str) -> None:
-    r"""
-    Test the correct error behavior when `onyo tree <path>` is called on
-    non-existing directories and sub-directories.
-    """
+    r"""Error when passed a non-existing directory."""
+
     ret = subprocess.run(['onyo', 'tree', directory], capture_output=True, text=True)
 
     # verify output
@@ -103,9 +97,8 @@ def test_tree_error_dir_does_not_exist(repo: OnyoRepo, directory: str) -> None:
 @pytest.mark.repo_files(*assets)
 @pytest.mark.parametrize('asset', assets)
 def test_tree_error_is_file(repo: OnyoRepo, asset: str) -> None:
-    r"""
-    Test the correct error behavior when `onyo tree ASSET` is called on assets.
-    """
+    r"""Error when passed a file."""
+
     ret = subprocess.run(['onyo', 'tree', asset], capture_output=True, text=True)
 
     # verify output
@@ -117,9 +110,8 @@ def test_tree_error_is_file(repo: OnyoRepo, asset: str) -> None:
 
 @pytest.mark.repo_files(*assets)
 def test_tree_relative_path(repo: OnyoRepo) -> None:
-    r"""
-    Test `onyo tree <path>` with a relative path given as input.
-    """
+    r"""Relative paths work."""
+
     ret = subprocess.run(["onyo", "tree", "simple/../s p a c e s"], capture_output=True, text=True)
 
     # verify output
@@ -130,10 +122,8 @@ def test_tree_relative_path(repo: OnyoRepo) -> None:
 
 @pytest.mark.repo_files(*assets)
 def test_tree_error_relative_path_outside_repo(repo: OnyoRepo) -> None:
-    r"""
-    Test `onyo tree <path>` gives error with a relative path that leads outside
-    of the repository.
-    """
+    r"""Error when path is outside of the repository."""
+
     ret = subprocess.run(["onyo", "tree", ".."], capture_output=True, text=True)
 
     # verify output

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -844,7 +844,7 @@ def onyo_mv(inventory: Inventory,
                     # from inventory.operations (e.g. inventory.operations[0].operator.recorder()),
                     # but recorders are currently inconvenient to use (they even
                     # have a TODO to simplify them to use Inventory).
-                    # Furthermore, record_move() explicitly notes that it
+                    # Furthermore, _record_move() explicitly notes that it
                     # assumes that it's passed the complete paths, which is the
                     # exact same problem that we have here, so it actually
                     # doesn't help us. :-/

--- a/onyo/lib/differs.py
+++ b/onyo/lib/differs.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 from difflib import unified_diff
-from functools import partial
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from onyo.lib.onyo import OnyoRepo
 from onyo.lib.utils import dict_to_asset_yaml
 
 if TYPE_CHECKING:
+    from pathlib import Path
     from typing import Generator
 
 # Differs signature: (repo: OnyoRepo, operands: tuple) -> Generator[str, None, None]:
@@ -29,16 +28,8 @@ def diff_path_change(src: Path, dst: Path) -> Generator[str, None, None]:
     yield f"{str(src)} -> {str(dst)}"
 
 
-diff_new_asset = partial(diff_assets, asset_old={})
-diff_rm_asset = partial(diff_assets, asset_new={})
-diff_modified_asset = diff_assets
-diff_renamed_asset = diff_assets  # This is the same, because a rename requires a change in keys composing the name (or change in config).
 
 
-def diff_moved_asset(asset_old: dict | Path, asset_new: Path) -> Generator[str, None, None]:
-    # could be same. Just check isinstance?
-    yield from diff_path_change(asset_old if isinstance(asset_old, Path) else asset_old.get('onyo.path.absolute'),
-                                asset_new)
 
 
 def differ_new_assets(repo: OnyoRepo, operands: tuple) -> Generator[str, None, None]:

--- a/onyo/lib/differs.py
+++ b/onyo/lib/differs.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 def _diff_assets(asset_old: Item,
                  asset_new: Item
                  ) -> Generator[str, None, None]:
-    r"""Helper for ``{modify,new}_assets()`` differs.
+    r"""Helper for ``{modify,new}_asset()`` differs.
 
     Parameters
     ----------
@@ -35,7 +35,7 @@ def _diff_assets(asset_old: Item,
 def _diff_path_change(src: Path,
                       dst: Path
                       ) -> Generator[str, None, None]:
-    r"""Helper for ``{move,rename}_{assets,directories}()`` differs.
+    r"""Helper for ``{move,rename}_{asset,directory}()`` differs.
 
     Parameters
     ----------
@@ -48,9 +48,9 @@ def _diff_path_change(src: Path,
     yield f"{str(src)} -> {str(dst)}"
 
 
-def differ_modify_assets(repo: OnyoRepo,
-                         operands: tuple[Item, Item]
-                         ) -> Generator[str, None, None]:
+def differ_modify_asset(repo: OnyoRepo,
+                        operands: tuple[Item, Item]
+                        ) -> Generator[str, None, None]:
     r"""Differ for the 'modify_assets' operation.
 
     Not intended for direct use. It is called from an Operator, which is assumed
@@ -69,9 +69,9 @@ def differ_modify_assets(repo: OnyoRepo,
     yield from _diff_assets(operands[0], operands[1])
 
 
-def differ_move_assets(repo: OnyoRepo,
-                       operands: tuple[Path, Path]
-                       ) -> Generator[str, None, None]:
+def differ_move_asset(repo: OnyoRepo,
+                      operands: tuple[Path, Path]
+                      ) -> Generator[str, None, None]:
     r"""Differ for the 'move_assets' operation.
 
     Not intended for direct use. It is called from an Operator, which is assumed
@@ -90,9 +90,9 @@ def differ_move_assets(repo: OnyoRepo,
     yield from _diff_path_change(operands[0], operands[1])
 
 
-def differ_move_directories(repo: OnyoRepo,
-                            operands: tuple[Path, Path]
-                            ) -> Generator[str, None, None]:
+def differ_move_directory(repo: OnyoRepo,
+                          operands: tuple[Path, Path]
+                          ) -> Generator[str, None, None]:
     r"""Differ for the 'move_directories' operation.
 
     Not intended for direct use. It is called from an Operator, which is assumed
@@ -111,9 +111,9 @@ def differ_move_directories(repo: OnyoRepo,
     yield from _diff_path_change(operands[0], operands[1])
 
 
-def differ_new_assets(repo: OnyoRepo,
-                      operands: tuple[Item]
-                      ) -> Generator[str, None, None]:
+def differ_new_asset(repo: OnyoRepo,
+                     operands: tuple[Item]
+                     ) -> Generator[str, None, None]:
     r"""Differ for the 'new_assets' operation.
 
     Not intended for direct use. It is called from an Operator, which is assumed
@@ -132,9 +132,9 @@ def differ_new_assets(repo: OnyoRepo,
     yield from _diff_assets(asset_old=Item({}, repo=repo), asset_new=operands[0])
 
 
-def differ_new_directories(repo: OnyoRepo,
-                           operands: tuple[Path]
-                           ) -> Generator[str, None, None]:
+def differ_new_directory(repo: OnyoRepo,
+                         operands: tuple[Path]
+                         ) -> Generator[str, None, None]:
     r"""Differ for the 'new_directories' operation.
 
     Not intended for direct use. It is called from an Operator, which is assumed
@@ -153,9 +153,9 @@ def differ_new_directories(repo: OnyoRepo,
     yield f"+{str(operands[0])}"
 
 
-def differ_remove_assets(repo: OnyoRepo,
-                         operands: tuple[Item]
-                         ) -> Generator[str, None, None]:
+def differ_remove_asset(repo: OnyoRepo,
+                        operands: tuple[Item]
+                        ) -> Generator[str, None, None]:
     r"""Differ for the 'remove_assets' operation.
 
     Not intended for direct use. It is called from an Operator, which is assumed
@@ -174,9 +174,9 @@ def differ_remove_assets(repo: OnyoRepo,
     yield f"-{operands[0].get('onyo.path.absolute')}"
 
 
-def differ_remove_directories(repo: OnyoRepo,
-                              operands: tuple[Item]
-                              ) -> Generator[str, None, None]:
+def differ_remove_directory(repo: OnyoRepo,
+                            operands: tuple[Item]
+                            ) -> Generator[str, None, None]:
     r"""Differ for the 'remove_directories' operation.
 
     Not intended for direct use. It is called from an Operator, which is assumed
@@ -195,9 +195,9 @@ def differ_remove_directories(repo: OnyoRepo,
     yield f"-{operands[0].get('onyo.path.absolute')}"
 
 
-def differ_rename_assets(repo: OnyoRepo,
-                         operands: tuple[Path, Path]
-                         ) -> Generator[str, None, None]:
+def differ_rename_asset(repo: OnyoRepo,
+                        operands: tuple[Path, Path]
+                        ) -> Generator[str, None, None]:
     r"""Differ for the 'rename_assets' operation.
 
     Not intended for direct use. It is called from an Operator, which is assumed
@@ -216,9 +216,9 @@ def differ_rename_assets(repo: OnyoRepo,
     yield from _diff_path_change(operands[0], operands[1])
 
 
-def differ_rename_directories(repo: OnyoRepo,
-                              operands: tuple[Path, Path]
-                              ) -> Generator[str, None, None]:
+def differ_rename_directory(repo: OnyoRepo,
+                            operands: tuple[Path, Path]
+                            ) -> Generator[str, None, None]:
     r"""Differ for the 'rename_directories' operation.
 
     Not intended for direct use. It is called from an Operator, which is assumed

--- a/onyo/lib/differs.py
+++ b/onyo/lib/differs.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from difflib import unified_diff
 from typing import TYPE_CHECKING
 
+from onyo.lib.items import Item
 from onyo.lib.onyo import OnyoRepo
 from onyo.lib.utils import dict_to_asset_yaml
 
@@ -10,13 +11,20 @@ if TYPE_CHECKING:
     from pathlib import Path
     from typing import Generator
 
-# Differs signature: (repo: OnyoRepo, operands: tuple) -> Generator[str, None, None]:
-# yielded strings are supposed to be lines of a diff for a given operation
 
-# TODO: Double-check we always report posix paths!
+def _diff_assets(asset_old: Item,
+                 asset_new: Item
+                 ) -> Generator[str, None, None]:
+    r"""Helper for ``{modify,new}_assets()`` differs.
 
+    Parameters
+    ----------
+    src
+        Absolute Path of source location.
+    dst
+        Absolute Path of destination parent.
+    """
 
-def diff_assets(asset_old: dict, asset_new: dict) -> Generator[str, None, None]:
     yield from unified_diff(dict_to_asset_yaml(asset_old).splitlines(keepends=False),
                             dict_to_asset_yaml(asset_new).splitlines(keepends=False),
                             fromfile=str(asset_old.get('onyo.path.absolute', '')),
@@ -24,45 +32,206 @@ def diff_assets(asset_old: dict, asset_new: dict) -> Generator[str, None, None]:
                             lineterm="")
 
 
-def diff_path_change(src: Path, dst: Path) -> Generator[str, None, None]:
+def _diff_path_change(src: Path,
+                      dst: Path
+                      ) -> Generator[str, None, None]:
+    r"""Helper for ``{move,rename}_{assets,directories}()`` differs.
+
+    Parameters
+    ----------
+    src
+        Absolute Path of source location.
+    dst
+        Absolute Path of destination parent.
+    """
+
     yield f"{str(src)} -> {str(dst)}"
 
 
+def differ_new_assets(repo: OnyoRepo,
+                      operands: tuple[Item]
+                      ) -> Generator[str, None, None]:
+    r"""Differ for the 'new_assets' operation.
+
+    Not intended for direct use. It is called from an Operator, which is assumed
+    to have validated all input passed to this (trusting) differ.
+
+    Yields the diff of the operation line-by-line.
+
+    Parameters
+    ----------
+    repo
+        Onyo repository to operate on.
+    operands
+        Asset to create.
+    """
+
+    yield from _diff_assets(asset_old=Item({}, repo=repo), asset_new=operands[0])
 
 
+def differ_new_directories(repo: OnyoRepo,
+                           operands: tuple[Path]
+                           ) -> Generator[str, None, None]:
+    r"""Differ for the 'new_directories' operation.
 
+    Not intended for direct use. It is called from an Operator, which is assumed
+    to have validated all input passed to this (trusting) differ.
 
-def differ_new_assets(repo: OnyoRepo, operands: tuple) -> Generator[str, None, None]:
-    yield from diff_assets(asset_old={}, asset_new=operands[0])
+    Yields the diff of the operation line-by-line.
 
+    Parameters
+    ----------
+    repo
+        Onyo repository to operate on.
+    operands
+        Absolute Path of directory to create.
+    """
 
-def differ_new_directories(repo: OnyoRepo, operands: tuple) -> Generator[str, None, None]:
     yield f"+{str(operands[0])}"
 
 
-def differ_remove_assets(repo: OnyoRepo, operands: tuple) -> Generator[str, None, None]:
-    yield f"-{str(operands[0]) if isinstance(operands[0], Path) else operands[0].get('onyo.path.absolute')}"
+def differ_remove_assets(repo: OnyoRepo,
+                         operands: tuple[Item]
+                         ) -> Generator[str, None, None]:
+    r"""Differ for the 'remove_assets' operation.
+
+    Not intended for direct use. It is called from an Operator, which is assumed
+    to have validated all input passed to this (trusting) differ.
+
+    Yields the diff of the operation line-by-line.
+
+    Parameters
+    ----------
+    repo
+        Onyo repository to operate on.
+    operands
+        Asset to remove.
+    """
+
+    yield f"-{operands[0].get('onyo.path.absolute')}"
 
 
-def differ_remove_directories(repo: OnyoRepo, operands: tuple) -> Generator[str, None, None]:
-    yield f"-{str(operands[0])}"
+def differ_remove_directories(repo: OnyoRepo,
+                              operands: tuple[Item]
+                              ) -> Generator[str, None, None]:
+    r"""Differ for the 'remove_directories' operation.
+
+    Not intended for direct use. It is called from an Operator, which is assumed
+    to have validated all input passed to this (trusting) differ.
+
+    Yields the diff of the operation line-by-line.
+
+    Parameters
+    ----------
+    repo
+        Onyo repository to operate on.
+    operands
+        Directory to remove.
+    """
+
+    yield f"-{operands[0].get('onyo.path.absolute')}"
 
 
-def differ_move_assets(repo: OnyoRepo, operands: tuple) -> Generator[str, None, None]:
-    yield from diff_path_change(operands[0], operands[1])
+def differ_move_assets(repo: OnyoRepo,
+                       operands: tuple[Path, Path]
+                       ) -> Generator[str, None, None]:
+    r"""Differ for the 'move_assets' operation.
+
+    Not intended for direct use. It is called from an Operator, which is assumed
+    to have validated all input passed to this (trusting) differ.
+
+    Yields the diff of the operation line-by-line.
+
+    Parameters
+    ----------
+    repo
+        Onyo repository to operate on.
+    operands
+        Absolute Paths of the source and destination parent.
+    """
+
+    yield from _diff_path_change(operands[0], operands[1])
 
 
-def differ_move_directories(repo: OnyoRepo, operands: tuple) -> Generator[str, None, None]:
-    yield from diff_path_change(operands[0], operands[1])
+def differ_move_directories(repo: OnyoRepo,
+                            operands: tuple[Path, Path]
+                            ) -> Generator[str, None, None]:
+    r"""Differ for the 'move_directories' operation.
+
+    Not intended for direct use. It is called from an Operator, which is assumed
+    to have validated all input passed to this (trusting) differ.
+
+    Yields the diff of the operation line-by-line.
+
+    Parameters
+    ----------
+    repo
+        Onyo repository to operate on.
+    operands
+        Absolute Paths of the source and destination parent.
+    """
+
+    yield from _diff_path_change(operands[0], operands[1])
 
 
-def differ_rename_directories(repo: OnyoRepo, operands: tuple) -> Generator[str, None, None]:
-    yield from diff_path_change(operands[0], operands[1])
+def differ_rename_directories(repo: OnyoRepo,
+                              operands: tuple[Path, Path]
+                              ) -> Generator[str, None, None]:
+    r"""Differ for the 'rename_directories' operation.
+
+    Not intended for direct use. It is called from an Operator, which is assumed
+    to have validated all input passed to this (trusting) differ.
+
+    Yields the diff of the operation line-by-line.
+
+    Parameters
+    ----------
+    repo
+        Onyo repository to operate on.
+    operands
+        Absolute Paths of the source and destination.
+    """
+
+    yield from _diff_path_change(operands[0], operands[1])
 
 
-def differ_modify_assets(repo: OnyoRepo, operands: tuple) -> Generator[str, None, None]:
-    yield from diff_assets(operands[0], operands[1])
+def differ_modify_assets(repo: OnyoRepo,
+                         operands: tuple[Item, Item]
+                         ) -> Generator[str, None, None]:
+    r"""Differ for the 'modify_assets' operation.
+
+    Not intended for direct use. It is called from an Operator, which is assumed
+    to have validated all input passed to this (trusting) differ.
+
+    Yields the diff of the operation line-by-line.
+
+    Parameters
+    ----------
+    repo
+        Onyo repository to operate on.
+    operands
+        Items of the original and updated asset.
+    """
+
+    yield from _diff_assets(operands[0], operands[1])
 
 
-def differ_rename_assets(repo: OnyoRepo, operands: tuple) -> Generator[str, None, None]:
-    yield from diff_path_change(operands[0], operands[1])
+def differ_rename_assets(repo: OnyoRepo,
+                         operands: tuple[Path, Path]
+                         ) -> Generator[str, None, None]:
+    r"""Differ for the 'rename_assets' operation.
+
+    Not intended for direct use. It is called from an Operator, which is assumed
+    to have validated all input passed to this (trusting) differ.
+
+    Yields the diff of the operation line-by-line.
+
+    Parameters
+    ----------
+    repo
+        Onyo repository to operate on.
+    operands
+        Absolute Paths of the source and destination.
+    """
+
+    yield from _diff_path_change(operands[0], operands[1])

--- a/onyo/lib/differs.py
+++ b/onyo/lib/differs.py
@@ -48,6 +48,69 @@ def _diff_path_change(src: Path,
     yield f"{str(src)} -> {str(dst)}"
 
 
+def differ_modify_assets(repo: OnyoRepo,
+                         operands: tuple[Item, Item]
+                         ) -> Generator[str, None, None]:
+    r"""Differ for the 'modify_assets' operation.
+
+    Not intended for direct use. It is called from an Operator, which is assumed
+    to have validated all input passed to this (trusting) differ.
+
+    Yields the diff of the operation line-by-line.
+
+    Parameters
+    ----------
+    repo
+        Onyo repository to operate on.
+    operands
+        Items of the original and updated asset.
+    """
+
+    yield from _diff_assets(operands[0], operands[1])
+
+
+def differ_move_assets(repo: OnyoRepo,
+                       operands: tuple[Path, Path]
+                       ) -> Generator[str, None, None]:
+    r"""Differ for the 'move_assets' operation.
+
+    Not intended for direct use. It is called from an Operator, which is assumed
+    to have validated all input passed to this (trusting) differ.
+
+    Yields the diff of the operation line-by-line.
+
+    Parameters
+    ----------
+    repo
+        Onyo repository to operate on.
+    operands
+        Absolute Paths of the source and destination parent.
+    """
+
+    yield from _diff_path_change(operands[0], operands[1])
+
+
+def differ_move_directories(repo: OnyoRepo,
+                            operands: tuple[Path, Path]
+                            ) -> Generator[str, None, None]:
+    r"""Differ for the 'move_directories' operation.
+
+    Not intended for direct use. It is called from an Operator, which is assumed
+    to have validated all input passed to this (trusting) differ.
+
+    Yields the diff of the operation line-by-line.
+
+    Parameters
+    ----------
+    repo
+        Onyo repository to operate on.
+    operands
+        Absolute Paths of the source and destination parent.
+    """
+
+    yield from _diff_path_change(operands[0], operands[1])
+
+
 def differ_new_assets(repo: OnyoRepo,
                       operands: tuple[Item]
                       ) -> Generator[str, None, None]:
@@ -132,52 +195,10 @@ def differ_remove_directories(repo: OnyoRepo,
     yield f"-{operands[0].get('onyo.path.absolute')}"
 
 
-def differ_move_assets(repo: OnyoRepo,
-                       operands: tuple[Path, Path]
-                       ) -> Generator[str, None, None]:
-    r"""Differ for the 'move_assets' operation.
-
-    Not intended for direct use. It is called from an Operator, which is assumed
-    to have validated all input passed to this (trusting) differ.
-
-    Yields the diff of the operation line-by-line.
-
-    Parameters
-    ----------
-    repo
-        Onyo repository to operate on.
-    operands
-        Absolute Paths of the source and destination parent.
-    """
-
-    yield from _diff_path_change(operands[0], operands[1])
-
-
-def differ_move_directories(repo: OnyoRepo,
-                            operands: tuple[Path, Path]
-                            ) -> Generator[str, None, None]:
-    r"""Differ for the 'move_directories' operation.
-
-    Not intended for direct use. It is called from an Operator, which is assumed
-    to have validated all input passed to this (trusting) differ.
-
-    Yields the diff of the operation line-by-line.
-
-    Parameters
-    ----------
-    repo
-        Onyo repository to operate on.
-    operands
-        Absolute Paths of the source and destination parent.
-    """
-
-    yield from _diff_path_change(operands[0], operands[1])
-
-
-def differ_rename_directories(repo: OnyoRepo,
-                              operands: tuple[Path, Path]
-                              ) -> Generator[str, None, None]:
-    r"""Differ for the 'rename_directories' operation.
+def differ_rename_assets(repo: OnyoRepo,
+                         operands: tuple[Path, Path]
+                         ) -> Generator[str, None, None]:
+    r"""Differ for the 'rename_assets' operation.
 
     Not intended for direct use. It is called from an Operator, which is assumed
     to have validated all input passed to this (trusting) differ.
@@ -195,31 +216,10 @@ def differ_rename_directories(repo: OnyoRepo,
     yield from _diff_path_change(operands[0], operands[1])
 
 
-def differ_modify_assets(repo: OnyoRepo,
-                         operands: tuple[Item, Item]
-                         ) -> Generator[str, None, None]:
-    r"""Differ for the 'modify_assets' operation.
-
-    Not intended for direct use. It is called from an Operator, which is assumed
-    to have validated all input passed to this (trusting) differ.
-
-    Yields the diff of the operation line-by-line.
-
-    Parameters
-    ----------
-    repo
-        Onyo repository to operate on.
-    operands
-        Items of the original and updated asset.
-    """
-
-    yield from _diff_assets(operands[0], operands[1])
-
-
-def differ_rename_assets(repo: OnyoRepo,
-                         operands: tuple[Path, Path]
-                         ) -> Generator[str, None, None]:
-    r"""Differ for the 'rename_assets' operation.
+def differ_rename_directories(repo: OnyoRepo,
+                              operands: tuple[Path, Path]
+                              ) -> Generator[str, None, None]:
+    r"""Differ for the 'rename_directories' operation.
 
     Not intended for direct use. It is called from an Operator, which is assumed
     to have validated all input passed to this (trusting) differ.

--- a/onyo/lib/exceptions.py
+++ b/onyo/lib/exceptions.py
@@ -7,9 +7,20 @@ class UIInputError(Exception):
 
 class OnyoCLIExitCode(Exception):
     r"""Raise if the Onyo CLI should exit with a specific value."""
+
     def __init__(self,
                  message: str,
                  returncode: int):
+        r"""Instantiate an ``OnyoCLIExitCode`` with a message and exit code.
+
+        Parameters
+        ----------
+        message
+            The exception message
+        returncode
+            The code to exit the command as.
+        """
+
         self.message = message
         self.returncode = returncode
 

--- a/onyo/lib/executors.py
+++ b/onyo/lib/executors.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 def _mover(src: Path,
            dst: Path) -> list[Path]:
-    r"""Helper for ``move_{assets,directories}()`` executors.
+    r"""Helper for ``move_{asset,directory}()`` executors.
 
     Parameters
     ----------
@@ -28,7 +28,7 @@ def _mover(src: Path,
 
 def _renamer(src: Path,
              dst: Path) -> list[Path]:
-    r"""Helper for ``rename_{assets,directories}()`` executors.
+    r"""Helper for ``rename_{asset,directory}()`` executors.
 
     Parameters
     ----------
@@ -42,9 +42,9 @@ def _renamer(src: Path,
     return [src, dst]
 
 
-def exec_modify_assets(repo: OnyoRepo,
-                       operands: tuple[Item, Item]
-                       ) -> tuple[list[Path], list[Path]]:
+def exec_modify_asset(repo: OnyoRepo,
+                      operands: tuple[Item, Item]
+                      ) -> tuple[list[Path], list[Path]]:
     r"""Executor for the 'modify_assets' operation.
 
     Not intended for direct use. It is called from an Operator, which is assumed
@@ -67,9 +67,9 @@ def exec_modify_assets(repo: OnyoRepo,
     return [new['onyo.path.absolute']], []
 
 
-def exec_move_assets(repo: OnyoRepo,
-                     operands: tuple[Path, Path]
-                     ) -> tuple[list[Path], list[Path]]:
+def exec_move_asset(repo: OnyoRepo,
+                    operands: tuple[Path, Path]
+                    ) -> tuple[list[Path], list[Path]]:
     r"""Executor for the 'move_assets' operation.
 
     Not intended for direct use. It is called from an Operator, which is assumed
@@ -89,9 +89,9 @@ def exec_move_assets(repo: OnyoRepo,
     return _mover(operands[0], operands[1]), []
 
 
-def exec_move_directories(repo: OnyoRepo,
-                          operands: tuple[Path, Path]
-                          ) -> tuple[list[Path], list[Path]]:
+def exec_move_directory(repo: OnyoRepo,
+                        operands: tuple[Path, Path]
+                        ) -> tuple[list[Path], list[Path]]:
     r"""Executor for the 'move_directories' operation.
 
     Not intended for direct use. It is called from an Operator, which is assumed
@@ -111,9 +111,9 @@ def exec_move_directories(repo: OnyoRepo,
     return _mover(operands[0], operands[1]), []
 
 
-def exec_new_assets(repo: OnyoRepo,
-                    operands: tuple[Item]
-                    ) -> tuple[list[Path], list[Path]]:
+def exec_new_asset(repo: OnyoRepo,
+                   operands: tuple[Item]
+                   ) -> tuple[list[Path], list[Path]]:
     r"""Executor for the 'new_assets' operation.
 
     Not intended for direct use. It is called from an Operator, which is assumed
@@ -139,9 +139,9 @@ def exec_new_assets(repo: OnyoRepo,
     return [path], [path]
 
 
-def exec_new_directories(repo: OnyoRepo,
-                         operands: tuple[Path]
-                         ) -> tuple[list[Path], list[Path]]:
+def exec_new_directory(repo: OnyoRepo,
+                       operands: tuple[Path]
+                       ) -> tuple[list[Path], list[Path]]:
     r"""Executor for the 'new_directories' operation.
 
     Not intended for direct use. It is called from an Operator, which is assumed
@@ -174,9 +174,9 @@ def exec_new_directories(repo: OnyoRepo,
     return paths, paths
 
 
-def exec_remove_assets(repo: OnyoRepo,
-                       operands: tuple[Item]
-                       ) -> tuple[list[Path], list[Path]]:
+def exec_remove_asset(repo: OnyoRepo,
+                      operands: tuple[Item]
+                      ) -> tuple[list[Path], list[Path]]:
     r"""Executor for the 'remove_assets' operation.
 
     Not intended for direct use. It is called from an Operator, which is assumed
@@ -211,9 +211,9 @@ def exec_remove_assets(repo: OnyoRepo,
     return paths, []
 
 
-def exec_remove_directories(repo: OnyoRepo,
-                            operands: tuple[Item]
-                            ) -> tuple[list[Path], list[Path]]:
+def exec_remove_directory(repo: OnyoRepo,
+                          operands: tuple[Item]
+                          ) -> tuple[list[Path], list[Path]]:
     r"""Executor for the 'remove_directories' operation.
 
     Not intended for direct use. It is called from an Operator, which is assumed
@@ -252,9 +252,9 @@ def exec_remove_directories(repo: OnyoRepo,
     return paths, []
 
 
-def exec_rename_assets(repo: OnyoRepo,
-                       operands: tuple[Path, Path]
-                       ) -> tuple[list[Path], list[Path]]:
+def exec_rename_asset(repo: OnyoRepo,
+                      operands: tuple[Path, Path]
+                      ) -> tuple[list[Path], list[Path]]:
     r"""Executor for the 'rename_assets' operation.
 
     Not intended for direct use. It is called from an Operator, which is assumed
@@ -274,9 +274,9 @@ def exec_rename_assets(repo: OnyoRepo,
     return _renamer(operands[0], operands[1]), []
 
 
-def exec_rename_directories(repo: OnyoRepo,
-                            operands: tuple[Path, Path]
-                            ) -> tuple[list[Path], list[Path]]:
+def exec_rename_directory(repo: OnyoRepo,
+                          operands: tuple[Path, Path]
+                          ) -> tuple[list[Path], list[Path]]:
     r"""Executor for the 'rename_directories' operation.
 
     Not intended for direct use. It is called from an Operator, which is assumed

--- a/onyo/lib/executors.py
+++ b/onyo/lib/executors.py
@@ -61,7 +61,6 @@ def exec_modify_asset(repo: OnyoRepo,
         Items of the original and updated asset.
     """
 
-    # expected: (Asset, Asset)
     new = operands[1]
     repo.write_asset_content(new)
     return [new['onyo.path.absolute']], []
@@ -130,8 +129,7 @@ def exec_new_asset(repo: OnyoRepo,
         Asset to create.
     """
 
-    # NOTE: No need to implicitly create parent dirs. That is done previously in
-    #       its own operation.
+    # No need to check/create parent dirs. That's done prior in its own operation.
     asset = operands[0]
     repo.write_asset_content(asset)  # TODO: a = ...; reassignment for potential updates on metadata
     path = asset.get('onyo.path.absolute')

--- a/onyo/lib/executors.py
+++ b/onyo/lib/executors.py
@@ -9,42 +9,54 @@ from onyo.lib.items import Item
 if TYPE_CHECKING:
     from typing import Callable
 
-# Executors signature: (repo: OnyoRepo, operands: tuple) -> tuple[list[Path], list[Path]]
-#                      first returned list are the paths that need to be committed
-#                      second list are the paths that need to be staged (not previously tracked)
 
-# Attention! No input validation in executors -> document "not intended for direct use"
-# Those callables are to be registered with operators. Operations have to make sure to deliver
-# valid objects. We don't want to issue a ton of stat calls just to validate the same paths
-# throughout every layer of onyo over and over.
+def exec_new_assets(repo: OnyoRepo,
+                    operands: tuple[Item]
+                    ) -> tuple[list[Path], list[Path]]:
+    r"""Executor for the 'new_assets' operation.
 
+    Not intended for direct use. It is called from an Operator, which is assumed
+    to have validated all input passed to this (trusting) executor.
 
-def exec_new_assets(repo: OnyoRepo, operands: tuple) -> tuple[list[Path], list[Path]]:
-    r"""Executor for the 'new_asset' operation
+    Returns two lists:
+    1) Paths to be committed 2) Paths to be staged (not previously tracked)
 
     Parameters
     ----------
     repo
-      Onyo repository to operate on
+        Onyo repository to operate on.
     operands
-      Each item of the list is a tuple of operation operands.
-      Here a single item per tuple is expected: The to-be-added `Asset`
-
-    Returns
-    -------
-    list of Path
-      paths to the newly added assets
+        Asset to create.
     """
-    # Note: No need to account for implicitly to create dirs herein. That would be its own operation done before.
+
+    # NOTE: No need to implicitly create parent dirs. That is done previously in
+    #       its own operation.
     asset = operands[0]
     repo.write_asset_content(asset)  # TODO: a = ...; reassignment for potential updates on metadata
     path = asset.get('onyo.path.absolute')
+
     return [path], [path]
 
 
-def exec_new_directories(repo: OnyoRepo, operands: tuple) -> tuple[list[Path], list[Path]]:
-    r"""Executor for the 'new_directory' operation
+def exec_new_directories(repo: OnyoRepo,
+                         operands: tuple[Path]
+                         ) -> tuple[list[Path], list[Path]]:
+    r"""Executor for the 'new_directories' operation.
+
+    Not intended for direct use. It is called from an Operator, which is assumed
+    to have validated all input passed to this (trusting) executor.
+
+    Returns two lists:
+    1) Paths to be committed 2) Paths to be staged (not previously tracked)
+
+    Parameters
+    ----------
+    repo
+        Onyo repository to operate on.
+    operands
+        Absolute Path of directory to create.
     """
+
     p: Path = operands[0]
     asset = dict()
     # This may be an asset file that needs to be turned into an asset dir:
@@ -57,85 +69,254 @@ def exec_new_directories(repo: OnyoRepo, operands: tuple) -> tuple[list[Path], l
         asset['onyo.is.directory'] = True
         repo.write_asset_content(asset)
         paths.append(p / OnyoRepo.ASSET_DIR_FILE_NAME)
+
     return paths, paths
 
 
-def exec_remove_assets(repo: OnyoRepo, operands: tuple) -> tuple[list[Path], list[Path]]:
-    p = operands[0] if isinstance(operands[0], Path) else operands[0].get('onyo.path.absolute')
+def exec_remove_assets(repo: OnyoRepo,
+                       operands: tuple[Item]
+                       ) -> tuple[list[Path], list[Path]]:
+    r"""Executor for the 'remove_assets' operation.
+
+    Not intended for direct use. It is called from an Operator, which is assumed
+    to have validated all input passed to this (trusting) executor.
+
+    Returns two lists:
+    1) Paths to be committed 2) Paths to be staged (not previously tracked)
+
+    Parameters
+    ----------
+    repo
+        Onyo repository to operate on.
+    operands
+        Asset to remove.
+    """
+
+    p: Path = operands[0].get('onyo.path.absolute')
     paths = []
+
     if p.is_dir():
         # we were told p is an asset. It's also a dir, ergo an asset dir
         paths.append(p / OnyoRepo.ASSET_DIR_FILE_NAME)
     else:
         paths = [p]
+
     for p in paths:
-        # missing_ok=True, b/c several operations may want to remove the same thing. No reason to fail here.
+        # Missing_`ok=True`, because several operations may want to remove the
+        # same thing. That's ok.
         # TODO: Reconsider w/ #546
         p.unlink(missing_ok=True)
+
     return paths, []
 
 
-def exec_remove_directories(repo: OnyoRepo, operands: tuple) -> tuple[list[Path], list[Path]]:
+def exec_remove_directories(repo: OnyoRepo,
+                            operands: tuple[Item]
+                            ) -> tuple[list[Path], list[Path]]:
+    r"""Executor for the 'remove_directories' operation.
+
+    Not intended for direct use. It is called from an Operator, which is assumed
+    to have validated all input passed to this (trusting) executor.
+
+    Returns two lists:
+    1) Paths to be committed 2) Paths to be staged (not previously tracked)
+
+    Parameters
+    ----------
+    repo
+        Onyo repository to operate on.
+    operands
+        Directory to remove.
+    """
+
+    p: Path = operands[0]['onyo.path.absolute']
     paths = []
-    p = operands[0]['onyo.path.absolute']
+
     is_asset_dir = (p / OnyoRepo.ASSET_DIR_FILE_NAME).exists()  # required after dir was removed, therefore store
     anchor = p / repo.ANCHOR_FILE_NAME
     anchor.unlink()
     paths.append(anchor)
+
     if is_asset_dir:
         asset = Item(p, repo=repo)
-        # TODO: asset['onyo.path.file']
-        asset_dir_file = p / OnyoRepo.ASSET_DIR_FILE_NAME
-        asset_dir_file.unlink()
-        paths.append(asset_dir_file)
+        paths.append(asset['onyo.path.file'])
+        asset['onyo.path.file'].unlink()
+
     p.rmdir()
     if is_asset_dir:
         asset['onyo.is.directory'] = False  # pyre-ignore[61]  No, this is not "not always defined".
         repo.write_asset_content(asset)  # pyre-ignore[61]
         paths.append(p)  # TODO: Does this need staging? Don't think so, but make sure.
+
     return paths, []
 
 
-def mover(src: Path, dst: Path) -> list[Path]:
-    r"""helper function for move assets/directories executors"""
-    # expected: dst is inventory dir!
+def _mover(src: Path,
+           dst: Path) -> list[Path]:
+    r"""Helper for move_{assets,directories}() executors.
+
+    Parameters
+    ----------
+    src
+        Absolute Path of source location.
+    dst
+        Absolute Path of destination parent.
+    """
+
     src.rename(dst / src.name)
     return [src, dst / src.name]
 
 
-def exec_move_assets(repo: OnyoRepo, operands: tuple) -> tuple[list[Path], list[Path]]:
-    return mover(operands[0], operands[1]), []
+def exec_move_assets(repo: OnyoRepo,
+                     operands: tuple[Path, Path]
+                     ) -> tuple[list[Path], list[Path]]:
+    r"""Executor for the 'move_assets' operation.
+
+    Not intended for direct use. It is called from an Operator, which is assumed
+    to have validated all input passed to this (trusting) executor.
+
+    Returns two lists:
+    1) Paths to be committed 2) Paths to be staged (not previously tracked)
+
+    Parameters
+    ----------
+    repo
+        Onyo repository to operate on.
+    operands
+        Absolute Paths of the source and destination parent.
+    """
+
+    return _mover(operands[0], operands[1]), []
 
 
-def exec_move_directories(repo: OnyoRepo, operands: tuple) -> tuple[list[Path], list[Path]]:
-    return mover(operands[0], operands[1]), []
+def exec_move_directories(repo: OnyoRepo,
+                          operands: tuple[Path, Path]
+                          ) -> tuple[list[Path], list[Path]]:
+    r"""Executor for the 'move_directories' operation.
+
+    Not intended for direct use. It is called from an Operator, which is assumed
+    to have validated all input passed to this (trusting) executor.
+
+    Returns two lists:
+    1) Paths to be committed 2) Paths to be staged (not previously tracked)
+
+    Parameters
+    ----------
+    repo
+        Onyo repository to operate on.
+    operands
+        Absolute Paths of the source and destination parent.
+    """
+
+    return _mover(operands[0], operands[1]), []
 
 
-def renamer(src: Path, dst: Path) -> list[Path]:
-    # expected: full path as dst
+def _renamer(src: Path,
+             dst: Path) -> list[Path]:
+    r"""Helper for rename_{assets,directories}() executors.
+
+    Parameters
+    ----------
+    src
+        Absolute Path of source location.
+    dst
+        Absolute Path of destination location.
+    """
+
     src.rename(dst)
     return [src, dst]
 
 
-def exec_rename_directories(repo: OnyoRepo, operands: tuple) -> tuple[list[Path], list[Path]]:
-    return renamer(operands[0], operands[1]), []
+def exec_rename_directories(repo: OnyoRepo,
+                            operands: tuple[Path, Path]
+                            ) -> tuple[list[Path], list[Path]]:
+    r"""Executor for the 'rename_directories' operation.
+
+    Not intended for direct use. It is called from an Operator, which is assumed
+    to have validated all input passed to this (trusting) executor.
+
+    Returns two lists:
+    1) Paths to be committed 2) Paths to be staged (not previously tracked)
+
+    Parameters
+    ----------
+    repo
+        Onyo repository to operate on.
+    operands
+        Absolute Paths of the source and destination.
+    """
+
+    return _renamer(operands[0], operands[1]), []
 
 
-def exec_rename_assets(repo: OnyoRepo, operands: tuple) -> tuple[list[Path], list[Path]]:
-    return renamer(operands[0], operands[1]), []
+def exec_rename_assets(repo: OnyoRepo,
+                       operands: tuple[Path, Path]
+                       ) -> tuple[list[Path], list[Path]]:
+    r"""Executor for the 'rename_assets' operation.
+
+    Not intended for direct use. It is called from an Operator, which is assumed
+    to have validated all input passed to this (trusting) executor.
+
+    Returns two lists:
+    1) Paths to be committed 2) Paths to be staged (not previously tracked)
+
+    Parameters
+    ----------
+    repo
+        Onyo repository to operate on.
+    operands
+        Absolute Paths of the source and destination.
+    """
+
+    return _renamer(operands[0], operands[1]), []
 
 
-def exec_modify_assets(repo: OnyoRepo, operands: tuple) -> tuple[list[Path], list[Path]]:
+def exec_modify_assets(repo: OnyoRepo,
+                       operands: tuple[Item, Item]
+                       ) -> tuple[list[Path], list[Path]]:
+    r"""Executor for the 'modify_assets' operation.
+
+    Not intended for direct use. It is called from an Operator, which is assumed
+    to have validated all input passed to this (trusting) executor.
+
+    Returns two lists:
+    1) Paths to be committed 2) Paths to be staged (not previously tracked)
+
+    Parameters
+    ----------
+    repo
+        Onyo repository to operate on.
+    operands
+        Items of the original and updated asset.
+    """
+
     # expected: (Asset, Asset)
     new = operands[1]
     repo.write_asset_content(new)
     return [new['onyo.path.absolute']], []
 
 
-def generic_executor(func: Callable, repo: OnyoRepo, operands: tuple) -> tuple[list[Path], list[Path]]:
-    r"""This is intended for simple FS operations on non-inventory files
+def generic_executor(func: Callable,
+                     repo: OnyoRepo,
+                     operands: tuple
+                     ) -> tuple[list[Path], list[Path]]:
+    r"""Executor for simple FS operations on non-inventory files.
 
-    only current usecase is recursive remove_directory. Not yet meant to be a stable implementation
+    Not intended for direct use. It is called from an Operator, which is assumed
+    to have validated all input passed to this (trusting) executor.
+
+    Returns two lists:
+    1) Paths to be committed 2) Paths to be staged (not previously tracked)
+
+    Parameters
+    ----------
+    func
+        Function to pass ``operands`` to.
+    repo
+        Onyo repository to operate on.
+    operands
+        Operands to pass to ``func``.
     """
+
     func(operands)
     return [operands[0]], []

--- a/onyo/lib/executors.py
+++ b/onyo/lib/executors.py
@@ -10,6 +10,107 @@ if TYPE_CHECKING:
     from typing import Callable
 
 
+def _mover(src: Path,
+           dst: Path) -> list[Path]:
+    r"""Helper for ``move_{assets,directories}()`` executors.
+
+    Parameters
+    ----------
+    src
+        Absolute Path of source location.
+    dst
+        Absolute Path of destination parent.
+    """
+
+    src.rename(dst / src.name)
+    return [src, dst / src.name]
+
+
+def _renamer(src: Path,
+             dst: Path) -> list[Path]:
+    r"""Helper for ``rename_{assets,directories}()`` executors.
+
+    Parameters
+    ----------
+    src
+        Absolute Path of source location.
+    dst
+        Absolute Path of destination location.
+    """
+
+    src.rename(dst)
+    return [src, dst]
+
+
+def exec_modify_assets(repo: OnyoRepo,
+                       operands: tuple[Item, Item]
+                       ) -> tuple[list[Path], list[Path]]:
+    r"""Executor for the 'modify_assets' operation.
+
+    Not intended for direct use. It is called from an Operator, which is assumed
+    to have validated all input passed to this (trusting) executor.
+
+    Returns two lists:
+    1) Paths to be committed 2) Paths to be staged (not previously tracked)
+
+    Parameters
+    ----------
+    repo
+        Onyo repository to operate on.
+    operands
+        Items of the original and updated asset.
+    """
+
+    # expected: (Asset, Asset)
+    new = operands[1]
+    repo.write_asset_content(new)
+    return [new['onyo.path.absolute']], []
+
+
+def exec_move_assets(repo: OnyoRepo,
+                     operands: tuple[Path, Path]
+                     ) -> tuple[list[Path], list[Path]]:
+    r"""Executor for the 'move_assets' operation.
+
+    Not intended for direct use. It is called from an Operator, which is assumed
+    to have validated all input passed to this (trusting) executor.
+
+    Returns two lists:
+    1) Paths to be committed 2) Paths to be staged (not previously tracked)
+
+    Parameters
+    ----------
+    repo
+        Onyo repository to operate on.
+    operands
+        Absolute Paths of the source and destination parent.
+    """
+
+    return _mover(operands[0], operands[1]), []
+
+
+def exec_move_directories(repo: OnyoRepo,
+                          operands: tuple[Path, Path]
+                          ) -> tuple[list[Path], list[Path]]:
+    r"""Executor for the 'move_directories' operation.
+
+    Not intended for direct use. It is called from an Operator, which is assumed
+    to have validated all input passed to this (trusting) executor.
+
+    Returns two lists:
+    1) Paths to be committed 2) Paths to be staged (not previously tracked)
+
+    Parameters
+    ----------
+    repo
+        Onyo repository to operate on.
+    operands
+        Absolute Paths of the source and destination parent.
+    """
+
+    return _mover(operands[0], operands[1]), []
+
+
 def exec_new_assets(repo: OnyoRepo,
                     operands: tuple[Item]
                     ) -> tuple[list[Path], list[Path]]:
@@ -151,104 +252,6 @@ def exec_remove_directories(repo: OnyoRepo,
     return paths, []
 
 
-def _mover(src: Path,
-           dst: Path) -> list[Path]:
-    r"""Helper for move_{assets,directories}() executors.
-
-    Parameters
-    ----------
-    src
-        Absolute Path of source location.
-    dst
-        Absolute Path of destination parent.
-    """
-
-    src.rename(dst / src.name)
-    return [src, dst / src.name]
-
-
-def exec_move_assets(repo: OnyoRepo,
-                     operands: tuple[Path, Path]
-                     ) -> tuple[list[Path], list[Path]]:
-    r"""Executor for the 'move_assets' operation.
-
-    Not intended for direct use. It is called from an Operator, which is assumed
-    to have validated all input passed to this (trusting) executor.
-
-    Returns two lists:
-    1) Paths to be committed 2) Paths to be staged (not previously tracked)
-
-    Parameters
-    ----------
-    repo
-        Onyo repository to operate on.
-    operands
-        Absolute Paths of the source and destination parent.
-    """
-
-    return _mover(operands[0], operands[1]), []
-
-
-def exec_move_directories(repo: OnyoRepo,
-                          operands: tuple[Path, Path]
-                          ) -> tuple[list[Path], list[Path]]:
-    r"""Executor for the 'move_directories' operation.
-
-    Not intended for direct use. It is called from an Operator, which is assumed
-    to have validated all input passed to this (trusting) executor.
-
-    Returns two lists:
-    1) Paths to be committed 2) Paths to be staged (not previously tracked)
-
-    Parameters
-    ----------
-    repo
-        Onyo repository to operate on.
-    operands
-        Absolute Paths of the source and destination parent.
-    """
-
-    return _mover(operands[0], operands[1]), []
-
-
-def _renamer(src: Path,
-             dst: Path) -> list[Path]:
-    r"""Helper for rename_{assets,directories}() executors.
-
-    Parameters
-    ----------
-    src
-        Absolute Path of source location.
-    dst
-        Absolute Path of destination location.
-    """
-
-    src.rename(dst)
-    return [src, dst]
-
-
-def exec_rename_directories(repo: OnyoRepo,
-                            operands: tuple[Path, Path]
-                            ) -> tuple[list[Path], list[Path]]:
-    r"""Executor for the 'rename_directories' operation.
-
-    Not intended for direct use. It is called from an Operator, which is assumed
-    to have validated all input passed to this (trusting) executor.
-
-    Returns two lists:
-    1) Paths to be committed 2) Paths to be staged (not previously tracked)
-
-    Parameters
-    ----------
-    repo
-        Onyo repository to operate on.
-    operands
-        Absolute Paths of the source and destination.
-    """
-
-    return _renamer(operands[0], operands[1]), []
-
-
 def exec_rename_assets(repo: OnyoRepo,
                        operands: tuple[Path, Path]
                        ) -> tuple[list[Path], list[Path]]:
@@ -271,10 +274,10 @@ def exec_rename_assets(repo: OnyoRepo,
     return _renamer(operands[0], operands[1]), []
 
 
-def exec_modify_assets(repo: OnyoRepo,
-                       operands: tuple[Item, Item]
-                       ) -> tuple[list[Path], list[Path]]:
-    r"""Executor for the 'modify_assets' operation.
+def exec_rename_directories(repo: OnyoRepo,
+                            operands: tuple[Path, Path]
+                            ) -> tuple[list[Path], list[Path]]:
+    r"""Executor for the 'rename_directories' operation.
 
     Not intended for direct use. It is called from an Operator, which is assumed
     to have validated all input passed to this (trusting) executor.
@@ -287,13 +290,10 @@ def exec_modify_assets(repo: OnyoRepo,
     repo
         Onyo repository to operate on.
     operands
-        Items of the original and updated asset.
+        Absolute Paths of the source and destination.
     """
 
-    # expected: (Asset, Asset)
-    new = operands[1]
-    repo.write_asset_content(new)
-    return [new['onyo.path.absolute']], []
+    return _renamer(operands[0], operands[1]), []
 
 
 def generic_executor(func: Callable,

--- a/onyo/lib/git.py
+++ b/onyo/lib/git.py
@@ -19,7 +19,7 @@ log: logging.Logger = logging.getLogger('onyo.git')
 
 
 class GitRepo(object):
-    r"""An object representing a Git repository.
+    r"""Representation of a Git repository.
 
     Uses :py:mod:`subprocess` to execute git commands on a repository.
 
@@ -156,14 +156,12 @@ class GitRepo(object):
         return files
 
     def is_clean_worktree(self) -> bool:
-        r"""Whether the git worktree is clean.
-        """
+        r"""Whether the git worktree is clean."""
 
         return not bool(self._git(['status', '--porcelain']))
 
     def init_without_reinit(self) -> None:
-        r"""Initialize ``self.root`` as a git repo, but not if it's already one.
-        """
+        r"""Initialize ``self.root`` as a git repo, but not if it's already one."""
 
         # make sure target dir exists
         self.root.mkdir(exist_ok=True)

--- a/onyo/lib/inventory.py
+++ b/onyo/lib/inventory.py
@@ -327,8 +327,11 @@ class Inventory(object):
     # Operations
     #
 
-    def _add_operation(self, name: str, operands: tuple) -> InventoryOperation:
-        r"""Internal convenience helper to register an operation."""
+    def _add_operation(self,
+                       name: str,
+                       operands: tuple) -> InventoryOperation:
+        r"""Helper to register an operation."""
+
         op = InventoryOperation(operator=OPERATIONS_MAPPING[name],
                                 operands=operands,
                                 repo=self.repo)
@@ -823,8 +826,11 @@ class Inventory(object):
                 # report the error, and proceed
                 ui.error(e)
 
-    def get_asset_from_template(self, template: Path | str | None) -> Item:
-        # TODO: Possibly join with get_asset (path optional)
+    def get_asset_from_template(self,
+                                template: Path | str | None) -> Item:
+        r"""Get a template as an Item."""
+
+        # TODO: Possibly join with get_asset_content()
         return Item(self.repo.get_template(template))  # , repo=self.repo ?? Probably not. Template is not yet bound.
 
     def generate_asset_name(self,

--- a/onyo/lib/inventory.py
+++ b/onyo/lib/inventory.py
@@ -51,7 +51,6 @@ from onyo.lib.recorders import (
 )
 from onyo.lib.utils import (
     deduplicate,
-    is_equal_assets_dict,
 )
 from onyo.lib.ui import ui
 
@@ -593,7 +592,7 @@ class Inventory(object):
 
         # We keep the old path - if it needs to change, this will be done by a rename operation down the road
         new_asset['onyo.path.absolute'] = path
-        if is_equal_assets_dict(asset, new_asset):
+        if asset == new_asset:
             raise NoopError
 
         # If a change in is.directory is implied, do this first:

--- a/onyo/lib/inventory.py
+++ b/onyo/lib/inventory.py
@@ -6,15 +6,15 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from onyo.lib.differs import (
-    differ_modify_assets,
-    differ_move_assets,
-    differ_move_directories,
-    differ_new_assets,
-    differ_new_directories,
-    differ_remove_assets,
-    differ_remove_directories,
-    differ_rename_assets,
-    differ_rename_directories,
+    differ_modify_asset,
+    differ_move_asset,
+    differ_move_directory,
+    differ_new_asset,
+    differ_new_directory,
+    differ_remove_asset,
+    differ_remove_directory,
+    differ_rename_asset,
+    differ_rename_directory,
 )
 from onyo.lib.exceptions import (
     InvalidInventoryOperationError,
@@ -24,30 +24,30 @@ from onyo.lib.exceptions import (
     NotAnAssetError,
 )
 from onyo.lib.executors import (
-    exec_modify_assets,
-    exec_move_assets,
-    exec_move_directories,
-    exec_new_assets,
-    exec_new_directories,
-    exec_remove_assets,
-    exec_remove_directories,
-    exec_rename_assets,
-    exec_rename_directories,
+    exec_modify_asset,
+    exec_move_asset,
+    exec_move_directory,
+    exec_new_asset,
+    exec_new_directory,
+    exec_remove_asset,
+    exec_remove_directory,
+    exec_rename_asset,
+    exec_rename_directory,
     generic_executor,
 )
 from onyo.lib.items import Item
 from onyo.lib.onyo import OnyoRepo
 from onyo.lib.pseudokeys import PSEUDO_KEYS
 from onyo.lib.recorders import (
-    record_modify_assets,
-    record_move_assets,
-    record_move_directories,
-    record_new_assets,
-    record_new_directories,
-    record_remove_assets,
-    record_remove_directories,
-    record_rename_assets,
-    record_rename_directories,
+    record_modify_asset,
+    record_move_asset,
+    record_move_directory,
+    record_new_asset,
+    record_new_directory,
+    record_remove_asset,
+    record_remove_directory,
+    record_rename_asset,
+    record_rename_directory,
 )
 from onyo.lib.utils import (
     deduplicate,
@@ -104,54 +104,54 @@ class InventoryOperation(object):
 
 OPERATIONS_MAPPING: dict = {
     'modify_assets': InventoryOperator(
-        executor=exec_modify_assets,
-        differ=differ_modify_assets,
-        recorder=record_modify_assets,
+        executor=exec_modify_asset,
+        differ=differ_modify_asset,
+        recorder=record_modify_asset,
     ),
     'move_assets': InventoryOperator(
-        executor=exec_move_assets,
-        differ=differ_move_assets,
-        recorder=record_move_assets,
+        executor=exec_move_asset,
+        differ=differ_move_asset,
+        recorder=record_move_asset,
     ),
     'move_directories': InventoryOperator(
-        executor=exec_move_directories,
-        differ=differ_move_directories,
-        recorder=record_move_directories,
+        executor=exec_move_directory,
+        differ=differ_move_directory,
+        recorder=record_move_directory,
     ),
     'new_assets': InventoryOperator(
-        executor=exec_new_assets,
-        differ=differ_new_assets,
-        recorder=record_new_assets,
+        executor=exec_new_asset,
+        differ=differ_new_asset,
+        recorder=record_new_asset,
     ),
     'new_directories': InventoryOperator(
-        executor=exec_new_directories,
-        differ=differ_new_directories,
-        recorder=record_new_directories,
+        executor=exec_new_directory,
+        differ=differ_new_directory,
+        recorder=record_new_directory,
     ),
     'remove_assets': InventoryOperator(
-        executor=exec_remove_assets,
-        differ=differ_remove_assets,
-        recorder=record_remove_assets,
+        executor=exec_remove_asset,
+        differ=differ_remove_asset,
+        recorder=record_remove_asset,
     ),
     'remove_directories': InventoryOperator(
-        executor=exec_remove_directories,
-        differ=differ_remove_directories,
-        recorder=record_remove_directories,
+        executor=exec_remove_directory,
+        differ=differ_remove_directory,
+        recorder=record_remove_directory,
     ),
     'remove_generic_file': InventoryOperator(
         executor=partial(generic_executor, lambda x: x[0].unlink()),
-        differ=differ_remove_assets,
+        differ=differ_remove_asset,
         recorder=lambda x: dict()  # no operations record for this, not an inventory item
     ),
     'rename_assets': InventoryOperator(
-        executor=exec_rename_assets,
-        differ=differ_rename_assets,
-        recorder=record_rename_assets,
+        executor=exec_rename_asset,
+        differ=differ_rename_asset,
+        recorder=record_rename_asset,
     ),
     'rename_directories': InventoryOperator(
-        executor=exec_rename_directories,
-        differ=differ_rename_directories,
-        recorder=record_rename_directories,
+        executor=exec_rename_directory,
+        differ=differ_rename_directory,
+        recorder=record_rename_directory,
     ),
 }
 r"""Mapping of Inventory Operation types with the appropriate operators."""

--- a/onyo/lib/inventory.py
+++ b/onyo/lib/inventory.py
@@ -6,11 +6,11 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from onyo.lib.differs import (
-    differ_new_assets,
-    differ_new_directories,
     differ_modify_assets,
     differ_move_assets,
     differ_move_directories,
+    differ_new_assets,
+    differ_new_directories,
     differ_remove_assets,
     differ_remove_directories,
     differ_rename_assets,

--- a/onyo/lib/items.py
+++ b/onyo/lib/items.py
@@ -45,7 +45,9 @@ class Item(DotNotationWrapper):
     def __init__(self,
                  item: Mapping[_KT, _VT] | Path | None = None,
                  repo: onyo.lib.onyo.OnyoRepo | None = None,
-                 **kwargs: _VT):
+                 **kwargs: _VT) -> None:
+        r"""Initialize an Item."""
+
         super().__init__()
         self.repo: onyo.lib.onyo.OnyoRepo | None = repo
         self._path: Path | None = None
@@ -66,13 +68,15 @@ class Item(DotNotationWrapper):
             self.update(**kwargs)
 
     def __setitem__(self,
-                    key,
-                    value):
+                    key: _KT,
+                    value: _VT) -> None:
+        r"""Set the value of a key."""
+
         key = resolve_alias(key)
         super().__setitem__(key, value)
 
     def __getitem__(self,
-                    key):
+                    key: _KT) -> Any:
         r"""Get the value of a ``key``.
 
         The initializer methods are referenced in the mapping
@@ -97,11 +101,15 @@ class Item(DotNotationWrapper):
         return value
 
     def __delitem__(self,
-                    key):
-        return super().__delitem__(resolve_alias(key))
+                    key: _KT) -> None:
+        r"""Remove a ``key`` from self."""
+
+        super().__delitem__(resolve_alias(key))
 
     def __contains__(self,
-                     key):
+                     key: _KT) -> bool:
+        """Whether ``key`` is in self."""
+
         return super().__contains__(resolve_alias(key))
 
     def __eq__(self,
@@ -138,9 +146,11 @@ class Item(DotNotationWrapper):
 
         return self.equal_content(other)
 
-    def get(self,
-            key,
-            default=None):
+    def get(self,  # pyre-ignore[14]
+            key: _KT,
+            default: Any = None) -> Any:
+        r"""Return the value of ``key`` if it's in the dictionary, otherwise ``default``."""
+
         return super().get(resolve_alias(key), default=default)
 
     def equal_content(self,
@@ -190,7 +200,7 @@ class Item(DotNotationWrapper):
             map_from_file.copy_attributes(self.data)  # pyre-ignore[16]
 
     def fill_created(self,
-                     key: str | None = None):
+                     key: str | None = None) -> str | None:
         """Initializer for the ``'onyo.was.created'`` pseudo-keys.
 
         The entire ``'onyo.was.created'`` dict is initialized, regardless of
@@ -225,7 +235,7 @@ class Item(DotNotationWrapper):
             return None
 
     def fill_modified(self,
-                      key: str | None = None):
+                      key: str | None = None) -> str | None:
         """Initializer for the ``'onyo.was.modified'`` pseudo-keys.
 
         The entire ``'onyo.was.modified'`` dict is initialized, regardless of
@@ -259,7 +269,7 @@ class Item(DotNotationWrapper):
 
         return None
 
-    def get_path_absolute(self):
+    def get_path_absolute(self) -> Path | None:
         """Initializer for the ``'onyo.path.absolute'`` pseudo-key."""
 
         if self.repo and self._path and self._path.name == self.repo.ASSET_DIR_FILE_NAME:
@@ -267,19 +277,19 @@ class Item(DotNotationWrapper):
 
         return self._path
 
-    def get_path_relative(self):
+    def get_path_relative(self) -> Path | None:
         """Initializer for the ``'onyo.path.relative'`` pseudo-key."""
 
         if self.repo and self['onyo.path.absolute']:
             try:
-                return self['onyo.path.absolute'].relative_to(self.repo.git.root)
+                return self['onyo.path.absolute'].relative_to(self.repo.git.root)  # pyre-ignore[16]
             except ValueError:
                 # return None (translates to '<unset>') if relative_to() fails b/c path is outside repo.
                 pass
 
         return None
 
-    def get_path_parent(self):
+    def get_path_parent(self) -> Path | None:
         """Initializer for the ``'onyo.path.parent'`` pseudo-key."""
 
         if self.repo and self['onyo.path.relative']:
@@ -287,7 +297,7 @@ class Item(DotNotationWrapper):
 
         return None
 
-    def get_path_file(self):
+    def get_path_file(self) -> Path | None:
         """Initializer for the ``'onyo.path.file'`` pseudo-key."""
 
         if self.repo and self['onyo.path.relative']:
@@ -299,7 +309,7 @@ class Item(DotNotationWrapper):
 
         return None
 
-    def get_path_name(self):
+    def get_path_name(self) -> Path | None:
         """Initializer for the ``'onyo.path.name'`` pseudo-key."""
 
         if self['onyo.path.absolute']:

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -29,7 +29,7 @@ log: logging.Logger = logging.getLogger('onyo.onyo')
 
 
 class OnyoRepo(object):
-    r"""An object representing an Onyo repository.
+    r"""Representation of an Onyo repository.
 
     Identify and work with asset paths and directories. Get and set onyo config
     information.
@@ -164,8 +164,7 @@ class OnyoRepo(object):
 
     @property
     def auto_message(self) -> bool:
-        r"""The configured value of ``onyo.commit.auto-message``.
-        """
+        r"""The configured value of ``onyo.commit.auto-message``."""
 
         raw = self.get_config("onyo.commit.auto-message")
         if raw:
@@ -771,7 +770,7 @@ class OnyoRepo(object):
         Parameters
         ----------
         path
-            The Path to get the history of. Defaults to ``HEAD`` (default).
+            The Path to get the history of. Defaults to the repo root.
         n
             Limit history to ``n`` commits. ``None`` for no limit (default).
         """

--- a/onyo/lib/pseudokeys.py
+++ b/onyo/lib/pseudokeys.py
@@ -27,16 +27,26 @@ class PseudoKey:
     :py:class:`onyo.lib.items.Item`.
     """
 
-    def __eq__(self, other):
+    def __eq__(self,
+               other) -> bool:
+        r"""Whether another ``PseudoKey`` matches self."""
+
         if not isinstance(other, PseudoKey):
             return False
 
         # TODO: This isn't clean yet, since it relies on `implementation` being a `partial`:
-        return self.description == other.description and self.implementation.func == other.implementation.func
+        return self.description == other.description and self.implementation.func == other.implementation.func  # pyre-ignore[16]
 
 
-def delegate(self: Item, attribute: str, *args, **kwargs):
-    # This is to avoid circular imports ATM.
+def delegate(self: Item,
+             attribute: str,
+             *args,
+             **kwargs):
+    r"""Call function ``attribute`` and pass all args.
+
+    To avoid circular imports between this file and :py:data`onyo.lib.inventory.OPERATIONS_MAPPING`.
+    """
+
     return self.__getattribute__(attribute)(*args, **kwargs)
 
 

--- a/onyo/lib/recorders.py
+++ b/onyo/lib/recorders.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 def _record_item(repo: OnyoRepo,
                  item: Path | Item) -> str:
-    r"""Helper for {new,modify,remove}_{assets,directories}() recorders.
+    r"""Helper for ``{new,modify,remove}_{assets,directories}()`` recorders.
 
     Parameters
     ----------
@@ -27,7 +27,7 @@ def _record_item(repo: OnyoRepo,
 def _record_move(repo: OnyoRepo,
                  src: Path | Item,
                  dst: Path) -> str:
-    r"""Helper for move_{assets,directories}() recorders.
+    r"""Helper for ``move_{assets,directories}()`` recorders.
 
     Parameters
     ----------
@@ -49,7 +49,7 @@ def _record_move(repo: OnyoRepo,
 def _record_rename(repo: OnyoRepo,
                    src: Path | Item,
                    dst: Path) -> str:
-    r"""Helper for rename_{assets,directories}() recorders.
+    r"""Helper for ``rename_{assets,directories}()`` recorders.
 
     Parameters
     ----------
@@ -65,6 +65,85 @@ def _record_rename(repo: OnyoRepo,
     dst_path = dst.relative_to(repo.git.root).as_posix()
 
     return f"- {src_path} -> {dst_path}\n"
+
+
+def record_modify_assets(repo: OnyoRepo,
+                         operands: tuple[Item, Item]
+                         ) -> dict[str, list[str]]:
+    r"""Recorder for the 'modify_assets' operation.
+
+    Not intended for direct use. It is called from an Operator, which is assumed
+    to have validated all input passed to this (trusting) recorder.
+
+    Returns a dict in the format:
+    ``key``: title of the Inventory Operations section
+    ``value``: list of textual records of Inventory Operations
+
+    Parameters
+    ----------
+    repo
+        Onyo repository to operate on.
+    operands
+        Items of the original and updated asset.
+    """
+
+    return {"Modified assets:\n": [_record_item(repo, operands[0])]}
+
+
+def record_move_assets(repo: OnyoRepo,
+                       operands: tuple[Path, Path]
+                       ) -> dict[str, list[str]]:
+    r"""Recorder for the 'move_assets' operation.
+
+    Not intended for direct use. It is called from an Operator, which is assumed
+    to have validated all input passed to this (trusting) recorder.
+
+    Returns a dict in the format:
+    ``key``: title of the Inventory Operations section
+    ``value``: list of textual records of Inventory Operations
+
+    Parameters
+    ----------
+    repo
+        Onyo repository to operate on.
+    operands
+        Absolute Paths of the source and destination parent.
+    """
+
+    records = {"Moved assets:\n": [_record_move(repo, operands[0], operands[1])]}
+    if repo.is_asset_dir(operands[0]):
+        # In case of an asset dir, we need to record an operation for both aspects
+        records.update({"Moved directories:\n": [_record_move(repo, operands[0], operands[1])]})
+
+    return records
+
+
+def record_move_directories(repo: OnyoRepo,
+                            operands: tuple[Path, Path]
+                            ) -> dict[str, list[str]]:
+    r"""Recorder for the 'move_directories' operation.
+
+    Not intended for direct use. It is called from an Operator, which is assumed
+    to have validated all input passed to this (trusting) recorder.
+
+    Returns a dict in the format:
+    ``key``: title of the Inventory Operations section
+    ``value``: list of textual records of Inventory Operations
+
+    Parameters
+    ----------
+    repo
+        Onyo repository to operate on.
+    operands
+        Absolute Paths of the source and destination parent.
+    """
+
+    records = {"Moved directories:\n": [_record_move(repo, operands[0], operands[1])]}
+    if repo.is_asset_dir(operands[0]):
+        # In case of an asset dir, we need to record an operation for both aspects
+        records.update({"Moved assets:\n": [_record_move(repo, operands[0], operands[1])]})
+
+    return records
 
 
 def record_new_assets(repo: OnyoRepo,
@@ -159,85 +238,6 @@ def record_remove_directories(repo: OnyoRepo,
     return {"Removed directories:\n": [_record_item(repo, operands[0])]}
 
 
-def record_move_assets(repo: OnyoRepo,
-                       operands: tuple[Path, Path]
-                       ) -> dict[str, list[str]]:
-    r"""Recorder for the 'move_assets' operation.
-
-    Not intended for direct use. It is called from an Operator, which is assumed
-    to have validated all input passed to this (trusting) recorder.
-
-    Returns a dict in the format:
-    ``key``: title of the Inventory Operations section
-    ``value``: list of textual records of Inventory Operations
-
-    Parameters
-    ----------
-    repo
-        Onyo repository to operate on.
-    operands
-        Absolute Paths of the source and destination parent.
-    """
-
-    records = {"Moved assets:\n": [_record_move(repo, operands[0], operands[1])]}
-    if repo.is_asset_dir(operands[0]):
-        # In case of an asset dir, we need to record an operation for both aspects
-        records.update({"Moved directories:\n": [_record_move(repo, operands[0], operands[1])]})
-
-    return records
-
-
-def record_move_directories(repo: OnyoRepo,
-                            operands: tuple[Path, Path]
-                            ) -> dict[str, list[str]]:
-    r"""Recorder for the 'move_directories' operation.
-
-    Not intended for direct use. It is called from an Operator, which is assumed
-    to have validated all input passed to this (trusting) recorder.
-
-    Returns a dict in the format:
-    ``key``: title of the Inventory Operations section
-    ``value``: list of textual records of Inventory Operations
-
-    Parameters
-    ----------
-    repo
-        Onyo repository to operate on.
-    operands
-        Absolute Paths of the source and destination parent.
-    """
-
-    records = {"Moved directories:\n": [_record_move(repo, operands[0], operands[1])]}
-    if repo.is_asset_dir(operands[0]):
-        # In case of an asset dir, we need to record an operation for both aspects
-        records.update({"Moved assets:\n": [_record_move(repo, operands[0], operands[1])]})
-
-    return records
-
-
-def record_rename_directories(repo: OnyoRepo,
-                              operands: tuple[Path, Path]
-                              ) -> dict[str, list[str]]:
-    r"""Recorder for the 'rename_directories' operation.
-
-    Not intended for direct use. It is called from an Operator, which is assumed
-    to have validated all input passed to this (trusting) recorder.
-
-    Returns a dict in the format:
-    ``key``: title of the Inventory Operations section
-    ``value``: list of textual records of Inventory Operations
-
-    Parameters
-    ----------
-    repo
-        Onyo repository to operate on.
-    operands
-        Absolute Paths of the source and destination.
-    """
-
-    return {"Renamed directories:\n": [_record_rename(repo, operands[0], operands[1])]}
-
-
 def record_rename_assets(repo: OnyoRepo,
                          operands: tuple[Path, Path]
                          ) -> dict[str, list[str]]:
@@ -266,10 +266,10 @@ def record_rename_assets(repo: OnyoRepo,
     return records
 
 
-def record_modify_assets(repo: OnyoRepo,
-                         operands: tuple[Item, Item]
-                         ) -> dict[str, list[str]]:
-    r"""Recorder for the 'modify_assets' operation.
+def record_rename_directories(repo: OnyoRepo,
+                              operands: tuple[Path, Path]
+                              ) -> dict[str, list[str]]:
+    r"""Recorder for the 'rename_directories' operation.
 
     Not intended for direct use. It is called from an Operator, which is assumed
     to have validated all input passed to this (trusting) recorder.
@@ -283,7 +283,7 @@ def record_modify_assets(repo: OnyoRepo,
     repo
         Onyo repository to operate on.
     operands
-        Items of the original and updated asset.
+        Absolute Paths of the source and destination.
     """
 
-    return {"Modified assets:\n": [_record_item(repo, operands[0])]}
+    return {"Renamed directories:\n": [_record_rename(repo, operands[0], operands[1])]}

--- a/onyo/lib/recorders.py
+++ b/onyo/lib/recorders.py
@@ -1,94 +1,289 @@
+from __future__ import annotations
+
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from onyo.lib.onyo import OnyoRepo
 
-
-# Recorders signature: (repo: OnyoRepo, operands: tuple) -> dict[str, list[str]]
-# Returned dict: {<title for operations record section>: [<snippet recording concrete operation>, ..]
-#
-# This is meant to result in a commit message footer composed by `Inventory.commit()`:
-#
-# --- Inventory Operations ---
-# <title for operations record section>:
-#   <snippet recording concrete operation>
-#   <snippet recording concrete operation>
-# <title for operations record section>:
-#   <snippet recording concrete operation>
-#   <snippet recording concrete operation>
-#
-# While a recorder currently only ever returns a single snippet (line) for an operation,
-# the dict assumes a list in order to provide the option to deliver several.
-
-# TODO: Most functions here account for asset being given as dict or Path.
-#       This is probably superfluous. Re-evaluate, when the `Inventory` class
-#       is reasonably stable.
+if TYPE_CHECKING:
+    from onyo.lib.items import Item
 
 
-def record_item(repo: OnyoRepo, item: Path | dict) -> str:
+def _record_item(repo: OnyoRepo,
+                 item: Path | Item) -> str:
+    r"""Helper for {new,modify,remove}_{assets,directories}() recorders.
+
+    Parameters
+    ----------
+    item
+        Absolute Path or Item of target.
+    """
+
     path = item if isinstance(item, Path) else item['onyo.path.absolute']
+
     return f"- {path.relative_to(repo.git.root).as_posix()}\n"
 
 
-def record_move(repo: OnyoRepo, src: Path | dict, dst: Path) -> str:
-    # This currently expects `dst` to be the dir to move src into,
-    # rather than already containing src' name at the destination.
+def _record_move(repo: OnyoRepo,
+                 src: Path | Item,
+                 dst: Path) -> str:
+    r"""Helper for move_{assets,directories}() recorders.
+
+    Parameters
+    ----------
+    src
+        Absolute Path or Item of source location.
+    dst
+        Absolute Path of destination parent.
+    """
+
+    # This expects `dst` to be the dir to move src into, rather than already
+    # containing the `src.name` at the destination.
     src_path = src if isinstance(src, Path) else src['onyo.path.absolute']
     dst_path = (dst / src_path.name).relative_to(repo.git.root).as_posix()
     src_path = src_path.relative_to(repo.git.root).as_posix()
+
     return f"- {src_path} -> {dst_path}\n"
 
 
-def record_rename(repo: OnyoRepo, src: Path | dict, dst: Path) -> str:
-    # In opposition to record_move, this expects the full target path in `dst`
+def _record_rename(repo: OnyoRepo,
+                   src: Path | Item,
+                   dst: Path) -> str:
+    r"""Helper for rename_{assets,directories}() recorders.
+
+    Parameters
+    ----------
+    src
+        Absolute Path or Item of source location.
+    dst
+        Absolute Path of destination location.
+    """
+
+    # In contrast to _record_move(), this expects the full target path in `dst`.
     src_path = src if isinstance(src, Path) else src['onyo.path.absolute']
     src_path = src_path.relative_to(repo.git.root).as_posix()
     dst_path = dst.relative_to(repo.git.root).as_posix()
+
     return f"- {src_path} -> {dst_path}\n"
 
 
-def record_new_assets(repo: OnyoRepo, operands: tuple) -> dict[str, list[str]]:
-    return {"New assets:\n": [record_item(repo, operands[0])]}
+def record_new_assets(repo: OnyoRepo,
+                      operands: tuple[Item]
+                      ) -> dict[str, list[str]]:
+    r"""Recorder for the 'new_assets' operation.
+
+    Not intended for direct use. It is called from an Operator, which is assumed
+    to have validated all input passed to this (trusting) recorder.
+
+    Returns a dict in the format:
+    ``key``: title of the Inventory Operations section
+    ``value``: list of textual records of Inventory Operations
+
+    Parameters
+    ----------
+    repo
+        Onyo repository to operate on.
+    operands
+        Asset to create.
+    """
+
+    return {"New assets:\n": [_record_item(repo, operands[0])]}
 
 
-def record_new_directories(repo: OnyoRepo, operands: tuple) -> dict[str, list[str]]:
-    return {"New directories:\n": [record_item(repo, operands[0])]}
+def record_new_directories(repo: OnyoRepo,
+                           operands: tuple[Path]
+                           ) -> dict[str, list[str]]:
+    r"""Recorder for the 'new_directories' operation.
+
+    Not intended for direct use. It is called from an Operator, which is assumed
+    to have validated all input passed to this (trusting) recorder.
+
+    Returns a dict in the format:
+    ``key``: title of the Inventory Operations section
+    ``value``: list of textual records of Inventory Operations
+
+    Parameters
+    ----------
+    repo
+        Onyo repository to operate on.
+    operands
+        Absolute Path of directory to create.
+    """
+
+    return {"New directories:\n": [_record_item(repo, operands[0])]}
 
 
-def record_remove_assets(repo: OnyoRepo, operands: tuple) -> dict[str, list[str]]:
-    return {"Removed assets:\n": [record_item(repo, operands[0])]}
+def record_remove_assets(repo: OnyoRepo,
+                         operands: tuple[Item]
+                         ) -> dict[str, list[str]]:
+    r"""Recorder for the 'remove_assets' operation.
+
+    Not intended for direct use. It is called from an Operator, which is assumed
+    to have validated all input passed to this (trusting) recorder.
+
+    Returns a dict in the format:
+    ``key``: title of the Inventory Operations section
+    ``value``: list of textual records of Inventory Operations
+
+    Parameters
+    ----------
+    repo
+        Onyo repository to operate on.
+    operands
+        Asset to remove.
+    """
+
+    return {"Removed assets:\n": [_record_item(repo, operands[0])]}
 
 
-def record_remove_directories(repo: OnyoRepo, operands: tuple) -> dict[str, list[str]]:
-    return {"Removed directories:\n": [record_item(repo, operands[0])]}
+def record_remove_directories(repo: OnyoRepo,
+                              operands: tuple[Item]
+                              ) -> dict[str, list[str]]:
+    r"""Recorder for the 'remove_directories' operation.
+
+    Not intended for direct use. It is called from an Operator, which is assumed
+    to have validated all input passed to this (trusting) recorder.
+
+    Returns a dict in the format:
+    ``key``: title of the Inventory Operations section
+    ``value``: list of textual records of Inventory Operations
+
+    Parameters
+    ----------
+    repo
+        Onyo repository to operate on.
+    operands
+        Directory to remove.
+    """
+
+    return {"Removed directories:\n": [_record_item(repo, operands[0])]}
 
 
-def record_move_assets(repo: OnyoRepo, operands: tuple) -> dict[str, list[str]]:
-    records = {"Moved assets:\n": [record_move(repo, operands[0], operands[1])]}
+def record_move_assets(repo: OnyoRepo,
+                       operands: tuple[Path, Path]
+                       ) -> dict[str, list[str]]:
+    r"""Recorder for the 'move_assets' operation.
+
+    Not intended for direct use. It is called from an Operator, which is assumed
+    to have validated all input passed to this (trusting) recorder.
+
+    Returns a dict in the format:
+    ``key``: title of the Inventory Operations section
+    ``value``: list of textual records of Inventory Operations
+
+    Parameters
+    ----------
+    repo
+        Onyo repository to operate on.
+    operands
+        Absolute Paths of the source and destination parent.
+    """
+
+    records = {"Moved assets:\n": [_record_move(repo, operands[0], operands[1])]}
     if repo.is_asset_dir(operands[0]):
         # In case of an asset dir, we need to record an operation for both aspects
-        records.update({"Moved directories:\n": [record_move(repo, operands[0], operands[1])]})
+        records.update({"Moved directories:\n": [_record_move(repo, operands[0], operands[1])]})
+
     return records
 
 
-def record_move_directories(repo: OnyoRepo, operands: tuple) -> dict[str, list[str]]:
-    records = {"Moved directories:\n": [record_move(repo, operands[0], operands[1])]}
+def record_move_directories(repo: OnyoRepo,
+                            operands: tuple[Path, Path]
+                            ) -> dict[str, list[str]]:
+    r"""Recorder for the 'move_directories' operation.
+
+    Not intended for direct use. It is called from an Operator, which is assumed
+    to have validated all input passed to this (trusting) recorder.
+
+    Returns a dict in the format:
+    ``key``: title of the Inventory Operations section
+    ``value``: list of textual records of Inventory Operations
+
+    Parameters
+    ----------
+    repo
+        Onyo repository to operate on.
+    operands
+        Absolute Paths of the source and destination parent.
+    """
+
+    records = {"Moved directories:\n": [_record_move(repo, operands[0], operands[1])]}
     if repo.is_asset_dir(operands[0]):
         # In case of an asset dir, we need to record an operation for both aspects
-        records.update({"Moved assets:\n": [record_move(repo, operands[0], operands[1])]})
+        records.update({"Moved assets:\n": [_record_move(repo, operands[0], operands[1])]})
+
     return records
 
 
-def record_rename_directories(repo: OnyoRepo, operands: tuple) -> dict[str, list[str]]:
-    return {"Renamed directories:\n": [record_rename(repo, operands[0], operands[1])]}
+def record_rename_directories(repo: OnyoRepo,
+                              operands: tuple[Path, Path]
+                              ) -> dict[str, list[str]]:
+    r"""Recorder for the 'rename_directories' operation.
+
+    Not intended for direct use. It is called from an Operator, which is assumed
+    to have validated all input passed to this (trusting) recorder.
+
+    Returns a dict in the format:
+    ``key``: title of the Inventory Operations section
+    ``value``: list of textual records of Inventory Operations
+
+    Parameters
+    ----------
+    repo
+        Onyo repository to operate on.
+    operands
+        Absolute Paths of the source and destination.
+    """
+
+    return {"Renamed directories:\n": [_record_rename(repo, operands[0], operands[1])]}
 
 
-def record_rename_assets(repo: OnyoRepo, operands: tuple) -> dict[str, list[str]]:
-    records = {"Renamed assets:\n": [record_rename(repo, operands[0], operands[1])]}
+def record_rename_assets(repo: OnyoRepo,
+                         operands: tuple[Path, Path]
+                         ) -> dict[str, list[str]]:
+    r"""Recorder for the 'rename_assets' operation.
+
+    Not intended for direct use. It is called from an Operator, which is assumed
+    to have validated all input passed to this (trusting) recorder.
+
+    Returns a dict in the format:
+    ``key``: title of the Inventory Operations section
+    ``value``: list of textual records of Inventory Operations
+
+    Parameters
+    ----------
+    repo
+        Onyo repository to operate on.
+    operands
+        Absolute Paths of the source and destination.
+    """
+
+    records = {"Renamed assets:\n": [_record_rename(repo, operands[0], operands[1])]}
     if repo.is_asset_dir(operands[0]):
         # In case of an asset dir, we need to record an operation for both aspects
-        records.update({"Renamed directories:\n": [record_rename(repo, operands[0], operands[1])]})
+        records.update({"Renamed directories:\n": [_record_rename(repo, operands[0], operands[1])]})
+
     return records
 
 
-def record_modify_assets(repo: OnyoRepo, operands: tuple) -> dict[str, list[str]]:
-    return {"Modified assets:\n": [record_item(repo, operands[0])]}
+def record_modify_assets(repo: OnyoRepo,
+                         operands: tuple[Item, Item]
+                         ) -> dict[str, list[str]]:
+    r"""Recorder for the 'modify_assets' operation.
+
+    Not intended for direct use. It is called from an Operator, which is assumed
+    to have validated all input passed to this (trusting) recorder.
+
+    Returns a dict in the format:
+    ``key``: title of the Inventory Operations section
+    ``value``: list of textual records of Inventory Operations
+
+    Parameters
+    ----------
+    repo
+        Onyo repository to operate on.
+    operands
+        Items of the original and updated asset.
+    """
+
+    return {"Modified assets:\n": [_record_item(repo, operands[0])]}

--- a/onyo/lib/recorders.py
+++ b/onyo/lib/recorders.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 def _record_item(repo: OnyoRepo,
                  item: Path | Item) -> str:
-    r"""Helper for ``{new,modify,remove}_{assets,directories}()`` recorders.
+    r"""Helper for ``{new,modify,remove}_{asset,directory}()`` recorders.
 
     Parameters
     ----------
@@ -27,7 +27,7 @@ def _record_item(repo: OnyoRepo,
 def _record_move(repo: OnyoRepo,
                  src: Path | Item,
                  dst: Path) -> str:
-    r"""Helper for ``move_{assets,directories}()`` recorders.
+    r"""Helper for ``move_{asset,directory}()`` recorders.
 
     Parameters
     ----------
@@ -49,7 +49,7 @@ def _record_move(repo: OnyoRepo,
 def _record_rename(repo: OnyoRepo,
                    src: Path | Item,
                    dst: Path) -> str:
-    r"""Helper for ``rename_{assets,directories}()`` recorders.
+    r"""Helper for ``rename_{asset,directory}()`` recorders.
 
     Parameters
     ----------
@@ -67,9 +67,9 @@ def _record_rename(repo: OnyoRepo,
     return f"- {src_path} -> {dst_path}\n"
 
 
-def record_modify_assets(repo: OnyoRepo,
-                         operands: tuple[Item, Item]
-                         ) -> dict[str, list[str]]:
+def record_modify_asset(repo: OnyoRepo,
+                        operands: tuple[Item, Item]
+                        ) -> dict[str, list[str]]:
     r"""Recorder for the 'modify_assets' operation.
 
     Not intended for direct use. It is called from an Operator, which is assumed
@@ -90,9 +90,9 @@ def record_modify_assets(repo: OnyoRepo,
     return {"Modified assets:\n": [_record_item(repo, operands[0])]}
 
 
-def record_move_assets(repo: OnyoRepo,
-                       operands: tuple[Path, Path]
-                       ) -> dict[str, list[str]]:
+def record_move_asset(repo: OnyoRepo,
+                      operands: tuple[Path, Path]
+                      ) -> dict[str, list[str]]:
     r"""Recorder for the 'move_assets' operation.
 
     Not intended for direct use. It is called from an Operator, which is assumed
@@ -118,9 +118,9 @@ def record_move_assets(repo: OnyoRepo,
     return records
 
 
-def record_move_directories(repo: OnyoRepo,
-                            operands: tuple[Path, Path]
-                            ) -> dict[str, list[str]]:
+def record_move_directory(repo: OnyoRepo,
+                          operands: tuple[Path, Path]
+                          ) -> dict[str, list[str]]:
     r"""Recorder for the 'move_directories' operation.
 
     Not intended for direct use. It is called from an Operator, which is assumed
@@ -146,9 +146,9 @@ def record_move_directories(repo: OnyoRepo,
     return records
 
 
-def record_new_assets(repo: OnyoRepo,
-                      operands: tuple[Item]
-                      ) -> dict[str, list[str]]:
+def record_new_asset(repo: OnyoRepo,
+                     operands: tuple[Item]
+                     ) -> dict[str, list[str]]:
     r"""Recorder for the 'new_assets' operation.
 
     Not intended for direct use. It is called from an Operator, which is assumed
@@ -169,9 +169,9 @@ def record_new_assets(repo: OnyoRepo,
     return {"New assets:\n": [_record_item(repo, operands[0])]}
 
 
-def record_new_directories(repo: OnyoRepo,
-                           operands: tuple[Path]
-                           ) -> dict[str, list[str]]:
+def record_new_directory(repo: OnyoRepo,
+                         operands: tuple[Path]
+                         ) -> dict[str, list[str]]:
     r"""Recorder for the 'new_directories' operation.
 
     Not intended for direct use. It is called from an Operator, which is assumed
@@ -192,9 +192,9 @@ def record_new_directories(repo: OnyoRepo,
     return {"New directories:\n": [_record_item(repo, operands[0])]}
 
 
-def record_remove_assets(repo: OnyoRepo,
-                         operands: tuple[Item]
-                         ) -> dict[str, list[str]]:
+def record_remove_asset(repo: OnyoRepo,
+                        operands: tuple[Item]
+                        ) -> dict[str, list[str]]:
     r"""Recorder for the 'remove_assets' operation.
 
     Not intended for direct use. It is called from an Operator, which is assumed
@@ -215,9 +215,9 @@ def record_remove_assets(repo: OnyoRepo,
     return {"Removed assets:\n": [_record_item(repo, operands[0])]}
 
 
-def record_remove_directories(repo: OnyoRepo,
-                              operands: tuple[Item]
-                              ) -> dict[str, list[str]]:
+def record_remove_directory(repo: OnyoRepo,
+                            operands: tuple[Item]
+                            ) -> dict[str, list[str]]:
     r"""Recorder for the 'remove_directories' operation.
 
     Not intended for direct use. It is called from an Operator, which is assumed
@@ -238,9 +238,9 @@ def record_remove_directories(repo: OnyoRepo,
     return {"Removed directories:\n": [_record_item(repo, operands[0])]}
 
 
-def record_rename_assets(repo: OnyoRepo,
-                         operands: tuple[Path, Path]
-                         ) -> dict[str, list[str]]:
+def record_rename_asset(repo: OnyoRepo,
+                        operands: tuple[Path, Path]
+                        ) -> dict[str, list[str]]:
     r"""Recorder for the 'rename_assets' operation.
 
     Not intended for direct use. It is called from an Operator, which is assumed
@@ -266,9 +266,9 @@ def record_rename_assets(repo: OnyoRepo,
     return records
 
 
-def record_rename_directories(repo: OnyoRepo,
-                              operands: tuple[Path, Path]
-                              ) -> dict[str, list[str]]:
+def record_rename_directory(repo: OnyoRepo,
+                            operands: tuple[Path, Path]
+                            ) -> dict[str, list[str]]:
     r"""Recorder for the 'rename_directories' operation.
 
     Not intended for direct use. It is called from an Operator, which is assumed

--- a/onyo/lib/tests/test_Filter.py
+++ b/onyo/lib/tests/test_Filter.py
@@ -7,10 +7,7 @@ from onyo.lib.items import Item
 
 @pytest.mark.parametrize('filt', ['type=laptop', 'key=value', 'foo=<unset>'])
 def test_filter(filt: str) -> None:
-    """
-    Test whether instances of the Filter object are set up properly, including
-    post-initialization behavior
-    """
+    """Test whether ``Filter`` object are set up, including post-initialization."""
 
     def read_asset(name: str) -> Item:
         if name == 'laptop_make_model.1':
@@ -63,9 +60,7 @@ def test_filter(filt: str) -> None:
 
 @pytest.mark.parametrize('filt', ['key=<list>', 'key=<dict>'])
 def test_filter_match_type(filt: str) -> None:
-    """
-    Test filtering by string type (e.g., <list> or <dict>)
-    """
+    """Filtering by variable type (e.g., <list> or <dict>)."""
 
     def read_asset(name: str):
         if name == 'type_make_model.1':
@@ -92,7 +87,8 @@ def test_filter_match_type(filt: str) -> None:
 
 
 def test_filter_re_match() -> None:
-    """Test filtering by regular expression"""
+    """Filtering with regular expressions."""
+
     assert not Filter._re_match(text='foo(', r='foo(')
     assert Filter._re_match(text='foo', r='foo')
     assert Filter._re_match(text='foobar', r='foo.*')
@@ -101,7 +97,7 @@ def test_filter_re_match() -> None:
 @pytest.mark.parametrize('filter_arg', [
     'key', 'key!value', '┻━┻ ︵ヽ(`Д´)ﾉ︵ ┻━┻'])
 def test_filter_invalid(filter_arg: str) -> None:
-    """Test whether invalid filters raise the expected exception"""
+    """Invalid filters raise the correct exception."""
 
     with pytest.raises(OnyoInvalidFilterError) as exc:
         Filter('key')
@@ -110,8 +106,7 @@ def test_filter_invalid(filter_arg: str) -> None:
 
 
 def test_filter_format() -> None:
-    """Test whether the input argument 'key=value' is properly formatted into
-    the `key` and `value` properties
-    """
+    """The input argument 'key=value' is formatted into ``key`` and ``value`` properties."""
+
     assert Filter._format('key=value') == ['key', 'value']
     assert Filter._format('key=value=value') == ['key', 'value=value']

--- a/onyo/lib/tests/test_commands_get.py
+++ b/onyo/lib/tests/test_commands_get.py
@@ -11,7 +11,7 @@ from ..commands import onyo_get
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_errors(inventory: Inventory) -> None:
-    r"""`onyo_get()` must raise the correct error in different illegal or impossible calls."""
+    r"""Raise the correct error in different illegal or impossible calls."""
 
     # get on non-existing asset
     pytest.raises(ValueError,
@@ -55,9 +55,8 @@ def test_onyo_get_errors(inventory: Inventory) -> None:
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_empty_keys(inventory: Inventory,
                              capsys) -> None:
-    r"""Verify `onyo_get()` prints values for non-existing keys as unset,
-    and values for keys that exist but have an empty value correctly.
-    """
+    r"""Print <unset> for non-existing keys and keys with an empty value."""
+
     from onyo.lib.consts import UNSET_VALUE
     asset_path1 = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     asset_path2 = inventory.root / "one_that_exists.test"
@@ -89,7 +88,8 @@ def test_onyo_get_empty_keys(inventory: Inventory,
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_on_empty_directory(inventory: Inventory) -> None:
-    r"""`onyo_get()` does not error when called on a valid but empty directory."""
+    r"""No error when called on a valid but empty directory."""
+
     dir_path = inventory.root / 'empty'
 
     # `onyo_get()` on a directory without assets does not error
@@ -100,9 +100,8 @@ def test_onyo_get_on_empty_directory(inventory: Inventory) -> None:
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_reserved_keys(inventory: Inventory,
                                 capsys) -> None:
-    r"""`onyo_get()` allows to specify all reserved keys to query
-    and display information for.
-    """
+    r"""Get all reserved keys."""
+
     from onyo.lib.consts import RESERVED_KEYS
     from onyo.lib.pseudokeys import PSEUDO_KEYS
     reserved = ["type", "make", "model.name", "serial"] + list(PSEUDO_KEYS.keys()) + RESERVED_KEYS
@@ -124,9 +123,8 @@ def test_onyo_get_reserved_keys(inventory: Inventory,
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_name_keys(inventory: Inventory,
                             capsys) -> None:
-    r"""If no keys are specified when calling `onyo_get()`
-    the name keys are printed by default.
-    """
+    r"""Print asset-name keys by default."""
+
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     name_keys = ["type", "make", "model.name", "serial"]
 
@@ -151,9 +149,8 @@ def test_onyo_get_name_keys(inventory: Inventory,
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_errors_before_get(inventory: Inventory) -> None:
-    r"""`onyo_get()` must raise the correct error if one of
-    the specified paths is not valid.
-    """
+    r"""Raise the correct error if one of the specified paths is not valid."""
+
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     non_existing_asset_path = inventory.root / "non-existing" / "TYPE_MAKER_MODEL.SERIAL"
 
@@ -168,7 +165,8 @@ def test_onyo_get_errors_before_get(inventory: Inventory) -> None:
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_simple(inventory: Inventory,
                          capsys) -> None:
-    r"""`onyo_get()` gets a value in an asset."""
+    r"""Get a value in an asset."""
+
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     get_key = "some_key"
 
@@ -186,9 +184,8 @@ def test_onyo_get_simple(inventory: Inventory,
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_machine_readable(inventory: Inventory,
                                    capsys) -> None:
-    r"""`onyo_get()` with machine_readable=True gives different
-    output that contains all requested information.
-    """
+    r"""Get machine readable output."""
+
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     get_key = "some_key"
 
@@ -218,9 +215,8 @@ def test_onyo_get_machine_readable(inventory: Inventory,
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_sorting(inventory: Inventory,
                           capsys) -> None:
-    r"""`onyo_get()` allows different types of sorting the output,
-    but errors if illegal sorting is specified.
-    """
+    r"""Sort the output, and error on illegal sorting type."""
+
     asset_path1 = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     asset_path2 = inventory.root / "one_that_exists.test"
     get_key = "some_key"
@@ -257,7 +253,8 @@ def test_onyo_get_sorting(inventory: Inventory,
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_on_directory(inventory: Inventory,
                                capsys) -> None:
-    r"""`onyo_get()` gets a value in assets inside a directory."""
+    r"""Get a value from assets inside a directory."""
+
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     dir_path = inventory.root / "somewhere"
     get_key = "some_key"
@@ -278,7 +275,8 @@ def test_onyo_get_on_directory(inventory: Inventory,
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_match(inventory: Inventory,
                         capsys) -> None:
-    r"""`onyo_get()` lists just matching assets when `match` is used."""
+    r"""List only only matching assets."""
+
     asset_path1 = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     asset_path2 = inventory.root / "one_that_exists.test"
     matches = [Filter("other=1").match]
@@ -306,7 +304,8 @@ def test_onyo_get_match(inventory: Inventory,
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_no_matches(inventory: Inventory,
                              capsys) -> None:
-    r"""`onyo_get()` behaves correctly when `match` matches no assets."""
+    r"""Get a list with no matching assets."""
+
     asset_path1 = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     asset_path2 = inventory.root / "one_that_exists.test"
     matches = [Filter("unfound=values").match]
@@ -328,7 +327,8 @@ def test_onyo_get_no_matches(inventory: Inventory,
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_multiple(inventory: Inventory,
                            capsys) -> None:
-    r"""`onyo_get()` finds information about multiple assets in a single call."""
+    r"""Get multiple assets in a single call."""
+
     asset_path1 = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     asset_path2 = inventory.root / "one_that_exists.test"
     get_key = "some_key"
@@ -352,7 +352,8 @@ def test_onyo_get_multiple(inventory: Inventory,
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_limited(inventory: Inventory,
                           capsys) -> None:
-    r"""`onyo_get()` with limits (--exclude/--depth) selects the correct assets."""
+    r"""Limit with --exclude and --depth."""
+
     asset_path1 = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     asset_path2 = inventory.root / "one_that_exists.test"
 
@@ -382,7 +383,8 @@ def test_onyo_get_limited(inventory: Inventory,
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_depth_zero(inventory: Inventory,
                              capsys) -> None:
-    r"""Calling `onyo_get(depth=0)` is legal and selects all assets from all subpaths."""
+    r"""``depth=0`` selects all assets from all subpaths."""
+
     onyo_get(inventory,
              include=[inventory.root],
              depth=0,
@@ -399,9 +401,8 @@ def test_onyo_get_depth_zero(inventory: Inventory,
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_default_inventory_root(inventory: Inventory,
                                          capsys) -> None:
-    r"""Calling `onyo_get()` without path uses inventory.root as default
-    and selects all assets of the inventory.
-    """
+    r"""Empty ``include`` uses ``inventory.root`` as default."""
+
     onyo_get(inventory, machine_readable=True)
 
     # verify output contains all assets and "onyo.path.relative" as default key
@@ -413,9 +414,8 @@ def test_onyo_get_default_inventory_root(inventory: Inventory,
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_allows_duplicates(inventory: Inventory,
                                     capsys) -> None:
-    r"""Calling `onyo_get()` with a list containing the same asset multiple
-    times does not error, but displays information just once.
-    """
+    r"""The same asset twice in ``include`` will produce it only once."""
+
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
 
     # call `onyo_get()` with `include` containing duplicates
@@ -430,6 +430,8 @@ def test_onyo_get_allows_duplicates(inventory: Inventory,
 
 def test_onyo_get_asset_dir(inventory: Inventory,
                             capsys) -> None:
+    r"""Get keys from an asset directory."""
+
     asset = Item(some_key="some_value",
                  type="TYPE",
                  make="MAKER",
@@ -458,7 +460,8 @@ def test_onyo_get_is_asset_dir(inventory: Inventory,
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_type_matching(inventory: Inventory,
                                 capsys) -> None:
-    r"""`onyo_get()` allows matching types instead of values."""
+    r"""Match variable type (e.g. dict)."""
+
     inventory.add_asset(Item(some_key=dict(),
                              type="TYPE",
                              make="MAKE",
@@ -503,7 +506,8 @@ def test_onyo_get_type_matching(inventory: Inventory,
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_match_empty_dict(inventory: Inventory,
                                    capsys) -> None:
-    r"""onyo_get can match `{}` (empty dict)"""
+    r"""Match an empty dict (e.g. ``{}``)."""
+
     inventory.add_asset(Item(some_key=dict(),
                              type="TYPE",
                              make="MAKER",
@@ -534,7 +538,8 @@ def test_onyo_get_match_empty_dict(inventory: Inventory,
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_match_empty_list(inventory: Inventory,
                                    capsys) -> None:
-    r"""onyo_get can match `[]` (empty list)"""
+    r"""Match an empty list (e.g. ``[]``)."""
+
     inventory.add_asset(Item({"some_key": list(),
                               "type": "TYPE",
                               "make": "MAKER",
@@ -567,7 +572,8 @@ def test_onyo_get_match_empty_list(inventory: Inventory,
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_unset_values(inventory: Inventory,
                                capsys) -> None:
-    """`get` does return `<unset>` value"""
+    """Unset keys and values return as ``<unset>``."""
+
     from onyo.lib.consts import UNSET_VALUE
     asset = Item(type="TYPE",
                  make="MAKE",
@@ -597,7 +603,7 @@ def test_onyo_get_unset_values(inventory: Inventory,
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_get_items(inventory: Inventory, capsys) -> None:
-    """`get` can also query dirs and templates"""
+    """Get directories and templates."""
 
     onyo_get(inventory,
              keys=["onyo.path.relative"],

--- a/onyo/lib/tests/test_commands_set.py
+++ b/onyo/lib/tests/test_commands_set.py
@@ -11,7 +11,8 @@ from ..commands import onyo_set
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_set_errors(inventory: Inventory) -> None:
-    r"""`onyo_set()` must raise the correct error in different illegal or impossible calls."""
+    r"""Raise the correct error in different illegal or impossible calls."""
+
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     key_value = {"this_key": "that_value"}
 
@@ -70,7 +71,8 @@ def test_onyo_set_errors(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_set_empty_keys_or_values(inventory: Inventory) -> None:
-    r"""Verify the correct behavior for empty keys or values in `onyo_set()`."""
+    r"""Verify the correct behavior for empty keys or values in ``onyo_set()``."""
+
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     old_hexsha = inventory.repo.git.get_hexsha()
 
@@ -105,9 +107,8 @@ def test_onyo_set_empty_keys_or_values(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_set_illegal_fields(inventory: Inventory) -> None:
-    r"""`onyo_set()` must raise an error when attempting to set an
-    illegal/reserved field.
-    """
+    r"""Raise when attempting to set an illegal/reserved field."""
+
     from onyo.lib.consts import RESERVED_KEYS
     from onyo.lib.pseudokeys import PSEUDO_KEYS
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
@@ -134,9 +135,8 @@ def test_onyo_set_illegal_fields(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_set_errors_before_set(inventory: Inventory) -> None:
-    r"""`onyo_set()` must raise the correct error and is not allowed to
-    modify/commit anything, if one of the specified paths is not valid.
-    """
+    r"""Raise and don't modify/commit when one of paths is not valid."""
+
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     non_existing_asset_path = inventory.root / "non-existing" / "TYPE_MAKER_MODEL.SERIAL"
     key_value = {"this_key": "that_value"}
@@ -164,7 +164,8 @@ def test_onyo_set_errors_before_set(inventory: Inventory) -> None:
 def test_onyo_set_simple(inventory: Inventory,
                          message,
                          auto_message) -> None:
-    r"""`onyo_set()` sets a value in an asset."""
+    r"""Set a value in an asset."""
+
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     key_value = {"this_key": "that_value"}
     old_hexsha = inventory.repo.git.get_hexsha()
@@ -188,9 +189,8 @@ def test_onyo_set_simple(inventory: Inventory,
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_set_already_set(inventory: Inventory) -> None:
-    r"""`onyo_set()` does not error if called with values
-    that are already set.
-    """
+    r"""Do not error if called with values that are already set."""
+
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     key_value = {"some_key": "some_value"}
     old_hexsha = inventory.repo.git.get_hexsha()
@@ -215,7 +215,8 @@ def test_onyo_set_already_set(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_set_overwrite_existing_value(inventory: Inventory) -> None:
-    r"""`onyo_set()` overwrites an existing value with a new one in an asset."""
+    r"""Overwrite an existing value with a new one in an asset."""
+
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     new_key_value = {"some_key": "that_new_value"}
     old_hexsha = inventory.repo.git.get_hexsha()
@@ -243,10 +244,8 @@ def test_onyo_set_overwrite_existing_value(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_set_some_values_already_set(inventory: Inventory) -> None:
-    r"""When `onyo_set()` is called with two key value pairs, and one
-    is already set and the other not, onyo changes the second one
-    without error.
-    """
+    r"""Do not error when two key-value pairs result in one change and the other no-op."""
+
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     new_key_values = {"some_key": "some_value",  # exists in asset
                       "new_key": "new_value"}  # exists not in asset
@@ -279,6 +278,7 @@ def test_onyo_set_some_values_already_set(inventory: Inventory) -> None:
 @pytest.mark.ui({'yes': True})
 def test_onyo_set_multiple(inventory: Inventory) -> None:
     r"""Modify multiple assets in a single call and with one commit."""
+
     asset_path1 = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     asset_path2 = inventory.root / "one_that_exists.test"
     key_value = {"this_key": "that_value"}
@@ -303,9 +303,8 @@ def test_onyo_set_multiple(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_set_allows_duplicates(inventory: Inventory) -> None:
-    r"""Calling `onyo_set()` with a list containing the same asset multiple
-    times does not error.
-    """
+    r"""Do not error when the same asset is passed multiple times."""
+
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     key_value = {"this_key": "that_value"}
     old_hexsha = inventory.repo.git.get_hexsha()
@@ -369,7 +368,8 @@ def test_onyo_set_asset_dir(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_set_empty_dictlist(inventory: Inventory) -> None:
-    r"""`onyo_set` can set empty dicts and lists as values"""
+    r"""Set empty dicts and lists as values."""
+
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     onyo_set(inventory, assets=[asset_path], keys={"new_key": dict()})
     assert inventory.repo.git.is_clean_worktree()

--- a/onyo/lib/tests/test_commands_tree.py
+++ b/onyo/lib/tests/test_commands_tree.py
@@ -8,6 +8,7 @@ from ..commands import onyo_tree
 def test_onyo_tree_errors(inventory: Inventory,
                           capsys) -> None:
     r"""Raise the correct error for illegal or impossible calls."""
+
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     dir_path = inventory.root / 'empty'
 
@@ -39,6 +40,7 @@ def test_onyo_tree_errors(inventory: Inventory,
 def test_onyo_tree(inventory: Inventory,
                    capsys) -> None:
     r"""Display a tree for a directory."""
+
     directory_path = inventory.root / "somewhere" / "nested"
 
     onyo_tree(inventory,
@@ -62,6 +64,7 @@ def test_onyo_tree_description(inventory: Inventory,
                                desc: str,
                                capsys) -> None:
     r"""The description should be used and unaltered."""
+
     directory_path = inventory.root / "somewhere" / "nested"
 
     onyo_tree(inventory,
@@ -76,7 +79,8 @@ def test_onyo_tree_description(inventory: Inventory,
 
 def test_onyo_tree_dirs_only(inventory: Inventory,
                              capsys) -> None:
-    r"""Display a tree w/o any files"""
+    r"""Display a tree without any files."""
+
     asset = Item(type="atype",
                  make="someone",
                  model=dict(name="fancy"),

--- a/onyo/lib/tests/test_commands_unset.py
+++ b/onyo/lib/tests/test_commands_unset.py
@@ -12,7 +12,8 @@ from ..commands import onyo_unset
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_unset_errors(inventory: Inventory) -> None:
-    """`onyo_unset` must raise the correct error in different illegal or impossible calls."""
+    """Raise the correct error in different illegal or impossible calls."""
+
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     key = "some_key"
 
@@ -64,9 +65,8 @@ def test_onyo_unset_errors(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_unset_name_fields_error(inventory: Inventory) -> None:
-    """`onyo_unset` must raise an error when requested to unset a
-    reserved name field.
-    """
+    """Raise when requested to unset a reserved name field."""
+
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     old_hexsha = inventory.repo.git.get_hexsha()
     illegal_fields = ["type",
@@ -91,9 +91,8 @@ def test_onyo_unset_name_fields_error(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_unset_illegal_fields(inventory: Inventory) -> None:
-    """`onyo_unset` must raise an error when requested to unset an
-    illegal/reserverd field.
-    """
+    """Raise an error when requested to unset an illegal/reserverd field."""
+
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     old_hexsha = inventory.repo.git.get_hexsha()
 
@@ -114,9 +113,8 @@ def test_onyo_unset_illegal_fields(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_unset_errors_before_unset(inventory: Inventory) -> None:
-    """`onyo_unset` must raise the correct error and is not allowed to
-    modify/commit anything, if one of the specified paths is not valid.
-    """
+    """Raise an error and do not modify/commit if a path is not valid."""
+
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     non_existing_asset_path = inventory.root / "non-existing" / "TYPE_MAKER_MODEL.SERIAL"
     key = "some_key"
@@ -147,6 +145,7 @@ def test_onyo_unset_simple(inventory: Inventory,
                            message,
                            auto_message) -> None:
     """Unset a key in an asset."""
+
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     key = "some_key"
     old_hexsha = inventory.repo.git.get_hexsha()
@@ -175,6 +174,7 @@ def test_onyo_unset_simple(inventory: Inventory,
 @pytest.mark.ui({'yes': True})
 def test_onyo_unset_multiple(inventory: Inventory) -> None:
     """Modify multiple assets in a single call and with one commit."""
+
     asset_path1 = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     asset_path2 = inventory.root / "one_that_exists.test"
     key = "some_key"
@@ -201,9 +201,8 @@ def test_onyo_unset_multiple(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_unset_allows_asset_duplicates(inventory: Inventory) -> None:
-    """Calling `onyo_unset()` with a list containing the same asset
-    multiple times does not error.
-    """
+    """Do not error when the same asset is passed multiple times."""
+
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     key = "some_key"
     old_hexsha = inventory.repo.git.get_hexsha()
@@ -225,7 +224,8 @@ def test_onyo_unset_allows_asset_duplicates(inventory: Inventory) -> None:
     ["one_that_exists.test", "type: one\nmake: that\nmodel:\n  name: exists\nserial: test\nother_key: value"])
 @pytest.mark.ui({'yes': True})
 def test_onyo_unset_non_existing_keys(inventory: Inventory) -> None:
-    """Calling `onyo_unset()` on a non-existing key does not error."""
+    """Unset a non-existing key does not error."""
+
     asset_path1 = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     asset_path2 = inventory.root / "one_that_exists.test"
     other_key = "other_key"
@@ -258,7 +258,8 @@ def test_onyo_unset_non_existing_keys(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_unset_allows_key_duplicates(inventory: Inventory) -> None:
-    """Calling `onyo_unset()` with the same key multiple times does not error."""
+    """Unsetting the same key multiple times does not error."""
+
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     key = "some_key"
     old_hexsha = inventory.repo.git.get_hexsha()
@@ -302,7 +303,8 @@ def test_onyo_unset_asset_dir(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_unset_empty(inventory: Inventory) -> None:
-    """`unset` does work on empty dicts and lists, and None values"""
+    """Cannot unset empty dicts, empty lists, and None values."""
+
     # Note: This is making sure onyo does not confuse an "empty value",
     #       w/ the key not being present.
 

--- a/onyo/lib/tests/test_onyo.py
+++ b/onyo/lib/tests/test_onyo.py
@@ -7,17 +7,15 @@ from onyo.lib.items import Item
 
 
 def test_OnyoRepo_instantiation_existing(onyorepo: OnyoRepo) -> None:
-    """The OnyoRepo class must instantiate correctly for paths to
-    existing repositories.
-    """
+    """Instantiate OnyoRepo with an existing repository."""
+
     new_repo = OnyoRepo(onyorepo.git.root, init=False)
     assert new_repo.git.root.samefile(onyorepo.git.root)
 
 
 def test_OnyoRepo_instantiation_non_existing(tmp_path: Path) -> None:
-    """The OnyoRepo class must instantiate correctly for paths to
-    non-existing repositories.
-    """
+    """Instantiate OnyoRepo with a non-existing repository."""
+
     new_repo = OnyoRepo(tmp_path, init=True)
     assert new_repo.git.root.samefile(tmp_path)
     assert (new_repo.git.root / '.onyo').is_dir()
@@ -40,7 +38,7 @@ def test_OnyoRepo_instantiation_non_existing(tmp_path: Path) -> None:
 
 def test_OnyoRepo_incorrect_input_arguments_raise_error(onyorepo: OnyoRepo,
                                                         tmp_path: Path) -> None:
-    """The OnyoRepo must raise certain errors for invalid or conflicting arguments.
+    """OnyoRepo riases for invalid or conflicting arguments.
 
     - raise a OnyoInvalidRepoError when called on a path that is
       not yet a valid onyo repository.
@@ -49,6 +47,7 @@ def test_OnyoRepo_incorrect_input_arguments_raise_error(onyorepo: OnyoRepo,
     - raise a `FileExistsError` when trying to initialize a new OnyoRepo for a
       path that is already an OnyoRepo.
     """
+
     # try OnyoRepo with a non-repo path
     with pytest.raises(OnyoInvalidRepoError):
         OnyoRepo(tmp_path / 'no-existy', init=False)
@@ -66,10 +65,7 @@ def test_OnyoRepo_incorrect_input_arguments_raise_error(onyorepo: OnyoRepo,
                                    serial=0,
                                    path=Path('a') / 'test' / 'asset_for_test.0'))
 def test_clear_cache(onyorepo) -> None:
-    """The function `OnyoRepo.clear_cache()` must allow to empty the cache of
-    the OnyoRepo, so that an invalid cache can be re-loaded by a newly call of
-    the property.
-    """
+    """``OnyoRepo.clear_cache()`` empties the cache."""
 
     # Use arbitrary asset here:
     asset = onyorepo.test_annotation['assets'][0]['onyo.path.absolute']
@@ -92,10 +88,8 @@ def test_clear_cache(onyorepo) -> None:
 
 
 def test_Repo_generate_commit_subject(onyorepo: OnyoRepo) -> None:
-    """A generated commit message has to have a header with less then
-    80 characters length, and a body with the paths to changed files
-    and directories relative to the root of the repository.
-    """
+    """Commit subject has correct asset count and paths are relative."""
+
     modified = [onyorepo.git.root / 's p a c e s',
                 onyorepo.git.root / 'a/new/folder']
 
@@ -114,9 +108,8 @@ def test_Repo_generate_commit_subject(onyorepo: OnyoRepo) -> None:
 
 @pytest.mark.gitrepo_contents((Path('a/test/asset_for_test.0'), ""))
 def test_is_onyo_path(onyorepo) -> None:
-    """Verify that `OnyoRepo.is_onyo_path()` differentiates correctly between
-    paths under `.onyo/` and outside of it.
-    """
+    """``is_onyo_path()` detects paths under `.onyo/` and outside of it."""
+
     # True for the directory `.onyo/` itself
     assert onyorepo.is_onyo_path(onyorepo.dot_onyo)
     # True for the directory `templates` inside of `.onyo/`
@@ -140,12 +133,15 @@ def test_is_onyo_path(onyorepo) -> None:
 
 
 def test_Repo_get_template(onyorepo: OnyoRepo) -> None:
+    """``get_template`` gets a dictionary of a template file.
+
+    If a relative path is specified, it looks in ``.onyo/templates/`` first and
+    then CWD.
+
+    With no config and no name given, returns an empty dict (from the default
+    template ``empty``).
     """
-    The function `OnyoRepo.get_template` returns a dictionary representing
-    a template file. If a relative path is specified, it will first look in
-    `.onyo/templates/`. A default template can be configured via
-    'onyo.new.template'. With no config and no name given, returns an empty dict.
-    """
+
     # Call the function without parameter to get the empty template:
     assert onyorepo.get_template() == dict()
 
@@ -175,10 +171,8 @@ def test_Repo_get_template(onyorepo: OnyoRepo) -> None:
 @pytest.mark.inventory_dirs(Path('a/test/directory/structure/'),
                             Path('another/dir/'))
 def test_Repo_validate_anchors(onyorepo) -> None:
-    """
-    `OnyoRepo.validate_anchors()` must return True when all existing directories
-    have an `.anchor` file, and otherwise False.
-    """
+    """``validate_anchors()`` returns True when all dirs have an `.anchor` file, and otherwise False."""
+
     # Must be true for valid repository
     assert onyorepo.validate_anchors()
 
@@ -231,7 +225,7 @@ def test_onyo_ignore(onyorepo) -> None:
 
 
 def test_onyo_auto_message(onyorepo, caplog) -> None:
-    """Test configuration onyo.commit.auto-message"""
+    """Test configuration ``'onyo.commit.auto-message'``."""
 
     # default after repo init: True
     assert onyorepo.auto_message

--- a/onyo/lib/tests/test_utils.py
+++ b/onyo/lib/tests/test_utils.py
@@ -37,7 +37,8 @@ description: |
 
 
 def test_dict_to_asset_yaml() -> None:
-    r"""Test Dict, CommentedMap, and empty dict."""
+    r"""``dict_to_asset_yaml`` accepts Dict, CommentedMap, and empty dict."""
+
     # normal python dict
     d = {'type': 'TYPE', 'make': 'MAKE', 'model': 'MODEL', 'serial': '008675309', 'explicit': 123}
     d_expected_output = "---\ntype: TYPE\nmake: MAKE\nmodel: MODEL\nserial: 008675309\nexplicit: !!int '123'\n"
@@ -56,7 +57,8 @@ def test_dict_to_asset_yaml() -> None:
 
 @pytest.mark.parametrize('rkey', list(PSEUDO_KEYS.keys()) + RESERVED_KEYS)
 def test_redaction_dict_to_asset_yaml(rkey: str) -> None:
-    r"""Reserved- and Pseudo-Keys should not be serialized."""
+    r"""Reserved- and Pseudo-Keys are not serialized."""
+
     d = DotNotationWrapper({'type': 'TYPE', 'make': 'MAKE', 'model': 'MODEL', 'serial': '008675309', 'explicit': 123})
     d[rkey] = 'REDACT_ME'
     d_expected_output = "---\ntype: TYPE\nmake: MAKE\nmodel: MODEL\nserial: 008675309\nexplicit: !!int '123'\n"
@@ -91,7 +93,8 @@ def test_get_asset_content(tmp_path) -> None:
 
 
 def test_roundtrip(tmp_path) -> None:
-    """Test roundtrip get_asset_content->dict_to_asset_yaml"""
+    """Test roundtrip get_asset_content->dict_to_asset_yaml."""
+
     asset_file = tmp_path / "asset-file"
     asset_file.write_text(asset_file_content)
 

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -38,8 +38,8 @@ class OnyoArgumentParser(ArgumentParser):
     def _print_message(self,
                        message: str,
                        file: IO[str] | None = None) -> None:
-        r"""Print help text with Rich.
-        """
+        r"""Print help text with Rich."""
+
         if message:
             rich.print(message, file=file)
 
@@ -69,6 +69,7 @@ class OnyoRawTextHelpFormatter(RawTextHelpFormatter):
         indent
             Indentation text to precede lines with.
         """
+
         text = rst_to_rich(text)
         return super()._fill_text(text, width, indent)
 
@@ -101,6 +102,7 @@ class OnyoRawTextHelpFormatter(RawTextHelpFormatter):
         action
             ArgParse Action.
         """
+
         if action.option_strings:
             # -s, --long
             rendered_options = ', '.join([f"[cyan]{x}[/cyan]" for x in action.option_strings])
@@ -132,6 +134,7 @@ class OnyoRawTextHelpFormatter(RawTextHelpFormatter):
         width
             Max character length to wrap lines at.
         """
+
         text = rst_to_rich(text)
         return super()._split_lines(text, width)
 
@@ -146,6 +149,7 @@ class OnyoRawTextHelpFormatter(RawTextHelpFormatter):
         heading
             Heading text.
         """
+
         if heading:
             heading = f'[orange1]{heading.title()}[/orange1]'
         super().start_section(heading)
@@ -162,6 +166,7 @@ def rst_to_rich(text: str) -> str:
     text
         reStructuredText to convert.
     """
+
     # de-indent text
     text = textwrap.dedent(text).strip()
 
@@ -231,6 +236,7 @@ def build_parser(parser: ArgumentParser,
         }
         build_parser(parser, args)
     """
+
     for cmd in args:
         args[cmd]['dest'] = cmd
         try:  # option flag
@@ -246,9 +252,8 @@ subcmds = None
 
 
 def setup_parser() -> OnyoArgumentParser:
-    r"""Setup and return a fully populated OnyoArgumentParser for Onyo and all subcommands.
-    """
-    from onyo.onyo_arguments import args_onyo
+    r"""Return a fully populated OnyoArgumentParser for Onyo and all subcommands."""
+
     from onyo.cli.cat import args_cat, epilog_cat
     from onyo.cli.config import args_config, epilog_config
     from onyo.cli.edit import args_edit, epilog_edit
@@ -265,6 +270,7 @@ def setup_parser() -> OnyoArgumentParser:
     from onyo.cli.tree import args_tree, epilog_tree
     from onyo.cli.tsv_to_yaml import args_tsv_to_yaml, epilog_tsv_to_yaml
     from onyo.cli.unset import args_unset, epilog_unset
+    from onyo.onyo_arguments import args_onyo
 
     global subcmds
 
@@ -491,6 +497,7 @@ def get_subcmd_index(arglist: list,
     -------
     >>> subcmd_index = get_subcmd_index(sys.argv)
     """
+
     onyo_flags_with_args = ['-C', '--onyopath']
 
     try:
@@ -508,8 +515,8 @@ def get_subcmd_index(arglist: list,
 
 
 def main() -> None:
-    r"""Execute Onyo's CLI.
-    """
+    r"""Execute Onyo's CLI."""
+
     #
     # ARGPARSE Hack #1
     #

--- a/onyo/tests/benchmark.py
+++ b/onyo/tests/benchmark.py
@@ -1,30 +1,43 @@
+from __future__ import annotations
+
 import random
 import subprocess
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
 from onyo.lib.commands import (
-        onyo_cat,
-        onyo_get,
-        onyo_new,
-        onyo_set,
-    )
+    onyo_cat,
+    onyo_get,
+    onyo_new,
+    onyo_set,
+)
 from onyo.lib.inventory import Inventory
 from onyo.lib.onyo import OnyoRepo
 from onyo.lib.utils import DotNotationWrapper
+
+if TYPE_CHECKING:
+    from typing import Generator
 
 
 @pytest.mark.ui({'yes': True, 'quiet': True})
 @pytest.mark.parametrize('num', [100, 1000])
 class TestOnyoBenchmark:
+    r"""Run a suite of benchmarks for Onyo."""
+
     @pytest.fixture(scope='function')
     def benchmark_inventory(self,
                             num: int,
                             request,
                             tmp_path: Path,
                             fake,
-                            monkeypatch):
+                            monkeypatch) -> Generator[Inventory, None, None]:
+        r"""Yield an Inventory, populated with ``num`` of fake assets.
+
+        The generated repositories are cached. A clone is produced for
+        subsequent requests of Inventories with the same population count.
+        """
 
         repo_path = tmp_path
 
@@ -74,6 +87,7 @@ class TestOnyoBenchmark:
                                 benchmark,
                                 fake) -> None:
         r"""Create 50 assets in the repo."""
+
         inventory = benchmark_inventory
         # fifty additional assets
         fifty_assets = [DotNotationWrapper(a) for a in fake.onyo_asset_dicts(num=50)]
@@ -86,6 +100,7 @@ class TestOnyoBenchmark:
             The benchmarked function is run multiple times, but without re-running
             the entire test function. This can create conflicts, etc.
             """
+
             inventory.repo.git._git(["reset", "--hard", self._class_old_hexsha[num]])
             # gc the repo
             inventory.repo.git._git(["gc", "--aggressive", "--quiet", "--prune=now"])
@@ -105,6 +120,7 @@ class TestOnyoBenchmark:
                               benchmark_inventory: Inventory,
                               benchmark) -> None:
         r"""Get all assets in the repo."""
+
         inventory = benchmark_inventory
 
         # Per default, this will return all keys in the asset name + path and
@@ -122,6 +138,7 @@ class TestOnyoBenchmark:
                                 benchmark_inventory: Inventory,
                                 benchmark) -> None:
         r"""Get 50 assets from the repo."""
+
         from onyo.lib.filters import Filter
 
         inventory = benchmark_inventory
@@ -148,6 +165,7 @@ class TestOnyoBenchmark:
                                 benchmark_inventory: Inventory,
                                 benchmark) -> None:
         r"""Set 50 assets in the repo."""
+
         from onyo.lib.filters import Filter
 
         inventory = benchmark_inventory
@@ -162,6 +180,7 @@ class TestOnyoBenchmark:
             The benchmarked function is run multiple times, but without re-running
             the entire test function. This can create conflicts, etc.
             """
+
             inventory.repo.git._git(["reset", "--hard", self._class_old_hexsha[num]])
             # gc the repo
             inventory.repo.git._git(["gc", "--aggressive", "--quiet", "--prune=now"])
@@ -183,6 +202,7 @@ class TestOnyoBenchmark:
                               benchmark_inventory: Inventory,
                               benchmark) -> None:
         r"""Cat 1 asset in the repo."""
+
         inventory = benchmark_inventory
         # get 1 asset
         assets = [a["onyo.path.absolute"]
@@ -199,6 +219,7 @@ class TestOnyoBenchmark:
                               benchmark_inventory: Inventory,
                               benchmark) -> None:
         r"""Cat 1 asset from the CLI."""
+
         inventory = benchmark_inventory
         # get 1 asset
         asset = random.sample(onyo_get(inventory, keys=["onyo.path.absolute"]), k=1)[0]['onyo.path.absolute']

--- a/onyo/tests/test_main.py
+++ b/onyo/tests/test_main.py
@@ -26,10 +26,12 @@ def test_get_subcmd_index_valid(helpers: Helpers) -> None:
             assert idx == full_cmd.index('config')
 
 
-def test_get_subcmd_index_overlap(helpers: Helpers) -> None:
-    r"""
-    Arg values overlap with onyo or its subcommands. Borderline pathological.
+def test_get_subcmd_index_overlap() -> None:
+    r"""Argument values are named the same as "onyo" or its subcommands.
+
+    Borderline pathological.
     """
+
     full_cmd = ['onyo', '-C', 'onyo', '-d', 'mv', 'onyo', 'mv']
     idx = main.get_subcmd_index(full_cmd)
     assert idx == 4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,6 @@ lint.ignore = [
     "D105",  # Missing docstring in magic method
     "D200",  # One-line docstring should fit on one line
     "D202",  # No blank lines allowed after function docstring (found {num_lines})
-    "D204",  # 1 blank line required after class docstring
     "D205",  # 1 blank line required between summary line and description
     "D400",  # First line should end with a period
     "D401",  # First line of docstring should be in imperative mood: "{first_line}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,18 +65,11 @@ find = {}  # Scanning implicit namespaces is active by default
 exclude = ["build/"]
 lint.ignore = [
     "D100",  # Missing docstring in public module
-    "D101",  # Missing docstring in public class
-    "D102",  # Missing docstring in public method
     "D103",  # Missing docstring in public function
     "D104",  # Missing docstring in public package
-    "D105",  # Missing docstring in magic method
-    "D200",  # One-line docstring should fit on one line
     "D202",  # No blank lines allowed after function docstring (found {num_lines})
     "D205",  # 1 blank line required between summary line and description
-    "D400",  # First line should end with a period
     "D401",  # First line of docstring should be in imperative mood: "{first_line}"
-    "D403",  # First word of the docstring should be capitalized: {} -> {}
-    "D404",  # First word of the docstring should not be "This"
     "E501",  # Line too long (82 > 79 characters)
 ]
 lint.select = [


### PR DESCRIPTION
This is the last PR in my recent series of giga PRs making sweeping changes everywhere. Thank you for putting in the effort to review them.

The primary purpose of this PR is to bring docstrings to everything that is not a test. That, along with a spree through the tests to fix the lowest hanging fruit, led to 8 more `ruff` linting rules being enabled.

As usual, there is some refactoring in this PR (details in commit messages):

- some Item()-ization.
- normalization of differs, executors, and recorders to be alphabetized and renamed to be singular.
- removal of dead code from `differs.py` and `argparse_helpers.py`
- `StoreSortOption` sort direction is explicit rather than magical
- add `Item.__eq__()` and retire `is_equal_assets_dict()` and `YAMLDumpWrapper()`