### PR TITLE
BF/RF: fix command length overflow; cache `OnyoRepo.get_config()`

### DIFF
--- a/onyo/cli/tests/test_edit.py
+++ b/onyo/cli/tests/test_edit.py
@@ -76,11 +76,13 @@ def test_get_editor_precedence(repo: OnyoRepo) -> None:
 
     # onyo should win
     ret = subprocess.run(["git", "config", '--unset', "onyo.core.editor"])
+    repo.clear_cache()
     assert ret.returncode == 0
     assert repo.get_editor() == 'onyo'
 
     # $EDITOR is all that's left
     ret = subprocess.run(["onyo", "config", '--unset', "onyo.core.editor"])
+    repo.clear_cache()
     assert ret.returncode == 0
     assert repo.get_editor() == 'editor'
 

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -341,11 +341,13 @@ def _edit_asset(inventory: Inventory,
                 case 'edit':
                     continue
                 case 'skip':
+                    tmp_path.unlink()
                     return Item()
                 case 'abort':
                     # Error message was already passed to ui. Raise a different exception instead.
                     # TODO: Own exception class for that purpose? Can we have no message at all?
                     #       -> Make possible in main.py
+                    tmp_path.unlink()
                     raise ValueError("Command canceled.") from e
                 case _:
                     # should not be possible
@@ -380,8 +382,10 @@ def _edit_asset(inventory: Inventory,
             case 'edit':
                 continue
             case 'skip':
+                tmp_path.unlink()
                 return Item()
             case 'abort':
+                tmp_path.unlink()
                 raise KeyboardInterrupt
             case _:
                 # should not be possible

--- a/onyo/lib/git.py
+++ b/onyo/lib/git.py
@@ -109,7 +109,7 @@ class GitRepo(object):
     def files(self) -> list[Path]:
         r"""Get the absolute ``Path``\ s of all tracked files.
 
-        This property is cached, and is reset automatically by :py:func:`commit()`.
+        This property is cached, and is reset automatically by :py:func:`commit`.
         """
 
         if not self._files:

--- a/onyo/lib/git.py
+++ b/onyo/lib/git.py
@@ -186,12 +186,29 @@ class GitRepo(object):
             The git commit message.
         """
 
+        from onyo.lib.utils import get_temp_file
+
         if isinstance(paths, Path):
             paths = [paths]
 
+        # Pass paths and message as files to avoid exceeding the OS's maximum
+        # command and argument length.
+        # Detecting this accurately cross-platform is buggy and complicated for
+        # no gain.
         pathspecs = [str(p) for p in paths]
-        self._git(['add'] + pathspecs)
-        self._git(['commit', '-m', message, '--'] + pathspecs)
+        tmpfile_paths = get_temp_file(suffix='.commit-paths')
+        tmpfile_paths.write_text('\x00'.join(pathspecs))
+
+        tmpfile_message = get_temp_file(suffix='.commit-message')
+        tmpfile_message.write_text(message)
+
+        # stage and commit
+        self._git(['add', '--pathspec-file-nul', '--pathspec-from-file', str(tmpfile_paths)])
+        self._git(['commit', '--file', str(tmpfile_message), '--pathspec-file-nul', '--pathspec-from-file', str(tmpfile_paths)])
+
+        # clean up
+        tmpfile_paths.unlink()
+        tmpfile_message.unlink()
         self.clear_cache()
 
     @staticmethod

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -343,10 +343,10 @@ class OnyoRepo(object):
     def asset_paths(self) -> list[Path]:
         r"""Get the absolute ``Path``\ s of all assets in this repository.
 
-        This property is cached and is reset automatically on :py:func:`commit()`.
+        This property is cached and is reset automatically on :py:func:`commit`.
 
-        If changes are made by other means, use :py:func:`clear_cache()` to
-        reset the cache.
+        If changes are made by other means, use :py:func:`clear_cache` to reset
+        the cache.
         """
 
         if self._asset_paths is None:

--- a/onyo/lib/utils.py
+++ b/onyo/lib/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import os
 from collections import UserDict
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -331,13 +332,22 @@ def get_asset_content(asset_file: Path) -> dict:
     return contents
 
 
-def get_temp_file() -> Path:
-    r"""Return the Path of a new temporary file."""
+def get_temp_file(suffix='.yaml') -> Path:
+    r"""Return the Path of a new temporary file.
+
+    Parameters
+    ----------
+    suffix
+        String to append to the filename. Passed to :py:func:`tempfile.mkstemp`.
+    """
 
     from tempfile import mkstemp
-    fd, tmp_path = mkstemp(prefix='onyo_', suffix='.yaml', text=True)
+    fd, file = mkstemp(prefix='onyo_', suffix=suffix, text=True)
 
-    return Path(tmp_path)
+    # close the file descriptor; we don't need it
+    os.close(fd)
+
+    return Path(file)
 
 
 def validate_yaml(asset_files: list[Path] | None) -> bool:


### PR DESCRIPTION
Fixes in this PR are:

1) don't error when creating a boatload of assets and thus overflowing the maximum command length (#727) 
2) introduce caching for `OnyoRepo.get_config()`
3) cleanup around temp files (dangling file handles, leaked paths, etc)

---
Regarding 1: I introduced a test to overflow with paths (since the overflow can happen with either the message or paths), but left it disabled by default because it takes 30+ minutes to run on my machine. The paths need to be relatively short (beneath the size of the most limiting OS/FS) in order to run reliably. And then in total exceed the maximum argument length of the most capable OS/FS. This results in 150k+ files, and that understandably takes a long time to run.

So the test is there for reference if we are ever uncertain. But is skipped by default.

---
Regarding 2: The motivation is the significant overhead of querying `onyo.assets.name-format`, which is used on a per-asset basis by `set` and `new`.

Initially, I attempted to introduce a per-file file cache at the GitRepo layer, and track the mtime of files that would be queried. However, in the case of a bare `git config` call, the number of locations is quite a few and are modified by environmental variables. These environmental variables would need to be resolved and tracked as well for changes.

CLI users will not have any issues managing the cache (and the new behavior is arguably an improvement, as Onyo's behavior can no longer change mid-flight if the system config changes in parallel). For users of the API, they only encounter issues if they explicitly avoid `OnyoRepo.set_config()`; in which case `clear_cache()` solves their problems.

This speeds up the benchmark considerably:

- `test_cli_onyo_new_fifty[1000] `: 2.09s -> 1.46s (30%)
- `test_cli_onyo_new_fifty[100]`: 1.12s -> 0.42s (63%)
- `test_cli_onyo_set_fifty[1000]`: 2.51s -> 2.31s (8%)
- `test_cli_onyo_set_fifty[100]`: 1.06s -> 0.79s (25%)

Old times:
```
------------------------------------------ benchmark 'test_cli_onyo_new_fifty': 2 tests ------------------------------------------
Name (time in s)                     Min               Max              Mean            StdDev            Median            Rounds
----------------------------------------------------------------------------------------------------------------------------------
test_cli_onyo_new_fifty[1000]     1.8910 (1.74)     2.1347 (1.88)     2.0508 (1.84)     0.0981 (5.01)     2.0877 (1.87)          5
test_cli_onyo_new_fifty[100]      1.0864 (1.0)      1.1338 (1.0)      1.1162 (1.0)      0.0196 (1.0)      1.1177 (1.0)           5
----------------------------------------------------------------------------------------------------------------------------------

------------------------------------------ benchmark 'test_cli_onyo_set_fifty': 2 tests ------------------------------------------
Name (time in s)                     Min               Max              Mean            StdDev            Median            Rounds
----------------------------------------------------------------------------------------------------------------------------------
test_cli_onyo_set_fifty[1000]     2.4798 (2.38)     2.6454 (2.44)     2.5503 (2.40)     0.0700 (4.48)     2.5134 (2.37)          5
test_cli_onyo_set_fifty[100]      1.0427 (1.0)      1.0849 (1.0)      1.0613 (1.0)      0.0156 (1.0)      1.0589 (1.0)           5
----------------------------------------------------------------------------------------------------------------------------------
```

New times:
```
------------------------------------------ benchmark 'test_cli_onyo_new_fifty': 2 tests ------------------------------------------
Name (time in s)                     Min               Max              Mean            StdDev            Median            Rounds
----------------------------------------------------------------------------------------------------------------------------------
test_cli_onyo_new_fifty[1000]     1.4381 (3.47)     1.6802 (3.61)     1.5081 (3.48)     0.0999 (4.20)     1.4568 (3.49)          5
test_cli_onyo_new_fifty[100]      0.4146 (1.0)      0.4654 (1.0)      0.4329 (1.0)      0.0238 (1.0)      0.4178 (1.0)           5
----------------------------------------------------------------------------------------------------------------------------------

------------------------------------------ benchmark 'test_cli_onyo_set_fifty': 2 tests ------------------------------------------
Name (time in s)                     Min               Max              Mean            StdDev            Median            Rounds
----------------------------------------------------------------------------------------------------------------------------------
test_cli_onyo_set_fifty[1000]     2.2197 (2.83)     2.3716 (2.99)     2.2920 (2.90)     0.0629 (15.11)    2.3075 (2.92)          5
test_cli_onyo_set_fifty[100]      0.7846 (1.0)      0.7940 (1.0)      0.7897 (1.0)      0.0042 (1.0)      0.7911 (1.0)           5
----------------------------------------------------------------------------------------------------------------------------------
```

---
fix #727