### PR TITLE
BF/RF: use pathspec module for `.{git,onyo}ignore` files

### DIFF
--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -351,11 +351,14 @@ def _edit_asset(inventory: Inventory,
                     # should not be possible
                     raise RuntimeError(f"Unexpected response: {response}")
 
+        # if no edits were made, move on
+        if not operations:
+            break
+
         # show diff and ask for confirmation
-        if operations:
-            ui.print("Effective changes:")
-            for op in operations:
-                print_diff(op)
+        ui.print("Effective changes:")
+        for op in operations:
+            print_diff(op)
 
         response = ui.request_user_response(
             "Accept changes? (y)es / continue (e)diting / (s)kip asset / (a)bort command ",

--- a/onyo/lib/tests/test_git.py
+++ b/onyo/lib/tests/test_git.py
@@ -323,9 +323,11 @@ def test_GitRepo_check_ignore(gitrepo) -> None:
                      committed]
     excluded = gitrepo.check_ignore(ignore=ignore_file,
                                     paths=paths_to_test)
+
+    assert len(excluded) == 3
     assert all(p in excluded for p in paths_to_test if p.name.endswith('.pdf'))
     assert all(p in excluded for p in paths_to_test if gitrepo.root / 'sub' in p.parents)
     assert all(p not in excluded for p in paths_to_test if p.name.endswith('.txt'))
 
-    pytest.raises(subprocess.CalledProcessError, gitrepo.check_ignore,
+    pytest.raises(ValueError, gitrepo.check_ignore,
                   ignore=ignore_file, paths=[Path('/') / 'outside' / 'sub' / 'file'])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,11 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "ruamel.yaml",
-    "rich",
+    "fastnumbers",  # not strictly necessary; makes natsort's number parsing faster
     "natsort",
-    "fastnumbers"  # not strictly neccessary, but makes natsort's number parsing faster
+    "pathspec",
+    "rich",
+    "ruamel.yaml",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 description = "Textual inventory system backed by git"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.13"
 keywords = ["inventory", "git"]
 license = {text = "ISC"}
 classifiers = [


### PR DESCRIPTION
Though `GitRepo.check_ignore()` allows a list of paths to be passed, upper levels of Onyo only ever check one path at a time.

This inefficiency was made even more expensive, as each call spawned a subprocess for `git check-ignore` to check the path against the ignore file.

On our internal repository, this caused over 1,100 calls to `git check-ignore` for a single `onyo get` call.

Thankfully, there is a (seemingly) mature project (pathspec) that understands the patterns used in git ignore files.

Here, I swap out `git check-ignore` for pathspec.

In our internal inventory repository (which has three `.onyoignore` files), it brought that same `onyo get` call (with 1,100 `git check-ignore` invocations) down from an average of 2.80s to 1.18s.

I would love to show numbers from the benchmarking suite, however, the generated repos did not include `.onyoignore` files, and so were unaffected by this.

Also includes two unrelated bugfixes.

fix #767