### PR TITLE
Bump python baseline from 3.11 -> 3.13

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.11', '3.13']
+        python-version: ['3.13']
 
     steps:
     - uses: actions/checkout@v4

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,9 +3,9 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-lts-latest
   tools:
-    python: "3.12"
+    python: latest
   jobs:
     pre_build:
       - make -C docs generate

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ For bug reports and suggestions, please [open an issue](https://github.com/psyin
 ### Setup
 
 > **Note**
-> Onyo requires Python 3.11 or higher.
+> Onyo requires Python 3.13 or higher.
 
 #### (1) Fork the Onyo repository
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ and general information about Onyo.
 
 #### Non-Python Dependencies
 
-Onyo requires Python >= 3.11 and a few system utilities.
+Onyo requires Python >= 3.13 and a few system utilities.
 
 Debian/Ubuntu:
 ```

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -4,7 +4,7 @@ Installation
 Non-Python Dependencies
 ***********************
 
-In addition to Python >= 3.11 and a few Python modules, Onyo depends on a few
+In addition to Python >= 3.13 and a few Python modules, Onyo depends on a few
 system utilities.
 
 **Debian/Ubuntu**:

--- a/onyo/argparse_helpers.py
+++ b/onyo/argparse_helpers.py
@@ -51,11 +51,9 @@ class StoreMultipleKeyValuePairs(argparse.Action):
 
         key_counts = {k: len(v) for k, v in key_lists.items()}
         key_max_count = max(key_counts.values())
-        # Python < 3.12 does not support backslashes in f-strings
-        linesep = '\n'
         if any([True for k, c in key_counts.items() if 1 < c < key_max_count]):
             parser.error(f"All keys given multiple times must be given the same number of times:\n"
-                         f"{f'{linesep}'.join(['{}: {}'.format(k, c) for k, c in key_counts.items() if 1 < c])}")
+                         f"{'\n'.join(['{}: {}'.format(k, c) for k, c in key_counts.items() if 1 < c])}")
 
         results = []
         for i in range(key_max_count):


### PR DESCRIPTION
This bumps the baseline Python version from 3.11 to 3.13.

In the future, we won't bump so aggressively. But while developing, there is little incentive to support versions that we are not running and have little intention of supporting.

I also bumped the ReadTheDocs build environment.