### PR TITLE
BF/NF/TST/DOC: allow multiple `onyo get --match` statements (enabling OR)

### DIFF
--- a/onyo/argparse_helpers.py
+++ b/onyo/argparse_helpers.py
@@ -109,6 +109,39 @@ class StoreSingleKeyValuePairs(argparse.Action):
         setattr(namespace, self.dest, results)
 
 
+class StoreMatchOption(argparse.Action):
+    r"""Store match statements and retain their order across multiple invocations."""
+
+    def __call__(self,
+                 parser: argparse.ArgumentParser,
+                 namespace: argparse.Namespace,
+                 keys: list[str],
+                 option_string: str | None = None) -> None:
+        r"""Store a list of match statements in a list.
+
+        This way multiple invocations of ``--match``  won't have their lists
+        merged together, and can be considered independently of one another
+        (i.e. ``OR``).
+
+        Parameters
+        ----------
+        parser
+            ArgumentParser object that contains this action.
+        namespace
+            Namespace object returned by :py:meth:`argparse.ArgumentParser.parse_args`.
+        keys
+            List of strings containing match statements.
+        option_string
+            Option string used to invoke this action.
+        """
+
+        items = getattr(namespace, self.dest, None)
+        items = list() if items is None else items
+        items.append(keys)
+
+        setattr(namespace, self.dest, items)
+
+
 class StoreSortOption(argparse.Action):
     r"""Store keys-to-sort and retain their order across multiple invoking options.
 

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -455,7 +455,7 @@ def onyo_get(inventory: Inventory,
              exclude: list[Path] | Path | None = None,
              depth: int = 0,
              machine_readable: bool = False,
-             match: list[Callable[[dict], bool]] | None = None,
+             match: list[Callable[[dict], bool]] | list[list[Callable[[dict], bool]]] | None = None,
              keys: list[str] | None = None,
              sort: dict[str, sort_t] | None = None,
              types: list[Literal['assets', 'directories']] | None = None,
@@ -472,13 +472,16 @@ def onyo_get(inventory: Inventory,
         The Inventory to query.
     include
         Paths under which to query. Default is inventory root.
+
         Passed to :py:func:`onyo.lib.inventory.Inventory.get_items`.
     exclude
         Paths to exclude (i.e. results underneath will not be returned).
+
         Passed to :py:func:`onyo.lib.inventory.Inventory.get_items`.
     depth
         Number of levels to descend into the directories specified by
         ``include``. A depth of ``0`` descends recursively without limit.
+
         Passed to :py:func:`onyo.lib.inventory.Inventory.get_items`.
     machine_readable
         Print results in a machine-friendly format (no headers; separate values
@@ -489,6 +492,12 @@ def onyo_get(inventory: Inventory,
         are passed an :py:class:`onyo.lib.items.Item` and are expected to
         return a ``bool``. All keys can be matched, and are not limited to
         those specified by ``keys``.
+
+        Within a list of Callables, all must return True for an Item to
+        match. When multiple lists are passed, only one list of Callables
+        must match for an Item to match (e.g. each list of Callables is
+        connected with a logical ``or``).
+
         Passed to :py:func:`onyo.lib.inventory.Inventory.get_items`.
     keys
         Keys to print the values of. Default is asset-name keys and ``path``.
@@ -503,6 +512,7 @@ def onyo_get(inventory: Inventory,
         Types of inventory items to consider. Equivalent to
         ``onyo.is.asset=True`` and ``onyo.is.directory=True``.
         Default is ``['assets']``.
+
         Passed to :py:func:`onyo.lib.inventory.Inventory.get_items`.
 
     Raises

--- a/onyo/lib/tests/test_item.py
+++ b/onyo/lib/tests/test_item.py
@@ -37,6 +37,9 @@ def test_item_init(onyorepo) -> None:
         assert (item.get('some.nested') == '0_03') if idx in [1, 2] else item.get('some.nested') is None
         # Non-existing keys raise proper error:
         pytest.raises(KeyError, lambda: item['doesnotexist'])
+        # however get() does not raise for non-existing keys
+        for key in ['dne', 'type.dne', 'model.dne', 'path.dne', 'dne.dne']:
+            assert item.get(key) is None
         # If a Path was given, at the very least the absolute path is available:
         if idx in [3, 4, 5, 6]:
             assert isinstance(item.get('onyo.path.absolute'), Path)

--- a/onyo/lib/tests/test_utils_dotnotationwrapper.py
+++ b/onyo/lib/tests/test_utils_dotnotationwrapper.py
@@ -36,19 +36,19 @@ def test_get_values():
     with pytest.raises(KeyError) as exc_info:
         dne = wrapper["dne"]  # noqa: F841
     assert exc_info.match("dne")
-    with pytest.raises(TypeError) as exc_info:
+    with pytest.raises(KeyError) as exc_info:
         dne = wrapper['some.dne']  # noqa: F841
     assert exc_info.match("'some' is not a dictionary.")
     with pytest.raises(KeyError) as exc_info:
         dne = wrapper['nested.dne']  # noqa: F841
     assert exc_info.match("nested.dne")
-    with pytest.raises(TypeError) as exc_info:
+    with pytest.raises(KeyError) as exc_info:
         dne = wrapper['nested.one.dne']  # noqa: F841
     assert exc_info.match("'nested.one' is not a dictionary.")
     with pytest.raises(KeyError) as exc_info:
         dne = wrapper['nested.deep.dne']  # noqa: F841
     assert exc_info.match("nested.deep.dne")
-    with pytest.raises(TypeError) as exc_info:
+    with pytest.raises(KeyError) as exc_info:
         dne = wrapper['nested.deep.key.dne']  # noqa: F841
     assert exc_info.match("'nested.deep.key' is not a dictionary.")
 

--- a/onyo/lib/utils.py
+++ b/onyo/lib/utils.py
@@ -148,14 +148,14 @@ class DotNotationWrapper(UserDict):
                     except KeyError as e:
                         raise KeyError(f"'{'.'.join(parts[:lvl + 1])}'") from e
                     except TypeError as e:
-                        raise TypeError(f"'{'.'.join(parts[:lvl])}' is not a dictionary.") from e
+                        raise KeyError(f"'{'.'.join(parts[:lvl])}' is not a dictionary.") from e
 
             try:
                 return effective_dict[parts[-1]]
             except KeyError as e:
                 raise KeyError(f"'{key}'") from e
             except TypeError as e:
-                raise TypeError(f"'{'.'.join(parts[:-1])}' is not a dictionary.") from e
+                raise KeyError(f"'{'.'.join(parts[:-1])}' is not a dictionary.") from e
 
         return super().__getitem__(key)
 


### PR DESCRIPTION
The big feature is enabling `onyo get` to have multiple `--match` invocations. This allows for an "OR" operator in addition to what was previously just "AND".

The behavior is the exact same as before, and this feature is the equivalent of running multiple `onyo get` statements and deduplicating the results. Having this supported directly in `onyo get` is more performant, and saves the user the effort of deduplicating and re-sorting the merged outputs.

An unrelated (but annoying) bug was fixed, WRT to querying subkeys of a missing key.

fix #361
fix #649
fix #697