### PR TITLE
Enhance YAML tooling

### DIFF
--- a/onyo/lib/inventory.py
+++ b/onyo/lib/inventory.py
@@ -793,7 +793,8 @@ class Inventory(object):
                   exclude: Iterable[Path] | Path | None = None,
                   depth: int | None = 0,
                   match: list[Callable[[Item], bool]] | list[list[Callable[[Item], bool]]] | None = None,
-                  types: list[Literal['assets', 'directories']] | None = None
+                  types: list[Literal['assets', 'directories']] | None = None,
+                  intermediates: bool = True
                   ) -> Generator[Item, None, None] | filter:
         r"""Yield all Items matching paths and filters.
 
@@ -831,6 +832,9 @@ class Inventory(object):
             Default is ``['assets']``.
 
             Passed to :py:func:`onyo.lib.onyo.OnyoRepo.get_item_paths`.
+        intermediates
+            Return intermediate directory items. If ``False``, the only directories
+            explicitly contained in the returned list are leaves.
         """
 
         depth = 0 if depth is None else depth
@@ -838,7 +842,11 @@ class Inventory(object):
         match = [[]] if match is None else match
         match = [match] if isinstance(match[0], Callable) else match  # pyre-ignore [9]
 
-        for p in self.repo.get_item_paths(include=include, exclude=exclude, depth=depth, types=types):
+        for p in self.repo.get_item_paths(include=include,
+                                          exclude=exclude,
+                                          depth=depth,
+                                          types=types,
+                                          intermediates=intermediates):
             try:
                 item = self.get_item(p)
                 # check against filters

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -685,15 +685,22 @@ class OnyoRepo(object):
             files = [f for f in files if all(f != p and p not in f.parents for p in exclude)]
 
         paths = []
-        if 'assets' in types:
-            paths.extend([f for f in files if not f.name == ANCHOR_FILE_NAME and self.is_item_path(f)] +
-                         [f.parent for f in files if f.name == ASSET_DIR_FILE_NAME])
-        if 'directories' in types:
-            paths.extend([f.parent for f in files
-                          if f.name == ANCHOR_FILE_NAME and self.is_item_path(f.parent)])
-            # special case root - has no anchor file that would show up in `files`:
-            if self.git.root in include:
-                paths.append(self.git.root)
+        # special case root - has no anchor file that would show up in `files`:
+        if "directories" in types and self.git.root in include:
+            paths.append(self.git.root)
+
+        for f in files:
+            if "assets" in types and f.name == ASSET_DIR_FILE_NAME:
+                if f.parent not in paths:
+                    paths.append(f.parent)
+                continue
+            if "assets" in types and f.name != ANCHOR_FILE_NAME and self.is_item_path(f):
+                paths.append(f)
+                continue
+            if "directories" in types and f.name == ANCHOR_FILE_NAME and self.is_item_path(f.parent):
+                if f.parent not in paths:
+                    paths.append(f.parent)
+                continue
 
         return paths
 

