### PR TITLE
NF/DOC/TST: add `rmdir` command

### DIFF
--- a/docs/source/cmd_rmdir.rst
+++ b/docs/source/cmd_rmdir.rst
@@ -1,0 +1,8 @@
+onyo rmdir
+==========
+
+.. argparse::
+   :module: onyo.main
+   :func: setup_parser
+   :prog: onyo
+   :path: rmdir

--- a/docs/source/command_line_reference.rst
+++ b/docs/source/command_line_reference.rst
@@ -16,6 +16,7 @@ Command Line Reference
    cmd_mv
    cmd_new
    cmd_rm
+   cmd_rmdir
    cmd_set
    cmd_shell-completion
    cmd_tree

--- a/onyo/cli/__init__.py
+++ b/onyo/cli/__init__.py
@@ -9,6 +9,7 @@ from .mkdir import mkdir
 from .mv import mv
 from .new import new
 from .rm import rm
+from .rmdir import rmdir
 from .set import set
 from .shell_completion import shell_completion
 from .tree import tree
@@ -27,6 +28,7 @@ __all__ = [
     'mv',
     'new',
     'rm',
+    'rmdir',
     'set',
     'shell_completion',
     'tree',

--- a/onyo/cli/rmdir.py
+++ b/onyo/cli/rmdir.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from onyo.lib.onyo import OnyoRepo
+from onyo.lib.commands import onyo_rmdir
+from onyo.lib.inventory import Inventory
+from onyo.shared_arguments import (
+    shared_arg_message,
+    shared_arg_no_auto_message,
+)
+
+if TYPE_CHECKING:
+    import argparse
+
+args_rmdir = {
+    'directory': dict(
+        metavar='PATH',
+        nargs='+',
+        help=r"""
+            Directories to delete; or Asset Directories to convert into Asset Files.
+        """
+    ),
+    'message': shared_arg_message,
+    'no_auto_message': shared_arg_no_auto_message,
+}
+
+epilog_rmdir = r"""
+.. rubric:: Examples
+
+Remove a user from a group:
+
+.. code:: shell
+
+    $ onyo rmdir accounting/Bingo\ Bob/
+
+Convert an empty Asset Directory into an Asset File:
+
+.. code:: shell
+
+    $ onyo rmdir accounting/Bingo\ Bob/laptop_apple_macbook.oiw629/
+
+"""
+
+
+def rmdir(args: argparse.Namespace) -> None:
+    r"""
+    Delete empty **DIRECTORY**\ s or convert empty Asset Directories into Asset
+    Files.
+
+    If the **DIRECTORY** does not exist, the path is protected, or the asset is
+    already an Asset File, then Onyo will error and leave everything
+    unmodified.
+    """
+
+    dirs = [Path(d).resolve() for d in args.directory]
+    inventory = Inventory(repo=OnyoRepo(Path.cwd(), find_root=True))
+    onyo_rmdir(inventory,
+               dirs=dirs,
+               message='\n\n'.join(m for m in args.message) if args.message else None,
+               auto_message=False if args.no_auto_message else None)

--- a/onyo/cli/tests/test_rmdir.py
+++ b/onyo/cli/tests/test_rmdir.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from onyo.lib.items import Item
+
+
+assets = [
+    Item({
+        "type": "type",
+        "make": "make",
+        "model.name": "model",
+        "serial": "001",
+        "onyo.is.directory": True,
+        "onyo.path.relative": Path("subdir") / "type_make_model.001",
+    }),
+    Item({
+        "type": "type",
+        "make": "make",
+        "model.name": "model",
+        "serial": "002",
+        "onyo.is.directory": True,
+        "onyo.path.relative": Path("subdir") / "type_make_model.002",
+    }),
+    Item({
+        "type": "type",
+        "make": "make",
+        "model.name": "model",
+        "serial": "003",
+        "onyo.is.directory": False,
+        "onyo.path.relative": Path("subdir") / "type_make_model.003",
+    }),
+    Item({
+        "type": "type",
+        "make": "make",
+        "model.name": "model",
+        "serial": "004",
+        "onyo.is.directory": False,
+        "onyo.path.relative": Path("subdir") / "type_make_model.004",
+    }),
+]
+directories = [
+    Path('one'),
+    Path('s p a c e s'),
+    Path('r/e/c/u/r/s/i/v/e'),
+    Path('overlap/alpha'),
+    Path('overlap/beta'),
+    Path('subdir/type_make_model.001/subdir'),
+]
+directories_without_asset_subdirectories = [d for d in directories if all([False for a in assets if a['onyo']['path']['relative'] in d.parents])]
+
+@pytest.mark.inventory_assets(*assets)
+@pytest.mark.inventory_dirs(*directories)
+@pytest.mark.parametrize('directory', directories)
+def test_rmdir_single_input(onyorepo,
+                            directory: Path) -> None:
+    r"""Delete a single directory.
+
+    ``onyo rmdir DIRECTORY``
+    """
+
+    ret = subprocess.run(['onyo', '--yes', 'rmdir', str(directory)],
+                         capture_output=True, text=True)
+    assert ret.returncode == 0
+    assert "Removed directories:" in ret.stdout
+    assert str(directory) in ret.stdout
+    assert not ret.stderr
+
+    # delete was successful
+    assert not directory.exists()
+
+    # other directories are untouched
+    for d in [x for x in directories if x != directory]:
+        assert d.exists()
+
+    # repository is clean
+    assert onyorepo.git.is_clean_worktree()
+
+
+@pytest.mark.inventory_assets(*assets)
+@pytest.mark.inventory_dirs(*directories)
+def test_rmdir_multiple_inputs(onyorepo) -> None:
+    r"""Delete multiple directories at once.
+
+    ``onyo rmdir DIRECTORY DIRECTORY``
+    """
+
+    ret = subprocess.run(['onyo', '--yes', 'rmdir', *directories],
+                         capture_output=True, text=True)
+    assert ret.returncode == 0
+    assert "Removed directories:" in ret.stdout
+    for d in directories:
+        assert str(d) in ret.stdout
+    assert not ret.stderr
+
+    # delete was successful
+    for d in directories:
+        # target was deleted
+        assert not d.exists()
+        # parent is untouched
+        assert d.parent.exists()
+
+    # repository is clean
+    assert onyorepo.git.is_clean_worktree()
+
+
+@pytest.mark.inventory_assets(*assets)
+@pytest.mark.inventory_dirs(*directories)
+def test_rmdir_error_non_empty(onyorepo) -> None:
+    r"""Error on non-empty directories."""
+
+    # apologies for the hardcoded list
+    non_empty_dirs = [
+        Path('r/'),
+        Path('r/e/'),
+        Path('r/e/c/'),
+        Path('r/e/c/u/'),
+        Path('r/e/c/u/r/'),
+        Path('r/e/c/u/r/s/'),
+        Path('r/e/c/u/r/s/i/'),
+        Path('r/e/c/u/r/s/i/v/'),
+        Path('overlap/'),
+        Path('subdir/'),
+        Path('subdir/type_make_model.001/'),
+    ]
+
+    for d in non_empty_dirs:
+        ret = subprocess.run(['onyo', '--yes', 'rmdir', d],
+                             capture_output=True, text=True)
+
+        assert ret.stderr
+        assert ret.returncode == 1
+
+        # directory was not deleted, and is mentioned in output
+        assert str(d) in ret.stderr
+        assert d.is_dir()
+
+    # verify that the repository is clean
+    assert onyorepo.git.is_clean_worktree()
+
+
+@pytest.mark.inventory_assets(*assets)
+@pytest.mark.inventory_dirs(*directories_without_asset_subdirectories)
+def test_rmdir_convert_asset_dir(onyorepo) -> None:
+    r"""Convert Asset Directories into Asset Files."""
+
+    asset_dirs = [a['onyo.path.relative'] for a in onyorepo.test_annotation['assets'] if a.get('onyo.is.directory')]
+    ret = subprocess.run(['onyo', '--yes', 'rmdir', *asset_dirs],
+                         capture_output=True, text=True)
+
+    assert not ret.stderr
+    assert ret.returncode == 0
+
+    # directories were deleted, and are mentioned in output
+    for a in asset_dirs:
+        assert str(a) in ret.stdout
+        assert a.is_file()
+
+    # verify that the repository is clean
+    assert onyorepo.git.is_clean_worktree()
+
+
+@pytest.mark.inventory_assets(*assets)
+@pytest.mark.inventory_dirs(*directories)
+def test_rmdir_error_on_asset_files(onyorepo) -> None:
+    r"""Error on Asset Files."""
+
+    asset_files = [a['onyo.path.relative'] for a in onyorepo.test_annotation['assets'] if not a.get('onyo.is.directory')]
+    for a in asset_files:
+        ret = subprocess.run(['onyo', '--yes', 'rmdir', str(a)],
+                             capture_output=True, text=True)
+
+        assert not ret.stdout
+        assert ret.returncode == 1
+
+        # file was not deleted, and is mentioned in output
+        assert str(a) in ret.stderr
+        assert a.is_file()
+
+    # verify that the repository is clean
+    assert onyorepo.git.is_clean_worktree()

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -686,7 +686,7 @@ def onyo_mkdir(inventory: Inventory,
 
     Raises
     ------
-    ValueError
+    NoopError
         ``dirs`` is empty.
     """
 
@@ -694,7 +694,7 @@ def onyo_mkdir(inventory: Inventory,
         auto_message = inventory.repo.auto_message
 
     if not dirs:
-        raise ValueError("At least one directory path must be specified.")
+        raise NoopError("At least one directory path must be specified.")
 
     for d in deduplicate(dirs):  # pyre-ignore[16]
         inventory.add_directory(Item(d, repo=inventory.repo))

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -1085,6 +1085,67 @@ def onyo_rm(inventory: Inventory,
 
 
 @raise_on_inventory_state
+def onyo_rmdir(inventory: Inventory,
+               dirs: list[Path] | Path,
+               message: str | None = None,
+               auto_message: bool | None = None) -> None:
+    r"""Delete empty directories or convert empty Asset Directories into Asset Files.
+
+    If the directory does not exist, the path is protected, or the asset is
+    already an Asset File, then an error is raised nothing is modified.
+
+    Parameters
+    ----------
+    inventory
+        The Inventory in which to delete directories or convert asset directories.
+    dirs
+        Paths of directories to delete or convert.
+    message
+        Commit message to append to the auto-generated message.
+    auto_message
+        Generate a commit-message subject line.
+        If ``None``, lookup the config value from ``onyo.commit.auto-message``.
+
+    Raises
+    ------
+    NoopError
+        ``dirs`` is empty.
+    """
+
+    if auto_message is None:
+        auto_message = inventory.repo.auto_message
+
+    if not dirs:
+        raise NoopError("At least one directory path must be specified.")
+
+    dirs = [dirs] if not isinstance(dirs, list) else dirs
+    for d in deduplicate(dirs):  # pyre-ignore[16]
+        try:
+            inventory.remove_directory(inventory.get_item(d), recursive=False)
+        except InventoryDirNotEmpty as e:
+            raise InventoryDirNotEmpty(f"{str(e)}\nCannot remove a non-empty directory.") from e
+
+    if inventory.operations_pending():
+        ui.print(inventory.operations_summary())
+
+        if ui.request_user_response("Save changes? No discards all changes. (y/n) "):
+            if auto_message:
+                operation_paths = sorted(deduplicate([  # pyre-ignore[6]
+                    op.operands[0].get("onyo.path.relative")
+                    for op in inventory.operations
+                    if op.operator == OPERATIONS_MAPPING['remove_directories']]))
+                message = inventory.repo.generate_commit_subject(
+                    format_string="rmdir [{len}]: {operation_paths}\n",
+                    len=len(operation_paths),
+                    operation_paths=sorted(operation_paths)) + (message or "")
+
+            inventory.commit(message=message)
+            return
+
+    ui.print('No directories were removed.')
+
+
+@raise_on_inventory_state
 def onyo_set(inventory: Inventory,
              keys: dict | UserDict,
              assets: list[Path],

--- a/onyo/lib/inventory.py
+++ b/onyo/lib/inventory.py
@@ -646,6 +646,10 @@ class Inventory(object):
         ------
         InvalidInventoryOperationError
             ``item['onyo.path.absolute']`` is invalid.
+        InventoryDirNotEmpty
+            ``item['onyo.path.absolute']`` has children on the filesystem.
+        NoopError
+            ``item['onyo.path.absolute']`` is already an Asset File.
         """
 
         if item['onyo.path.absolute'] in [d['onyo.path.absolute'] for d in self._get_pending_removals(mode='dirs')]:
@@ -654,6 +658,8 @@ class Inventory(object):
             return []
         if item['onyo.path.absolute'] == self.root:
             raise InvalidInventoryOperationError("Can't remove inventory root.")
+        if item['onyo.is.asset'] and not item['onyo.is.directory']:
+            raise NoopError(f"{item['onyo.path.absolute']} is already an Asset File.")
         if not item['onyo.is.directory']:
             raise InvalidInventoryOperationError(f"Not an inventory directory: {item['onyo.path.absolute']}")
 

--- a/onyo/lib/tests/test_commands_mkdir.py
+++ b/onyo/lib/tests/test_commands_mkdir.py
@@ -25,7 +25,7 @@ def test_onyo_mkdir_errors(inventory: Inventory) -> None:
                   dirs=[(inventory.root / ".." / "outside").resolve()])
 
     # mkdir with empty list
-    pytest.raises(ValueError,
+    pytest.raises(NoopError,
                   onyo_mkdir,
                   inventory,
                   dirs=[])

--- a/onyo/lib/tests/test_commands_rmdir.py
+++ b/onyo/lib/tests/test_commands_rmdir.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import pytest
+
+from onyo.lib.commands import (
+    onyo_mkdir,
+    onyo_rmdir,
+)
+from onyo.lib.consts import ANCHOR_FILE_NAME
+from onyo.lib.exceptions import (
+    InventoryDirNotEmpty,
+    InvalidInventoryOperationError,
+    NoopError,
+)
+from onyo.lib.inventory import Inventory
+from . import check_commit_msg
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_rmdir_errors(inventory: Inventory) -> None:
+    r"""Raise the correct error in different illegal or impossible calls."""
+
+    asset_file = inventory.root / 'somewhere/nested/TYPE_MAKER_MODEL.SERIAL'
+    dir_not_empty = inventory.root / 'somewhere'
+
+    # rmdir on existing asset file
+    pytest.raises(NoopError,
+                  onyo_rmdir,
+                  inventory,
+                  dirs=[asset_file])
+
+    # rmdir on non-empty directory
+    pytest.raises(InventoryDirNotEmpty,
+                  onyo_rmdir,
+                  inventory,
+                  dirs=[dir_not_empty])
+
+    # rmdir outside the repository
+    pytest.raises(InvalidInventoryOperationError,
+                  onyo_rmdir,
+                  inventory,
+                  dirs=[(inventory.root / ".." / "outside").resolve()])
+
+    # rmdir with empty list
+    pytest.raises(NoopError,
+                  onyo_rmdir,
+                  inventory,
+                  dirs=[])
+
+    # rmdir an empty dir that is under .git/
+    empty_under_git = inventory.root / ".git" / "empty"
+    empty_under_git.mkdir()
+    pytest.raises(InvalidInventoryOperationError,
+                  onyo_rmdir,
+                  inventory,
+                  dirs=[empty_under_git])
+
+    # rmdir an empty dir that is under .onyo/
+    empty_under_onyo = inventory.root / ".onyo" / "empty"
+    empty_under_onyo.mkdir()
+    pytest.raises(InvalidInventoryOperationError,
+                  onyo_rmdir,
+                  inventory,
+                  dirs=[empty_under_onyo])
+
+    # no error scenario leaves the inventory unclean
+    assert inventory.repo.git.is_clean_worktree()
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_rmdir_errors_before_rmdir(inventory: Inventory) -> None:
+    r"""Raise and don't remove/commit anything, if one of the specified paths is not valid."""
+
+    old_hexsha = inventory.repo.git.get_hexsha()
+
+    dir_empty = inventory.root / 'empty'
+    dir_not_empty = inventory.root / 'somewhere'
+    asset_file = inventory.root / 'somewhere/nested/TYPE_MAKER_MODEL.SERIAL'
+
+    # one of multiple targets is not empty
+    pytest.raises(InvalidInventoryOperationError,
+                  onyo_rmdir,
+                  inventory,
+                  dirs=[dir_empty,
+                        dir_not_empty,
+                        asset_file])
+
+    # targets were untouched
+    assert dir_empty.is_dir()
+    assert (dir_empty / ANCHOR_FILE_NAME).is_file()
+    assert (dir_empty / ANCHOR_FILE_NAME) in inventory.repo.git.files  # noqa: E713
+    assert dir_not_empty.is_dir()
+    assert (dir_not_empty / ANCHOR_FILE_NAME).is_file()
+    assert (dir_not_empty / ANCHOR_FILE_NAME) in inventory.repo.git.files  # noqa: E713
+    assert asset_file.is_file()
+    assert asset_file in inventory.repo.git.files  # noqa: E713
+
+    # no commit was added
+    assert inventory.repo.git.get_hexsha() == old_hexsha
+    assert inventory.repo.git.is_clean_worktree()
+
+
+@pytest.mark.ui({'yes': True})
+@pytest.mark.parametrize('message', ["", None, "message with spe\"cial\\char\'acteஞrs"])
+@pytest.mark.parametrize('auto_message', [True, False])
+def test_onyo_rmdir_simple(inventory: Inventory,
+                           message,
+                           auto_message) -> None:
+    r"""Remove a single directory."""
+
+    dir_path_empty = inventory.root / 'empty'
+    old_hexsha = inventory.repo.git.get_hexsha()
+
+    # remove a directory
+    onyo_rmdir(inventory,
+               dirs=[dir_path_empty],
+               message=message,
+               auto_message=auto_message)
+
+    # directory was deleted
+    assert not (dir_path_empty / ANCHOR_FILE_NAME).is_file()
+    assert (dir_path_empty / ANCHOR_FILE_NAME) not in inventory.repo.git.files
+    assert not dir_path_empty.is_dir()
+    assert not inventory.repo.is_inventory_dir(dir_path_empty)
+
+    # exactly one commit added
+    assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
+    assert inventory.repo.git.is_clean_worktree()
+    check_commit_msg(inventory, message, auto_message, "rmdir [")
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_rmdir_multiple(inventory: Inventory) -> None:
+    r"""Remove multiple directories in a single call and with one commit."""
+
+    empty_dirs = [
+        inventory.root / 'empty_dir1',
+        inventory.root / 'empty_dir2',
+        inventory.root / 'empty_dir3',
+    ]
+
+    # create the directories
+    onyo_mkdir(inventory,
+               dirs=[*empty_dirs])
+
+    # quick sanity check
+    for d in empty_dirs:
+        assert inventory.repo.is_inventory_dir(d)
+
+    # get the commit
+    old_hexsha = inventory.repo.git.get_hexsha()
+
+    # remove the directories
+    onyo_rmdir(inventory,
+               dirs=[*empty_dirs])
+
+    # directories were deleted
+    for d in empty_dirs:
+        assert not (d / ANCHOR_FILE_NAME).is_file()
+        assert (d / ANCHOR_FILE_NAME) not in inventory.repo.git.files
+        assert not d.is_dir()
+        assert not inventory.repo.is_inventory_dir(d)
+
+    # exactly one commit added
+    assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
+    assert inventory.repo.git.is_clean_worktree()
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_rmdir_allows_duplicates(inventory: Inventory) -> None:
+    r"""Do not error when the same path is passed multiple times."""
+
+    dir_path_empty = inventory.root / 'empty'
+    old_hexsha = inventory.repo.git.get_hexsha()
+
+    # remove the same single directory multiple times
+    onyo_rmdir(inventory,
+               dirs=[dir_path_empty, dir_path_empty, dir_path_empty])
+
+    # directory was deleted
+    assert not (dir_path_empty / ANCHOR_FILE_NAME).is_file()
+    assert (dir_path_empty / ANCHOR_FILE_NAME) not in inventory.repo.git.files
+    assert not dir_path_empty.is_dir()
+    assert not inventory.repo.is_inventory_dir(dir_path_empty)
+
+    # exactly one commit added
+    assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
+    assert inventory.repo.git.is_clean_worktree()
+
+
+@pytest.mark.ui({'yes': True})
+def test_onyo_rmdir_asset(inventory: Inventory) -> None:
+    r"""Convert an Asset Directory into an Asset File."""
+
+    asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
+
+    # convert to an asset directory
+    onyo_mkdir(inventory,
+               dirs=[asset_path])
+
+    # quick sanity check
+    assert inventory.repo.is_inventory_dir(asset_path)
+
+    # get the commit
+    old_hexsha = inventory.repo.git.get_hexsha()
+
+    # convert the asset directory back to an asset file
+    onyo_rmdir(inventory,
+               dirs=[asset_path])
+
+    assert not inventory.repo.is_inventory_dir(asset_path)
+    assert asset_path.is_file()
+    assert asset_path in inventory.repo.git.files
+
+    # exactly one commit added
+    assert inventory.repo.git.get_hexsha('HEAD~1') == old_hexsha
+    assert inventory.repo.git.is_clean_worktree()
+
+    # re-execution fails
+    with pytest.raises(NoopError, match="is already an Asset File"):
+        onyo_rmdir(inventory,
+                   dirs=[asset_path])

--- a/onyo/lib/tests/test_inventory_operations.py
+++ b/onyo/lib/tests/test_inventory_operations.py
@@ -402,6 +402,7 @@ def test_remove_directory(repo: OnyoRepo) -> None:
     newdir1 = repo.git.root / "somewhere"
     newdir2 = newdir1 / "new"
     emptydir = newdir1 / "empty"
+    does_not_exist = repo.git.root / 'does' / 'not' / 'exist'
     asset_file = newdir2 / "TYPE_MAKE_MODEL.SERIAL"
     asset = Item(
         some_key="some_value",
@@ -415,8 +416,10 @@ def test_remove_directory(repo: OnyoRepo) -> None:
     inventory.add_directory(Item(emptydir, repo=repo))
     inventory.commit("First asset added")
 
+    # raise on asset file
+    pytest.raises(NoopError, inventory.remove_directory, Item(asset_file, repo=repo))
     # raise on non-dir
-    pytest.raises(InvalidInventoryOperationError, inventory.remove_directory, Item(asset_file, repo=repo))
+    pytest.raises(InvalidInventoryOperationError, inventory.remove_directory, Item(does_not_exist, repo=repo))
 
     emptydir_item = inventory.get_item(emptydir)
     inventory.remove_directory(emptydir_item)

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -265,6 +265,7 @@ def setup_parser() -> OnyoArgumentParser:
     from onyo.cli.mv import args_mv, epilog_mv
     from onyo.cli.new import args_new, epilog_new
     from onyo.cli.rm import args_rm, epilog_rm
+    from onyo.cli.rmdir import args_rmdir, epilog_rmdir
     from onyo.cli.set import args_set, epilog_set
     from onyo.cli.shell_completion import args_shell_completion, epilog_shell_completion
     from onyo.cli.tree import args_tree, epilog_tree
@@ -417,6 +418,18 @@ def setup_parser() -> OnyoArgumentParser:
     )
     cmd_rm.set_defaults(run=cli.rm)
     build_parser(cmd_rm, args_rm)
+    #
+    # subcommand "rmdir"
+    #
+    cmd_rmdir = subcmds.add_parser(
+        'rmdir',
+        description=cli.rmdir.__doc__,
+        epilog=epilog_rmdir,
+        formatter_class=parser.formatter_class,
+        help='Delete empty directories or convert empty Asset Directories into Asset Files.'
+    )
+    cmd_rmdir.set_defaults(run=cli.rmdir)
+    build_parser(cmd_rmdir, args_rmdir)
     #
     # subcommand "set"
     #

--- a/onyo/main.py
+++ b/onyo/main.py
@@ -377,7 +377,7 @@ def setup_parser() -> OnyoArgumentParser:
         description=cli.mkdir.__doc__,
         epilog=epilog_mkdir,
         formatter_class=parser.formatter_class,
-        help='Create directories.'
+        help='Create directories and/or convert Asset Files to Asset Directories.'
     )
     cmd_mkdir.set_defaults(run=cli.mkdir)
     build_parser(cmd_mkdir, args_mkdir)

--- a/onyo/shell_completion/zsh
+++ b/onyo/shell_completion/zsh
@@ -61,7 +61,7 @@ _onyo() {
         'get:return matching ASSET values corresponding to the requested KEYs'
         'history:display the history of an ASSET or DIRECTORY'
         'init:initialize a new Onyo repository'
-        'mkdir:create DIRECTORYs'
+        'mkdir:create DIRECTORYs or convert Asset Files to Asset Directories'
         'mv:move SOURCEs (assets and/or directories) to the DEST directory, or rename a SOURCE directory to DEST'
         'new:create new ASSETs and populate with KEY-VALUE pairs'
         'rm:delete ASSETs and DIRECTORYs'

--- a/onyo/shell_completion/zsh
+++ b/onyo/shell_completion/zsh
@@ -65,6 +65,7 @@ _onyo() {
         'mv:move SOURCEs (assets and/or directories) to the DEST directory, or rename a SOURCE directory to DEST'
         'new:create new ASSETs and populate with KEY-VALUE pairs'
         'rm:delete ASSETs and DIRECTORYs'
+        'rmdir:delete empty DIRECTORYs or convert empty Asset Directories to Asset Files'
         'set:set the VALUE of KEYs for ASSETs'
         'shell-completion:display a tab-completion script for Onyo'
         'tree:list the assets and directories of DIRECTORYs in a tree-like format'


### PR DESCRIPTION
It's the counterpart to `mkdir`. It removes empty directories and (more interestingly) converts asset directories into asset files.

fix #648