### PR TITLE
NF/TST: add `<`, `<=`, `>`, and `>=` support to `--match` 

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,6 +27,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        # get proper PyICU (for natsort)
+        sudo apt-get install pkg-config libicu-dev
+        pip install --no-binary=:pyicu: pyicu
+        # install onyo
         pip install -e ".[tests]"
         sudo apt-get install -y zsh
     - name: ruff linting

--- a/onyo/cli/get.py
+++ b/onyo/cli/get.py
@@ -55,13 +55,21 @@ args_get = {
         default=None,
         help=r"""
             Criteria to match in the form ``KEY=VALUE`` — where **VALUE** is a
-            literal string or a python regular expression. All keys can be
+            literal string or a python regular expression. Valid operands are
+            ``=``, ``!=``, ``>``, ``>=``, ``<``, and ``<=``. All keys can be
             matched, and are not limited to those specified by ``--keys``.
-            Special values supported are:
+            Tags supported are:
 
-              * ``<dict>``
-              * ``<list>``
-              * ``<unset>``
+              * ``<bool>``: a boolean
+              * ``<dict>``: a dictionary
+              * ``<empty>``: null or an empty string, dictionary, or list
+              * ``<false>``: ``false``, ``False`` or ``FALSE``
+              * ``<list>``: a list
+              * ``<null>``: ``null``, ``Null``, ``NULL``, ``~``, or nothing
+              * ``<true>``: ``true``, ``True``, or ``TRUE``
+              * ``<unset>``: the key does not exist
+
+            Tags and regular expressions work only with ``=`` and ``!=``.
         """
     ),
 

--- a/onyo/cli/mv.py
+++ b/onyo/cli/mv.py
@@ -65,8 +65,7 @@ Rename a department:
 
 def mv(args: argparse.Namespace) -> None:
     r"""
-    Move **SOURCE**\ s (assets and/or directories) into the **DEST** directory,
-    or rename a **SOURCE** directory to **DEST**.
+    Move **SOURCE**\ s into the **DEST** directory, or rename **SOURCE** to **DEST**.
 
     If **DEST** is an Asset File, it will be converted into an Asset Directory
     and then the **SOURCE**\ s will be moved into it.
@@ -74,6 +73,7 @@ def mv(args: argparse.Namespace) -> None:
     Assets cannot be renamed using ``onyo mv``. Their names are generated from
     keys in their contents. To rename a file, use ``onyo set`` or ``onyo edit``.
     """
+
     inventory = Inventory(repo=OnyoRepo(Path.cwd(), find_root=True))
 
     sources = [Path(p).resolve() for p in args.source]

--- a/onyo/cli/new.py
+++ b/onyo/cli/new.py
@@ -131,8 +131,9 @@ message:
 
 def new(args: argparse.Namespace) -> None:
     r"""
-    Create new **ASSET**\ s and populate with **KEY-VALUE** pairs. Destination
-    directories are created if they are missing.
+    Create new **ASSET**\ s and populate with **KEY-VALUE** pairs.
+
+    Destination directories are created if they are missing.
 
     Asset contents are populated in a waterfall pattern and can overwrite
     values from previous steps:

--- a/onyo/cli/rmdir.py
+++ b/onyo/cli/rmdir.py
@@ -46,12 +46,11 @@ Convert an empty Asset Directory into an Asset File:
 
 def rmdir(args: argparse.Namespace) -> None:
     r"""
-    Delete empty **DIRECTORY**\ s or convert empty Asset Directories into Asset
-    Files.
+    Delete **DIRECTORY**\ s or convert Asset Directories into Asset Files.
 
-    If the **DIRECTORY** does not exist, the path is protected, or the asset is
-    already an Asset File, then Onyo will error and leave everything
-    unmodified.
+    If the **DIRECTORY** is not empty, does not exist, the path is protected, or
+    the asset is already an Asset File, then Onyo will error and leave
+    everything unmodified.
     """
 
     dirs = [Path(d).resolve() for d in args.directory]

--- a/onyo/cli/tests/test_unset.py
+++ b/onyo/cli/tests/test_unset.py
@@ -180,9 +180,8 @@ def test_unset_interactive(repo: OnyoRepo,
 @pytest.mark.parametrize('asset', [t[0] for t in asset_contents if "num" not in t[1]])
 def test_unset_key_does_not_exist(repo: OnyoRepo,
                                   asset: str) -> None:
-    r"""Test that `onyo unset --keys KEY --asset ASSET` does not error when one of the KEYs does not
-    exist.
-    """
+    r"""Do not error when one of the KEYs does not exist."""
+
     no_key = "non_existing"
 
     # test un-setting a non-existing key from an empty file
@@ -285,10 +284,8 @@ def test_unset_discard_changes_single_assets(repo: OnyoRepo,
     ["num", "type"]])
 def test_unset_error_unset_name_fields(repo: OnyoRepo,
                                        name_field: list[str]) -> None:
-    r"""Test that `onyo unset KEY --asset <asset>` raises the correct error without printing the usual
-    information (e.g. diff output), when called with a KEY that is a name field (type, make, model
-    or/and serial number), not a content field.
-    """
+    r"""Error without printing a diff (etc) when called with a KEY that is a name field."""
+
     asset = 'laptop_apple_macbookpro.1'
     ret = subprocess.run(['onyo', '--yes', 'unset', '--keys', *name_field,
                           '--asset', asset],

--- a/onyo/cli/tsv_to_yaml.py
+++ b/onyo/cli/tsv_to_yaml.py
@@ -37,8 +37,7 @@ desired) using ``csplit``.
 
 def tsv_to_yaml(args: argparse.Namespace) -> None:
     r"""
-    Convert a tabular file (e.g. TSV, CSV) to YAML suitable for passing to
-    ``onyo new`` and ``onyo set``.
+    Convert a TSV file into YAML suitable to pass to ``onyo new`` and ``onyo set``.
 
     The header declares the key names to be populated. The values to populate
     documents are declared with one line per YAML document.

--- a/onyo/conftest.py
+++ b/onyo/conftest.py
@@ -44,6 +44,7 @@ def clean_env(request) -> None:
     except KeyError:
         pass
 
+
 def params(d: dict) -> MarkDecorator:
     r"""Parameterize a dictionary with human-friendly names.
 
@@ -123,6 +124,7 @@ class AnnotatedGitRepo(GitRepo):
 
         super().__init__(path, find_root)
         self.test_annotation = None
+
 
 @contextmanager
 def fixture_gitrepo(tmp_path: Path,
@@ -208,6 +210,7 @@ def gitrepo_session_scope(tmp_path: Path,
 
     with fixture_gitrepo(tmp_path, request) as result:
         yield result
+
 
 ########################################
 #
@@ -739,6 +742,7 @@ def fake_class_scope() -> Generator:
 @pytest.fixture(scope='module')
 def fake_module_scope() -> Generator:
     r"""Scope the ``fake`` parameter fixture for modules."""
+
     with fixture_fake() as result:
         yield result
 
@@ -746,5 +750,6 @@ def fake_module_scope() -> Generator:
 @pytest.fixture(scope='session')
 def fake_session_scope() -> Generator:
     r"""Scope the ``fake`` parameter fixture for sessions."""
+
     with fixture_fake() as result:
         yield result

--- a/onyo/conftest.py
+++ b/onyo/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import locale
 import os
 import subprocess
 from collections.abc import Iterable
@@ -43,6 +44,25 @@ def clean_env(request) -> None:
         del os.environ['EDITOR']
     except KeyError:
         pass
+
+
+@pytest.fixture(scope="function", autouse=True)
+def clean_locale(request) -> None:
+    r"""Ensure that the locale is set to 'en_US.UTF-8'.
+
+    Tests that involve sorting can be impacted by the locale. This sets it to a
+    known, static target.
+    """
+
+    lc = 'en_US.UTF-8'
+
+    locale.setlocale(locale.LC_ALL, lc)
+    locale.setlocale(locale.LC_COLLATE, lc)
+    locale.setlocale(locale.LC_CTYPE, lc)
+    locale.setlocale(locale.LC_MESSAGES, lc)
+    locale.setlocale(locale.LC_MONETARY, lc)
+    locale.setlocale(locale.LC_NUMERIC, lc)
+    locale.setlocale(locale.LC_TIME, lc)
 
 
 def params(d: dict) -> MarkDecorator:

--- a/onyo/conftest.py
+++ b/onyo/conftest.py
@@ -245,8 +245,7 @@ class AnnotatedOnyoRepo(OnyoRepo):
 
 @contextmanager
 def fixture_onyorepo(gitrepo,
-                     request,
-                     monkeypatch) -> Generator[AnnotatedOnyoRepo, None, None]:
+                     request) -> Generator[AnnotatedOnyoRepo, None, None]:
     r"""Yield an AnnotatedOnyoRepo object, populated from fixtures.
 
     A fresh repository is created in a unique temporary directory. It is
@@ -329,48 +328,45 @@ def fixture_onyorepo(gitrepo,
     if to_commit:
         onyo.commit(deduplicate(to_commit), "onyorepo: setup")  # pyre-ignore[6] - not None if `to_commit` is not None
 
-    # cd into repo; to ease testing
-    monkeypatch.chdir(gitrepo.root)
-    yield onyo
+    with pytest.MonkeyPatch.context() as m:
+        m.chdir(gitrepo.root)
+
+        yield onyo
 
 
 @pytest.fixture(scope='function', name='onyorepo')
 def onyorepo_function_scope(gitrepo,
-                            request,
-                            monkeypatch) -> Generator:
+                            request) -> Generator:
     r"""Scope the ``onyorepo`` parameter fixture for functions."""
 
-    with fixture_onyorepo(gitrepo, request, monkeypatch) as result:
+    with fixture_onyorepo(gitrepo, request) as result:
         yield result
 
 
 @pytest.fixture(scope='class')
 def onyorepo_class_scope(gitrepo_class_scope,
-                         request,
-                         monkeypatch) -> Generator:
+                         request) -> Generator:
     r"""Scope the ``onyorepo`` parameter fixture for classes."""
 
-    with fixture_onyorepo(gitrepo_class_scope, request, monkeypatch) as result:
+    with fixture_onyorepo(gitrepo_class_scope, request) as result:
         yield result
 
 
 @pytest.fixture(scope='module')
 def onyorepo_module_scope(gitrepo_module_scope,
-                          request,
-                          monkeypatch) -> Generator:
+                          request) -> Generator:
     r"""Scope the ``onyorepo`` parameter fixture for modules."""
 
-    with fixture_onyorepo(gitrepo_module_scope, request, monkeypatch) as result:
+    with fixture_onyorepo(gitrepo_module_scope, request) as result:
         yield result
 
 
 @pytest.fixture(scope='session')
 def onyorepo_session_scope(gitrepo_session_scope,
-                           request,
-                           monkeypatch) -> Generator:
+                           request) -> Generator:
     r"""Scope the ``onyorepo`` parameter fixture for sessions."""
 
-    with fixture_onyorepo(gitrepo_session_scope, request, monkeypatch) as result:
+    with fixture_onyorepo(gitrepo_session_scope, request) as result:
         yield result
 
 