--- a/onyo/lib/utils.py
+++ b/onyo/lib/utils.py
@@ -328,25 +328,32 @@ def get_asset_content(asset_file: Path) -> dict:
         The YAML is invalid.
     """
 
-    yaml = get_patched_yaml()
-    contents = dict()
     try:
-        contents = yaml.load(asset_file)
+        contents = yaml_to_dict_multi(asset_file).__next__()
+    except StopIteration:
+        # no document yielded
+        contents = dict()
+    return contents
+
+
+def yaml_to_dict_multi(stream: Path | str) -> Generator[dict | CommentedMap, None, None]:  # pyre-ignore[11]
+    """Yield dictionaries from a (potential) multi-document YAML."""
+    # TODO: Input should actually be stream (`TextIO` or sth) not str
+    #       Figure when utilizing properly via `onyo_new` where things can come in from file or stdin.
+    # TODO: Utilize this function in `get_asset_content` by retrieving only the first document and ignore the rest.
+    yaml = get_patched_yaml()
+    try:
+        for document in yaml.load_all(stream):
+            if not isinstance(document, (dict, CommentedMap)):
+                # TODO: Better error. See also get_asset_content
+                raise NotAnAssetError("Invalid item in YAML document.")
+            yield document
     except YAMLError as e:  # pyre-ignore[66]
         # Remove ruamel usage pointer (see github issue 436)
         if hasattr(e, 'note') and isinstance(e.note, str) and "suppress this check" in e.note:
             e.note = ""
-        raise NotAnAssetError(f"Invalid YAML in {asset_file}:\n{str(e)}") from e
-
-    if contents is None:
-        return dict()
-
-    if not isinstance(contents, (dict, CommentedMap)):
-        # For example: a simple text file may technically be valid YAML,
-        # but we may get a string instead of dict.
-        raise NotAnAssetError(f"{asset_file} does not appear to be an asset.")
-
-    return contents
+        # TODO: Better error. See also get_asset_content
+        raise NotAnAssetError(f"Invalid YAML:\n{str(e)}") from e
 
 
 def get_temp_file(suffix='.yaml') -> Path:

--- a/onyo/lib/utils.py
+++ b/onyo/lib/utils.py
@@ -10,7 +10,6 @@ from ruamel.yaml import CommentedMap, scanner, YAML  # pyre-ignore[21]
 from ruamel.yaml.error import YAMLError  # pyre-ignore[21]
 
 from onyo.lib.consts import RESERVED_KEYS
-from onyo.lib.pseudokeys import PSEUDO_KEYS
 from onyo.lib.exceptions import NotAnAssetError
 from onyo.lib.ui import ui
 
@@ -275,23 +274,41 @@ def dict_to_asset_yaml(d: Dict | UserDict) -> str:
 
     # deepcopy to keep comments when `d` is `ruamel.yaml.comments.CommentedMap`.
     content = copy.deepcopy(d)
-    for key in RESERVED_KEYS + list(PSEUDO_KEYS.keys()):
+
+    # TODO: RESERVED_KEYS has an artificial "onyo" in it, in order
+    #       to remove the subdict altogether, since iterating over pseudokeys would leave empty dicts behind.
+    #       This needs to be addressed in a nicer way with namespace handling in `Item`.
+    for key in RESERVED_KEYS:
         if key in content:
             del content[key]
+    return dict_to_yaml(content)
+
+
+def dict_to_yaml(d: dict | UserDict) -> str:
+    """Convert a python dictionary to a YAML string.
+
+    Dictionaries that contain a map of comments (ruamel, etc) will have those
+    comments included in the string.
+
+    Parameters
+    ----------
+    d:
+        Dictionary to convert to a YAML string.
+    """
 
     # Empty dicts are serialized to '{}', and I was unable to find any input
     # ('', None, etc) that would serialize to nothing. Hardcoding, though ugly,
     # seems to be the only option.
-    if not content:
+    if not d:
         return '---\n'
 
     from io import StringIO
     yaml = get_patched_yaml()
     yaml.explicit_start = True
     s = StringIO()
-    yaml.dump(content.data
-              if isinstance(content, DotNotationWrapper)
-              else content,
+    yaml.dump(d.data
+              if isinstance(d, DotNotationWrapper)
+              else d,
               s)
 
     return s.getvalue()


### PR DESCRIPTION
This is preparing the YAML tooling for multidoc, layered, recursive templates for the envisioned change to the `new` command.
- Enables asset files to contain multiple documents as "sidecars" (everything but the first doc is ignored by onyo, but multidoc is valid content that doesn't crash anything).
- Have generic YAML writing/reading that doesn't come with asset contraints in preparation of reading YAML input that can contain pseudo-keys.
- Proof-of-concept functions to demonstrate how `onyo show` and `onyo new` would deal with a YAML description of an inventory tree