@@ -381,7 +377,6 @@ def onyorepo_session_scope(gitrepo_session_scope,
 ########################################
 @contextmanager
 def fixture_repo(tmp_path: Path,
-                 monkeypatch,
                  request) -> Generator[OnyoRepo, None, None]:
     r"""Yield an OnyoRepo object, populated from fixtures.
 
@@ -443,52 +438,45 @@ def fixture_repo(tmp_path: Path,
         repo_.commit(paths=files,
                      message="populate files for tests")
 
-    # TODO: Do we still need/want that? CWD should only ever be relevant for CLI tests.
-    #       Hence, should probably be done there.
-    # cd into repo; to ease testing
-    monkeypatch.chdir(repo_path)
+    with pytest.MonkeyPatch.context() as m:
+        m.chdir(repo_path)
 
-    # hand it off
-    yield repo_
+        yield repo_
 
 
 @pytest.fixture(scope='function', name='repo')
 def repo_function_scope(tmp_path: Path,
-                        monkeypatch,
                         request) -> Generator:
     r"""Scope the ``repo`` parameter fixture for functions."""
 
-    with fixture_repo(tmp_path, monkeypatch, request) as result:
+    with fixture_repo(tmp_path, request) as result:
         yield result
 
 
 @pytest.fixture(scope='class')
 def repo_class_scope(tmp_path_class_scope: Path,
-                     monkeypatch,
                      request) -> Generator:
     r"""Scope the ``repo`` parameter fixture for classes."""
 
-    with fixture_repo(tmp_path_class_scope, monkeypatch, request) as result:
+    with fixture_repo(tmp_path_class_scope, request) as result:
         yield result
 
 
 @pytest.fixture(scope='module')
 def repo_module_scope(tmp_path_module_scope: Path,
-                      monkeypatch,
                       request) -> Generator:
     r"""Scope the ``repo`` parameter fixture for modules."""
 
-    with fixture_repo(tmp_path_module_scope, monkeypatch, request) as result:
+    with fixture_repo(tmp_path_module_scope, request) as result:
         yield result
 
 
 @pytest.fixture(scope='session')
 def repo_session_scope(tmp_path_session_scope: Path,
-                       monkeypatch,
                        request) -> Generator:
     r"""Scope the ``repo`` parameter fixture for sessions."""
 
-    with fixture_repo(tmp_path_session_scope, monkeypatch, request) as result:
+    with fixture_repo(tmp_path_session_scope, request) as result:
         yield result
 
 

--- a/onyo/conftest.py
+++ b/onyo/conftest.py
@@ -345,32 +345,32 @@ def onyorepo_function_scope(gitrepo,
 
 
 @pytest.fixture(scope='class')
-def onyorepo_class_scope(gitrepo,
+def onyorepo_class_scope(gitrepo_class_scope,
                          request,
                          monkeypatch) -> Generator:
     r"""Scope the ``onyorepo`` parameter fixture for classes."""
 
-    with fixture_onyorepo(gitrepo, request, monkeypatch) as result:
+    with fixture_onyorepo(gitrepo_class_scope, request, monkeypatch) as result:
         yield result
 
 
 @pytest.fixture(scope='module')
-def onyorepo_module_scope(gitrepo,
+def onyorepo_module_scope(gitrepo_module_scope,
                           request,
                           monkeypatch) -> Generator:
     r"""Scope the ``onyorepo`` parameter fixture for modules."""
 
-    with fixture_onyorepo(gitrepo, request, monkeypatch) as result:
+    with fixture_onyorepo(gitrepo_module_scope, request, monkeypatch) as result:
         yield result
 
 
 @pytest.fixture(scope='session')
-def onyorepo_session_scope(gitrepo,
+def onyorepo_session_scope(gitrepo_session_scope,
                            request,
                            monkeypatch) -> Generator:
     r"""Scope the ``onyorepo`` parameter fixture for sessions."""
 
-    with fixture_onyorepo(gitrepo, request, monkeypatch) as result:
+    with fixture_onyorepo(gitrepo_session_scope, request, monkeypatch) as result:
         yield result
 
 
@@ -540,26 +540,26 @@ def inventory_function_scope(repo: OnyoRepo) -> Generator:
 
 
 @pytest.fixture(scope='class')
-def inventory_class_scope(repo: OnyoRepo) -> Generator:
+def inventory_class_scope(repo_class_scope: OnyoRepo) -> Generator:
     r"""Scope the ``inventory`` parameter fixture for classes."""
 
-    with fixture_inventory(repo) as result:
+    with fixture_inventory(repo_class_scope) as result:
         yield result
 
 
 @pytest.fixture(scope='module')
-def inventory_module_scope(repo: OnyoRepo) -> Generator:
+def inventory_module_scope(repo_module_scope: OnyoRepo) -> Generator:
     r"""Scope the ``inventory`` parameter fixture for modules."""
 
-    with fixture_inventory(repo) as result:
+    with fixture_inventory(repo_module_scope) as result:
         yield result
 
 
 @pytest.fixture(scope='session')
-def inventory_session_scope(repo: OnyoRepo) -> Generator:
+def inventory_session_scope(repo_session_scope: OnyoRepo) -> Generator:
     r"""Scope the ``inventory`` parameter fixture for sessions."""
 
-    with fixture_inventory(repo) as result:
+    with fixture_inventory(repo_session_scope) as result:
         yield result
 
 

--- a/onyo/conftest.py
+++ b/onyo/conftest.py
@@ -65,6 +65,36 @@ def params(d: dict) -> MarkDecorator:
         ids=d.keys(),
     )
 
+
+########################################
+#
+# tmp_path
+#
+########################################
+@pytest.fixture(scope="class")
+def tmp_path_class_scope(tmp_path_factory,
+                         request):
+    r"""Scope the ``tmp_path`` parameter fixture for classes."""
+
+    yield tmp_path_factory.mktemp(request.node.name)
+
+
+@pytest.fixture(scope="module")
+def tmp_path_module_scope(tmp_path_factory,
+                          request):
+    r"""Scope the ``tmp_path`` parameter fixture for modules."""
+
+    yield tmp_path_factory.mktemp(request.node.name)
+
+
+@pytest.fixture(scope="session")
+def tmp_path_session_scope(tmp_path_factory,
+                           request):
+    r"""Scope the ``tmp_path`` parameter fixture for sessions."""
+
+    yield tmp_path_factory.mktemp(request.node.name)
+
+
 ########################################
 #
 # gitrepo
@@ -154,20 +184,20 @@ def gitrepo_function_scope(tmp_path: Path,
 
 
 @pytest.fixture(scope='class')
-def gitrepo_class_scope(tmp_path: Path,
+def gitrepo_class_scope(tmp_path_class_scope: Path,
                         request) -> Generator:
     r"""Scope the ``gitrepo`` parameter fixture for classes."""
 
-    with fixture_gitrepo(tmp_path, request) as result:
+    with fixture_gitrepo(tmp_path_class_scope, request) as result:
         yield result
 
 
 @pytest.fixture(scope='module')
-def gitrepo_module_scope(tmp_path: Path,
+def gitrepo_module_scope(tmp_path_module_scope: Path,
                          request) -> Generator:
     r"""Scope the ``gitrepo`` parameter fixture for modules."""
 
-    with fixture_gitrepo(tmp_path, request) as result:
+    with fixture_gitrepo(tmp_path_module_scope, request) as result:
         yield result
 
 
@@ -433,32 +463,32 @@ def repo_function_scope(tmp_path: Path,
 
 
 @pytest.fixture(scope='class')
-def repo_class_scope(tmp_path: Path,
+def repo_class_scope(tmp_path_class_scope: Path,
                      monkeypatch,
                      request) -> Generator:
     r"""Scope the ``repo`` parameter fixture for classes."""
 
-    with fixture_repo(tmp_path, monkeypatch, request) as result:
+    with fixture_repo(tmp_path_class_scope, monkeypatch, request) as result:
         yield result
 
 
 @pytest.fixture(scope='module')
-def repo_module_scope(tmp_path: Path,
+def repo_module_scope(tmp_path_module_scope: Path,
                       monkeypatch,
                       request) -> Generator:
     r"""Scope the ``repo`` parameter fixture for modules."""
 
-    with fixture_repo(tmp_path, monkeypatch, request) as result:
+    with fixture_repo(tmp_path_module_scope, monkeypatch, request) as result:
         yield result
 
 
 @pytest.fixture(scope='session')
-def repo_session_scope(tmp_path: Path,
+def repo_session_scope(tmp_path_session_scope: Path,
                        monkeypatch,
                        request) -> Generator:
     r"""Scope the ``repo`` parameter fixture for sessions."""
 
-    with fixture_repo(tmp_path, monkeypatch, request) as result:
+    with fixture_repo(tmp_path_session_scope, monkeypatch, request) as result:
         yield result
 
 

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -511,7 +511,7 @@ def onyo_get(inventory: Inventory,
         Invalid argument
     """
 
-    from .consts import TYPE_SYMBOL_MAPPING, UNSET_VALUE
+    from onyo.lib.consts import TAG_MAP_OUTPUT, TAG_UNSET
 
     selected_keys = keys.copy() if keys else None
     include = include or [inventory.root]
@@ -541,13 +541,13 @@ def onyo_get(inventory: Inventory,
         keys=sort or {'onyo.path.relative': SORT_ASCENDING})  # pyre-ignore[6]
 
     # reduce results to just the `selected_keys`
-    results = [{k: r[k] if k in r and r[k] not in [None, ""] else UNSET_VALUE
+    results = [{k: r[k] if k in r else TAG_UNSET
                 for k in selected_keys}
                for r in results]
 
     # replace structures with an indication of type.
-    for symbol in TYPE_SYMBOL_MAPPING:
-        results = [{k: symbol if isinstance(v, TYPE_SYMBOL_MAPPING[symbol]) else v
+    for symbol in TAG_MAP_OUTPUT:
+        results = [{k: symbol if isinstance(v, TAG_MAP_OUTPUT[symbol]) else v
                     for k, v in r.items()}
                    for r in results]
 

--- a/onyo/lib/consts.py
+++ b/onyo/lib/consts.py
@@ -1,8 +1,10 @@
 from collections import UserDict
 from pathlib import Path
+from types import NoneType
 from typing import TYPE_CHECKING
 
 from onyo.lib.pseudokeys import PSEUDOKEY_ALIASES
+
 if TYPE_CHECKING:
     from typing import Literal
     sort_t = Literal['ascending', 'descending']
@@ -35,17 +37,82 @@ r"""Sort descending.
 Use to sort the output of :py:func:`onyo_get`.
 """
 
-UNSET_VALUE = '<unset>'
-r"""Type-symbol for unset keys.
+TAG_BOOL = '<bool>'
+r"""Tag symbol for keys with a boolean as the value.
+
+Use for type matching (:py:func:`onyo_get`).
+"""
+
+TAG_DICT = '<dict>'
+r"""Tag symbol for keys with a dict as the value.
 
 Use for type matching (:py:func:`onyo_get`) and output.
 """
 
-TYPE_SYMBOL_MAPPING = {"<dict>": (dict, UserDict),
-                       "<list>": list}
-r"""Mapping of Onyo type-symbols with Python types.
+TAG_EMPTY = '<empty>'
+r"""Tag symbol for keys set to null or are an empty string, dictionary, or list.
+
+Use for type matching (:py:func:`onyo_get`).
+"""
+
+TAG_FALSE = '<false>'
+r"""Tag symbol for keys with False as the value.
+
+Use for type matching (:py:func:`onyo_get`).
+"""
+
+TAG_LIST = '<list>'
+r"""Tag symbol for keys with a list as the value.
 
 Use for type matching (:py:func:`onyo_get`) and output.
+"""
+
+TAG_NULL = '<null>'
+r"""Tag symbol for keys with a null value.
+
+Use for type matching (:py:func:`onyo_get`) and output.
+"""
+
+TAG_TRUE = '<true>'
+r"""Tag symbol for keys with True as the value.
+
+Use for type matching (:py:func:`onyo_get`).
+"""
+
+TAG_UNSET = '<unset>'
+r"""Tag symbol for unset keys.
+
+Use for type matching (:py:func:`onyo_get`) and output.
+"""
+
+TAG_MAP_TYPES = {
+    TAG_BOOL: bool,
+    TAG_DICT: (dict, UserDict),
+    TAG_LIST: list,
+}
+r"""Mapping of Onyo type-symbols with Python types.
+
+Use for type matching (:py:func:`onyo_get`) queries.
+"""
+
+TAG_MAP_VALUES = {
+    TAG_FALSE: False,
+    TAG_NULL: None,
+    TAG_TRUE: True,
+}
+r"""Mapping of Onyo value symbols with Python values.
+
+Use for type matching (:py:func:`onyo_get`) queries.
+"""
+
+TAG_MAP_OUTPUT = {
+    TAG_DICT: (dict, UserDict),
+    TAG_LIST: list,
+    TAG_NULL: NoneType,
+}
+r"""Mapping of Onyo types/values for user-oriented output.
+
+Use for :py:func:`onyo_get` output.
 """
 
 ONYO_DIR = Path('.onyo')

--- a/onyo/lib/filters.py
+++ b/onyo/lib/filters.py
@@ -39,7 +39,7 @@ class Filter:
     _arg: str = field(repr=False)
     key: str = field(init=False)
     value: str = field(init=False)
-    operand: str = field(init=False)
+    operator: str = field(init=False)
 
     def __post_init__(self) -> None:
         r"""Set up a ``key=value`` conditional as a filter.
@@ -47,13 +47,13 @@ class Filter:
         ``value`` must be a valid Python regular expression.
         """
 
-        self.key, self.operand, self.value = self._format(self._arg)
+        self.key, self.operator, self.value = self._format(self._arg)
 
     @staticmethod
     def _format(arg: str) -> Tuple[str, str, str]:
-        r"""Split filters on the first occurrence of an operand.
+        r"""Split filters on the first occurrence of an operator.
 
-        Valid operands are ``=``, ``!=``, ``>``, ``>=``, ``<``, and ``<=``.
+        Valid operators are ``=``, ``!=``, ``>``, ``>=``, ``<``, and ``<=``.
 
         Parameters
         ----------
@@ -63,7 +63,7 @@ class Filter:
         Raises
         ------
         OnyoInvalidFilterError
-            No valid operand was found.
+            No valid operator was found.
         """
 
         index = None
@@ -78,21 +78,21 @@ class Filter:
 
         match arg[index:index + 2]:
             case "<=":
-                operand = "<="
+                operator = "<="
             case ">=":
-                operand = ">="
+                operator = ">="
             case "!=":
-                operand = "!="
+                operator = "!="
             case _:
-                operand = arg[index]
+                operator = arg[index]
 
-        if index in (0, len(arg) - len(operand)):
+        if index in (0, len(arg) - len(operator)):
             raise OnyoInvalidFilterError(
                 'Filters must be formatted as `key=value`')
 
-        key, value = arg.split(operand, 1)
+        key, value = arg.split(operator, 1)
 
-        return key, operand, value
+        return key, operator, value
 
     @staticmethod
     def _re_match(text: str,
@@ -322,11 +322,11 @@ class Filter:
         Raises
         ------
         OnyoInvalidFilterError
-            No valid operand was found.
+            No valid operator was found.
         """
 
         try:
-            match self.operand:
+            match self.operator:
                 case "=":
                     return self._match_equal_with_re(item)
                 case "!=":

--- a/onyo/lib/git.py
+++ b/onyo/lib/git.py
@@ -51,8 +51,7 @@ class GitRepo(object):
 
     @staticmethod
     def find_root(path: Path) -> Path:
-        r"""Return the absolute path of the git worktree root that ``path``
-        belongs to.
+        r"""Return the absolute path of the git worktree root that ``path`` belongs to.
 
         Checks ``path`` itself and each of its parents.
 
@@ -340,8 +339,7 @@ class GitRepo(object):
     def check_ignore(self,
                      ignore: Path,
                      paths: list[Path]) -> list[Path]:
-        r"""Get the subset of ``paths`` that are matched by patterns defined in
-        the ``ignore`` file.
+        r"""Get the subset of ``paths`` that match patterns defined in ``ignore``.
 
         Parameters
         ----------

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -56,8 +56,7 @@ class OnyoRepo(object):
                  path: Path,
                  init: bool = False,
                  find_root: bool = False) -> None:
-        r"""Instantiate an ``OnyoRepo`` object with ``path`` as the root
-        directory.
+        r"""Instantiate an ``OnyoRepo`` object with ``path`` as the root directory.
 
         Parameters
         ----------
@@ -227,8 +226,7 @@ class OnyoRepo(object):
         return editor
 
     def clear_cache(self) -> None:
-        r"""Clear the cache of this instance of OnyoRepo (and the
-        sub-:py:class:`onyo.lib.git.GitRepo`).
+        r"""Clear the cache of this instance of OnyoRepo (and the sub-:py:class:`onyo.lib.git.GitRepo`).
 
         When the repository is modified using only the public API functions, the
         cache is consistent. This method is only necessary if the repository is

--- a/onyo/lib/tests/test_Filter.py
+++ b/onyo/lib/tests/test_Filter.py
@@ -100,7 +100,7 @@ def test_filter_invalid(filter_arg: str) -> None:
     """Invalid filters raise the correct exception."""
 
     with pytest.raises(OnyoInvalidFilterError) as exc:
-        Filter('key')
+        Filter(filter_arg)
 
     assert 'Filters must be formatted as `key=value`' in str(exc.value)
 

--- a/onyo/lib/tests/test_Filter.py
+++ b/onyo/lib/tests/test_Filter.py
@@ -46,7 +46,7 @@ class TestFilter:
 
         f = Filter(filt)
         assert f.key == filt.split('=', 1)[0]
-        assert f.operand == '='
+        assert f.operator == '='
         assert f.value == filt.split('=', 1)[1]
 
         match filt.split('=', 1)[1]:
@@ -76,7 +76,7 @@ class TestFilter:
 
         f = Filter(filt)
         assert f.key == filt.split('!=', 1)[0]
-        assert f.operand == '!='
+        assert f.operator == '!='
         assert f.value == filt.split('!=', 1)[1]
 
         match filt.split('=', 1)[1]:
@@ -106,7 +106,7 @@ class TestFilter:
 
         f = Filter(filt)
         assert f.key == filt.split('>', 1)[0]
-        assert f.operand == '>'
+        assert f.operator == '>'
         assert f.value == filt.split('>', 1)[1]
         assert not f.match(self.read_asset('laptop_make_model.1'))
 
@@ -134,7 +134,7 @@ class TestFilter:
 
         f = Filter(filt)
         assert f.key == filt.split('>=', 1)[0]
-        assert f.operand == '>='
+        assert f.operator == '>='
         assert f.value == filt.split('>=', 1)[1]
 
         match filt.split('>=', 1)[1]:
@@ -164,7 +164,7 @@ class TestFilter:
 
         f = Filter(filt)
         assert f.key == filt.split('<', 1)[0]
-        assert f.operand == '<'
+        assert f.operator == '<'
         assert f.value == filt.split('<', 1)[1]
 
         match filt.split('<', 1)[1]:
@@ -194,7 +194,7 @@ class TestFilter:
 
         f = Filter(filt)
         assert f.key == filt.split('<=', 1)[0]
-        assert f.operand == '<='
+        assert f.operator == '<='
         assert f.value == filt.split('<=', 1)[1]
 
         match filt.split('<=', 1)[1]:
@@ -262,7 +262,7 @@ class TestFilterRegex:
 
         f = Filter(filt)
         assert f.key == filt.split('=', 1)[0]
-        assert f.operand == '='
+        assert f.operator == '='
         assert f.value == filt.split('=', 1)[1]
 
         if f.key == 'missing':
@@ -311,7 +311,7 @@ class TestFilterRegex:
 
         f = Filter(filt)
         assert f.key == filt.split('!=', 1)[0]
-        assert f.operand == '!='
+        assert f.operator == '!='
         assert f.value == filt.split('!=', 1)[1]
 
         if f.key == 'missing':
@@ -475,7 +475,7 @@ class TestFilterTags:
 
         f = Filter(filt)
         assert f.key == filt.split('=', 1)[0]
-        assert f.operand == '='
+        assert f.operator == '='
         assert f.value == filt.split('=', 1)[1]
 
         if f.key == 'missing':
@@ -534,7 +534,7 @@ class TestFilterTags:
 
         f = Filter(filt)
         assert f.key == filt.split('!=', 1)[0]
-        assert f.operand == '!='
+        assert f.operator == '!='
         assert f.value == filt.split('!=', 1)[1]
 
         if f.key == 'missing':
@@ -619,7 +619,7 @@ class TestFilterTags:
 
         f = Filter(filt)
         assert f.key == filt.split('=', 1)[0]
-        assert f.operand == '='
+        assert f.operator == '='
         assert f.value == filt.split('=', 1)[1]
 
         if f.key == 'missing':
@@ -688,7 +688,7 @@ class TestFilterTags:
 
         f = Filter(filt)
         assert f.key == filt.split('!=', 1)[0]
-        assert f.operand == '!='
+        assert f.operator == '!='
         assert f.value == filt.split('!=', 1)[1]
 
         if f.key == 'missing':
@@ -783,7 +783,7 @@ class TestFilterTags:
 
         f = Filter(filt)
         assert f.key == filt.split('=', 1)[0]
-        assert f.operand == '='
+        assert f.operator == '='
         assert f.value == filt.split('=', 1)[1]
 
         match f.key:
@@ -820,7 +820,7 @@ class TestFilterTags:
 
         f = Filter(filt)
         assert f.key == filt.split('!=', 1)[0]
-        assert f.operand == '!='
+        assert f.operator == '!='
         assert f.value == filt.split('!=', 1)[1]
 
         match f.key:
@@ -927,7 +927,7 @@ class TestFilterLiterals:
 
         f = Filter(filt)
         assert f.key == filt.split('=', 1)[0]
-        assert f.operand == '='
+        assert f.operator == '='
         assert f.value == filt.split('=', 1)[1]
 
         if f.key == 'missing':
@@ -986,7 +986,7 @@ class TestFilterLiterals:
 
         f = Filter(filt)
         assert f.key == filt.split('!=', 1)[0]
-        assert f.operand == '!='
+        assert f.operator == '!='
         assert f.value == filt.split('!=', 1)[1]
 
         if f.key == 'missing':
@@ -1045,7 +1045,7 @@ class TestFilterLiterals:
 
         f = Filter(filt)
         assert f.key == filt.split('>', 1)[0]
-        assert f.operand == '>'
+        assert f.operator == '>'
         assert f.value == filt.split('>', 1)[1]
 
         if f.key == 'missing':
@@ -1104,7 +1104,7 @@ class TestFilterLiterals:
 
         f = Filter(filt)
         assert f.key == filt.split('>=', 1)[0]
-        assert f.operand == '>='
+        assert f.operator == '>='
         assert f.value == filt.split('>=', 1)[1]
 
         if f.key == 'missing':
@@ -1163,7 +1163,7 @@ class TestFilterLiterals:
 
         f = Filter(filt)
         assert f.key == filt.split('<', 1)[0]
-        assert f.operand == '<'
+        assert f.operator == '<'
         assert f.value == filt.split('<', 1)[1]
 
         # nothing can be less than empty
@@ -1189,7 +1189,7 @@ class TestFilterLiterals:
 
         f = Filter(filt)
         assert f.key == filt.split('<=', 1)[0]
-        assert f.operand == '<='
+        assert f.operator == '<='
         assert f.value == filt.split('<=', 1)[1]
 
         if f.key == 'missing':
@@ -1253,7 +1253,7 @@ def test_filter_invalid(filter_arg: str) -> None:
 
 
 def test_filter_format() -> None:
-    """Split filter string into ``key``, ``operand``, and ``value`` properties."""
+    """Split filter string into ``key``, ``operator``, and ``value`` properties."""
 
     # =
     assert Filter._format('key=value') == ('key', '=', 'value')

--- a/onyo/lib/tests/test_Filter.py
+++ b/onyo/lib/tests/test_Filter.py
@@ -5,11 +5,13 @@ from onyo.lib.filters import Filter
 from onyo.lib.items import Item
 
 
-@pytest.mark.parametrize('filt', ['type=laptop', 'key=value', 'foo=<unset>'])
-def test_filter(filt: str) -> None:
-    """Test whether ``Filter`` object are set up, including post-initialization."""
+class TestFilter:
 
-    def read_asset(name: str) -> Item:
+    def read_asset(self,
+                   name: str) -> Item:
+        r"""
+        """
+
         if name == 'laptop_make_model.1':
             return Item(type='laptop',
                         make='make',
@@ -42,25 +44,221 @@ def test_filter(filt: str) -> None:
         else:
             raise ValueError("Unknown asset")
 
-    f = Filter(filt)
-    assert f.key == filt.split('=', 1)[0]
-    assert f.operand == '='
-    assert f.value == filt.split('=', 1)[1]
-    assert f.match(read_asset('laptop_make_model.1'))
-    assert not f.match(read_asset('monitor_make_model.2'))
+    @pytest.mark.parametrize('filt', ['type=laptop', 'key=value', 'foo=<unset>', 'serial=2'])
+    def test_filter_equal(self,
+                          filt: str) -> None:
+        """Test whether ``Filter`` object are set up, including post-initialization."""
 
-    if filt.split('=', 1)[1] == '<unset>':
-        assert f.match(read_asset('headphones_make_model.3'))
-        assert f.match(read_asset('wheelchair_make_model.4'))
-        assert f.match(read_asset('wheelchair_make_model.5'))
-    else:
-        assert not f.match(read_asset('headphones_make_model.3'))
-        assert not f.match(read_asset('wheelchair_make_model.4'))
-        assert not f.match(read_asset('wheelchair_make_model.5'))
+        f = Filter(filt)
+        assert f.key == filt.split('=', 1)[0]
+        assert f.operand == '='
+        assert f.value == filt.split('=', 1)[1]
 
+        match filt.split('=', 1)[1]:
+            case 'laptop':
+                assert f.match(self.read_asset('laptop_make_model.1'))
+                assert not f.match(self.read_asset('monitor_make_model.2'))
+                assert not f.match(self.read_asset('headphones_make_model.3'))
+                assert not f.match(self.read_asset('wheelchair_make_model.4'))
+                assert not f.match(self.read_asset('wheelchair_make_model.5'))
+            case 'value':
+                assert f.match(self.read_asset('laptop_make_model.1'))
+                assert not f.match(self.read_asset('monitor_make_model.2'))
+                assert not f.match(self.read_asset('headphones_make_model.3'))
+                assert not f.match(self.read_asset('wheelchair_make_model.4'))
+                assert not f.match(self.read_asset('wheelchair_make_model.5'))
+            case '<unset>':
+                assert f.match(self.read_asset('laptop_make_model.1'))
+                assert not f.match(self.read_asset('monitor_make_model.2'))
+                assert f.match(self.read_asset('headphones_make_model.3'))
+                assert f.match(self.read_asset('wheelchair_make_model.4'))
+                assert f.match(self.read_asset('wheelchair_make_model.5'))
+            case '2':
+                assert not f.match(self.read_asset('laptop_make_model.1'))
+                assert f.match(self.read_asset('monitor_make_model.2'))
+                assert not f.match(self.read_asset('headphones_make_model.3'))
+                assert not f.match(self.read_asset('wheelchair_make_model.4'))
+                assert not f.match(self.read_asset('wheelchair_make_model.5'))
+
+    @pytest.mark.parametrize('filt', ['type!=laptop', 'key!=value', 'foo!=<unset>', 'serial!=2'])
+    def test_filter_not_equal(self,
+                              filt: str) -> None:
+        """Test whether ``Filter`` object are set up, including post-initialization."""
+
+        f = Filter(filt)
+        assert f.key == filt.split('!=', 1)[0]
+        assert f.operand == '!='
+        assert f.value == filt.split('!=', 1)[1]
+
+        match filt.split('=', 1)[1]:
+            case 'laptop':
+                assert not f.match(self.read_asset('laptop_make_model.1'))
+                assert f.match(self.read_asset('monitor_make_model.2'))
+                assert f.match(self.read_asset('headphones_make_model.3'))
+                assert f.match(self.read_asset('wheelchair_make_model.4'))
+                assert f.match(self.read_asset('wheelchair_make_model.5'))
+            case 'value':
+                assert not f.match(self.read_asset('laptop_make_model.1'))
+                assert f.match(self.read_asset('monitor_make_model.2'))
+                assert f.match(self.read_asset('headphones_make_model.3'))
+                assert f.match(self.read_asset('wheelchair_make_model.4'))
+                assert f.match(self.read_asset('wheelchair_make_model.5'))
+            case '<unset>':
+                assert not f.match(self.read_asset('laptop_make_model.1'))
+                assert f.match(self.read_asset('monitor_make_model.2'))
+                assert not f.match(self.read_asset('headphones_make_model.3'))
+                assert not f.match(self.read_asset('wheelchair_make_model.4'))
+                assert not f.match(self.read_asset('wheelchair_make_model.5'))
+            case '2':
+                assert f.match(self.read_asset('laptop_make_model.1'))
+                assert not f.match(self.read_asset('monitor_make_model.2'))
+                assert f.match(self.read_asset('headphones_make_model.3'))
+                assert f.match(self.read_asset('wheelchair_make_model.4'))
+                assert f.match(self.read_asset('wheelchair_make_model.5'))
+
+    @pytest.mark.parametrize('filt', ['type>laptop', 'key>value', 'foo><unset>', 'serial>2'])
+    def test_filter_greater_than(self,
+                                 filt: str) -> None:
+        """Test whether ``Filter`` object are set up, including post-initialization."""
+
+        f = Filter(filt)
+        assert f.key == filt.split('>', 1)[0]
+        assert f.operand == '>'
+        assert f.value == filt.split('>', 1)[1]
+        assert not f.match(self.read_asset('laptop_make_model.1'))
+
+        match filt.split('>', 1)[1]:
+            case 'laptop':
+                assert f.match(self.read_asset('monitor_make_model.2'))
+                assert not f.match(self.read_asset('headphones_make_model.3'))
+                assert f.match(self.read_asset('wheelchair_make_model.4'))
+                assert f.match(self.read_asset('wheelchair_make_model.5'))
+            case 'value':
+                assert not f.match(self.read_asset('monitor_make_model.2'))
+                assert not f.match(self.read_asset('headphones_make_model.3'))
+                assert not f.match(self.read_asset('wheelchair_make_model.4'))
+                assert not f.match(self.read_asset('wheelchair_make_model.5'))
+            case '<unset>':
+                assert not f.match(self.read_asset('monitor_make_model.2'))
+                assert not f.match(self.read_asset('headphones_make_model.3'))
+                assert not f.match(self.read_asset('wheelchair_make_model.4'))
+                assert not f.match(self.read_asset('wheelchair_make_model.5'))
+            case '2':
+                assert not f.match(self.read_asset('monitor_make_model.2'))
+                assert f.match(self.read_asset('headphones_make_model.3'))
+                assert f.match(self.read_asset('wheelchair_make_model.4'))
+                assert f.match(self.read_asset('wheelchair_make_model.5'))
+
+    @pytest.mark.parametrize('filt', ['type>=laptop', 'key>=value', 'foo>=<unset>', 'serial>=2'])
+    def test_filter_greater_than_or_equal(self,
+                                          filt: str) -> None:
+        """Test whether ``Filter`` object are set up, including post-initialization."""
+
+        f = Filter(filt)
+        assert f.key == filt.split('>=', 1)[0]
+        assert f.operand == '>='
+        assert f.value == filt.split('>=', 1)[1]
+
+        match filt.split('>=', 1)[1]:
+            case 'laptop':
+                assert f.match(self.read_asset('laptop_make_model.1'))
+                assert f.match(self.read_asset('monitor_make_model.2'))
+                assert not f.match(self.read_asset('headphones_make_model.3'))
+                assert f.match(self.read_asset('wheelchair_make_model.4'))
+                assert f.match(self.read_asset('wheelchair_make_model.5'))
+            case 'value':
+                assert f.match(self.read_asset('laptop_make_model.1'))
+                assert not f.match(self.read_asset('monitor_make_model.2'))
+                assert not f.match(self.read_asset('headphones_make_model.3'))
+                assert not f.match(self.read_asset('wheelchair_make_model.4'))
+                assert not f.match(self.read_asset('wheelchair_make_model.5'))
+            case '<unset>':
+                assert f.match(self.read_asset('laptop_make_model.1'))
+                assert not f.match(self.read_asset('monitor_make_model.2'))
+                assert f.match(self.read_asset('headphones_make_model.3'))
+                assert f.match(self.read_asset('wheelchair_make_model.4'))
+                assert f.match(self.read_asset('wheelchair_make_model.5'))
+            case '2':
+                assert not f.match(self.read_asset('laptop_make_model.1'))
+                assert f.match(self.read_asset('monitor_make_model.2'))
+                assert f.match(self.read_asset('headphones_make_model.3'))
+                assert f.match(self.read_asset('wheelchair_make_model.4'))
+                assert f.match(self.read_asset('wheelchair_make_model.5'))
+
+    @pytest.mark.parametrize('filt', ['type<laptop', 'key<value', 'foo<<unset>', 'serial<2'])
+    def test_filter_less_than(self,
+                              filt: str) -> None:
+        """Test whether ``Filter`` object are set up, including post-initialization."""
+
+        f = Filter(filt)
+        assert f.key == filt.split('<', 1)[0]
+        assert f.operand == '<'
+        assert f.value == filt.split('<', 1)[1]
+
+        match filt.split('<', 1)[1]:
+            case 'laptop':
+                assert not f.match(self.read_asset('laptop_make_model.1'))
+                assert not f.match(self.read_asset('monitor_make_model.2'))
+                assert f.match(self.read_asset('headphones_make_model.3'))
+                assert not f.match(self.read_asset('wheelchair_make_model.4'))
+                assert not f.match(self.read_asset('wheelchair_make_model.5'))
+            case 'value':
+                assert not f.match(self.read_asset('laptop_make_model.1'))
+                assert not f.match(self.read_asset('monitor_make_model.2'))
+                assert not f.match(self.read_asset('headphones_make_model.3'))
+                assert not f.match(self.read_asset('wheelchair_make_model.4'))
+                assert not f.match(self.read_asset('wheelchair_make_model.5'))
+            case '<unset>':
+                assert not f.match(self.read_asset('laptop_make_model.1'))
+                assert not f.match(self.read_asset('monitor_make_model.2'))
+                assert not f.match(self.read_asset('headphones_make_model.3'))
+                assert not f.match(self.read_asset('wheelchair_make_model.4'))
+                assert not f.match(self.read_asset('wheelchair_make_model.5'))
+            case '2':
+                assert f.match(self.read_asset('laptop_make_model.1'))
+                assert not f.match(self.read_asset('monitor_make_model.2'))
+                assert not f.match(self.read_asset('headphones_make_model.3'))
+                assert not f.match(self.read_asset('wheelchair_make_model.4'))
+                assert not f.match(self.read_asset('wheelchair_make_model.5'))
+
+    @pytest.mark.parametrize('filt', ['type<=laptop', 'key<=value', 'foo<=<unset>', 'serial<=2'])
+    def test_filter_less_than_or_equal(self,
+                                       filt: str) -> None:
+        """Test whether ``Filter`` object are set up, including post-initialization."""
+
+        f = Filter(filt)
+        assert f.key == filt.split('<=', 1)[0]
+        assert f.operand == '<='
+        assert f.value == filt.split('<=', 1)[1]
+
+        match filt.split('<=', 1)[1]:
+            case 'laptop':
+                assert f.match(self.read_asset('laptop_make_model.1'))
+                assert not f.match(self.read_asset('monitor_make_model.2'))
+                assert f.match(self.read_asset('headphones_make_model.3'))
+                assert not f.match(self.read_asset('wheelchair_make_model.4'))
+                assert not f.match(self.read_asset('wheelchair_make_model.5'))
+            case 'value':
+                assert f.match(self.read_asset('laptop_make_model.1'))
+                assert not f.match(self.read_asset('monitor_make_model.2'))
+                assert not f.match(self.read_asset('headphones_make_model.3'))
+                assert not f.match(self.read_asset('wheelchair_make_model.4'))
+                assert not f.match(self.read_asset('wheelchair_make_model.5'))
+            case '<unset>':
+                assert f.match(self.read_asset('laptop_make_model.1'))
+                assert not f.match(self.read_asset('monitor_make_model.2'))
+                assert f.match(self.read_asset('headphones_make_model.3'))
+                assert f.match(self.read_asset('wheelchair_make_model.4'))
+                assert f.match(self.read_asset('wheelchair_make_model.5'))
+            case '2':
+                assert f.match(self.read_asset('laptop_make_model.1'))
+                assert f.match(self.read_asset('monitor_make_model.2'))
+                assert not f.match(self.read_asset('headphones_make_model.3'))
+                assert not f.match(self.read_asset('wheelchair_make_model.4'))
+                assert not f.match(self.read_asset('wheelchair_make_model.5'))
 
 @pytest.mark.parametrize('filt', ['key=<list>', 'key=<dict>'])
-def test_filter_match_type(filt: str) -> None:
+def test_filter_type_equal(filt: str) -> None:
     """Filtering by variable type (e.g., <list> or <dict>)."""
 
     def read_asset(name: str):
@@ -87,7 +285,355 @@ def test_filter_match_type(filt: str) -> None:
         assert f.match(read_asset('type_make_model.2'))
 
 
-def test_filter_re_match() -> None:
+@pytest.mark.parametrize('filt', ['key><list>', 'key><dict>'])
+def test_filter_type_greater_than(filt: str) -> None:
+    """Filtering by variable type (e.g., <list> or <dict>)."""
+
+    def read_asset(name: str):
+        if name == 'type_make_model.1':
+            return dict(type='type',
+                        make='make',
+                        model='model',
+                        serial='1',
+                        key=['a', 'b', 'c'])
+        elif name == 'type_make_model.2':
+            return dict(type='type',
+                        make='make',
+                        model='model',
+                        serial='2',
+                        key={'a': 'b', 'c': 'd'})
+
+    string_type = filt.split('>', 1)[1]
+    f = Filter(filt)
+    if string_type == '<list>':
+        assert not f.match(read_asset('type_make_model.1'))
+        assert not f.match(read_asset('type_make_model.2'))
+    elif string_type == '<dict>':
+        assert not f.match(read_asset('type_make_model.1'))
+        assert not f.match(read_asset('type_make_model.2'))
+
+
+@pytest.mark.parametrize('filt', ['key>=<list>', 'key>=<dict>'])
+def test_filter_type_greater_than_or_equal(filt: str) -> None:
+    """Filtering by variable type (e.g., <list> or <dict>)."""
+
+    def read_asset(name: str):
+        if name == 'type_make_model.1':
+            return dict(type='type',
+                        make='make',
+                        model='model',
+                        serial='1',
+                        key=['a', 'b', 'c'])
+        elif name == 'type_make_model.2':
+            return dict(type='type',
+                        make='make',
+                        model='model',
+                        serial='2',
+                        key={'a': 'b', 'c': 'd'})
+
+    string_type = filt.split('>=', 1)[1]
+    f = Filter(filt)
+    if string_type == '<list>':
+        assert f.match(read_asset('type_make_model.1'))
+        assert not f.match(read_asset('type_make_model.2'))
+    elif string_type == '<dict>':
+        assert not f.match(read_asset('type_make_model.1'))
+        assert f.match(read_asset('type_make_model.2'))
+
+
+@pytest.mark.parametrize('filt', ['key<<list>', 'key<<dict>'])
+def test_filter_type_less_than(filt: str) -> None:
+    """Filtering by variable type (e.g., <list> or <dict>)."""
+
+    def read_asset(name: str):
+        if name == 'type_make_model.1':
+            return dict(type='type',
+                        make='make',
+                        model='model',
+                        serial='1',
+                        key=['a', 'b', 'c'])
+        elif name == 'type_make_model.2':
+            return dict(type='type',
+                        make='make',
+                        model='model',
+                        serial='2',
+                        key={'a': 'b', 'c': 'd'})
+
+    string_type = filt.split('<', 1)[1]
+    f = Filter(filt)
+    if string_type == '<list>':
+        assert not f.match(read_asset('type_make_model.1'))
+        assert not f.match(read_asset('type_make_model.2'))
+    elif string_type == '<dict>':
+        assert not f.match(read_asset('type_make_model.1'))
+        assert not f.match(read_asset('type_make_model.2'))
+
+
+@pytest.mark.parametrize('filt', ['key<=<list>', 'key<=<dict>'])
+def test_filter_type_less_than_or_equal(filt: str) -> None:
+    """Filtering by variable type (e.g., <list> or <dict>)."""
+
+    def read_asset(name: str):
+        if name == 'type_make_model.1':
+            return dict(type='type',
+                        make='make',
+                        model='model',
+                        serial='1',
+                        key=['a', 'b', 'c'])
+        if name == 'type_make_model.2':
+            return dict(type='type',
+                        make='make',
+                        model='model',
+                        serial='2',
+                        key=[])
+        elif name == 'type_make_model.3':
+            return dict(type='type',
+                        make='make',
+                        model='model',
+                        serial='3',
+                        key={'a': 'b', 'c': 'd'})
+        elif name == 'type_make_model.4':
+            return dict(type='type',
+                        make='make',
+                        model='model',
+                        serial='4',
+                        key={})
+
+    string_type = filt.split('<=', 1)[1]
+    f = Filter(filt)
+    if string_type == '<list>':
+        assert f.match(read_asset('type_make_model.1'))
+        assert f.match(read_asset('type_make_model.2'))
+        assert not f.match(read_asset('type_make_model.3'))
+        assert not f.match(read_asset('type_make_model.4'))
+    elif string_type == '<dict>':
+        assert not f.match(read_asset('type_make_model.1'))
+        assert not f.match(read_asset('type_make_model.2'))
+        assert f.match(read_asset('type_make_model.3'))
+        assert f.match(read_asset('type_make_model.4'))
+
+
+@pytest.mark.parametrize('filt', ['key=[]', 'key={}'])
+def test_filter_empty_literal_equal(filt: str) -> None:
+    """Filtering by variable type (e.g., <list> or <dict>)."""
+
+    def read_asset(name: str):
+        if name == 'type_make_model.1':
+            return dict(type='type',
+                        make='make',
+                        model='model',
+                        serial='1',
+                        key=['a', 'b', 'c'])
+        if name == 'type_make_model.2':
+            return dict(type='type',
+                        make='make',
+                        model='model',
+                        serial='2',
+                        key=[])
+        elif name == 'type_make_model.3':
+            return dict(type='type',
+                        make='make',
+                        model='model',
+                        serial='3',
+                        key={'a': 'b', 'c': 'd'})
+        elif name == 'type_make_model.4':
+            return dict(type='type',
+                        make='make',
+                        model='model',
+                        serial='4',
+                        key={})
+
+    string_type = filt.split('=', 1)[1]
+    f = Filter(filt)
+    if string_type == '[]':
+        assert not f.match(read_asset('type_make_model.1'))
+        assert f.match(read_asset('type_make_model.2'))
+        assert not f.match(read_asset('type_make_model.3'))
+        assert not f.match(read_asset('type_make_model.4'))
+    elif string_type == '{}':
+        assert not f.match(read_asset('type_make_model.1'))
+        assert not f.match(read_asset('type_make_model.2'))
+        assert not f.match(read_asset('type_make_model.3'))
+        assert f.match(read_asset('type_make_model.4'))
+
+
+@pytest.mark.parametrize('filt', ['key>[]', 'key>{}'])
+def test_filter_empty_literal_greater_than(filt: str) -> None:
+    """Compare against a literal empty value (e.g., [] or {})."""
+
+    def read_asset(name: str):
+        if name == 'type_make_model.1':
+            return dict(type='type',
+                        make='make',
+                        model='model',
+                        serial='1',
+                        key=['a', 'b', 'c'])
+        if name == 'type_make_model.2':
+            return dict(type='type',
+                        make='make',
+                        model='model',
+                        serial='2',
+                        key=[])
+        elif name == 'type_make_model.3':
+            return dict(type='type',
+                        make='make',
+                        model='model',
+                        serial='3',
+                        key={'a': 'b', 'c': 'd'})
+        elif name == 'type_make_model.4':
+            return dict(type='type',
+                        make='make',
+                        model='model',
+                        serial='4',
+                        key={})
+
+    string_type = filt.split('>', 1)[1]
+    f = Filter(filt)
+    if string_type == '[]':
+        assert f.match(read_asset('type_make_model.1'))
+        assert not f.match(read_asset('type_make_model.2'))
+        assert not f.match(read_asset('type_make_model.3'))
+        assert not f.match(read_asset('type_make_model.4'))
+    elif string_type == '{}':
+        assert not f.match(read_asset('type_make_model.1'))
+        assert not f.match(read_asset('type_make_model.2'))
+        assert f.match(read_asset('type_make_model.3'))
+        assert not f.match(read_asset('type_make_model.4'))
+
+
+@pytest.mark.parametrize('filt', ['key>=[]', 'key>={}'])
+def test_filter_empty_literal_greater_than_or_equal(filt: str) -> None:
+    """Compare against a literal empty value (e.g., [] or {})."""
+
+    def read_asset(name: str):
+        if name == 'type_make_model.1':
+            return dict(type='type',
+                        make='make',
+                        model='model',
+                        serial='1',
+                        key=['a', 'b', 'c'])
+        if name == 'type_make_model.2':
+            return dict(type='type',
+                        make='make',
+                        model='model',
+                        serial='2',
+                        key=[])
+        elif name == 'type_make_model.3':
+            return dict(type='type',
+                        make='make',
+                        model='model',
+                        serial='3',
+                        key={'a': 'b', 'c': 'd'})
+        elif name == 'type_make_model.4':
+            return dict(type='type',
+                        make='make',
+                        model='model',
+                        serial='4',
+                        key={})
+
+    string_type = filt.split('>=', 1)[1]
+    f = Filter(filt)
+    if string_type == '[]':
+        assert f.match(read_asset('type_make_model.1'))
+        assert f.match(read_asset('type_make_model.2'))
+        assert not f.match(read_asset('type_make_model.3'))
+        assert not f.match(read_asset('type_make_model.4'))
+    elif string_type == '{}':
+        assert not f.match(read_asset('type_make_model.1'))
+        assert not f.match(read_asset('type_make_model.2'))
+        assert f.match(read_asset('type_make_model.3'))
+        assert f.match(read_asset('type_make_model.4'))
+
+
+@pytest.mark.parametrize('filt', ['key<[]', 'key<{}'])
+def test_filter_empty_literal_less_than(filt: str) -> None:
+    """Compare against a literal empty value (e.g., [] or {})."""
+
+    def read_asset(name: str):
+        if name == 'type_make_model.1':
+            return dict(type='type',
+                        make='make',
+                        model='model',
+                        serial='1',
+                        key=['a', 'b', 'c'])
+        if name == 'type_make_model.2':
+            return dict(type='type',
+                        make='make',
+                        model='model',
+                        serial='2',
+                        key=[])
+        elif name == 'type_make_model.3':
+            return dict(type='type',
+                        make='make',
+                        model='model',
+                        serial='3',
+                        key={'a': 'b', 'c': 'd'})
+        elif name == 'type_make_model.4':
+            return dict(type='type',
+                        make='make',
+                        model='model',
+                        serial='4',
+                        key={})
+
+    string_type = filt.split('<', 1)[1]
+    f = Filter(filt)
+    if string_type == '[]':
+        assert not f.match(read_asset('type_make_model.1'))
+        assert not f.match(read_asset('type_make_model.2'))
+        assert not f.match(read_asset('type_make_model.3'))
+        assert not f.match(read_asset('type_make_model.4'))
+    elif string_type == '{}':
+        assert not f.match(read_asset('type_make_model.1'))
+        assert not f.match(read_asset('type_make_model.2'))
+        assert not f.match(read_asset('type_make_model.3'))
+        assert not f.match(read_asset('type_make_model.4'))
+
+
+@pytest.mark.parametrize('filt', ['key<=[]', 'key<={}'])
+def test_filter_empty_literal_less_than_or_equal(filt: str) -> None:
+    """Compare against a literal empty value (e.g., [] or {})."""
+
+    def read_asset(name: str):
+        if name == 'type_make_model.1':
+            return dict(type='type',
+                        make='make',
+                        model='model',
+                        serial='1',
+                        key=['a', 'b', 'c'])
+        if name == 'type_make_model.2':
+            return dict(type='type',
+                        make='make',
+                        model='model',
+                        serial='2',
+                        key=[])
+        elif name == 'type_make_model.3':
+            return dict(type='type',
+                        make='make',
+                        model='model',
+                        serial='3',
+                        key={'a': 'b', 'c': 'd'})
+        elif name == 'type_make_model.4':
+            return dict(type='type',
+                        make='make',
+                        model='model',
+                        serial='4',
+                        key={})
+
+    string_type = filt.split('<=', 1)[1]
+    f = Filter(filt)
+    if string_type == '[]':
+        assert not f.match(read_asset('type_make_model.1'))
+        assert f.match(read_asset('type_make_model.2'))
+        assert not f.match(read_asset('type_make_model.3'))
+        assert not f.match(read_asset('type_make_model.4'))
+    elif string_type == '{}':
+        assert not f.match(read_asset('type_make_model.1'))
+        assert not f.match(read_asset('type_make_model.2'))
+        assert not f.match(read_asset('type_make_model.3'))
+        assert f.match(read_asset('type_make_model.4'))
+
+
+def test_filter_re_equal() -> None:
     """Filtering with regular expressions."""
 
     assert not Filter._re_match(text='foo(', r='foo(')

--- a/onyo/lib/tests/test_Filter.py
+++ b/onyo/lib/tests/test_Filter.py
@@ -351,12 +351,12 @@ class TestFilterRegex:
     @pytest.mark.parametrize('filt',
                              [''.join(x) for x in product(
                                  ['type', 'missing'],
-                                 ['>'],
+                                 ['>', '>='],
                                  ['.*', '.*no-match.*', '.*eel.*', '(?i)LAPTOP'],
                              )])
     def test_filter_regex_greater_than(self,
                                        filt: str) -> None:
-        """Regex greater than.
+        """Regex greater than and greater than or equal.
 
         Regular expressions are weird when used with greater than and less than.
 
@@ -368,9 +368,6 @@ class TestFilterRegex:
         """
 
         f = Filter(filt)
-        assert f.key == filt.split('>', 1)[0]
-        assert f.operand == '>'
-        assert f.value == filt.split('>', 1)[1]
 
         if f.key == 'missing':
             # cannot match against an unset key
@@ -380,99 +377,21 @@ class TestFilterRegex:
             assert not f.match(self.read_asset('wheelchair_make_model.4'))
             assert not f.match(self.read_asset('wheelchair_make_model.5'))
         else:
-            match f.value:
-                case '.*':
-                    assert f.match(self.read_asset('laptop_make_model.1'))
-                    assert f.match(self.read_asset('monitor_make_model.2'))
-                    assert f.match(self.read_asset('headphones_make_model.3'))
-                    assert f.match(self.read_asset('wheelchair_make_model.4'))
-                    assert f.match(self.read_asset('wheelchair_make_model.5'))
-                case '.*no-match.*':
-                    assert not f.match(self.read_asset('laptop_make_model.1'))
-                    assert not f.match(self.read_asset('monitor_make_model.2'))
-                    assert not f.match(self.read_asset('headphones_make_model.3'))
-                    assert f.match(self.read_asset('wheelchair_make_model.4'))
-                    assert f.match(self.read_asset('wheelchair_make_model.5'))
-                case '.*eel.*':
-                    assert f.match(self.read_asset('laptop_make_model.1'))
-                    assert f.match(self.read_asset('monitor_make_model.2'))
-                    assert f.match(self.read_asset('headphones_make_model.3'))
-                    assert f.match(self.read_asset('wheelchair_make_model.4'))
-                    assert f.match(self.read_asset('wheelchair_make_model.5'))
-                case '(?i)LAPTOP':
-                    assert f.match(self.read_asset('laptop_make_model.1'))
-                    assert f.match(self.read_asset('monitor_make_model.2'))
-                    assert not f.match(self.read_asset('headphones_make_model.3'))
-                    assert f.match(self.read_asset('wheelchair_make_model.4'))
-                    assert f.match(self.read_asset('wheelchair_make_model.5'))
+            assert f.match(self.read_asset('laptop_make_model.1'))
+            assert f.match(self.read_asset('monitor_make_model.2'))
+            assert f.match(self.read_asset('headphones_make_model.3'))
+            assert f.match(self.read_asset('wheelchair_make_model.4'))
+            assert f.match(self.read_asset('wheelchair_make_model.5'))
 
     @pytest.mark.parametrize('filt',
                              [''.join(x) for x in product(
                                  ['type', 'missing'],
-                                 ['>='],
-                                 ['.*', '.*no-match.*', '.*eel.*', '(?i)LAPTOP'],
-                             )])
-    def test_filter_regex_greater_than_or_equal(self,
-                                                filt: str) -> None:
-        """Regex greater than or equal.
-
-        Regular expressions are weird when used with greater than and less than.
-
-        If it were possible, it would be disallowed (like tags).
-
-        ``>``, ``>=``, ``<``, and ``<=`` treat the regular expression as a
-        literal string, but sort it using natsort's humansort, which can lead to
-        surprising results.
-        """
-
-        f = Filter(filt)
-        assert f.key == filt.split('>=', 1)[0]
-        assert f.operand == '>='
-        assert f.value == filt.split('>=', 1)[1]
-
-        if f.key == 'missing':
-            # cannot match against an unset key
-            assert not f.match(self.read_asset('laptop_make_model.1'))
-            assert not f.match(self.read_asset('monitor_make_model.2'))
-            assert not f.match(self.read_asset('headphones_make_model.3'))
-            assert not f.match(self.read_asset('wheelchair_make_model.4'))
-            assert not f.match(self.read_asset('wheelchair_make_model.5'))
-        else:
-            match f.value:
-                case '.*':
-                    assert f.match(self.read_asset('laptop_make_model.1'))
-                    assert f.match(self.read_asset('monitor_make_model.2'))
-                    assert f.match(self.read_asset('headphones_make_model.3'))
-                    assert f.match(self.read_asset('wheelchair_make_model.4'))
-                    assert f.match(self.read_asset('wheelchair_make_model.5'))
-                case '.*no-match.*':
-                    assert not f.match(self.read_asset('laptop_make_model.1'))
-                    assert not f.match(self.read_asset('monitor_make_model.2'))
-                    assert not f.match(self.read_asset('headphones_make_model.3'))
-                    assert f.match(self.read_asset('wheelchair_make_model.4'))
-                    assert f.match(self.read_asset('wheelchair_make_model.5'))
-                case '.*eel.*':
-                    assert f.match(self.read_asset('laptop_make_model.1'))
-                    assert f.match(self.read_asset('monitor_make_model.2'))
-                    assert f.match(self.read_asset('headphones_make_model.3'))
-                    assert f.match(self.read_asset('wheelchair_make_model.4'))
-                    assert f.match(self.read_asset('wheelchair_make_model.5'))
-                case '(?i)LAPTOP':
-                    assert f.match(self.read_asset('laptop_make_model.1'))
-                    assert f.match(self.read_asset('monitor_make_model.2'))
-                    assert not f.match(self.read_asset('headphones_make_model.3'))
-                    assert f.match(self.read_asset('wheelchair_make_model.4'))
-                    assert f.match(self.read_asset('wheelchair_make_model.5'))
-
-    @pytest.mark.parametrize('filt',
-                             [''.join(x) for x in product(
-                                 ['type', 'missing'],
-                                 ['<'],
+                                 ['<', '<='],
                                  ['.*', '.*no-match.*', '.*eel.*', '(?i)LAPTOP'],
                              )])
     def test_filter_regex_less_than(self,
                                     filt: str) -> None:
-        """Regex less than.
+        """Regex less than and less than or equal.
 
         Regular expressions are weird when used with greater than and less than.
 
@@ -484,9 +403,6 @@ class TestFilterRegex:
         """
 
         f = Filter(filt)
-        assert f.key == filt.split('<', 1)[0]
-        assert f.operand == '<'
-        assert f.value == filt.split('<', 1)[1]
 
         if f.key == 'missing':
             # cannot match against an unset key
@@ -496,89 +412,12 @@ class TestFilterRegex:
             assert not f.match(self.read_asset('wheelchair_make_model.4'))
             assert not f.match(self.read_asset('wheelchair_make_model.5'))
         else:
-            match f.value:
-                case '.*':
-                    assert not f.match(self.read_asset('laptop_make_model.1'))
-                    assert not f.match(self.read_asset('monitor_make_model.2'))
-                    assert not f.match(self.read_asset('headphones_make_model.3'))
-                    assert not f.match(self.read_asset('wheelchair_make_model.4'))
-                    assert not f.match(self.read_asset('wheelchair_make_model.5'))
-                case '.*no-match.*':
-                    assert f.match(self.read_asset('laptop_make_model.1'))
-                    assert f.match(self.read_asset('monitor_make_model.2'))
-                    assert f.match(self.read_asset('headphones_make_model.3'))
-                    assert not f.match(self.read_asset('wheelchair_make_model.4'))
-                    assert not f.match(self.read_asset('wheelchair_make_model.5'))
-                case '.*eel.*':
-                    assert not f.match(self.read_asset('laptop_make_model.1'))
-                    assert not f.match(self.read_asset('monitor_make_model.2'))
-                    assert not f.match(self.read_asset('headphones_make_model.3'))
-                    assert not f.match(self.read_asset('wheelchair_make_model.4'))
-                    assert not f.match(self.read_asset('wheelchair_make_model.5'))
-                case '(?i)LAPTOP':
-                    assert not f.match(self.read_asset('laptop_make_model.1'))
-                    assert not f.match(self.read_asset('monitor_make_model.2'))
-                    assert f.match(self.read_asset('headphones_make_model.3'))
-                    assert not f.match(self.read_asset('wheelchair_make_model.4'))
-                    assert not f.match(self.read_asset('wheelchair_make_model.5'))
-
-    @pytest.mark.parametrize('filt',
-                             [''.join(x) for x in product(
-                                 ['type', 'missing'],
-                                 ['<='],
-                                 ['.*', '.*no-match.*', '.*eel.*', '(?i)LAPTOP'],
-                             )])
-    def test_filter_regex_less_than_or_equal(self,
-                                             filt: str) -> None:
-        """Regex less than or equal.
-
-        Regular expressions are weird when used with greater than and less than.
-
-        If it were possible, it would be disallowed (like tags).
-
-        ``>``, ``>=``, ``<``, and ``<=`` treat the regular expression as a
-        literal string, but sort it using natsort's humansort, which can lead to
-        surprising results.
-        """
-
-        f = Filter(filt)
-        assert f.key == filt.split('<=', 1)[0]
-        assert f.operand == '<='
-        assert f.value == filt.split('<=', 1)[1]
-
-        if f.key == 'missing':
-            # cannot match against an unset key
             assert not f.match(self.read_asset('laptop_make_model.1'))
             assert not f.match(self.read_asset('monitor_make_model.2'))
             assert not f.match(self.read_asset('headphones_make_model.3'))
             assert not f.match(self.read_asset('wheelchair_make_model.4'))
             assert not f.match(self.read_asset('wheelchair_make_model.5'))
-        else:
-            match f.value:
-                case '.*':
-                    assert not f.match(self.read_asset('laptop_make_model.1'))
-                    assert not f.match(self.read_asset('monitor_make_model.2'))
-                    assert not f.match(self.read_asset('headphones_make_model.3'))
-                    assert not f.match(self.read_asset('wheelchair_make_model.4'))
-                    assert not f.match(self.read_asset('wheelchair_make_model.5'))
-                case '.*no-match.*':
-                    assert f.match(self.read_asset('laptop_make_model.1'))
-                    assert f.match(self.read_asset('monitor_make_model.2'))
-                    assert f.match(self.read_asset('headphones_make_model.3'))
-                    assert not f.match(self.read_asset('wheelchair_make_model.4'))
-                    assert not f.match(self.read_asset('wheelchair_make_model.5'))
-                case '.*eel.*':
-                    assert not f.match(self.read_asset('laptop_make_model.1'))
-                    assert not f.match(self.read_asset('monitor_make_model.2'))
-                    assert not f.match(self.read_asset('headphones_make_model.3'))
-                    assert not f.match(self.read_asset('wheelchair_make_model.4'))
-                    assert not f.match(self.read_asset('wheelchair_make_model.5'))
-                case '(?i)LAPTOP':
-                    assert not f.match(self.read_asset('laptop_make_model.1'))
-                    assert not f.match(self.read_asset('monitor_make_model.2'))
-                    assert f.match(self.read_asset('headphones_make_model.3'))
-                    assert not f.match(self.read_asset('wheelchair_make_model.4'))
-                    assert not f.match(self.read_asset('wheelchair_make_model.5'))
+
 
 class TestFilterTags:
     r"""Filter with tags.

--- a/onyo/lib/tests/test_Filter.py
+++ b/onyo/lib/tests/test_Filter.py
@@ -1,53 +1,48 @@
 import pytest
 
+from itertools import product
+
 from onyo.lib.exceptions import OnyoInvalidFilterError
 from onyo.lib.filters import Filter
 from onyo.lib.items import Item
 
 
 class TestFilter:
+    r"""Filter with literal text.
+
+    Whether the ``Filter`` objects are initialized correctly, and the matching
+    is correct.
+    """
 
     def read_asset(self,
                    name: str) -> Item:
-        r"""
-        """
+        r"""Get a populated Item."""
 
-        if name == 'laptop_make_model.1':
-            return Item(type='laptop',
-                        make='make',
-                        model='model',
-                        serial='1',
-                        key='value')
-        elif name == 'monitor_make_model.2':
-            return Item(type='monitor',
-                        make='make',
-                        model='model',
-                        serial='2',
-                        foo='bar')
-        elif name == 'headphones_make_model.3':
-            return Item(type='headphones',
-                        make='make',
-                        model='model',
-                        serial='3')
-        elif name == 'wheelchair_make_model.4':
-            return Item(type='wheelchair',
-                        make='make',
-                        model='model',
-                        serial='4',
-                        foo=None)
-        elif name == 'wheelchair_make_model.5':
-            return Item(type='wheelchair',
-                        make='make',
-                        model='model',
-                        serial='5',
-                        foo='')
-        else:
-            raise ValueError("Unknown asset")
+        item = Item(type='<to-set>',
+                    make='make',
+                    model='model',
+                    serial='<to-set>')
 
-    @pytest.mark.parametrize('filt', ['type=laptop', 'key=value', 'foo=<unset>', 'serial=2'])
+        match name:
+            case 'laptop_make_model.1':
+                item.update({'type': 'laptop', 'serial': '1', 'key': 'value'})
+            case 'monitor_make_model.2':
+                item.update({'type': 'monitor', 'serial': '2', 'foo': 'bar'})
+            case 'headphones_make_model.3':
+                item.update({'type': 'headphones', 'serial': '3'})
+            case 'wheelchair_make_model.4':
+                item.update({'type': 'wheelchair', 'serial': '4', 'foo': None})
+            case 'wheelchair_make_model.5':
+                item.update({'type': 'wheelchair', 'serial': '5', 'foo': ''})
+            case _:
+                raise ValueError("Unknown asset")
+
+        return item
+
+    @pytest.mark.parametrize('filt', ['type=laptop', 'key=value', 'serial=2'])
     def test_filter_equal(self,
                           filt: str) -> None:
-        """Test whether ``Filter`` object are set up, including post-initialization."""
+        """Literal text equals."""
 
         f = Filter(filt)
         assert f.key == filt.split('=', 1)[0]
@@ -67,12 +62,6 @@ class TestFilter:
                 assert not f.match(self.read_asset('headphones_make_model.3'))
                 assert not f.match(self.read_asset('wheelchair_make_model.4'))
                 assert not f.match(self.read_asset('wheelchair_make_model.5'))
-            case '<unset>':
-                assert f.match(self.read_asset('laptop_make_model.1'))
-                assert not f.match(self.read_asset('monitor_make_model.2'))
-                assert f.match(self.read_asset('headphones_make_model.3'))
-                assert f.match(self.read_asset('wheelchair_make_model.4'))
-                assert f.match(self.read_asset('wheelchair_make_model.5'))
             case '2':
                 assert not f.match(self.read_asset('laptop_make_model.1'))
                 assert f.match(self.read_asset('monitor_make_model.2'))
@@ -80,10 +69,10 @@ class TestFilter:
                 assert not f.match(self.read_asset('wheelchair_make_model.4'))
                 assert not f.match(self.read_asset('wheelchair_make_model.5'))
 
-    @pytest.mark.parametrize('filt', ['type!=laptop', 'key!=value', 'foo!=<unset>', 'serial!=2'])
+    @pytest.mark.parametrize('filt', ['type!=laptop', 'key!=value', 'serial!=2'])
     def test_filter_not_equal(self,
                               filt: str) -> None:
-        """Test whether ``Filter`` object are set up, including post-initialization."""
+        """Literal text not equals."""
 
         f = Filter(filt)
         assert f.key == filt.split('!=', 1)[0]
@@ -99,13 +88,7 @@ class TestFilter:
                 assert f.match(self.read_asset('wheelchair_make_model.5'))
             case 'value':
                 assert not f.match(self.read_asset('laptop_make_model.1'))
-                assert f.match(self.read_asset('monitor_make_model.2'))
-                assert f.match(self.read_asset('headphones_make_model.3'))
-                assert f.match(self.read_asset('wheelchair_make_model.4'))
-                assert f.match(self.read_asset('wheelchair_make_model.5'))
-            case '<unset>':
-                assert not f.match(self.read_asset('laptop_make_model.1'))
-                assert f.match(self.read_asset('monitor_make_model.2'))
+                assert not f.match(self.read_asset('monitor_make_model.2'))
                 assert not f.match(self.read_asset('headphones_make_model.3'))
                 assert not f.match(self.read_asset('wheelchair_make_model.4'))
                 assert not f.match(self.read_asset('wheelchair_make_model.5'))
@@ -116,10 +99,10 @@ class TestFilter:
                 assert f.match(self.read_asset('wheelchair_make_model.4'))
                 assert f.match(self.read_asset('wheelchair_make_model.5'))
 
-    @pytest.mark.parametrize('filt', ['type>laptop', 'key>value', 'foo><unset>', 'serial>2'])
+    @pytest.mark.parametrize('filt', ['type>laptop', 'key>value', 'serial>2'])
     def test_filter_greater_than(self,
                                  filt: str) -> None:
-        """Test whether ``Filter`` object are set up, including post-initialization."""
+        """Literal text greater than."""
 
         f = Filter(filt)
         assert f.key == filt.split('>', 1)[0]
@@ -138,21 +121,16 @@ class TestFilter:
                 assert not f.match(self.read_asset('headphones_make_model.3'))
                 assert not f.match(self.read_asset('wheelchair_make_model.4'))
                 assert not f.match(self.read_asset('wheelchair_make_model.5'))
-            case '<unset>':
-                assert not f.match(self.read_asset('monitor_make_model.2'))
-                assert not f.match(self.read_asset('headphones_make_model.3'))
-                assert not f.match(self.read_asset('wheelchair_make_model.4'))
-                assert not f.match(self.read_asset('wheelchair_make_model.5'))
             case '2':
                 assert not f.match(self.read_asset('monitor_make_model.2'))
                 assert f.match(self.read_asset('headphones_make_model.3'))
                 assert f.match(self.read_asset('wheelchair_make_model.4'))
                 assert f.match(self.read_asset('wheelchair_make_model.5'))
 
-    @pytest.mark.parametrize('filt', ['type>=laptop', 'key>=value', 'foo>=<unset>', 'serial>=2'])
+    @pytest.mark.parametrize('filt', ['type>=laptop', 'key>=value', 'serial>=2'])
     def test_filter_greater_than_or_equal(self,
                                           filt: str) -> None:
-        """Test whether ``Filter`` object are set up, including post-initialization."""
+        """Literal text greater than or equal."""
 
         f = Filter(filt)
         assert f.key == filt.split('>=', 1)[0]
@@ -172,12 +150,6 @@ class TestFilter:
                 assert not f.match(self.read_asset('headphones_make_model.3'))
                 assert not f.match(self.read_asset('wheelchair_make_model.4'))
                 assert not f.match(self.read_asset('wheelchair_make_model.5'))
-            case '<unset>':
-                assert f.match(self.read_asset('laptop_make_model.1'))
-                assert not f.match(self.read_asset('monitor_make_model.2'))
-                assert f.match(self.read_asset('headphones_make_model.3'))
-                assert f.match(self.read_asset('wheelchair_make_model.4'))
-                assert f.match(self.read_asset('wheelchair_make_model.5'))
             case '2':
                 assert not f.match(self.read_asset('laptop_make_model.1'))
                 assert f.match(self.read_asset('monitor_make_model.2'))
@@ -185,10 +157,10 @@ class TestFilter:
                 assert f.match(self.read_asset('wheelchair_make_model.4'))
                 assert f.match(self.read_asset('wheelchair_make_model.5'))
 
-    @pytest.mark.parametrize('filt', ['type<laptop', 'key<value', 'foo<<unset>', 'serial<2'])
+    @pytest.mark.parametrize('filt', ['type<laptop', 'key<value', 'serial<2'])
     def test_filter_less_than(self,
                               filt: str) -> None:
-        """Test whether ``Filter`` object are set up, including post-initialization."""
+        """Literal text less than."""
 
         f = Filter(filt)
         assert f.key == filt.split('<', 1)[0]
@@ -208,12 +180,6 @@ class TestFilter:
                 assert not f.match(self.read_asset('headphones_make_model.3'))
                 assert not f.match(self.read_asset('wheelchair_make_model.4'))
                 assert not f.match(self.read_asset('wheelchair_make_model.5'))
-            case '<unset>':
-                assert not f.match(self.read_asset('laptop_make_model.1'))
-                assert not f.match(self.read_asset('monitor_make_model.2'))
-                assert not f.match(self.read_asset('headphones_make_model.3'))
-                assert not f.match(self.read_asset('wheelchair_make_model.4'))
-                assert not f.match(self.read_asset('wheelchair_make_model.5'))
             case '2':
                 assert f.match(self.read_asset('laptop_make_model.1'))
                 assert not f.match(self.read_asset('monitor_make_model.2'))
@@ -221,10 +187,10 @@ class TestFilter:
                 assert not f.match(self.read_asset('wheelchair_make_model.4'))
                 assert not f.match(self.read_asset('wheelchair_make_model.5'))
 
-    @pytest.mark.parametrize('filt', ['type<=laptop', 'key<=value', 'foo<=<unset>', 'serial<=2'])
+    @pytest.mark.parametrize('filt', ['type<=laptop', 'key<=value', 'serial<=2'])
     def test_filter_less_than_or_equal(self,
                                        filt: str) -> None:
-        """Test whether ``Filter`` object are set up, including post-initialization."""
+        """Literal text less than or equal."""
 
         f = Filter(filt)
         assert f.key == filt.split('<=', 1)[0]
@@ -244,12 +210,6 @@ class TestFilter:
                 assert not f.match(self.read_asset('headphones_make_model.3'))
                 assert not f.match(self.read_asset('wheelchair_make_model.4'))
                 assert not f.match(self.read_asset('wheelchair_make_model.5'))
-            case '<unset>':
-                assert f.match(self.read_asset('laptop_make_model.1'))
-                assert not f.match(self.read_asset('monitor_make_model.2'))
-                assert f.match(self.read_asset('headphones_make_model.3'))
-                assert f.match(self.read_asset('wheelchair_make_model.4'))
-                assert f.match(self.read_asset('wheelchair_make_model.5'))
             case '2':
                 assert f.match(self.read_asset('laptop_make_model.1'))
                 assert f.match(self.read_asset('monitor_make_model.2'))
@@ -257,388 +217,1185 @@ class TestFilter:
                 assert not f.match(self.read_asset('wheelchair_make_model.4'))
                 assert not f.match(self.read_asset('wheelchair_make_model.5'))
 
-@pytest.mark.parametrize('filt', ['key=<list>', 'key=<dict>'])
-def test_filter_type_equal(filt: str) -> None:
-    """Filtering by variable type (e.g., <list> or <dict>)."""
 
-    def read_asset(name: str):
-        if name == 'type_make_model.1':
-            return dict(type='type',
-                        make='make',
-                        model='model',
-                        serial='1',
-                        key=['a', 'b', 'c'])
-        elif name == 'type_make_model.2':
-            return dict(type='type',
-                        make='make',
-                        model='model',
-                        serial='2',
-                        key={'a': 'b', 'c': 'd'})
+class TestFilterRegex:
+    r"""Filter with regular expressions.
 
-    string_type = filt.split('=', 1)[1]
-    f = Filter(filt)
-    if string_type == '<list>':
-        assert f.match(read_asset('type_make_model.1'))
-        assert not f.match(read_asset('type_make_model.2'))
-    elif string_type == '<dict>':
-        assert not f.match(read_asset('type_make_model.1'))
-        assert f.match(read_asset('type_make_model.2'))
+    Whether the ``Filter`` objects are initialized correctly, and the matching
+    is correct.
+    """
+
+    def read_asset(self,
+                   name: str) -> Item:
+        r"""Get a populated Item."""
+
+        item = Item(type='<to-set>',
+                    make='make',
+                    model='model',
+                    serial='<to-set>')
+
+        match name:
+            case 'laptop_make_model.1':
+                item.update({'type': 'laptop', 'serial': '1', 'key': 'value'})
+            case 'monitor_make_model.2':
+                item.update({'type': 'monitor', 'serial': '2', 'foo': 'bar'})
+            case 'headphones_make_model.3':
+                item.update({'type': 'headphones', 'serial': '3'})
+            case 'wheelchair_make_model.4':
+                item.update({'type': 'wheelchair', 'serial': '4', 'foo': None})
+            case 'wheelchair_make_model.5':
+                item.update({'type': 'wheelchair', 'serial': '5', 'foo': ''})
+            case _:
+                raise ValueError("Unknown asset")
+
+        return item
+
+    @pytest.mark.parametrize('filt',
+                             [''.join(x) for x in product(
+                                 ['type', 'missing'],
+                                 ['='],
+                                 ['.*', '.*no-match.*', '.*eel.*', '(?i)LAPTOP'],
+                             )])
+    def test_filter_regex_equal(self,
+                                filt: str) -> None:
+        """Regular expression equal."""
+
+        f = Filter(filt)
+        assert f.key == filt.split('=', 1)[0]
+        assert f.operand == '='
+        assert f.value == filt.split('=', 1)[1]
+
+        if f.key == 'missing':
+            # cannot match against an unset key
+            assert not f.match(self.read_asset('laptop_make_model.1'))
+            assert not f.match(self.read_asset('monitor_make_model.2'))
+            assert not f.match(self.read_asset('headphones_make_model.3'))
+            assert not f.match(self.read_asset('wheelchair_make_model.4'))
+            assert not f.match(self.read_asset('wheelchair_make_model.5'))
+        else:
+            match f.value:
+                case '.*':
+                    assert f.match(self.read_asset('laptop_make_model.1'))
+                    assert f.match(self.read_asset('monitor_make_model.2'))
+                    assert f.match(self.read_asset('headphones_make_model.3'))
+                    assert f.match(self.read_asset('wheelchair_make_model.4'))
+                    assert f.match(self.read_asset('wheelchair_make_model.5'))
+                case '.*no-match.*':
+                    assert not f.match(self.read_asset('laptop_make_model.1'))
+                    assert not f.match(self.read_asset('monitor_make_model.2'))
+                    assert not f.match(self.read_asset('headphones_make_model.3'))
+                    assert not f.match(self.read_asset('wheelchair_make_model.4'))
+                    assert not f.match(self.read_asset('wheelchair_make_model.5'))
+                case '.*eel.*':
+                    assert not f.match(self.read_asset('laptop_make_model.1'))
+                    assert not f.match(self.read_asset('monitor_make_model.2'))
+                    assert not f.match(self.read_asset('headphones_make_model.3'))
+                    assert f.match(self.read_asset('wheelchair_make_model.4'))
+                    assert f.match(self.read_asset('wheelchair_make_model.5'))
+                case '(?i)LAPTOP':
+                    assert f.match(self.read_asset('laptop_make_model.1'))
+                    assert not f.match(self.read_asset('monitor_make_model.2'))
+                    assert not f.match(self.read_asset('headphones_make_model.3'))
+                    assert not f.match(self.read_asset('wheelchair_make_model.4'))
+                    assert not f.match(self.read_asset('wheelchair_make_model.5'))
+
+    @pytest.mark.parametrize('filt',
+                             [''.join(x) for x in product(
+                                 ['type', 'missing'],
+                                 ['!='],
+                                 ['.*', '.*no-match.*', '.*eel.*', '(?i)LAPTOP'],
+                             )])
+    def test_filter_regex_not_equal(self,
+                                    filt: str) -> None:
+        """Regular expression not equal."""
+
+        f = Filter(filt)
+        assert f.key == filt.split('!=', 1)[0]
+        assert f.operand == '!='
+        assert f.value == filt.split('!=', 1)[1]
+
+        if f.key == 'missing':
+            # cannot match against an unset key
+            assert not f.match(self.read_asset('laptop_make_model.1'))
+            assert not f.match(self.read_asset('monitor_make_model.2'))
+            assert not f.match(self.read_asset('headphones_make_model.3'))
+            assert not f.match(self.read_asset('wheelchair_make_model.4'))
+            assert not f.match(self.read_asset('wheelchair_make_model.5'))
+        else:
+            match f.value:
+                case '.*':
+                    assert not f.match(self.read_asset('laptop_make_model.1'))
+                    assert not f.match(self.read_asset('monitor_make_model.2'))
+                    assert not f.match(self.read_asset('headphones_make_model.3'))
+                    assert not f.match(self.read_asset('wheelchair_make_model.4'))
+                    assert not f.match(self.read_asset('wheelchair_make_model.5'))
+                case '.*no-match.*':
+                    assert f.match(self.read_asset('laptop_make_model.1'))
+                    assert f.match(self.read_asset('monitor_make_model.2'))
+                    assert f.match(self.read_asset('headphones_make_model.3'))
+                    assert f.match(self.read_asset('wheelchair_make_model.4'))
+                    assert f.match(self.read_asset('wheelchair_make_model.5'))
+                case '.*eel.*':
+                    assert f.match(self.read_asset('laptop_make_model.1'))
+                    assert f.match(self.read_asset('monitor_make_model.2'))
+                    assert f.match(self.read_asset('headphones_make_model.3'))
+                    assert not f.match(self.read_asset('wheelchair_make_model.4'))
+                    assert not f.match(self.read_asset('wheelchair_make_model.5'))
+                case '(?i)LAPTOP':
+                    assert not f.match(self.read_asset('laptop_make_model.1'))
+                    assert f.match(self.read_asset('monitor_make_model.2'))
+                    assert f.match(self.read_asset('headphones_make_model.3'))
+                    assert f.match(self.read_asset('wheelchair_make_model.4'))
+                    assert f.match(self.read_asset('wheelchair_make_model.5'))
+
+    @pytest.mark.parametrize('filt',
+                             [''.join(x) for x in product(
+                                 ['type', 'missing'],
+                                 ['>'],
+                                 ['.*', '.*no-match.*', '.*eel.*', '(?i)LAPTOP'],
+                             )])
+    def test_filter_regex_greater_than(self,
+                                       filt: str) -> None:
+        """Regex greater than.
+
+        Regular expressions are weird when used with greater than and less than.
+
+        If it were possible, it would be disallowed (like tags).
+
+        ``>``, ``>=``, ``<``, and ``<=`` treat the regular expression as a
+        literal string, but sort it using natsort's humansort, which can lead to
+        surprising results.
+        """
+
+        f = Filter(filt)
+        assert f.key == filt.split('>', 1)[0]
+        assert f.operand == '>'
+        assert f.value == filt.split('>', 1)[1]
+
+        if f.key == 'missing':
+            # cannot match against an unset key
+            assert not f.match(self.read_asset('laptop_make_model.1'))
+            assert not f.match(self.read_asset('monitor_make_model.2'))
+            assert not f.match(self.read_asset('headphones_make_model.3'))
+            assert not f.match(self.read_asset('wheelchair_make_model.4'))
+            assert not f.match(self.read_asset('wheelchair_make_model.5'))
+        else:
+            match f.value:
+                case '.*':
+                    assert f.match(self.read_asset('laptop_make_model.1'))
+                    assert f.match(self.read_asset('monitor_make_model.2'))
+                    assert f.match(self.read_asset('headphones_make_model.3'))
+                    assert f.match(self.read_asset('wheelchair_make_model.4'))
+                    assert f.match(self.read_asset('wheelchair_make_model.5'))
+                case '.*no-match.*':
+                    assert not f.match(self.read_asset('laptop_make_model.1'))
+                    assert not f.match(self.read_asset('monitor_make_model.2'))
+                    assert not f.match(self.read_asset('headphones_make_model.3'))
+                    assert f.match(self.read_asset('wheelchair_make_model.4'))
+                    assert f.match(self.read_asset('wheelchair_make_model.5'))
+                case '.*eel.*':
+                    assert f.match(self.read_asset('laptop_make_model.1'))
+                    assert f.match(self.read_asset('monitor_make_model.2'))
+                    assert f.match(self.read_asset('headphones_make_model.3'))
+                    assert f.match(self.read_asset('wheelchair_make_model.4'))
+                    assert f.match(self.read_asset('wheelchair_make_model.5'))
+                case '(?i)LAPTOP':
+                    assert f.match(self.read_asset('laptop_make_model.1'))
+                    assert f.match(self.read_asset('monitor_make_model.2'))
+                    assert not f.match(self.read_asset('headphones_make_model.3'))
+                    assert f.match(self.read_asset('wheelchair_make_model.4'))
+                    assert f.match(self.read_asset('wheelchair_make_model.5'))
+
+    @pytest.mark.parametrize('filt',
+                             [''.join(x) for x in product(
+                                 ['type', 'missing'],
+                                 ['>='],
+                                 ['.*', '.*no-match.*', '.*eel.*', '(?i)LAPTOP'],
+                             )])
+    def test_filter_regex_greater_than_or_equal(self,
+                                                filt: str) -> None:
+        """Regex greater than or equal.
+
+        Regular expressions are weird when used with greater than and less than.
+
+        If it were possible, it would be disallowed (like tags).
+
+        ``>``, ``>=``, ``<``, and ``<=`` treat the regular expression as a
+        literal string, but sort it using natsort's humansort, which can lead to
+        surprising results.
+        """
+
+        f = Filter(filt)
+        assert f.key == filt.split('>=', 1)[0]
+        assert f.operand == '>='
+        assert f.value == filt.split('>=', 1)[1]
+
+        if f.key == 'missing':
+            # cannot match against an unset key
+            assert not f.match(self.read_asset('laptop_make_model.1'))
+            assert not f.match(self.read_asset('monitor_make_model.2'))
+            assert not f.match(self.read_asset('headphones_make_model.3'))
+            assert not f.match(self.read_asset('wheelchair_make_model.4'))
+            assert not f.match(self.read_asset('wheelchair_make_model.5'))
+        else:
+            match f.value:
+                case '.*':
+                    assert f.match(self.read_asset('laptop_make_model.1'))
+                    assert f.match(self.read_asset('monitor_make_model.2'))
+                    assert f.match(self.read_asset('headphones_make_model.3'))
+                    assert f.match(self.read_asset('wheelchair_make_model.4'))
+                    assert f.match(self.read_asset('wheelchair_make_model.5'))
+                case '.*no-match.*':
+                    assert not f.match(self.read_asset('laptop_make_model.1'))
+                    assert not f.match(self.read_asset('monitor_make_model.2'))
+                    assert not f.match(self.read_asset('headphones_make_model.3'))
+                    assert f.match(self.read_asset('wheelchair_make_model.4'))
+                    assert f.match(self.read_asset('wheelchair_make_model.5'))
+                case '.*eel.*':
+                    assert f.match(self.read_asset('laptop_make_model.1'))
+                    assert f.match(self.read_asset('monitor_make_model.2'))
+                    assert f.match(self.read_asset('headphones_make_model.3'))
+                    assert f.match(self.read_asset('wheelchair_make_model.4'))
+                    assert f.match(self.read_asset('wheelchair_make_model.5'))
+                case '(?i)LAPTOP':
+                    assert f.match(self.read_asset('laptop_make_model.1'))
+                    assert f.match(self.read_asset('monitor_make_model.2'))
+                    assert not f.match(self.read_asset('headphones_make_model.3'))
+                    assert f.match(self.read_asset('wheelchair_make_model.4'))
+                    assert f.match(self.read_asset('wheelchair_make_model.5'))
+
+    @pytest.mark.parametrize('filt',
+                             [''.join(x) for x in product(
+                                 ['type', 'missing'],
+                                 ['<'],
+                                 ['.*', '.*no-match.*', '.*eel.*', '(?i)LAPTOP'],
+                             )])
+    def test_filter_regex_less_than(self,
+                                    filt: str) -> None:
+        """Regex less than.
+
+        Regular expressions are weird when used with greater than and less than.
+
+        If it were possible, it would be disallowed (like tags).
+
+        ``>``, ``>=``, ``<``, and ``<=`` treat the regular expression as a
+        literal string, but sort it using natsort's humansort, which can lead to
+        surprising results.
+        """
+
+        f = Filter(filt)
+        assert f.key == filt.split('<', 1)[0]
+        assert f.operand == '<'
+        assert f.value == filt.split('<', 1)[1]
+
+        if f.key == 'missing':
+            # cannot match against an unset key
+            assert not f.match(self.read_asset('laptop_make_model.1'))
+            assert not f.match(self.read_asset('monitor_make_model.2'))
+            assert not f.match(self.read_asset('headphones_make_model.3'))
+            assert not f.match(self.read_asset('wheelchair_make_model.4'))
+            assert not f.match(self.read_asset('wheelchair_make_model.5'))
+        else:
+            match f.value:
+                case '.*':
+                    assert not f.match(self.read_asset('laptop_make_model.1'))
+                    assert not f.match(self.read_asset('monitor_make_model.2'))
+                    assert not f.match(self.read_asset('headphones_make_model.3'))
+                    assert not f.match(self.read_asset('wheelchair_make_model.4'))
+                    assert not f.match(self.read_asset('wheelchair_make_model.5'))
+                case '.*no-match.*':
+                    assert f.match(self.read_asset('laptop_make_model.1'))
+                    assert f.match(self.read_asset('monitor_make_model.2'))
+                    assert f.match(self.read_asset('headphones_make_model.3'))
+                    assert not f.match(self.read_asset('wheelchair_make_model.4'))
+                    assert not f.match(self.read_asset('wheelchair_make_model.5'))
+                case '.*eel.*':
+                    assert not f.match(self.read_asset('laptop_make_model.1'))
+                    assert not f.match(self.read_asset('monitor_make_model.2'))
+                    assert not f.match(self.read_asset('headphones_make_model.3'))
+                    assert not f.match(self.read_asset('wheelchair_make_model.4'))
+                    assert not f.match(self.read_asset('wheelchair_make_model.5'))
+                case '(?i)LAPTOP':
+                    assert not f.match(self.read_asset('laptop_make_model.1'))
+                    assert not f.match(self.read_asset('monitor_make_model.2'))
+                    assert f.match(self.read_asset('headphones_make_model.3'))
+                    assert not f.match(self.read_asset('wheelchair_make_model.4'))
+                    assert not f.match(self.read_asset('wheelchair_make_model.5'))
+
+    @pytest.mark.parametrize('filt',
+                             [''.join(x) for x in product(
+                                 ['type', 'missing'],
+                                 ['<='],
+                                 ['.*', '.*no-match.*', '.*eel.*', '(?i)LAPTOP'],
+                             )])
+    def test_filter_regex_less_than_or_equal(self,
+                                             filt: str) -> None:
+        """Regex less than or equal.
+
+        Regular expressions are weird when used with greater than and less than.
+
+        If it were possible, it would be disallowed (like tags).
+
+        ``>``, ``>=``, ``<``, and ``<=`` treat the regular expression as a
+        literal string, but sort it using natsort's humansort, which can lead to
+        surprising results.
+        """
+
+        f = Filter(filt)
+        assert f.key == filt.split('<=', 1)[0]
+        assert f.operand == '<='
+        assert f.value == filt.split('<=', 1)[1]
+
+        if f.key == 'missing':
+            # cannot match against an unset key
+            assert not f.match(self.read_asset('laptop_make_model.1'))
+            assert not f.match(self.read_asset('monitor_make_model.2'))
+            assert not f.match(self.read_asset('headphones_make_model.3'))
+            assert not f.match(self.read_asset('wheelchair_make_model.4'))
+            assert not f.match(self.read_asset('wheelchair_make_model.5'))
+        else:
+            match f.value:
+                case '.*':
+                    assert not f.match(self.read_asset('laptop_make_model.1'))
+                    assert not f.match(self.read_asset('monitor_make_model.2'))
+                    assert not f.match(self.read_asset('headphones_make_model.3'))
+                    assert not f.match(self.read_asset('wheelchair_make_model.4'))
+                    assert not f.match(self.read_asset('wheelchair_make_model.5'))
+                case '.*no-match.*':
+                    assert f.match(self.read_asset('laptop_make_model.1'))
+                    assert f.match(self.read_asset('monitor_make_model.2'))
+                    assert f.match(self.read_asset('headphones_make_model.3'))
+                    assert not f.match(self.read_asset('wheelchair_make_model.4'))
+                    assert not f.match(self.read_asset('wheelchair_make_model.5'))
+                case '.*eel.*':
+                    assert not f.match(self.read_asset('laptop_make_model.1'))
+                    assert not f.match(self.read_asset('monitor_make_model.2'))
+                    assert not f.match(self.read_asset('headphones_make_model.3'))
+                    assert not f.match(self.read_asset('wheelchair_make_model.4'))
+                    assert not f.match(self.read_asset('wheelchair_make_model.5'))
+                case '(?i)LAPTOP':
+                    assert not f.match(self.read_asset('laptop_make_model.1'))
+                    assert not f.match(self.read_asset('monitor_make_model.2'))
+                    assert f.match(self.read_asset('headphones_make_model.3'))
+                    assert not f.match(self.read_asset('wheelchair_make_model.4'))
+                    assert not f.match(self.read_asset('wheelchair_make_model.5'))
+
+class TestFilterTags:
+    r"""Filter with tags.
+
+    Whether the ``Filter`` objects are initialized correctly, and the matching
+    is correct.
+
+    This includes type tags (e.g. ``<bool>``, ``<dict>``, ``<list>``), value
+    tags (``<empty>``, ``<false>``, ``<null>``, ``<true>``), and ``<unset>``.
+    """
+
+    def read_asset(self,
+                   name: str) -> Item:
+        r"""Get a populated Item."""
+
+        item = Item(type='<to-set>',
+                    make='make',
+                    model='model',
+                    serial='<to-set>',
+                    key='<to-set>')
+
+        match name:
+            case 'str_make_model.1':
+                item.update({'type': 'str', 'serial': '1', 'key': 'value'})
+            case 'str_make_model.2':
+                item.update({'type': 'str', 'serial': '2', 'key': ''})
+            case 'list_make_model.3':
+                item.update({'type': 'list', 'serial': '3', 'key': ['a', 'b', 'c']})
+            case 'list_make_model.4':
+                item.update({'type': 'list', 'serial': '4', 'key': []})
+            case 'dict_make_model.5':
+                item.update({'type': 'dict', 'serial': '5', 'key': {'a': 'b', 'c': 'd'}})
+            case 'dict_make_model.6':
+                item.update({'type': 'dict', 'serial': '6', 'key': {}})
+            case 'bool_make_model.7':
+                item.update({'type': 'bool', 'serial': '7', 'key': True})
+            case 'bool_make_model.8':
+                item.update({'type': 'bool', 'serial': '8', 'key': False})
+            case 'null_make_model.9':
+                item.update({'type': 'null', 'serial': '9', 'key': None})
+            case _:
+                raise ValueError("Unknown asset")
+
+        return item
+
+    @pytest.mark.parametrize('filt',
+                             [''.join(x) for x in product(
+                                 ['key', 'missing'],
+                                 ['='],
+                                 ['<bool>', '<dict>', '<list>'],
+                             )])
+    def test_filter_tag_type_equal(self,
+                                   filt: str) -> None:
+        """Tag type equals."""
+
+        f = Filter(filt)
+        assert f.key == filt.split('=', 1)[0]
+        assert f.operand == '='
+        assert f.value == filt.split('=', 1)[1]
+
+        if f.key == 'missing':
+            # cannot match against an unset key
+            assert not f.match(self.read_asset('str_make_model.1'))
+            assert not f.match(self.read_asset('str_make_model.2'))
+            assert not f.match(self.read_asset('list_make_model.3'))
+            assert not f.match(self.read_asset('list_make_model.4'))
+            assert not f.match(self.read_asset('dict_make_model.5'))
+            assert not f.match(self.read_asset('dict_make_model.6'))
+            assert not f.match(self.read_asset('bool_make_model.7'))
+            assert not f.match(self.read_asset('bool_make_model.8'))
+            assert not f.match(self.read_asset('null_make_model.9'))
+        else:
+            match f.value:
+                case '<bool>':
+                    assert not f.match(self.read_asset('str_make_model.1'))
+                    assert not f.match(self.read_asset('str_make_model.2'))
+                    assert not f.match(self.read_asset('list_make_model.3'))
+                    assert not f.match(self.read_asset('list_make_model.4'))
+                    assert not f.match(self.read_asset('dict_make_model.5'))
+                    assert not f.match(self.read_asset('dict_make_model.6'))
+                    assert f.match(self.read_asset('bool_make_model.7'))
+                    assert f.match(self.read_asset('bool_make_model.8'))
+                    assert not f.match(self.read_asset('null_make_model.9'))
+                case '<dict>':
+                    assert not f.match(self.read_asset('str_make_model.1'))
+                    assert not f.match(self.read_asset('str_make_model.2'))
+                    assert not f.match(self.read_asset('list_make_model.3'))
+                    assert not f.match(self.read_asset('list_make_model.4'))
+                    assert f.match(self.read_asset('dict_make_model.5'))
+                    assert f.match(self.read_asset('dict_make_model.6'))
+                    assert not f.match(self.read_asset('bool_make_model.7'))
+                    assert not f.match(self.read_asset('bool_make_model.8'))
+                    assert not f.match(self.read_asset('null_make_model.9'))
+                case '<list>':
+                    assert not f.match(self.read_asset('str_make_model.1'))
+                    assert not f.match(self.read_asset('str_make_model.2'))
+                    assert f.match(self.read_asset('list_make_model.3'))
+                    assert f.match(self.read_asset('list_make_model.4'))
+                    assert not f.match(self.read_asset('dict_make_model.5'))
+                    assert not f.match(self.read_asset('dict_make_model.6'))
+                    assert not f.match(self.read_asset('bool_make_model.7'))
+                    assert not f.match(self.read_asset('bool_make_model.8'))
+                    assert not f.match(self.read_asset('null_make_model.9'))
+
+    @pytest.mark.parametrize('filt',
+                             [''.join(x) for x in product(
+                                 ['key', 'missing'],
+                                 ['!='],
+                                 ['<bool>', '<dict>', '<list>'],
+                             )])
+    def test_filter_tag_type_not_equal(self,
+                                       filt: str) -> None:
+        """Tag type not equals."""
+
+        f = Filter(filt)
+        assert f.key == filt.split('!=', 1)[0]
+        assert f.operand == '!='
+        assert f.value == filt.split('!=', 1)[1]
+
+        if f.key == 'missing':
+            # cannot match against an unset key
+            assert not f.match(self.read_asset('str_make_model.1'))
+            assert not f.match(self.read_asset('str_make_model.2'))
+            assert not f.match(self.read_asset('list_make_model.3'))
+            assert not f.match(self.read_asset('list_make_model.4'))
+            assert not f.match(self.read_asset('dict_make_model.5'))
+            assert not f.match(self.read_asset('dict_make_model.6'))
+            assert not f.match(self.read_asset('bool_make_model.7'))
+            assert not f.match(self.read_asset('bool_make_model.8'))
+            assert not f.match(self.read_asset('null_make_model.9'))
+        else:
+            match f.value:
+                case '<bool>':
+                    assert f.match(self.read_asset('str_make_model.1'))
+                    assert f.match(self.read_asset('str_make_model.2'))
+                    assert f.match(self.read_asset('list_make_model.3'))
+                    assert f.match(self.read_asset('list_make_model.4'))
+                    assert f.match(self.read_asset('dict_make_model.5'))
+                    assert f.match(self.read_asset('dict_make_model.6'))
+                    assert not f.match(self.read_asset('bool_make_model.7'))
+                    assert not f.match(self.read_asset('bool_make_model.8'))
+                    assert f.match(self.read_asset('null_make_model.9'))
+                case '<dict>':
+                    assert f.match(self.read_asset('str_make_model.1'))
+                    assert f.match(self.read_asset('str_make_model.2'))
+                    assert f.match(self.read_asset('list_make_model.3'))
+                    assert f.match(self.read_asset('list_make_model.4'))
+                    assert not f.match(self.read_asset('dict_make_model.5'))
+                    assert not f.match(self.read_asset('dict_make_model.6'))
+                    assert f.match(self.read_asset('bool_make_model.7'))
+                    assert f.match(self.read_asset('bool_make_model.8'))
+                    assert f.match(self.read_asset('null_make_model.9'))
+                case '<list>':
+                    assert f.match(self.read_asset('str_make_model.1'))
+                    assert f.match(self.read_asset('str_make_model.2'))
+                    assert not f.match(self.read_asset('list_make_model.3'))
+                    assert not f.match(self.read_asset('list_make_model.4'))
+                    assert f.match(self.read_asset('dict_make_model.5'))
+                    assert f.match(self.read_asset('dict_make_model.6'))
+                    assert f.match(self.read_asset('bool_make_model.7'))
+                    assert f.match(self.read_asset('bool_make_model.8'))
+                    assert f.match(self.read_asset('null_make_model.9'))
+
+    @pytest.mark.parametrize('filt',
+                             [''.join(x) for x in product(
+                                 ['key', 'missing'],
+                                 ['>', '>=', '<', '<='],
+                                 ['<bool>', '<dict>', '<list>'],
+                             )])
+    def test_filter_tag_type_gt_lt(self,
+                                   filt: str) -> None:
+        """Tag type greater/less than.
+
+        Filtering tags is not supported using ``>``, ``>=``, ``<``, and ``<=``.
+        """
+
+        f = Filter(filt)
+
+        # greater/less than comparison is not allowed for tags
+        assert not f.match(self.read_asset('str_make_model.1'))
+        assert not f.match(self.read_asset('str_make_model.2'))
+        assert not f.match(self.read_asset('list_make_model.3'))
+        assert not f.match(self.read_asset('list_make_model.4'))
+        assert not f.match(self.read_asset('dict_make_model.5'))
+        assert not f.match(self.read_asset('dict_make_model.6'))
+        assert not f.match(self.read_asset('bool_make_model.7'))
+        assert not f.match(self.read_asset('bool_make_model.8'))
+        assert not f.match(self.read_asset('null_make_model.9'))
+
+    @pytest.mark.parametrize('filt',
+                             [''.join(x) for x in product(
+                                 ['key', 'missing'],
+                                 ['='],
+                                 ['<empty>', '<false>', '<null>', '<true>'],
+                             )])
+    def test_filter_tag_value_equal(self,
+                                    filt: str) -> None:
+        """Tag value equal."""
+
+        f = Filter(filt)
+        assert f.key == filt.split('=', 1)[0]
+        assert f.operand == '='
+        assert f.value == filt.split('=', 1)[1]
+
+        if f.key == 'missing':
+            # cannot match against an unset key
+            assert not f.match(self.read_asset('str_make_model.1'))
+            assert not f.match(self.read_asset('str_make_model.2'))
+            assert not f.match(self.read_asset('list_make_model.3'))
+            assert not f.match(self.read_asset('list_make_model.4'))
+            assert not f.match(self.read_asset('dict_make_model.5'))
+            assert not f.match(self.read_asset('dict_make_model.6'))
+            assert not f.match(self.read_asset('bool_make_model.7'))
+            assert not f.match(self.read_asset('bool_make_model.8'))
+            assert not f.match(self.read_asset('null_make_model.9'))
+        else:
+            match f.value:
+                case '<empty>':
+                    assert not f.match(self.read_asset('str_make_model.1'))
+                    assert f.match(self.read_asset('str_make_model.2'))
+                    assert not f.match(self.read_asset('list_make_model.3'))
+                    assert f.match(self.read_asset('list_make_model.4'))
+                    assert not f.match(self.read_asset('dict_make_model.5'))
+                    assert f.match(self.read_asset('dict_make_model.6'))
+                    assert not f.match(self.read_asset('bool_make_model.7'))
+                    assert not f.match(self.read_asset('bool_make_model.8'))
+                    assert f.match(self.read_asset('null_make_model.9'))
+                case '<false>':
+                    assert not f.match(self.read_asset('str_make_model.1'))
+                    assert not f.match(self.read_asset('str_make_model.2'))
+                    assert not f.match(self.read_asset('list_make_model.3'))
+                    assert not f.match(self.read_asset('list_make_model.4'))
+                    assert not f.match(self.read_asset('dict_make_model.5'))
+                    assert not f.match(self.read_asset('dict_make_model.6'))
+                    assert not f.match(self.read_asset('bool_make_model.7'))
+                    assert f.match(self.read_asset('bool_make_model.8'))
+                    assert not f.match(self.read_asset('null_make_model.9'))
+                case '<null>':
+                    assert not f.match(self.read_asset('str_make_model.1'))
+                    assert not f.match(self.read_asset('str_make_model.2'))
+                    assert not f.match(self.read_asset('list_make_model.3'))
+                    assert not f.match(self.read_asset('list_make_model.4'))
+                    assert not f.match(self.read_asset('dict_make_model.5'))
+                    assert not f.match(self.read_asset('dict_make_model.6'))
+                    assert not f.match(self.read_asset('bool_make_model.7'))
+                    assert not f.match(self.read_asset('bool_make_model.8'))
+                    assert f.match(self.read_asset('null_make_model.9'))
+                case '<true>':
+                    assert not f.match(self.read_asset('str_make_model.1'))
+                    assert not f.match(self.read_asset('str_make_model.2'))
+                    assert not f.match(self.read_asset('list_make_model.3'))
+                    assert not f.match(self.read_asset('list_make_model.4'))
+                    assert not f.match(self.read_asset('dict_make_model.5'))
+                    assert not f.match(self.read_asset('dict_make_model.6'))
+                    assert f.match(self.read_asset('bool_make_model.7'))
+                    assert not f.match(self.read_asset('bool_make_model.8'))
+                    assert not f.match(self.read_asset('null_make_model.9'))
+
+    @pytest.mark.parametrize('filt',
+                             [''.join(x) for x in product(
+                                 ['key', 'missing'],
+                                 ['!='],
+                                 ['<empty>', '<false>', '<null>', '<true>'],
+                             )])
+    def test_filter_tag_value_not_equal(self,
+                                        filt: str) -> None:
+        """Tag value not equal."""
+
+        f = Filter(filt)
+        assert f.key == filt.split('!=', 1)[0]
+        assert f.operand == '!='
+        assert f.value == filt.split('!=', 1)[1]
+
+        if f.key == 'missing':
+            # cannot match against an unset key
+            assert not f.match(self.read_asset('str_make_model.1'))
+            assert not f.match(self.read_asset('str_make_model.2'))
+            assert not f.match(self.read_asset('list_make_model.3'))
+            assert not f.match(self.read_asset('list_make_model.4'))
+            assert not f.match(self.read_asset('dict_make_model.5'))
+            assert not f.match(self.read_asset('dict_make_model.6'))
+            assert not f.match(self.read_asset('bool_make_model.7'))
+            assert not f.match(self.read_asset('bool_make_model.8'))
+            assert not f.match(self.read_asset('null_make_model.9'))
+        else:
+            match f.value:
+                case '<empty>':
+                    assert f.match(self.read_asset('str_make_model.1'))
+                    assert not f.match(self.read_asset('str_make_model.2'))
+                    assert f.match(self.read_asset('list_make_model.3'))
+                    assert not f.match(self.read_asset('list_make_model.4'))
+                    assert f.match(self.read_asset('dict_make_model.5'))
+                    assert not f.match(self.read_asset('dict_make_model.6'))
+                    assert f.match(self.read_asset('bool_make_model.7'))
+                    assert f.match(self.read_asset('bool_make_model.8'))
+                    assert not f.match(self.read_asset('null_make_model.9'))
+                case '<false>':
+                    assert f.match(self.read_asset('str_make_model.1'))
+                    assert f.match(self.read_asset('str_make_model.2'))
+                    assert f.match(self.read_asset('list_make_model.3'))
+                    assert f.match(self.read_asset('list_make_model.4'))
+                    assert f.match(self.read_asset('dict_make_model.5'))
+                    assert f.match(self.read_asset('dict_make_model.6'))
+                    assert f.match(self.read_asset('bool_make_model.7'))
+                    assert not f.match(self.read_asset('bool_make_model.8'))
+                    assert f.match(self.read_asset('null_make_model.9'))
+                case '<null>':
+                    assert f.match(self.read_asset('str_make_model.1'))
+                    assert f.match(self.read_asset('str_make_model.2'))
+                    assert f.match(self.read_asset('list_make_model.3'))
+                    assert f.match(self.read_asset('list_make_model.4'))
+                    assert f.match(self.read_asset('dict_make_model.5'))
+                    assert f.match(self.read_asset('dict_make_model.6'))
+                    assert f.match(self.read_asset('bool_make_model.7'))
+                    assert f.match(self.read_asset('bool_make_model.8'))
+                    assert not f.match(self.read_asset('null_make_model.9'))
+                case '<true>':
+                    assert f.match(self.read_asset('str_make_model.1'))
+                    assert f.match(self.read_asset('str_make_model.2'))
+                    assert f.match(self.read_asset('list_make_model.3'))
+                    assert f.match(self.read_asset('list_make_model.4'))
+                    assert f.match(self.read_asset('dict_make_model.5'))
+                    assert f.match(self.read_asset('dict_make_model.6'))
+                    assert not f.match(self.read_asset('bool_make_model.7'))
+                    assert f.match(self.read_asset('bool_make_model.8'))
+                    assert f.match(self.read_asset('null_make_model.9'))
+
+    @pytest.mark.parametrize('filt',
+                             [''.join(x) for x in product(
+                                 ['key', 'missing'],
+                                 ['>', '>=', '<', '<='],
+                                 ['<empty>', '<false>', '<null>', '<true>'],
+                             )])
+    def test_filter_tag_value_gt_lt(self,
+                                   filt: str) -> None:
+        """Tag value greater/less than.
+
+        Filtering tags is not supported using ``>``, ``>=``, ``<``, and ``<=``.
+        """
+
+        f = Filter(filt)
+
+        # greater/less than comparison is not allowed for tags
+        assert not f.match(self.read_asset('str_make_model.1'))
+        assert not f.match(self.read_asset('str_make_model.2'))
+        assert not f.match(self.read_asset('list_make_model.3'))
+        assert not f.match(self.read_asset('list_make_model.4'))
+        assert not f.match(self.read_asset('dict_make_model.5'))
+        assert not f.match(self.read_asset('dict_make_model.6'))
+        assert not f.match(self.read_asset('bool_make_model.7'))
+        assert not f.match(self.read_asset('bool_make_model.8'))
+        assert not f.match(self.read_asset('null_make_model.9'))
+
+    @pytest.mark.parametrize('filt',
+                             [''.join(x) for x in product(
+                                 ['key', 'missing'],
+                                 ['='],
+                                 ['<unset>'],
+                             )])
+    def test_filter_tag_unset_equal(self,
+                                    filt: str) -> None:
+        """Tag ``<unset>`` equal."""
+
+        f = Filter(filt)
+        assert f.key == filt.split('=', 1)[0]
+        assert f.operand == '='
+        assert f.value == filt.split('=', 1)[1]
+
+        match f.key:
+            case 'key':
+                assert not f.match(self.read_asset('str_make_model.1'))
+                assert not f.match(self.read_asset('str_make_model.2'))
+                assert not f.match(self.read_asset('list_make_model.3'))
+                assert not f.match(self.read_asset('list_make_model.4'))
+                assert not f.match(self.read_asset('dict_make_model.5'))
+                assert not f.match(self.read_asset('dict_make_model.6'))
+                assert not f.match(self.read_asset('bool_make_model.7'))
+                assert not f.match(self.read_asset('bool_make_model.8'))
+                assert not f.match(self.read_asset('null_make_model.9'))
+            case 'missing':
+                assert f.match(self.read_asset('str_make_model.1'))
+                assert f.match(self.read_asset('str_make_model.2'))
+                assert f.match(self.read_asset('list_make_model.3'))
+                assert f.match(self.read_asset('list_make_model.4'))
+                assert f.match(self.read_asset('dict_make_model.5'))
+                assert f.match(self.read_asset('dict_make_model.6'))
+                assert f.match(self.read_asset('bool_make_model.7'))
+                assert f.match(self.read_asset('bool_make_model.8'))
+                assert f.match(self.read_asset('null_make_model.9'))
+
+    @pytest.mark.parametrize('filt',
+                             [''.join(x) for x in product(
+                                 ['key', 'missing'],
+                                 ['!='],
+                                 ['<unset>'],
+                             )])
+    def test_filter_tag_unset_not_equal(self,
+                                        filt: str) -> None:
+        """Tag ``<unset>`` not equal."""
+
+        f = Filter(filt)
+        assert f.key == filt.split('!=', 1)[0]
+        assert f.operand == '!='
+        assert f.value == filt.split('!=', 1)[1]
+
+        match f.key:
+            case 'key':
+                assert f.match(self.read_asset('str_make_model.1'))
+                assert f.match(self.read_asset('str_make_model.2'))
+                assert f.match(self.read_asset('list_make_model.3'))
+                assert f.match(self.read_asset('list_make_model.4'))
+                assert f.match(self.read_asset('dict_make_model.5'))
+                assert f.match(self.read_asset('dict_make_model.6'))
+                assert f.match(self.read_asset('bool_make_model.7'))
+                assert f.match(self.read_asset('bool_make_model.8'))
+                assert f.match(self.read_asset('null_make_model.9'))
+            case 'missing':
+                assert not f.match(self.read_asset('str_make_model.1'))
+                assert not f.match(self.read_asset('str_make_model.2'))
+                assert not f.match(self.read_asset('list_make_model.3'))
+                assert not f.match(self.read_asset('list_make_model.4'))
+                assert not f.match(self.read_asset('dict_make_model.5'))
+                assert not f.match(self.read_asset('dict_make_model.6'))
+                assert not f.match(self.read_asset('bool_make_model.7'))
+                assert not f.match(self.read_asset('bool_make_model.8'))
+                assert not f.match(self.read_asset('null_make_model.9'))
+
+    @pytest.mark.parametrize('filt',
+                             [''.join(x) for x in product(
+                                 ['key', 'missing'],
+                                 ['>', '>=', '<', '<='],
+                                 ['<unset>'],
+                             )])
+    def test_filter_tag_unset_gt_lt(self,
+                                    filt: str) -> None:
+        """Tag ``<unset>`` greater/less than.
+
+        Filtering tags is not supported using ``>``, ``>=``, ``<``, and ``<=``.
+        """
+
+        f = Filter(filt)
+
+        # greater/less than comparison is not allowed for tags
+        assert not f.match(self.read_asset('str_make_model.1'))
+        assert not f.match(self.read_asset('str_make_model.2'))
+        assert not f.match(self.read_asset('list_make_model.3'))
+        assert not f.match(self.read_asset('list_make_model.4'))
+        assert not f.match(self.read_asset('dict_make_model.5'))
+        assert not f.match(self.read_asset('dict_make_model.6'))
+        assert not f.match(self.read_asset('bool_make_model.7'))
+        assert not f.match(self.read_asset('bool_make_model.8'))
+        assert not f.match(self.read_asset('null_make_model.9'))
 
 
-@pytest.mark.parametrize('filt', ['key><list>', 'key><dict>'])
-def test_filter_type_greater_than(filt: str) -> None:
-    """Filtering by variable type (e.g., <list> or <dict>)."""
+class TestFilterLiterals:
+    r"""Filter with empty literals.
 
-    def read_asset(name: str):
-        if name == 'type_make_model.1':
-            return dict(type='type',
-                        make='make',
-                        model='model',
-                        serial='1',
-                        key=['a', 'b', 'c'])
-        elif name == 'type_make_model.2':
-            return dict(type='type',
-                        make='make',
-                        model='model',
-                        serial='2',
-                        key={'a': 'b', 'c': 'd'})
+    This includes ``[]``, ``{}``, ``''``, ``""``.
 
-    string_type = filt.split('>', 1)[1]
-    f = Filter(filt)
-    if string_type == '<list>':
-        assert not f.match(read_asset('type_make_model.1'))
-        assert not f.match(read_asset('type_make_model.2'))
-    elif string_type == '<dict>':
-        assert not f.match(read_asset('type_make_model.1'))
-        assert not f.match(read_asset('type_make_model.2'))
+    Whether the ``Filter`` objects are initialized correctly, and the matching
+    is correct.
+    """
 
+    def read_asset(self,
+                   name: str) -> Item:
+        r"""Get a populated Item."""
 
-@pytest.mark.parametrize('filt', ['key>=<list>', 'key>=<dict>'])
-def test_filter_type_greater_than_or_equal(filt: str) -> None:
-    """Filtering by variable type (e.g., <list> or <dict>)."""
+        item = Item(type='<to-set>',
+                    make='make',
+                    model='model',
+                    serial='<to-set>',
+                    key='<to-set>')
 
-    def read_asset(name: str):
-        if name == 'type_make_model.1':
-            return dict(type='type',
-                        make='make',
-                        model='model',
-                        serial='1',
-                        key=['a', 'b', 'c'])
-        elif name == 'type_make_model.2':
-            return dict(type='type',
-                        make='make',
-                        model='model',
-                        serial='2',
-                        key={'a': 'b', 'c': 'd'})
+        match name:
+            case 'str_make_model.1':
+                item.update({'type': 'str', 'serial': '1', 'key': 'value'})
+            case 'str_make_model.2':
+                item.update({'type': 'str', 'serial': '2', 'key': ''})
+            case 'list_make_model.3':
+                item.update({'type': 'list', 'serial': '3', 'key': ['a', 'b', 'c']})
+            case 'list_make_model.4':
+                item.update({'type': 'list', 'serial': '4', 'key': []})
+            case 'dict_make_model.5':
+                item.update({'type': 'dict', 'serial': '5', 'key': {'a': 'b', 'c': 'd'}})
+            case 'dict_make_model.6':
+                item.update({'type': 'dict', 'serial': '6', 'key': {}})
+            case 'bool_make_model.7':
+                item.update({'type': 'bool', 'serial': '7', 'key': True})
+            case 'bool_make_model.8':
+                item.update({'type': 'bool', 'serial': '8', 'key': False})
+            case 'null_make_model.9':
+                item.update({'type': 'null', 'serial': '9', 'key': None})
+            case _:
+                raise ValueError("Unknown asset")
 
-    string_type = filt.split('>=', 1)[1]
-    f = Filter(filt)
-    if string_type == '<list>':
-        assert f.match(read_asset('type_make_model.1'))
-        assert not f.match(read_asset('type_make_model.2'))
-    elif string_type == '<dict>':
-        assert not f.match(read_asset('type_make_model.1'))
-        assert f.match(read_asset('type_make_model.2'))
+        return item
 
+    @pytest.mark.parametrize('filt',
+                             [''.join(x) for x in product(
+                                 ['key', 'missing'],
+                                 ['='],
+                                 ['[]', '{}', "''", '""'],
+                             )])
+    def test_filter_literal_equal(self,
+                                  filt: str) -> None:
+        """Empty literal equal."""
 
-@pytest.mark.parametrize('filt', ['key<<list>', 'key<<dict>'])
-def test_filter_type_less_than(filt: str) -> None:
-    """Filtering by variable type (e.g., <list> or <dict>)."""
+        f = Filter(filt)
+        assert f.key == filt.split('=', 1)[0]
+        assert f.operand == '='
+        assert f.value == filt.split('=', 1)[1]
 
-    def read_asset(name: str):
-        if name == 'type_make_model.1':
-            return dict(type='type',
-                        make='make',
-                        model='model',
-                        serial='1',
-                        key=['a', 'b', 'c'])
-        elif name == 'type_make_model.2':
-            return dict(type='type',
-                        make='make',
-                        model='model',
-                        serial='2',
-                        key={'a': 'b', 'c': 'd'})
+        if f.key == 'missing':
+            # cannot match against an unset key
+            assert not f.match(self.read_asset('str_make_model.1'))
+            assert not f.match(self.read_asset('str_make_model.2'))
+            assert not f.match(self.read_asset('list_make_model.3'))
+            assert not f.match(self.read_asset('list_make_model.4'))
+            assert not f.match(self.read_asset('dict_make_model.5'))
+            assert not f.match(self.read_asset('dict_make_model.6'))
+            assert not f.match(self.read_asset('bool_make_model.7'))
+            assert not f.match(self.read_asset('bool_make_model.8'))
+            assert not f.match(self.read_asset('null_make_model.9'))
+        else:
+            match f.value:
+                case '[]':
+                    assert not f.match(self.read_asset('str_make_model.1'))
+                    assert not f.match(self.read_asset('str_make_model.2'))
+                    assert not f.match(self.read_asset('list_make_model.3'))
+                    assert f.match(self.read_asset('list_make_model.4'))
+                    assert not f.match(self.read_asset('dict_make_model.5'))
+                    assert not f.match(self.read_asset('dict_make_model.6'))
+                    assert not f.match(self.read_asset('bool_make_model.7'))
+                    assert not f.match(self.read_asset('bool_make_model.8'))
+                    assert not f.match(self.read_asset('null_make_model.9'))
+                case '{}':
+                    assert not f.match(self.read_asset('str_make_model.1'))
+                    assert not f.match(self.read_asset('str_make_model.2'))
+                    assert not f.match(self.read_asset('list_make_model.3'))
+                    assert not f.match(self.read_asset('list_make_model.4'))
+                    assert not f.match(self.read_asset('dict_make_model.5'))
+                    assert f.match(self.read_asset('dict_make_model.6'))
+                    assert not f.match(self.read_asset('bool_make_model.7'))
+                    assert not f.match(self.read_asset('bool_make_model.8'))
+                    assert not f.match(self.read_asset('null_make_model.9'))
+                case "''" | '""':
+                    assert not f.match(self.read_asset('str_make_model.1'))
+                    assert f.match(self.read_asset('str_make_model.2'))
+                    assert not f.match(self.read_asset('list_make_model.3'))
+                    assert not f.match(self.read_asset('list_make_model.4'))
+                    assert not f.match(self.read_asset('dict_make_model.5'))
+                    assert not f.match(self.read_asset('dict_make_model.6'))
+                    assert not f.match(self.read_asset('bool_make_model.7'))
+                    assert not f.match(self.read_asset('bool_make_model.8'))
+                    assert not f.match(self.read_asset('null_make_model.9'))
 
-    string_type = filt.split('<', 1)[1]
-    f = Filter(filt)
-    if string_type == '<list>':
-        assert not f.match(read_asset('type_make_model.1'))
-        assert not f.match(read_asset('type_make_model.2'))
-    elif string_type == '<dict>':
-        assert not f.match(read_asset('type_make_model.1'))
-        assert not f.match(read_asset('type_make_model.2'))
+    @pytest.mark.parametrize('filt',
+                             [''.join(x) for x in product(
+                                 ['key', 'missing'],
+                                 ['!='],
+                                 ['[]', '{}', "''", '""'],
+                             )])
+    def test_filter_literal_not_equal(self,
+                                      filt: str) -> None:
+        """Empty literal not equal."""
 
+        f = Filter(filt)
+        assert f.key == filt.split('!=', 1)[0]
+        assert f.operand == '!='
+        assert f.value == filt.split('!=', 1)[1]
 
-@pytest.mark.parametrize('filt', ['key<=<list>', 'key<=<dict>'])
-def test_filter_type_less_than_or_equal(filt: str) -> None:
-    """Filtering by variable type (e.g., <list> or <dict>)."""
+        if f.key == 'missing':
+            # cannot match against an unset key
+            assert not f.match(self.read_asset('str_make_model.1'))
+            assert not f.match(self.read_asset('str_make_model.2'))
+            assert not f.match(self.read_asset('list_make_model.3'))
+            assert not f.match(self.read_asset('list_make_model.4'))
+            assert not f.match(self.read_asset('dict_make_model.5'))
+            assert not f.match(self.read_asset('dict_make_model.6'))
+            assert not f.match(self.read_asset('bool_make_model.7'))
+            assert not f.match(self.read_asset('bool_make_model.8'))
+            assert not f.match(self.read_asset('null_make_model.9'))
+        else:
+            match f.value:
+                case '[]':
+                    assert f.match(self.read_asset('str_make_model.1'))
+                    assert f.match(self.read_asset('str_make_model.2'))
+                    assert f.match(self.read_asset('list_make_model.3'))
+                    assert not f.match(self.read_asset('list_make_model.4'))
+                    assert f.match(self.read_asset('dict_make_model.5'))
+                    assert f.match(self.read_asset('dict_make_model.6'))
+                    assert f.match(self.read_asset('bool_make_model.7'))
+                    assert f.match(self.read_asset('bool_make_model.8'))
+                    assert f.match(self.read_asset('null_make_model.9'))
+                case '{}':
+                    assert f.match(self.read_asset('str_make_model.1'))
+                    assert f.match(self.read_asset('str_make_model.2'))
+                    assert f.match(self.read_asset('list_make_model.3'))
+                    assert f.match(self.read_asset('list_make_model.4'))
+                    assert f.match(self.read_asset('dict_make_model.5'))
+                    assert not f.match(self.read_asset('dict_make_model.6'))
+                    assert f.match(self.read_asset('bool_make_model.7'))
+                    assert f.match(self.read_asset('bool_make_model.8'))
+                    assert f.match(self.read_asset('null_make_model.9'))
+                case "''" | '""':
+                    assert f.match(self.read_asset('str_make_model.1'))
+                    assert not f.match(self.read_asset('str_make_model.2'))
+                    assert f.match(self.read_asset('list_make_model.3'))
+                    assert f.match(self.read_asset('list_make_model.4'))
+                    assert f.match(self.read_asset('dict_make_model.5'))
+                    assert f.match(self.read_asset('dict_make_model.6'))
+                    assert f.match(self.read_asset('bool_make_model.7'))
+                    assert f.match(self.read_asset('bool_make_model.8'))
+                    assert f.match(self.read_asset('null_make_model.9'))
 
-    def read_asset(name: str):
-        if name == 'type_make_model.1':
-            return dict(type='type',
-                        make='make',
-                        model='model',
-                        serial='1',
-                        key=['a', 'b', 'c'])
-        if name == 'type_make_model.2':
-            return dict(type='type',
-                        make='make',
-                        model='model',
-                        serial='2',
-                        key=[])
-        elif name == 'type_make_model.3':
-            return dict(type='type',
-                        make='make',
-                        model='model',
-                        serial='3',
-                        key={'a': 'b', 'c': 'd'})
-        elif name == 'type_make_model.4':
-            return dict(type='type',
-                        make='make',
-                        model='model',
-                        serial='4',
-                        key={})
+    @pytest.mark.parametrize('filt',
+                             [''.join(x) for x in product(
+                                 ['key', 'missing'],
+                                 ['>'],
+                                 ['[]', '{}', "''", '""'],
+                             )])
+    def test_filter_literal_greater_than(self,
+                                         filt: str) -> None:
+        """Empty literal greater than."""
 
-    string_type = filt.split('<=', 1)[1]
-    f = Filter(filt)
-    if string_type == '<list>':
-        assert f.match(read_asset('type_make_model.1'))
-        assert f.match(read_asset('type_make_model.2'))
-        assert not f.match(read_asset('type_make_model.3'))
-        assert not f.match(read_asset('type_make_model.4'))
-    elif string_type == '<dict>':
-        assert not f.match(read_asset('type_make_model.1'))
-        assert not f.match(read_asset('type_make_model.2'))
-        assert f.match(read_asset('type_make_model.3'))
-        assert f.match(read_asset('type_make_model.4'))
+        f = Filter(filt)
+        assert f.key == filt.split('>', 1)[0]
+        assert f.operand == '>'
+        assert f.value == filt.split('>', 1)[1]
 
+        if f.key == 'missing':
+            # cannot match against an unset key
+            assert not f.match(self.read_asset('str_make_model.1'))
+            assert not f.match(self.read_asset('str_make_model.2'))
+            assert not f.match(self.read_asset('list_make_model.3'))
+            assert not f.match(self.read_asset('list_make_model.4'))
+            assert not f.match(self.read_asset('dict_make_model.5'))
+            assert not f.match(self.read_asset('dict_make_model.6'))
+            assert not f.match(self.read_asset('bool_make_model.7'))
+            assert not f.match(self.read_asset('bool_make_model.8'))
+            assert not f.match(self.read_asset('null_make_model.9'))
+        else:
+            match f.value:
+                case '[]':
+                    assert not f.match(self.read_asset('str_make_model.1'))
+                    assert not f.match(self.read_asset('str_make_model.2'))
+                    assert f.match(self.read_asset('list_make_model.3'))
+                    assert not f.match(self.read_asset('list_make_model.4'))
+                    assert not f.match(self.read_asset('dict_make_model.5'))
+                    assert not f.match(self.read_asset('dict_make_model.6'))
+                    assert not f.match(self.read_asset('bool_make_model.7'))
+                    assert not f.match(self.read_asset('bool_make_model.8'))
+                    assert not f.match(self.read_asset('null_make_model.9'))
+                case '{}':
+                    assert not f.match(self.read_asset('str_make_model.1'))
+                    assert not f.match(self.read_asset('str_make_model.2'))
+                    assert not f.match(self.read_asset('list_make_model.3'))
+                    assert not f.match(self.read_asset('list_make_model.4'))
+                    assert f.match(self.read_asset('dict_make_model.5'))
+                    assert not f.match(self.read_asset('dict_make_model.6'))
+                    assert not f.match(self.read_asset('bool_make_model.7'))
+                    assert not f.match(self.read_asset('bool_make_model.8'))
+                    assert not f.match(self.read_asset('null_make_model.9'))
+                case "''" | '""':
+                    assert f.match(self.read_asset('str_make_model.1'))
+                    assert not f.match(self.read_asset('str_make_model.2'))
+                    assert not f.match(self.read_asset('list_make_model.3'))
+                    assert not f.match(self.read_asset('list_make_model.4'))
+                    assert not f.match(self.read_asset('dict_make_model.5'))
+                    assert not f.match(self.read_asset('dict_make_model.6'))
+                    assert not f.match(self.read_asset('bool_make_model.7'))
+                    assert not f.match(self.read_asset('bool_make_model.8'))
+                    assert not f.match(self.read_asset('null_make_model.9'))
 
-@pytest.mark.parametrize('filt', ['key=[]', 'key={}'])
-def test_filter_empty_literal_equal(filt: str) -> None:
-    """Filtering by variable type (e.g., <list> or <dict>)."""
+    @pytest.mark.parametrize('filt',
+                             [''.join(x) for x in product(
+                                 ['key', 'missing'],
+                                 ['>='],
+                                 ['[]', '{}', "''", '""'],
+                             )])
+    def test_filter_literal_greater_than_or_equal(self,
+                                                  filt: str) -> None:
+        """Empty literal greater than or equal."""
 
-    def read_asset(name: str):
-        if name == 'type_make_model.1':
-            return dict(type='type',
-                        make='make',
-                        model='model',
-                        serial='1',
-                        key=['a', 'b', 'c'])
-        if name == 'type_make_model.2':
-            return dict(type='type',
-                        make='make',
-                        model='model',
-                        serial='2',
-                        key=[])
-        elif name == 'type_make_model.3':
-            return dict(type='type',
-                        make='make',
-                        model='model',
-                        serial='3',
-                        key={'a': 'b', 'c': 'd'})
-        elif name == 'type_make_model.4':
-            return dict(type='type',
-                        make='make',
-                        model='model',
-                        serial='4',
-                        key={})
+        f = Filter(filt)
+        assert f.key == filt.split('>=', 1)[0]
+        assert f.operand == '>='
+        assert f.value == filt.split('>=', 1)[1]
 
-    string_type = filt.split('=', 1)[1]
-    f = Filter(filt)
-    if string_type == '[]':
-        assert not f.match(read_asset('type_make_model.1'))
-        assert f.match(read_asset('type_make_model.2'))
-        assert not f.match(read_asset('type_make_model.3'))
-        assert not f.match(read_asset('type_make_model.4'))
-    elif string_type == '{}':
-        assert not f.match(read_asset('type_make_model.1'))
-        assert not f.match(read_asset('type_make_model.2'))
-        assert not f.match(read_asset('type_make_model.3'))
-        assert f.match(read_asset('type_make_model.4'))
+        if f.key == 'missing':
+            # cannot match against an unset key
+            assert not f.match(self.read_asset('str_make_model.1'))
+            assert not f.match(self.read_asset('str_make_model.2'))
+            assert not f.match(self.read_asset('list_make_model.3'))
+            assert not f.match(self.read_asset('list_make_model.4'))
+            assert not f.match(self.read_asset('dict_make_model.5'))
+            assert not f.match(self.read_asset('dict_make_model.6'))
+            assert not f.match(self.read_asset('bool_make_model.7'))
+            assert not f.match(self.read_asset('bool_make_model.8'))
+            assert not f.match(self.read_asset('null_make_model.9'))
+        else:
+            match f.value:
+                case '[]':
+                    assert not f.match(self.read_asset('str_make_model.1'))
+                    assert not f.match(self.read_asset('str_make_model.2'))
+                    assert f.match(self.read_asset('list_make_model.3'))
+                    assert f.match(self.read_asset('list_make_model.4'))
+                    assert not f.match(self.read_asset('dict_make_model.5'))
+                    assert not f.match(self.read_asset('dict_make_model.6'))
+                    assert not f.match(self.read_asset('bool_make_model.7'))
+                    assert not f.match(self.read_asset('bool_make_model.8'))
+                    assert not f.match(self.read_asset('null_make_model.9'))
+                case '{}':
+                    assert not f.match(self.read_asset('str_make_model.1'))
+                    assert not f.match(self.read_asset('str_make_model.2'))
+                    assert not f.match(self.read_asset('list_make_model.3'))
+                    assert not f.match(self.read_asset('list_make_model.4'))
+                    assert f.match(self.read_asset('dict_make_model.5'))
+                    assert f.match(self.read_asset('dict_make_model.6'))
+                    assert not f.match(self.read_asset('bool_make_model.7'))
+                    assert not f.match(self.read_asset('bool_make_model.8'))
+                    assert not f.match(self.read_asset('null_make_model.9'))
+                case "''" | '""':
+                    assert f.match(self.read_asset('str_make_model.1'))
+                    assert f.match(self.read_asset('str_make_model.2'))
+                    assert not f.match(self.read_asset('list_make_model.3'))
+                    assert not f.match(self.read_asset('list_make_model.4'))
+                    assert not f.match(self.read_asset('dict_make_model.5'))
+                    assert not f.match(self.read_asset('dict_make_model.6'))
+                    assert not f.match(self.read_asset('bool_make_model.7'))
+                    assert not f.match(self.read_asset('bool_make_model.8'))
+                    assert not f.match(self.read_asset('null_make_model.9'))
 
+    @pytest.mark.parametrize('filt',
+                             [''.join(x) for x in product(
+                                 ['key', 'missing'],
+                                 ['<'],
+                                 ['[]', '{}', "''", '""'],
+                             )])
+    def test_filter_literal_less_than(self,
+                                      filt: str) -> None:
+        """Empty literal less than."""
 
-@pytest.mark.parametrize('filt', ['key>[]', 'key>{}'])
-def test_filter_empty_literal_greater_than(filt: str) -> None:
-    """Compare against a literal empty value (e.g., [] or {})."""
+        f = Filter(filt)
+        assert f.key == filt.split('<', 1)[0]
+        assert f.operand == '<'
+        assert f.value == filt.split('<', 1)[1]
 
-    def read_asset(name: str):
-        if name == 'type_make_model.1':
-            return dict(type='type',
-                        make='make',
-                        model='model',
-                        serial='1',
-                        key=['a', 'b', 'c'])
-        if name == 'type_make_model.2':
-            return dict(type='type',
-                        make='make',
-                        model='model',
-                        serial='2',
-                        key=[])
-        elif name == 'type_make_model.3':
-            return dict(type='type',
-                        make='make',
-                        model='model',
-                        serial='3',
-                        key={'a': 'b', 'c': 'd'})
-        elif name == 'type_make_model.4':
-            return dict(type='type',
-                        make='make',
-                        model='model',
-                        serial='4',
-                        key={})
+        # nothing can be less than empty
+        assert not f.match(self.read_asset('str_make_model.1'))
+        assert not f.match(self.read_asset('str_make_model.2'))
+        assert not f.match(self.read_asset('list_make_model.3'))
+        assert not f.match(self.read_asset('list_make_model.4'))
+        assert not f.match(self.read_asset('dict_make_model.5'))
+        assert not f.match(self.read_asset('dict_make_model.6'))
+        assert not f.match(self.read_asset('bool_make_model.7'))
+        assert not f.match(self.read_asset('bool_make_model.8'))
+        assert not f.match(self.read_asset('null_make_model.9'))
 
-    string_type = filt.split('>', 1)[1]
-    f = Filter(filt)
-    if string_type == '[]':
-        assert f.match(read_asset('type_make_model.1'))
-        assert not f.match(read_asset('type_make_model.2'))
-        assert not f.match(read_asset('type_make_model.3'))
-        assert not f.match(read_asset('type_make_model.4'))
-    elif string_type == '{}':
-        assert not f.match(read_asset('type_make_model.1'))
-        assert not f.match(read_asset('type_make_model.2'))
-        assert f.match(read_asset('type_make_model.3'))
-        assert not f.match(read_asset('type_make_model.4'))
+    @pytest.mark.parametrize('filt',
+                             [''.join(x) for x in product(
+                                 ['key', 'missing'],
+                                 ['<='],
+                                 ['[]', '{}', "''", '""'],
+                             )])
+    def test_filter_literal_less_than_or_equal(self,
+                                               filt: str) -> None:
+        """Empty literal less than or equal."""
 
+        f = Filter(filt)
+        assert f.key == filt.split('<=', 1)[0]
+        assert f.operand == '<='
+        assert f.value == filt.split('<=', 1)[1]
 
-@pytest.mark.parametrize('filt', ['key>=[]', 'key>={}'])
-def test_filter_empty_literal_greater_than_or_equal(filt: str) -> None:
-    """Compare against a literal empty value (e.g., [] or {})."""
-
-    def read_asset(name: str):
-        if name == 'type_make_model.1':
-            return dict(type='type',
-                        make='make',
-                        model='model',
-                        serial='1',
-                        key=['a', 'b', 'c'])
-        if name == 'type_make_model.2':
-            return dict(type='type',
-                        make='make',
-                        model='model',
-                        serial='2',
-                        key=[])
-        elif name == 'type_make_model.3':
-            return dict(type='type',
-                        make='make',
-                        model='model',
-                        serial='3',
-                        key={'a': 'b', 'c': 'd'})
-        elif name == 'type_make_model.4':
-            return dict(type='type',
-                        make='make',
-                        model='model',
-                        serial='4',
-                        key={})
-
-    string_type = filt.split('>=', 1)[1]
-    f = Filter(filt)
-    if string_type == '[]':
-        assert f.match(read_asset('type_make_model.1'))
-        assert f.match(read_asset('type_make_model.2'))
-        assert not f.match(read_asset('type_make_model.3'))
-        assert not f.match(read_asset('type_make_model.4'))
-    elif string_type == '{}':
-        assert not f.match(read_asset('type_make_model.1'))
-        assert not f.match(read_asset('type_make_model.2'))
-        assert f.match(read_asset('type_make_model.3'))
-        assert f.match(read_asset('type_make_model.4'))
-
-
-@pytest.mark.parametrize('filt', ['key<[]', 'key<{}'])
-def test_filter_empty_literal_less_than(filt: str) -> None:
-    """Compare against a literal empty value (e.g., [] or {})."""
-
-    def read_asset(name: str):
-        if name == 'type_make_model.1':
-            return dict(type='type',
-                        make='make',
-                        model='model',
-                        serial='1',
-                        key=['a', 'b', 'c'])
-        if name == 'type_make_model.2':
-            return dict(type='type',
-                        make='make',
-                        model='model',
-                        serial='2',
-                        key=[])
-        elif name == 'type_make_model.3':
-            return dict(type='type',
-                        make='make',
-                        model='model',
-                        serial='3',
-                        key={'a': 'b', 'c': 'd'})
-        elif name == 'type_make_model.4':
-            return dict(type='type',
-                        make='make',
-                        model='model',
-                        serial='4',
-                        key={})
-
-    string_type = filt.split('<', 1)[1]
-    f = Filter(filt)
-    if string_type == '[]':
-        assert not f.match(read_asset('type_make_model.1'))
-        assert not f.match(read_asset('type_make_model.2'))
-        assert not f.match(read_asset('type_make_model.3'))
-        assert not f.match(read_asset('type_make_model.4'))
-    elif string_type == '{}':
-        assert not f.match(read_asset('type_make_model.1'))
-        assert not f.match(read_asset('type_make_model.2'))
-        assert not f.match(read_asset('type_make_model.3'))
-        assert not f.match(read_asset('type_make_model.4'))
-
-
-@pytest.mark.parametrize('filt', ['key<=[]', 'key<={}'])
-def test_filter_empty_literal_less_than_or_equal(filt: str) -> None:
-    """Compare against a literal empty value (e.g., [] or {})."""
-
-    def read_asset(name: str):
-        if name == 'type_make_model.1':
-            return dict(type='type',
-                        make='make',
-                        model='model',
-                        serial='1',
-                        key=['a', 'b', 'c'])
-        if name == 'type_make_model.2':
-            return dict(type='type',
-                        make='make',
-                        model='model',
-                        serial='2',
-                        key=[])
-        elif name == 'type_make_model.3':
-            return dict(type='type',
-                        make='make',
-                        model='model',
-                        serial='3',
-                        key={'a': 'b', 'c': 'd'})
-        elif name == 'type_make_model.4':
-            return dict(type='type',
-                        make='make',
-                        model='model',
-                        serial='4',
-                        key={})
-
-    string_type = filt.split('<=', 1)[1]
-    f = Filter(filt)
-    if string_type == '[]':
-        assert not f.match(read_asset('type_make_model.1'))
-        assert f.match(read_asset('type_make_model.2'))
-        assert not f.match(read_asset('type_make_model.3'))
-        assert not f.match(read_asset('type_make_model.4'))
-    elif string_type == '{}':
-        assert not f.match(read_asset('type_make_model.1'))
-        assert not f.match(read_asset('type_make_model.2'))
-        assert not f.match(read_asset('type_make_model.3'))
-        assert f.match(read_asset('type_make_model.4'))
-
-
-def test_filter_re_equal() -> None:
-    """Filtering with regular expressions."""
-
-    assert not Filter._re_match(text='foo(', r='foo(')
-    assert Filter._re_match(text='foo', r='foo')
-    assert Filter._re_match(text='foobar', r='foo.*')
+        if f.key == 'missing':
+            # cannot match against an unset key
+            assert not f.match(self.read_asset('str_make_model.1'))
+            assert not f.match(self.read_asset('str_make_model.2'))
+            assert not f.match(self.read_asset('list_make_model.3'))
+            assert not f.match(self.read_asset('list_make_model.4'))
+            assert not f.match(self.read_asset('dict_make_model.5'))
+            assert not f.match(self.read_asset('dict_make_model.6'))
+            assert not f.match(self.read_asset('bool_make_model.7'))
+            assert not f.match(self.read_asset('bool_make_model.8'))
+            assert not f.match(self.read_asset('null_make_model.9'))
+        else:
+            match f.value:
+                case '[]':
+                    assert not f.match(self.read_asset('str_make_model.1'))
+                    assert not f.match(self.read_asset('str_make_model.2'))
+                    assert not f.match(self.read_asset('list_make_model.3'))
+                    assert f.match(self.read_asset('list_make_model.4'))
+                    assert not f.match(self.read_asset('dict_make_model.5'))
+                    assert not f.match(self.read_asset('dict_make_model.6'))
+                    assert not f.match(self.read_asset('bool_make_model.7'))
+                    assert not f.match(self.read_asset('bool_make_model.8'))
+                    assert not f.match(self.read_asset('null_make_model.9'))
+                case '{}':
+                    assert not f.match(self.read_asset('str_make_model.1'))
+                    assert not f.match(self.read_asset('str_make_model.2'))
+                    assert not f.match(self.read_asset('list_make_model.3'))
+                    assert not f.match(self.read_asset('list_make_model.4'))
+                    assert not f.match(self.read_asset('dict_make_model.5'))
+                    assert f.match(self.read_asset('dict_make_model.6'))
+                    assert not f.match(self.read_asset('bool_make_model.7'))
+                    assert not f.match(self.read_asset('bool_make_model.8'))
+                    assert not f.match(self.read_asset('null_make_model.9'))
+                case "''" | '""':
+                    assert not f.match(self.read_asset('str_make_model.1'))
+                    assert f.match(self.read_asset('str_make_model.2'))
+                    assert not f.match(self.read_asset('list_make_model.3'))
+                    assert not f.match(self.read_asset('list_make_model.4'))
+                    assert not f.match(self.read_asset('dict_make_model.5'))
+                    assert not f.match(self.read_asset('dict_make_model.6'))
+                    assert not f.match(self.read_asset('bool_make_model.7'))
+                    assert not f.match(self.read_asset('bool_make_model.8'))
+                    assert not f.match(self.read_asset('null_make_model.9'))
 
 
 @pytest.mark.parametrize('filter_arg', [
@@ -648,7 +1405,7 @@ def test_filter_re_equal() -> None:
     'key<', '<value', 'key<=', '<=value',
 ])
 def test_filter_invalid(filter_arg: str) -> None:
-    """Invalid filters raise the correct exception."""
+    """Raise on invalid filter string."""
 
     with pytest.raises(OnyoInvalidFilterError) as exc:
         Filter(filter_arg)
@@ -657,7 +1414,7 @@ def test_filter_invalid(filter_arg: str) -> None:
 
 
 def test_filter_format() -> None:
-    """The input argument 'key=value' is formatted into ``key`` and ``value`` properties."""
+    """Split filter string into ``key``, ``operand``, and ``value`` properties."""
 
     # =
     assert Filter._format('key=value') == ('key', '=', 'value')

--- a/onyo/lib/tests/test_commands_mkdir.py
+++ b/onyo/lib/tests/test_commands_mkdir.py
@@ -66,9 +66,8 @@ def test_onyo_mkdir_errors(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_mkdir_errors_before_mkdir(inventory: Inventory) -> None:
-    r"""`onyo_mkdir` must raise the correct error and is not allowed to create/commit anything, if
-    one of the specified paths is not valid.
-    """
+    r"""Raise and do not commit/modify if one of the specified paths is not valid."""
+
     dir_path_new = inventory.root / 'new_dir'
     dir_path_existing = inventory.root / 'empty'
     old_hexsha = inventory.repo.git.get_hexsha()

--- a/onyo/lib/tests/test_commands_mv.py
+++ b/onyo/lib/tests/test_commands_mv.py
@@ -71,9 +71,8 @@ def test_onyo_mv_errors(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_mv_errors_before_mv(inventory: Inventory) -> None:
-    r"""`onyo_mv` must raise the correct error and is not allowed to move/commit anything, if one of
-    the sources does not exist.
-    """
+    r"""Raise and do not move/commit anything, if a source does not exist."""
+
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     destination_path = inventory.root / 'empty'
     old_hexsha = inventory.repo.git.get_hexsha()
@@ -156,9 +155,9 @@ def test_onyo_mv_move_simple(inventory: Inventory,
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_mv_move_to_explicit_destination(inventory: Inventory) -> None:
-    r"""Allow moving a source to a destination stating the
-    destination name explicitely, e.g.:
-    inventory.root/dir1/asset -> inventory.root/dir2/asset.
+    r"""Move with an explicit destination name.
+
+    For example: inventory.root/dir1/asset -> inventory.root/dir2/asset
     """
     dir_path = inventory.root / 'somewhere' / 'nested'
     # move by explicitly restating the source's name:

--- a/onyo/lib/tests/test_commands_new.py
+++ b/onyo/lib/tests/test_commands_new.py
@@ -32,8 +32,7 @@ def test_onyo_new_invalid(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_new_keys(inventory: Inventory) -> None:
-    r"""`onyo_new()` must create new assets with the contents set correctly
-    when called with `keys`.
+    r"""Create new assets with the contents set correctly, using ``keys``.
 
     Each successful call of `onyo_new()` must add one commit.
     """
@@ -132,9 +131,7 @@ def test_onyo_new_keys(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_new_creates_directories(inventory: Inventory) -> None:
-    r"""`onyo_new()` must create new directories and subdirectories when called
-    on a `directory` that does not yet exist, and add assets correctly to it.
-    """
+    r"""Create new directories and subdirectories when called on a ``directory`` that does not yet exist."""
 
     specs = [{'type': 'a type',
               'make': 'I made it',

--- a/onyo/lib/tests/test_commands_rm.py
+++ b/onyo/lib/tests/test_commands_rm.py
@@ -64,9 +64,8 @@ def test_onyo_rm_errors(inventory: Inventory) -> None:
 
 @pytest.mark.ui({'yes': True})
 def test_onyo_rm_errors_before_rm(inventory: Inventory) -> None:
-    r"""`onyo_rm` must raise the correct error and is not allowed to delete anything if one of
-    the paths does not exist.
-    """
+    r"""Raise and do not delete/commit anything if one of the paths does not exist."""
+
     asset_path = inventory.root / "somewhere" / "nested" / "TYPE_MAKER_MODEL.SERIAL"
     destination_path = inventory.root / 'empty'
     old_hexsha = inventory.repo.git.get_hexsha()

--- a/onyo/lib/tests/test_git.py
+++ b/onyo/lib/tests/test_git.py
@@ -14,10 +14,8 @@ from onyo.lib.git import GitRepo
 
 
 def test_GitRepo_instantiation(tmp_path: Path) -> None:
-    """
-    The `GitRepo` class must instantiate and set the root correctly for paths
-    to existing repositories.
-    """
+    """Instantiate and set the root correctly for paths to existing repositories."""
+
     # initialize the temp_path as a git repository
     subprocess.run(['git', 'init', tmp_path])
 
@@ -54,9 +52,10 @@ def test_GitRepo_init_without_reinit(tmp_path: Path) -> None:
 
 
 def test_GitRepo_find_root(tmp_path: Path) -> None:
-    """
-    `GitRepo.find_root()` MUST identify the root of a repository for the root
-    itself and sub-directories of a repository.
+    """``find_root()`` discovers the repo root correctly.
+
+    Both when passed the root itself and subdirectories of a repository.
+
     If called on a Path which is not a git repository it must raise an
     `OnyoInvalidRepoError`.
     """
@@ -88,10 +87,9 @@ def test_GitRepo_find_root(tmp_path: Path) -> None:
 
 
 def test_GitRepo_clear_cache(gitrepo) -> None:
-    """
-    The function `GitRepo.clear_cache()` must allow to empty the cache of the
-    GitRepo, so that an invalid cache can be re-loaded by a new call of the
-    property.
+    """``clear_cache()`` empties the cache of GitRepo.
+
+    So that an invalid cache can be re-loaded by a new call of the property.
     """
     # create+add a file so it is cached in the gitrepo.files
     file = gitrepo.root / 'asset_for_test.0'
@@ -113,9 +111,9 @@ def test_GitRepo_clear_cache(gitrepo) -> None:
 
 
 def test_GitRepo_is_clean_worktree(gitrepo) -> None:
-    """
-    `GitRepo.is_clean_worktree()´ must return True when the worktree is clean,
-    and otherwise (i.e. for changed, staged, and unstracked files) return False.
+    """``is_clean_worktree()`´ returns ``True`` when the worktree is clean and ``False`` otherwise.
+
+    Changed, staged, and untracked files return ``False``.
     """
     test_file = gitrepo.root / "test_file.txt"
 
@@ -155,10 +153,9 @@ def test_GitRepo_is_clean_worktree(gitrepo) -> None:
 
 
 def test_GitRepo_is_git_path(gitrepo) -> None:
-    """
-    `GitRepo.is_git_path()` needs to identify and return True for `.git/*`,
-    `.gitignore`, `.gitattributes`, `.gitmodules`, etc., and otherwise return
-    False.
+    """``is_git_path()`` identifies git paths.
+
+    Such as ``.git/*``, ``.gitignore``, ``.gitattributes``, ``.gitmodules``, etc.
     """
     directory = gitrepo.root / 'existing' / 'directory'
     directory.mkdir(parents=True, exist_ok=True)
@@ -182,8 +179,7 @@ def test_GitRepo_is_git_path(gitrepo) -> None:
 
 
 def test_GitRepo_commit(gitrepo) -> None:
-    """
-    `GitRepo.commit()` must commit all staged changes.
+    """`GitRepo.commit()` must commit all staged changes.
 
     This test follows the scheme of `test_GitRepo_add()`.
     """

--- a/onyo/lib/tests/test_git.py
+++ b/onyo/lib/tests/test_git.py
@@ -133,7 +133,7 @@ def test_GitRepo_is_clean_worktree(gitrepo) -> None:
     assert gitrepo.is_clean_worktree()
 
     # a file modified but not commit-ed (i.e. changed) must lead to return False
-    test_file.open('w').write('Test: content')
+    test_file.write_text('Test: content')
     subprocess.run(['git', 'add', str(test_file)], check=True, cwd=gitrepo.root)
     assert not gitrepo.is_clean_worktree()
 
@@ -197,7 +197,7 @@ def test_GitRepo_commit(gitrepo) -> None:
     assert test_file in gitrepo.files
 
     # modify an existing file, and add it
-    test_file.open('w').write('Test: content')
+    test_file.write_text('Test: content')
     gitrepo.commit(test_file, "Test commit message")
     assert hexsha == gitrepo.get_hexsha('HEAD~1')
     assert test_file in gitrepo.files

--- a/onyo/lib/tests/test_utils.py
+++ b/onyo/lib/tests/test_utils.py
@@ -26,6 +26,7 @@ model:  # comment at intermediate node
 # keys and values need to preserve leading zeroes and underscores:
 serial: 00012_3456
 003_5: true
+a_false: false
 explicit_null: null
 tilde_null: ~ # what now
 implicit_null:
@@ -87,7 +88,14 @@ def test_get_asset_content(tmp_path) -> None:
             if 'null' in key:
                 assert d[key] is None
                 continue
-            assert isinstance(d[key], int if key == 'explicit' else str)
+
+            match key:
+                case 'explicit':
+                    assert isinstance(d[key], int)
+                case '003_5'|'a_false':
+                    assert isinstance(d[key], bool)
+                case _:
+                    assert isinstance(d[key], str)
 
     assert_all_keys_strings(asset_dict)
 

--- a/onyo/lib/utils.py
+++ b/onyo/lib/utils.py
@@ -385,4 +385,4 @@ def write_asset_file(path: Path,
     """
 
     # TODO: Get file path from onyo.path.file?
-    path.open('w').write(dict_to_asset_yaml(asset))
+    path.write_text(dict_to_asset_yaml(asset))

--- a/onyo/lib/utils.py
+++ b/onyo/lib/utils.py
@@ -42,15 +42,23 @@ def get_patched_yaml() -> YAML:  # pyre-ignore[11]
     yaml = YAML(typ='rt', pure=True)
 
     # YAML nulls are `None`
-    yaml.resolver.add_implicit_resolver(tag="tag:yaml.org,2002:null",
-                                        regexp=RegExp('''^(?: ~
-                                                      |null|Null|NULL
-                                                      | )$''', re.X),
-                                        first=['~', 'n', 'N', ''])
+    yaml.resolver.add_implicit_resolver(
+            tag="tag:yaml.org,2002:null",
+            regexp=RegExp('''^(?: ~|null|Null|NULL| )$''', re.X),
+            first=['~', 'n', 'N', '']
+    )
+    # true/false are booleans (and ignore YAML's on/off yes/no madness)
+    yaml.resolver.add_implicit_resolver(
+            tag='tag:yaml.org,2002:bool',
+            regexp=RegExp(r'''^(?:true|True|TRUE|false|False|FALSE)$''', re.X),
+            first=['t', 'T', 'f', 'F']
+    )
     # everything else is a string
-    yaml.resolver.add_implicit_resolver(tag="tag:yaml.org,2002:str",
-                                        regexp=RegExp('^.*$'),
-                                        first=None)
+    yaml.resolver.add_implicit_resolver(
+            tag="tag:yaml.org,2002:str",
+            regexp=RegExp('^.*$'),
+            first=None
+    )
 
     return yaml
 

--- a/onyo/tests/demo/test_generate_demo_repo.py
+++ b/onyo/tests/demo/test_generate_demo_repo.py
@@ -3,10 +3,8 @@ from pathlib import Path
 
 
 def test_generate_demo_repo(tmp_path, request) -> None:
-    r"""
-    Generate an Onyo demo repository, and compare it against the git log of
-    another known-good-demo-repo.
-    """
+    r"""Generate an Onyo demo repository and compare it against a reference git log."""
+
     script = Path(request.path.parent.parent.parent.parent, 'demo/', 'generate_demo_repo.sh')
 
     ret = subprocess.run([script, tmp_path],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ lint.ignore = [
     "D103",  # Missing docstring in public function
     "D104",  # Missing docstring in public package
     "D202",  # No blank lines allowed after function docstring (found {num_lines})
-    "D205",  # 1 blank line required between summary line and description
     "D401",  # First line of docstring should be in imperative mood: "{first_line}"
     "E501",  # Line too long (82 > 79 characters)
 ]


### PR DESCRIPTION
The primary purpose of this is to allow filtering numerical fields (e.g. `cpu.cores < 4`, etc). However, we get string comparisons for free as well, so filtering according to alphabetical order, etc, is possible (e.g. `type>laptop`).

fixes #719 