### PR TITLE
RF: DotNotationWrapper -> ItemSpec

### DIFF
--- a/onyo/cli/tests/test_get.py
+++ b/onyo/cli/tests/test_get.py
@@ -783,16 +783,16 @@ def test_natural_sort(keys: dict[str, sort_t],
     assert expected == [data.get('id') for data in sorted_assets]
 
     # explicitly check path sorting:
-    assets = [{'path': Path('folder/file (1).txt')},
-              {'path': Path('folder/file.txt')},
-              {'path': Path('folder (1)/file.txt')},
-              {'path': Path('folder (10)/file.txt')}]
-    sorted_assets = natural_sort(assets, {'path': SORT_ASCENDING})  # pyre-ignore[6]
+    assets = [{'onyo.path.relative': Path('folder/file (1).txt')},
+              {'onyo.path.relative': Path('folder/file.txt')},
+              {'onyo.path.relative': Path('folder (1)/file.txt')},
+              {'onyo.path.relative': Path('folder (10)/file.txt')}]
+    sorted_assets = natural_sort(assets, {'onyo.path.relative': SORT_ASCENDING})  # pyre-ignore[6]
     expectation = ['folder/file.txt',
                    'folder/file (1).txt',
                    'folder (1)/file.txt',
                    'folder (10)/file.txt']
-    assert expectation == [str(a.get('path')) for a in sorted_assets]
+    assert expectation == [str(a.get('onyo.path.relative')) for a in sorted_assets]
 
 
 @pytest.mark.repo_contents(*convert_contents([t for t in asset_contents

--- a/onyo/cli/tests/test_get.py
+++ b/onyo/cli/tests/test_get.py
@@ -27,9 +27,9 @@ def convert_contents(
         raw_assets: list[tuple[str, dict[str, Any]]]) -> Generator:
     r"""Convert content dictionary to a plain-text string."""
 
-    from onyo.lib.utils import dict_to_asset_yaml
+    from onyo.lib.items import Item
     for file, raw_contents in raw_assets:
-        yield [file, dict_to_asset_yaml(raw_contents)]
+        yield [file, Item(raw_contents).yaml()]
 
 
 tag_asset_contents = [

--- a/onyo/cli/tests/test_get.py
+++ b/onyo/cli/tests/test_get.py
@@ -13,7 +13,10 @@ from onyo.lib.consts import (
 )
 from onyo.lib.onyo import OnyoRepo
 from onyo.lib.command_utils import natural_sort
-from onyo.lib.utils import DotNotationWrapper
+from onyo.lib.items import (
+    Item,
+    ItemSpec,
+)
 
 if TYPE_CHECKING:
     from typing import (
@@ -27,7 +30,6 @@ def convert_contents(
         raw_assets: list[tuple[str, dict[str, Any]]]) -> Generator:
     r"""Convert content dictionary to a plain-text string."""
 
-    from onyo.lib.items import Item
     for file, raw_contents in raw_assets:
         yield [file, Item(raw_contents).yaml()]
 
@@ -590,7 +592,7 @@ def test_get_keys(repo: OnyoRepo,
 
     # Get all the key values and make sure they match
     for line in output:
-        asset = DotNotationWrapper(raw_assets[[a[0] for a in raw_assets].index(line[-1])][1])
+        asset = ItemSpec(raw_assets[[a[0] for a in raw_assets].index(line[-1])][1])
 
         for i, key in enumerate(keys):
             if key in PSEUDO_KEYS:
@@ -771,13 +773,13 @@ def test_natural_sort(keys: dict[str, sort_t],
                       expected: list[int]) -> None:
     r"""Test implementation of natural sorting algorithm."""
 
-    assets = [DotNotationWrapper(t[1]) for t in asset_contents
+    assets = [ItemSpec(t[1]) for t in asset_contents
               if t[0] in ['a13bc_foo_bar.1',
                           'a2cd_foo_bar.2',
                           'a36ab_foo_bar.3',
                           'a36ab_afoo_bar.4']]
     sorted_assets = natural_sort(assets, keys=keys)  # pyre-ignore[6]
-    # ^ No idea why this is the only place where pyre can't figure that DotNotationWrapper is a UserDict
+    # ^ No idea why this is the only place where pyre can't figure that ItemSpec is a UserDict
     assert expected == [data.get('id') for data in sorted_assets]
 
     # explicitly check path sorting:

--- a/onyo/cli/tests/test_set.py
+++ b/onyo/cli/tests/test_set.py
@@ -6,11 +6,9 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from onyo.lib.items import Item
 from onyo.lib.onyo import OnyoRepo
-from onyo.lib.utils import (
-    dict_to_asset_yaml,
-    DotNotationWrapper,
-)
+from onyo.lib.utils import DotNotationWrapper
 
 if TYPE_CHECKING:
     from typing import List
@@ -35,7 +33,7 @@ for i, d in enumerate(directories):
     for spec in asset_specs:
         spec['serial'] = "00_" + str(i)
         name = f"{spec['type']}_{spec['make']}_{spec['model.name']}.{spec['serial']}"
-        content = dict_to_asset_yaml(spec)
+        content = Item(spec).yaml()
         assets.append([f"{d}/{name}", content])
 
 asset_paths = [a[0] for a in assets]

--- a/onyo/cli/tests/test_set.py
+++ b/onyo/cli/tests/test_set.py
@@ -6,9 +6,11 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from onyo.lib.items import Item
+from onyo.lib.items import (
+    Item,
+    ItemSpec,
+)
 from onyo.lib.onyo import OnyoRepo
-from onyo.lib.utils import DotNotationWrapper
 
 if TYPE_CHECKING:
     from typing import List
@@ -20,12 +22,12 @@ directories = ['.',
                'r/e/c/u/r/s/i/v/e',
                'very/very/very/deep'
                ]
-asset_specs = [DotNotationWrapper({'type': 'laptop',
-                                   'make': 'apple',
-                                   'model': {'name': 'macbookpro'}}),
-               DotNotationWrapper({'type': 'lap top',
-                                   'make': 'ap ple',
-                                   'model': {'name': 'mac book pro'}})
+asset_specs = [ItemSpec({'type': 'laptop',
+                         'make': 'apple',
+                         'model': {'name': 'macbookpro'}}),
+               ItemSpec({'type': 'lap top',
+                         'make': 'ap ple',
+                         'model': {'name': 'mac book pro'}})
                ]
 
 assets = []

--- a/onyo/cli/tests/test_unset.py
+++ b/onyo/cli/tests/test_unset.py
@@ -18,9 +18,11 @@ if TYPE_CHECKING:
 def convert_contents(
         raw_assets: list[tuple[str, dict[str, Any]]]) -> Generator:
     r"""Convert content dictionary to a plain-text string."""
-    from onyo.lib.utils import dict_to_asset_yaml
+
+    from onyo.lib.items import Item
+
     for file, raw_contents in raw_assets:
-        yield [file, dict_to_asset_yaml(raw_contents)]
+        yield [file, Item(raw_contents).yaml()]
 
 
 asset_contents = [

--- a/onyo/conftest.py
+++ b/onyo/conftest.py
@@ -324,7 +324,7 @@ def fixture_onyorepo(gitrepo,
                 implicit_dirs.append(spec['onyo.path.absolute'])
             to_commit += onyo.mk_inventory_dirs(implicit_dirs)
             onyo.test_annotation['dirs'].extend(implicit_dirs)
-            onyo.write_asset_content(spec)
+            onyo.write_asset(spec)
             onyo.test_annotation['assets'].append(spec)
             to_commit.append(spec['onyo.path.absolute'])
 

--- a/onyo/lib/command_utils.py
+++ b/onyo/lib/command_utils.py
@@ -226,7 +226,6 @@ def whosyourdaddy(inventory: Inventory,
                   base: Path | None = None) -> str:
     from onyo.lib.consts import SORT_ASCENDING
     from onyo.lib.pseudokeys import PSEUDO_KEYS
-    from onyo.lib.utils import dict_to_yaml
     base = base or (path.parent if path != inventory.root else inventory.root)
     stream_uuid = uuid.uuid4()
     items = list(inventory.get_items(include=[path],
@@ -277,7 +276,7 @@ def whosyourdaddy(inventory: Inventory,
                     del item[key]
         del item["onyo.was"]
 
-        output += dict_to_yaml(item)
+        output += item.yaml()
     return output
 
 

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -42,7 +42,7 @@ from onyo.lib.pseudokeys import PSEUDO_KEYS
 from onyo.lib.ui import ui
 from onyo.lib.utils import (
     deduplicate,
-    write_asset_file,
+    write_asset_to_file,
 )
 
 if TYPE_CHECKING:
@@ -236,7 +236,7 @@ def _edit_asset(inventory: Inventory,
     disallowed_keys.remove('onyo.path.parent')
 
     tmp_path = get_temp_file()
-    write_asset_file(tmp_path, asset)
+    write_asset_to_file(asset, path=tmp_path)
 
     # store operations queue length in case we need to roll-back
     queue_length = len(inventory.operations)

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -35,7 +35,10 @@ from onyo.lib.exceptions import (
     OnyoRepoError,
     PendingInventoryOperationError,
 )
-from onyo.lib.items import Item
+from onyo.lib.items import (
+    Item,
+    ItemSpec,
+)
 from onyo.lib.inventory import Inventory, OPERATIONS_MAPPING
 from onyo.lib.onyo import OnyoRepo
 from onyo.lib.pseudokeys import PSEUDO_KEYS
@@ -224,7 +227,7 @@ def _edit_asset(inventory: Inventory,
 
     from shlex import quote
     from onyo.lib.consts import RESERVED_KEYS
-    from onyo.lib.utils import DotNotationWrapper, get_temp_file, get_asset_content
+    from onyo.lib.utils import get_temp_file, get_asset_content
 
     if not editor:
         editor = inventory.repo.get_editor()
@@ -246,7 +249,7 @@ def _edit_asset(inventory: Inventory,
         subprocess.run(f'{editor} {quote(str(tmp_path))}', check=True, shell=True)
         operations = None
         try:
-            tmp_asset = DotNotationWrapper(get_asset_content(tmp_path))
+            tmp_asset = ItemSpec(get_asset_content(tmp_path))
             if 'onyo.is.directory' in tmp_asset.keys():
                 # 'onyo.is.directory' currently is the only modifiable, reserved key
                 reserved_keys['onyo.is.directory'] = tmp_asset['onyo.is.directory']
@@ -1298,7 +1301,7 @@ def onyo_tsv_to_yaml(tsv: Path) -> None:
     import csv
     from io import StringIO
 
-    from onyo.lib.utils import DotNotationWrapper, get_patched_yaml
+    from onyo.lib.utils import get_patched_yaml
 
     dicts = []
     with tsv.open('r', newline='') as tsv_file:
@@ -1308,7 +1311,7 @@ def onyo_tsv_to_yaml(tsv: Path) -> None:
         if reader.fieldnames is None:
             raise ValueError(f"No header fields in tsv {str(tsv)}")
 
-        dicts = [DotNotationWrapper(row, pristine_original=False) for row in reader]
+        dicts = [ItemSpec(row, pristine_original=False) for row in reader]
 
         # check for content
         if not dicts:

--- a/onyo/lib/commands.py
+++ b/onyo/lib/commands.py
@@ -1311,7 +1311,7 @@ def onyo_tsv_to_yaml(tsv: Path) -> None:
         if reader.fieldnames is None:
             raise ValueError(f"No header fields in tsv {str(tsv)}")
 
-        dicts = [ItemSpec(row, pristine_original=False) for row in reader]
+        dicts = [ItemSpec(row) for row in reader]
 
         # check for content
         if not dicts:

--- a/onyo/lib/differs.py
+++ b/onyo/lib/differs.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 
 from onyo.lib.items import Item
 from onyo.lib.onyo import OnyoRepo
-from onyo.lib.utils import dict_to_asset_yaml
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -25,8 +24,8 @@ def _diff_assets(asset_old: Item,
         Absolute Path of destination parent.
     """
 
-    yield from unified_diff(dict_to_asset_yaml(asset_old).splitlines(keepends=False),
-                            dict_to_asset_yaml(asset_new).splitlines(keepends=False),
+    yield from unified_diff(asset_old.yaml().splitlines(keepends=False),
+                            asset_new.yaml().splitlines(keepends=False),
                             fromfile=str(asset_old.get('onyo.path.absolute', '')),
                             tofile=str(asset_new.get('onyo.path.absolute', '')),
                             lineterm="")

--- a/onyo/lib/executors.py
+++ b/onyo/lib/executors.py
@@ -66,7 +66,7 @@ def exec_modify_asset(repo: OnyoRepo,
     """
 
     new = operands[1]
-    repo.write_asset_content(new)
+    repo.write_asset(new)
     return [new['onyo.path.absolute']], []
 
 
@@ -135,7 +135,7 @@ def exec_new_asset(repo: OnyoRepo,
 
     # No need to check/create parent dirs. That's done prior in its own operation.
     asset = operands[0]
-    repo.write_asset_content(asset)  # TODO: a = ...; reassignment for potential updates on metadata
+    repo.write_asset(asset)  # TODO: a = ...; reassignment for potential updates on metadata
     path = asset.get('onyo.path.absolute')
 
     return [path], [path]
@@ -161,7 +161,7 @@ def exec_new_directory(repo: OnyoRepo,
     """
 
     p: Path = operands[0]
-    asset = dict()
+    asset = Item()
     # This may be an asset file that needs to be turned into an asset dir:
     turn_asset_dir = p.is_file() and repo.is_asset_path(p)
     if turn_asset_dir:
@@ -170,7 +170,7 @@ def exec_new_directory(repo: OnyoRepo,
     paths = repo.mk_inventory_dirs(p)
     if turn_asset_dir:
         asset['onyo.is.directory'] = True
-        repo.write_asset_content(asset)
+        repo.write_asset(asset)
         paths.append(p / ASSET_DIR_FILE_NAME)
 
     return paths, paths
@@ -248,7 +248,7 @@ def exec_remove_directory(repo: OnyoRepo,
     p.rmdir()
     if is_asset_dir:
         asset['onyo.is.directory'] = False  # pyre-ignore[61]  No, this is not "not always defined".
-        repo.write_asset_content(asset)  # pyre-ignore[61]
+        repo.write_asset(asset)  # pyre-ignore[61]
         paths.append(p)  # TODO: Does this need staging? Don't think so, but make sure.
 
     return paths, []

--- a/onyo/lib/inventory.py
+++ b/onyo/lib/inventory.py
@@ -903,12 +903,12 @@ class Inventory(object):
 
     def get_faux_serials(self,
                          num: int = 1,
-                         length: int = 6) -> set[str]:
+                         length: int = 8) -> set[str]:
         r"""Generate a set of unique faux serials.
 
         The generated faux serials are unique within the set and repository.
 
-        The minimum serial length of 4 offers a serial space of 62^4 (~14.7
+        The minimum serial length of 5 offers a serial space of 36^5 (~60.5
         million). That is (arbitrarily) determined to be the highest acceptable
         risk of collisions between independent checkouts of a repo generating
         serials at the same time.
@@ -918,7 +918,7 @@ class Inventory(object):
         num
             Number of serials to generate.
         length
-            String length of the serials to generate. Must be >= 4.
+            String length of the serials to generate. Must be >= 5.
 
         Raises
         ------
@@ -929,12 +929,12 @@ class Inventory(object):
         import random
         import string
 
-        if length < 4:
-            raise ValueError('The length of faux serial numbers must be >= 4.')
+        if length < 5:
+            raise ValueError('The length of faux serial numbers must be >= 5.')
         if num < 1:
             raise ValueError('The number of faux serial numbers must be >= 1.')
 
-        alphanum = string.ascii_letters + string.digits
+        alphanum = string.ascii_lowercase + string.digits
         faux_serials = set()
         # TODO: This split actually puts the entire filename in the set if there's no "faux".
         repo_faux_serials = {str(x.name).split('faux')[-1] for x in self.repo.asset_paths}

--- a/onyo/lib/inventory.py
+++ b/onyo/lib/inventory.py
@@ -981,7 +981,7 @@ class Inventory(object):
         """
 
         if any(not k or not str(k).strip() or k == 'None' for k in asset.keys()):
-            # Note, that DotNotationWrapper.keys() delivers strings (and has to).
+            # Note, that ItemSpec.keys() delivers strings (and has to).
             # Hence, `None` as a key would show up here as 'None'.
             raise ValueError("Keys are not allowed to be empty or None-values.")
 

--- a/onyo/lib/items.py
+++ b/onyo/lib/items.py
@@ -317,12 +317,10 @@ class ItemSpec(UserDict):
         Parameters
         ----------
         exclude
-            Keys to exclude from the output. By default, all
-            :py:data:`onyo.lib.consts.RESERVED_KEYS` (e.g. pseudokeys) are
-            excluded.
+            Keys to exclude from the output. By default, none are excluded.
         """
 
-        exclude = RESERVED_KEYS if exclude is None else exclude
+        exclude = exclude or []
 
         # deepcopy to keep comments
         content = deepcopy(self)
@@ -606,6 +604,21 @@ class Item(ItemSpec):
             # We got a (subclass of) ruamel.yaml.CommentBase.
             # Copy the attributes re comments, format, etc. for roundtrip.
             map_from_file.copy_attributes(self.data)  # pyre-ignore[16]
+
+    def yaml(self,
+             exclude: list | None = None) -> str:
+        r"""Get the stringified YAML including content and comments.
+
+        Parameters
+        ----------
+        exclude
+            Keys to exclude from the output. By default, all
+            :py:data:`onyo.lib.consts.RESERVED_KEYS` (e.g. pseudokeys) are
+            excluded.
+        """
+
+        exclude = exclude or RESERVED_KEYS
+        return super().yaml(exclude)
 
 # TODO/Notes for next PR(s):
 # - Bug/Missing feature: pseudo-keys that are supposed to be settable by commands, are not yet

--- a/onyo/lib/items.py
+++ b/onyo/lib/items.py
@@ -8,7 +8,8 @@ from ruamel.yaml import CommentedMap  # pyre-ignore[21]
 
 from onyo.lib.consts import (
     ANCHOR_FILE_NAME,
-    ASSET_DIR_FILE_NAME
+    ASSET_DIR_FILE_NAME,
+    RESERVED_KEYS,
 )
 import onyo.lib.onyo
 import onyo.lib.inventory
@@ -19,7 +20,7 @@ from onyo.lib.pseudokeys import (
 )
 from onyo.lib.utils import (
     DotNotationWrapper,
-    dict_to_asset_yaml,
+    dict_to_yaml,
 )
 
 
@@ -365,13 +366,27 @@ class Item(DotNotationWrapper):
             # Copy the attributes re comments, format, etc. for roundtrip.
             map_from_file.copy_attributes(self.data)  # pyre-ignore[16]
 
-    def yaml(self) -> str:
+    def yaml(self,
+             exclude: list | None = None) -> str:
         r"""Get the stringified YAML including content and comments.
 
-        Pseudokeys are not included.
+        Parameters
+        ----------
+        exclude
+            Keys to exclude from the output. By default, all
+            :py:data:`onyo.lib.consts.RESERVED_KEYS` (e.g. pseudokeys) are
+            excluded.
         """
 
-        return dict_to_asset_yaml(self)
+        exclude = RESERVED_KEYS if exclude is None else exclude
+
+        # deepcopy to keep comments
+        content = deepcopy(self)
+        for key in exclude:
+            if key in content:
+                del content[key]
+
+        return dict_to_yaml(content.data)
 
 # TODO/Notes for next PR(s):
 # - Bug/Missing feature: pseudo-keys that are supposed to be settable by commands, are not yet

--- a/onyo/lib/items.py
+++ b/onyo/lib/items.py
@@ -313,7 +313,7 @@ class Item(DotNotationWrapper):
 
         return None
 
-    def get_path_name(self) -> Path | None:
+    def get_path_name(self) -> str | None:
         r"""Initializer for the ``'onyo.path.name'`` pseudo-key."""
 
         if self['onyo.path.absolute']:

--- a/onyo/lib/items.py
+++ b/onyo/lib/items.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 
 
 def resolve_alias(key: _KT,
-                  alias_map: Mapping[str, str] | None = None) -> Any:
+                  alias_map: Mapping[str, str] | None = None) -> _KT:
     r"""Return the target key of a key alias.
 
     Parameters
@@ -50,9 +50,9 @@ def resolve_alias(key: _KT,
 
     alias_map = {} if alias_map is None else alias_map
     try:
-        resolved_key = alias_map[key]
+        resolved_key = alias_map[key]  # pyre-ignore[6]
         # lookup again, in case it's an alias of an alias
-        return resolve_alias(resolved_key, alias_map=alias_map)
+        return resolve_alias(resolved_key, alias_map=alias_map)  # pyre-ignore[7]
     except KeyError:
         return key
 
@@ -106,24 +106,24 @@ class ItemSpec(UserDict):
 
         self._alias_map: Mapping[str, str] = {} if alias_map is None else alias_map
 
-        if isinstance(__spec, (ItemSpec, Item, Path)):
-            raise ValueError(f'ItemSpec does not accept {type(__spec)}')
+        if isinstance(__spec, (ItemSpec, Item, Path)):  # pyre-ignore[61]
+            raise ValueError(f'ItemSpec does not accept {type(__spec)}')  # pyre-ignore[61]
 
-        if isinstance(__spec, str):
+        if isinstance(__spec, str):  # pyre-ignore[61]
             # TODO: unlike other input methods, this does /not/ do alias
             #       resolution on init
             __spec = yaml_to_dict(__spec)
 
-        match __spec:
+        match __spec:  # pyre-ignore[61]
             case CommentedMap():
                 # TODO: unlike other input methods, this does /not/ do alias
                 #       resolution on init
                 super().__init__()
                 # direct assignment to retain comments
-                self.data = deepcopy(__spec)
+                self.data = deepcopy(__spec)  # pyre-ignore[61]
                 self.update(**kwargs)
             case _:
-                super().__init__(__spec, **kwargs)
+                super().__init__(__spec, **kwargs)  # pyre-ignore[61]
 
     def __contains__(self,
                      key: _KT) -> bool:

--- a/onyo/lib/items.py
+++ b/onyo/lib/items.py
@@ -71,50 +71,17 @@ class Item(DotNotationWrapper):
         if kwargs:
             self.update(**kwargs)
 
-    def __setitem__(self,
-                    key: _KT,
-                    value: _VT) -> None:
-        r"""Set the value of a key."""
+    def __contains__(self,
+                     key: _KT) -> bool:
+        r"""Whether ``key`` is in self."""
 
-        key = resolve_alias(key)
-        super().__setitem__(key, value)
-
-    def __getitem__(self,
-                    key: _KT) -> Any:
-        r"""Get the value of a ``key``.
-
-        The initializer methods are referenced in the mapping
-        :py:data:`onyo.lib.pseudokeys.PSEUDO_KEYS`. They are called on-demand,
-        when a pseudo-key is first accessed.
-
-        This allows to distinguish a meaningful ``None`` (<unset>) from a not
-        yet evaluated pseudo-key.
-        """
-
-        key = resolve_alias(key)
-        value = super().__getitem__(key)
-
-        if key in onyo.lib.pseudokeys.PSEUDO_KEYS and \
-                isinstance(value, onyo.lib.pseudokeys.PseudoKey):
-            # Value still is the pseudo-key definition.
-            # Actually load and set the response as the new value.
-            new_value = value.implementation(self)
-            self[key] = new_value
-            return new_value
-
-        return value
+        return super().__contains__(resolve_alias(key))
 
     def __delitem__(self,
                     key: _KT) -> None:
         r"""Remove a ``key`` from self."""
 
         super().__delitem__(resolve_alias(key))
-
-    def __contains__(self,
-                     key: _KT) -> bool:
-        r"""Whether ``key`` is in self."""
-
-        return super().__contains__(resolve_alias(key))
 
     def __eq__(self,
                other: Any) -> bool:
@@ -150,12 +117,38 @@ class Item(DotNotationWrapper):
 
         return self.equal_content(other)
 
-    def get(self,  # pyre-ignore[14]
-            key: _KT,
-            default: Any = None) -> Any:
-        r"""Return the value of ``key`` if it's in the dictionary, otherwise ``default``."""
+    def __getitem__(self,
+                    key: _KT) -> Any:
+        r"""Get the value of a ``key``.
 
-        return super().get(resolve_alias(key), default=default)
+        The initializer methods are referenced in the mapping
+        :py:data:`onyo.lib.pseudokeys.PSEUDO_KEYS`. They are called on-demand,
+        when a pseudo-key is first accessed.
+
+        This allows to distinguish a meaningful ``None`` (<unset>) from a not
+        yet evaluated pseudo-key.
+        """
+
+        key = resolve_alias(key)
+        value = super().__getitem__(key)
+
+        if key in onyo.lib.pseudokeys.PSEUDO_KEYS and \
+                isinstance(value, onyo.lib.pseudokeys.PseudoKey):
+            # Value still is the pseudo-key definition.
+            # Actually load and set the response as the new value.
+            new_value = value.implementation(self)
+            self[key] = new_value
+            return new_value
+
+        return value
+
+    def __setitem__(self,
+                    key: _KT,
+                    value: _VT) -> None:
+        r"""Set the value of a key."""
+
+        key = resolve_alias(key)
+        super().__setitem__(key, value)
 
     def equal_content(self,
                       other: Item) -> bool:
@@ -170,6 +163,13 @@ class Item(DotNotationWrapper):
         """
 
         return dict_to_asset_yaml(self) == dict_to_asset_yaml(other)
+
+    def get(self,  # pyre-ignore[14]
+            key: _KT,
+            default: Any = None) -> Any:
+        r"""Return the value of ``key`` if it's in the dictionary, otherwise ``default``."""
+
+        return super().get(resolve_alias(key), default=default)
 
     def update_from_path(self,
                          path: Path) -> None:

--- a/onyo/lib/items.py
+++ b/onyo/lib/items.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
 
 def resolve_alias(key: Any) -> Any:
-    """Return the target key of a key alias."""
+    r"""Return the target key of a key alias."""
 
     try:
         return onyo.lib.pseudokeys.PSEUDOKEY_ALIASES[key]
@@ -40,7 +40,7 @@ def resolve_alias(key: Any) -> Any:
 
 
 class Item(DotNotationWrapper):
-    """An item that an :py:class:`onyo.lib.inventory.Inventory` can potentially track.
+    r"""An item that an :py:class:`onyo.lib.inventory.Inventory` can potentially track.
 
     The main purpose is to attach pseudo-keys and alias resolution to things
     that can be inventoried (directories and YAML-files).
@@ -112,7 +112,7 @@ class Item(DotNotationWrapper):
 
     def __contains__(self,
                      key: _KT) -> bool:
-        """Whether ``key`` is in self."""
+        r"""Whether ``key`` is in self."""
 
         return super().__contains__(resolve_alias(key))
 
@@ -173,7 +173,7 @@ class Item(DotNotationWrapper):
 
     def update_from_path(self,
                          path: Path) -> None:
-        """Update the internal dictionary with key/values from a YAML file.
+        r"""Update the internal dictionary with key/values from a YAML file.
 
         YAML comments are preserved on a best-effort basis. There is no
         straightforward way to merge YAML comments, and thus ones from ``path``
@@ -205,7 +205,7 @@ class Item(DotNotationWrapper):
 
     def fill_created(self,
                      key: str | None = None) -> str | None:
-        """Initializer for the ``'onyo.was.created'`` pseudo-keys.
+        r"""Initializer for the ``'onyo.was.created'`` pseudo-keys.
 
         The entire ``'onyo.was.created'`` dict is initialized, regardless of
         which (if any) ``key`` is requested.
@@ -240,7 +240,7 @@ class Item(DotNotationWrapper):
 
     def fill_modified(self,
                       key: str | None = None) -> str | None:
-        """Initializer for the ``'onyo.was.modified'`` pseudo-keys.
+        r"""Initializer for the ``'onyo.was.modified'`` pseudo-keys.
 
         The entire ``'onyo.was.modified'`` dict is initialized, regardless of
         which (if any) ``key`` is requested.
@@ -274,7 +274,7 @@ class Item(DotNotationWrapper):
         return None
 
     def get_path_absolute(self) -> Path | None:
-        """Initializer for the ``'onyo.path.absolute'`` pseudo-key."""
+        r"""Initializer for the ``'onyo.path.absolute'`` pseudo-key."""
 
         if self.repo and self._path and self._path.name == ASSET_DIR_FILE_NAME:
             return self._path.parent
@@ -282,7 +282,7 @@ class Item(DotNotationWrapper):
         return self._path
 
     def get_path_relative(self) -> Path | None:
-        """Initializer for the ``'onyo.path.relative'`` pseudo-key."""
+        r"""Initializer for the ``'onyo.path.relative'`` pseudo-key."""
 
         if self.repo and self['onyo.path.absolute']:
             try:
@@ -294,7 +294,7 @@ class Item(DotNotationWrapper):
         return None
 
     def get_path_parent(self) -> Path | None:
-        """Initializer for the ``'onyo.path.parent'`` pseudo-key."""
+        r"""Initializer for the ``'onyo.path.parent'`` pseudo-key."""
 
         if self.repo and self['onyo.path.relative']:
             return self['onyo.path.relative'].parent
@@ -302,7 +302,7 @@ class Item(DotNotationWrapper):
         return None
 
     def get_path_file(self) -> Path | None:
-        """Initializer for the ``'onyo.path.file'`` pseudo-key."""
+        r"""Initializer for the ``'onyo.path.file'`` pseudo-key."""
 
         if self.repo and self['onyo.path.relative']:
             if not self['onyo.is.directory']:
@@ -314,7 +314,7 @@ class Item(DotNotationWrapper):
         return None
 
     def get_path_name(self) -> Path | None:
-        """Initializer for the ``'onyo.path.name'`` pseudo-key."""
+        r"""Initializer for the ``'onyo.path.name'`` pseudo-key."""
 
         if self['onyo.path.absolute']:
             return self['onyo.path.absolute'].name
@@ -322,7 +322,7 @@ class Item(DotNotationWrapper):
         return None
 
     def is_asset(self) -> bool | None:
-        """Initializer for the ``'onyo.is.asset'`` pseudo-key."""
+        r"""Initializer for the ``'onyo.is.asset'`` pseudo-key."""
 
         if not self.repo or not self._path:
             return None
@@ -335,7 +335,7 @@ class Item(DotNotationWrapper):
             any(k not in onyo.lib.pseudokeys.PSEUDO_KEYS for k in self.keys())
 
     def is_directory(self) -> bool | None:
-        """Initializer for the ``'onyo.is.directory'`` pseudo-key."""
+        r"""Initializer for the ``'onyo.is.directory'`` pseudo-key."""
 
         if not self.repo or not self._path:
             return None
@@ -345,7 +345,7 @@ class Item(DotNotationWrapper):
         return self.repo.is_inventory_dir(self._path) or (self._path.is_dir() and self["onyo.is.template"])  # pyre-ignore[16]
 
     def is_template(self) -> bool | None:
-        """Initializer for the ``'onyo.is.template'`` pseudo-key."""
+        r"""Initializer for the ``'onyo.is.template'`` pseudo-key."""
 
         if not self.repo or not self._path:
             return None
@@ -353,7 +353,7 @@ class Item(DotNotationWrapper):
         return self._path == self.repo.template_dir or self.repo.template_dir in self._path.parents   # pyre-ignore[16]
 
     def is_empty(self) -> bool | None:
-        """Initializer for the ``'onyo.is.empty'`` pseudo-key."""
+        r"""Initializer for the ``'onyo.is.empty'`` pseudo-key."""
 
         if self['onyo.is.directory'] and self.repo and self._path:
             # TODO: This likely can be faster when redoing/enhancing caching of repo paths.

--- a/onyo/lib/items.py
+++ b/onyo/lib/items.py
@@ -12,7 +12,11 @@ from onyo.lib.consts import (
 )
 import onyo.lib.onyo
 import onyo.lib.inventory
-import onyo.lib.pseudokeys
+from onyo.lib.pseudokeys import (
+    PSEUDO_KEYS,
+    PSEUDOKEY_ALIASES,
+    PseudoKey,
+)
 from onyo.lib.utils import (
     DotNotationWrapper,
     dict_to_asset_yaml,
@@ -34,7 +38,7 @@ def resolve_alias(key: Any) -> Any:
     r"""Return the target key of a key alias."""
 
     try:
-        return onyo.lib.pseudokeys.PSEUDOKEY_ALIASES[key]
+        return PSEUDOKEY_ALIASES[key]
     except KeyError:
         return key
 
@@ -56,7 +60,7 @@ class Item(DotNotationWrapper):
         self.repo: onyo.lib.onyo.OnyoRepo | None = repo
         self._path: Path | None = None
         self.data = CommentedMap()
-        self.update(onyo.lib.pseudokeys.PSEUDO_KEYS)
+        self.update(PSEUDO_KEYS)
 
         match item:
             case Item():
@@ -132,8 +136,8 @@ class Item(DotNotationWrapper):
         key = resolve_alias(key)
         value = super().__getitem__(key)
 
-        if key in onyo.lib.pseudokeys.PSEUDO_KEYS and \
-                isinstance(value, onyo.lib.pseudokeys.PseudoKey):
+        if key in PSEUDO_KEYS and \
+                isinstance(value, PseudoKey):
             # Value still is the pseudo-key definition.
             # Actually load and set the response as the new value.
             new_value = value.implementation(self)
@@ -279,7 +283,7 @@ class Item(DotNotationWrapper):
         # The latter implies it has non-pseudo-keys, or it is specifying "onyo.is.asset"
         # itself in which case this implementation here will be overruled anyway.
         return self.repo.is_asset_path(self._path) or \
-            any(k not in onyo.lib.pseudokeys.PSEUDO_KEYS for k in self.keys())
+            any(k not in PSEUDO_KEYS for k in self.keys())
 
     def _is_directory(self) -> bool | None:
         r"""Initializer for the ``'onyo.is.directory'`` pseudo-key."""

--- a/onyo/lib/items.py
+++ b/onyo/lib/items.py
@@ -91,14 +91,14 @@ class ItemSpec(UserDict):
     """
 
     def __init__(self,
-                 __spec: Mapping[_KT, _VT] | str | None = None,
+                 spec: Mapping[_KT, _VT] | str | None = None,
                  alias_map: Mapping[str, str] | None = None,
                  **kwargs: _VT) -> None:
         r"""Initialize an ItemSpec.
 
         Parameters
         ----------
-        __spec
+        spec
             Dictionary or YAML string to load.
         alias_map
             Dictionary mapping aliases to key names.
@@ -106,24 +106,24 @@ class ItemSpec(UserDict):
 
         self._alias_map: Mapping[str, str] = {} if alias_map is None else alias_map
 
-        if isinstance(__spec, (ItemSpec, Item, Path)):  # pyre-ignore[61]
-            raise ValueError(f'ItemSpec does not accept {type(__spec)}')  # pyre-ignore[61]
+        if isinstance(spec, (ItemSpec, Item, Path)):
+            raise ValueError(f'ItemSpec does not accept {type(spec)}')
 
-        if isinstance(__spec, str):  # pyre-ignore[61]
+        if isinstance(spec, str):
             # TODO: unlike other input methods, this does /not/ do alias
             #       resolution on init
-            __spec = yaml_to_dict(__spec)
+            spec = yaml_to_dict(spec)
 
-        match __spec:  # pyre-ignore[61]
+        match spec:
             case CommentedMap():
                 # TODO: unlike other input methods, this does /not/ do alias
                 #       resolution on init
                 super().__init__()
                 # direct assignment to retain comments
-                self.data = deepcopy(__spec)  # pyre-ignore[61]
+                self.data = deepcopy(spec)
                 self.update(**kwargs)
             case _:
-                super().__init__(__spec, **kwargs)  # pyre-ignore[61]
+                super().__init__(spec, **kwargs)
 
     def __contains__(self,
                      key: _KT) -> bool:

--- a/onyo/lib/items.py
+++ b/onyo/lib/items.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import UserDict
 from copy import deepcopy
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -19,7 +20,6 @@ from onyo.lib.pseudokeys import (
     PseudoKey,
 )
 from onyo.lib.utils import (
-    DotNotationWrapper,
     dict_to_yaml,
 )
 
@@ -27,6 +27,7 @@ from onyo.lib.utils import (
 if TYPE_CHECKING:
     from typing import (
         Any,
+        Generator,
         Mapping,
         TypeVar,
     )
@@ -44,7 +45,179 @@ def resolve_alias(key: Any) -> Any:
         return key
 
 
-class Item(DotNotationWrapper):
+class ItemSpec(UserDict):
+    """Access nested dictionaries via hierarchical keys.
+
+    Wrap a dictionary to traverse multidimensional dictionaries using a dot as
+    the delimiter. In other words, it provides a view of the flattened
+    dictionary::
+
+      > d = {'key': 'value', 'nested': {'key': 'another value'}}
+      > wrapper = ItemSpec(d)
+      > wrapper['nested.key']
+      'another value'
+      > list(wrapper.keys())
+      ['key', 'nested.key']
+
+    Iteration only considers the flattened view. Keys that contain a dictionary
+    are not yielded when using ``.keys()``, ``.values()``, and ``.items()``.
+
+    The underlying dictionary is available via the ``.data`` attribute when the
+    standard Python behavior is needed.
+    """
+
+    def __init__(self,
+                 __dict: Mapping[_KT, _VT] | None = None,
+                 pristine_original: bool = True,
+                 **kwargs: _VT) -> None:
+        r"""Initialize a dot notation wrapped dictionary.
+
+        Parameters
+        ----------
+        __dict
+            Dictionary to wrap.
+        pristine_original
+            Store ``__dict`` unaltered in the ``.data`` attribute.
+            This behavior is the primary intended use for the wrapper: just a
+            namespace wrapper for dicts.
+
+            Set to ``False`` to interpret the incoming dict's keys for dot
+            notation and set accordingly.
+        """
+
+        if pristine_original and __dict and isinstance(__dict, dict):
+            # Maintain the original dict object (and class).
+            # NOTE: Would modify wrapped dict w/ kwargs if both are given.
+            #       deepcopy would prevent this, but contradicts the idea of wrapping.
+            super().__init__()
+            self.data = __dict
+            self.update(**kwargs)
+        else:
+            # Resort to `UserDict` behavior.
+            super().__init__(__dict, **kwargs)
+
+    def _keys(self) -> Generator[str, None, None]:
+        """Yield all keys recursively from nested dictionaries in dot notation.
+
+        A by-product of dot notation is that all keys are strings, regardless of
+        their original type in the underlying dictionary.
+
+        Keys that contain a dictionary not yielded.
+        """
+
+        def recursive_keys(d: dict):
+            for k in d.keys():
+                if hasattr(d[k], "keys"):
+                    yield from (k + "." + sk for sk in recursive_keys(d[k]))
+                else:
+                    # Cast as a string. One can't have a key 'some.1.more',
+                    # where 1 remains an integer.
+                    yield str(k)
+
+        yield from recursive_keys(self.data)
+
+    def __getitem__(self,
+                    key: _KT) -> Any:
+        r"""Get the value of a key."""
+
+        if isinstance(key, str):
+            parts = key.split('.')
+            effective_dict = self.data
+            if len(parts) > 1:
+                for lvl in range(len(parts) - 1):
+                    try:
+                        effective_dict = effective_dict[parts[lvl]]
+                    except KeyError as e:
+                        raise KeyError(f"'{'.'.join(parts[:lvl + 1])}'") from e
+                    except TypeError as e:
+                        raise KeyError(f"'{'.'.join(parts[:lvl])}' is not a dictionary.") from e
+
+            try:
+                return effective_dict[parts[-1]]
+            except KeyError as e:
+                raise KeyError(f"'{key}'") from e
+            except TypeError as e:
+                raise KeyError(f"'{'.'.join(parts[:-1])}' is not a dictionary.") from e
+
+        return super().__getitem__(key)
+
+    def __setitem__(self,
+                    key: _KT,
+                    item: _VT) -> None:
+        r"""Set a key.
+
+        Keys that are strings are interpreted for dot notation, and intermediate
+        dictionaries are created as needed.
+        """
+
+        if isinstance(key, str):
+            parts = key.split('.')
+            effective_dict = self.data
+            if len(parts) > 1:
+                for lvl in range(len(parts) - 1):
+                    try:
+                        effective_dict = effective_dict[parts[lvl]]
+                    except KeyError:
+                        # nested dict doesn't exist yet
+                        effective_dict[parts[lvl]] = dict()
+                        effective_dict = effective_dict[parts[lvl]]
+
+            effective_dict[parts[-1]] = item
+        else:
+            super().__setitem__(key, item)
+
+    def __delitem__(self,
+                    key: _KT) -> None:
+        r"""Remove a ``key`` from self."""
+
+        if isinstance(key, str):
+            parts = key.split('.')
+            effective_dict = self.data
+            if len(parts) > 1:
+                for lvl in range(len(parts) - 1):
+                    try:
+                        effective_dict = effective_dict[parts[lvl]]
+                    except KeyError as e:
+                        raise KeyError(f"'{'.'.join(parts[:lvl + 1])}'") from e
+            del effective_dict[parts[-1]]
+        else:
+            super().__delitem__(key)
+
+    def __contains__(self,
+                     key: _KT) -> bool:
+        """Whether ``key`` is in self.
+
+        Unlike iteration over keys, keys that contain a dictionary are
+        matchable and return ``True``.
+        """
+
+        try:
+            self.__getitem__(key)
+            return True
+        except KeyError:
+            return False
+
+    def __iter__(self) -> Generator[str, None, None]:
+        r"""Return the iterator.
+
+        A by-product of dot notation is that all keys are strings, regardless of
+        their original type in the underlying dictionary.
+
+        Keys that contain a dictionary are not yielded.
+        """
+
+        return self._keys()
+
+    def __len__(self) -> int:
+        r"""Return the number of keys in the dot notation view.
+
+        Keys that contain a dictionary are not counted.
+        """
+
+        return len(list(self._keys()))
+
+
+class Item(ItemSpec):
     r"""An item that an :py:class:`onyo.lib.inventory.Inventory` can potentially track.
 
     The main purpose is to attach pseudo-keys and alias resolution to things

--- a/onyo/lib/items.py
+++ b/onyo/lib/items.py
@@ -492,11 +492,13 @@ class Item(ItemSpec):
         r"""Initializer for the ``'onyo.path.file'`` pseudo-key."""
 
         if self.repo and self['onyo.path.relative']:
-            if not self['onyo.is.directory']:
-                return self['onyo.path.relative']
-            if self['onyo.is.asset'] or self['onyo.is.template']:
-                return self['onyo.path.relative'] / ASSET_DIR_FILE_NAME
-            return self['onyo.path.relative'] / ANCHOR_FILE_NAME
+            if self['onyo.is.directory']:
+                if self['onyo.is.asset']:
+                    return self['onyo.path.relative'] / ASSET_DIR_FILE_NAME
+
+                return self['onyo.path.relative'] / ANCHOR_FILE_NAME
+
+            return self['onyo.path.relative']
 
         return None
 

--- a/onyo/lib/items.py
+++ b/onyo/lib/items.py
@@ -62,7 +62,7 @@ class ItemSpec(UserDict):
 
     Compared to a dictionary, the primary features are:
 
-    * load YAML (e.g. ``ItemSpec(Path('file.yaml'))``
+    * load YAML (e.g. ``ItemSpec(Path('file.yaml').read_text())``
     * dump YAML (e.g. ``spec.yaml()``)
     * equality including YAML comments (e.g. ``ItemSpec() == ItemSpec()``)
     * dot notation (e.g. ``spec['nested.dict.key']``)
@@ -327,6 +327,7 @@ class ItemSpec(UserDict):
         # deepcopy to keep comments
         content = deepcopy(self)
         for key in exclude:
+            # TODO: resolve_alias()?
             if key in content:
                 del content[key]
 
@@ -360,6 +361,12 @@ class Item(ItemSpec):
                  repo: OnyoRepo | None = None,
                  **kwargs: _VT) -> None:
         r"""Initialize an Item."""
+
+        # TODO:
+        # - accept only Item, ItemSpec, or Path (no dict or str)
+        # - repo is required
+        # - sanity check of incoming Path or ItemSpec (specifically
+        #   path-related keys)
 
         super().__init__()
         self.repo: OnyoRepo | None = repo
@@ -401,7 +408,7 @@ class Item(ItemSpec):
 
         if key in PSEUDO_KEYS and isinstance(value, PseudoKey):
             # Value still is the pseudo-key definition.
-            # Actually load and set the response as the new value.
+            # Query and set the response as the new value.
             new_value = value.implementation(self)
             self[key] = new_value
             return new_value

--- a/onyo/lib/items.py
+++ b/onyo/lib/items.py
@@ -324,7 +324,7 @@ class Item(DotNotationWrapper):
             Item to compare with self.
         """
 
-        return dict_to_asset_yaml(self) == dict_to_asset_yaml(other)
+        return self.yaml() == other.yaml()
 
     def get(self,  # pyre-ignore[14]
             key: _KT,
@@ -364,6 +364,14 @@ class Item(DotNotationWrapper):
             # We got a (subclass of) ruamel.yaml.CommentBase.
             # Copy the attributes re comments, format, etc. for roundtrip.
             map_from_file.copy_attributes(self.data)  # pyre-ignore[16]
+
+    def yaml(self) -> str:
+        r"""Get the stringified YAML including content and comments.
+
+        Pseudokeys are not included.
+        """
+
+        return dict_to_asset_yaml(self)
 
 # TODO/Notes for next PR(s):
 # - Bug/Missing feature: pseudo-keys that are supposed to be settable by commands, are not yet

--- a/onyo/lib/items.py
+++ b/onyo/lib/items.py
@@ -19,6 +19,7 @@ from onyo.lib.pseudokeys import (
 )
 from onyo.lib.utils import (
     dict_to_yaml,
+    yaml_to_dict,
 )
 
 
@@ -112,6 +113,11 @@ class ItemSpec(UserDict):
         """
 
         self._alias_map: Mapping[str, str] = {} if alias_map is None else alias_map
+
+        if isinstance(__spec, str):
+            # TODO: unlike other input methods, this does /not/ do alias
+            #       resolution on init
+            __spec = yaml_to_dict(__spec)
 
         if pristine_original and __spec and isinstance(__spec, dict):
             # Maintain the original dict object (and class).

--- a/onyo/lib/items.py
+++ b/onyo/lib/items.py
@@ -114,6 +114,9 @@ class ItemSpec(UserDict):
 
         self._alias_map: Mapping[str, str] = {} if alias_map is None else alias_map
 
+        if isinstance(__spec, (ItemSpec, Item, Path)):
+            raise ValueError(f'ItemSpec does not accept {type(__spec)}')
+
         if isinstance(__spec, str):
             # TODO: unlike other input methods, this does /not/ do alias
             #       resolution on init

--- a/onyo/lib/items.py
+++ b/onyo/lib/items.py
@@ -374,11 +374,10 @@ class Item(ItemSpec):
         self.update(PSEUDO_KEYS)
 
         match item:
-            case ItemSpec():
-                self._path = getattr(item, '_path', None)
-                self.data = deepcopy(item.data)
             case Item():
                 self._path = item._path
+                self.data = deepcopy(item.data)
+            case ItemSpec():
                 self.data = deepcopy(item.data)
             case Path():
                 assert item.is_absolute()  # currently no support for relative. This is how all existing code should work ATM.

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -23,7 +23,6 @@ from onyo.lib.exceptions import (
 from onyo.lib.git import GitRepo
 from onyo.lib.ui import ui
 from onyo.lib.utils import (
-    DotNotationWrapper,
     get_asset_content,
 )
 
@@ -875,6 +874,7 @@ class OnyoRepo(object):
         #       from Inventory to OnyoRepo and turn it into a commit-message part only,
         #       or have sort of a proxy in OnyoRepo.
         #       -> May be: get_history(Item) in Inventory and get_history(path) in OnyoRepo.
+        from onyo.lib.items import ItemSpec
         from onyo.lib.parser import parse_operations_record
 
         for commit in self.git.history(path, n):
@@ -889,4 +889,4 @@ class OnyoRepo(object):
             if record:
                 commit['operations'] = parse_operations_record(record)
 
-            yield DotNotationWrapper(commit)
+            yield ItemSpec(commit)

--- a/onyo/lib/onyo.py
+++ b/onyo/lib/onyo.py
@@ -769,8 +769,8 @@ class OnyoRepo(object):
         if not self.is_inventory_path(path):
             raise ValueError(f"{path} is not a valid inventory path")
 
-        # TODO: this should not be handled here. Perhaps Item.__setitem__() or
-        #       inventory.modify_asset().
+        # TODO: this should not be handled here. Rather in Inventory.modify_asset()
+        #       and Inventory.add_asset().
         if asset.get('onyo.is.directory') and path.name != ASSET_DIR_FILE_NAME:
             path = path / ASSET_DIR_FILE_NAME
 

--- a/onyo/lib/pseudokeys.py
+++ b/onyo/lib/pseudokeys.py
@@ -53,88 +53,88 @@ def delegate(self: Item,
 PSEUDO_KEYS: Dict[str, PseudoKey] = {
     'onyo.path.absolute': PseudoKey(
         description="Absolute path of the item.",
-        implementation=partial(delegate, attribute='get_path_absolute')
+        implementation=partial(delegate, attribute='_get_path_absolute')
     ),
     'onyo.path.relative': PseudoKey(
         description="Path of the item relative to the repository root.",
-        implementation=partial(delegate, attribute='get_path_relative')
+        implementation=partial(delegate, attribute='_get_path_relative')
     ),
     'onyo.path.parent': PseudoKey(
         description="Path of the directory the item is in, relative to the repository root.",
-        implementation=partial(delegate, attribute='get_path_parent')
+        implementation=partial(delegate, attribute='_get_path_parent')
     ),
     'onyo.path.file': PseudoKey(
         description="Path to the file containing an asset's YAML."
                     "Different from 'onyo.path.relative' in case of an asset directory.",
-        implementation=partial(delegate, attribute='get_path_file')
+        implementation=partial(delegate, attribute='_get_path_file')
     ),
     'onyo.path.name': PseudoKey(
         description="Basename of the item's path.",
-        implementation=partial(delegate, attribute='get_path_name')
+        implementation=partial(delegate, attribute='_get_path_name')
     ),
     'onyo.is.asset': PseudoKey(
         description="Is the item an asset.",
-        implementation=partial(delegate, attribute='is_asset')
+        implementation=partial(delegate, attribute='_is_asset')
     ),
     'onyo.is.directory': PseudoKey(
         description="Is the item a directory.",
-        implementation=partial(delegate, attribute='is_directory')
+        implementation=partial(delegate, attribute='_is_directory')
     ),
     'onyo.is.template': PseudoKey(
         description="Is the item a template.",
-        implementation=partial(delegate, attribute='is_template')
+        implementation=partial(delegate, attribute='_is_template')
     ),
     'onyo.is.empty': PseudoKey(
         description="Is the directory empty. <unset> if the item is not a directory.",
-        implementation=partial(delegate, attribute='is_empty')
+        implementation=partial(delegate, attribute='_is_empty')
     ),
     'onyo.was.modified.hexsha': PseudoKey(
         description="SHA of the most recent commit that modified the item.",
-        implementation=partial(delegate, attribute='fill_modified', key='hexsha')
+        implementation=partial(delegate, attribute='_fill_modified', key='hexsha')
     ),
     'onyo.was.modified.time': PseudoKey(
         description="Time of the most recent commit that modified the item.",
-        implementation=partial(delegate, attribute='fill_modified', key='time')
+        implementation=partial(delegate, attribute='_fill_modified', key='time')
     ),
     'onyo.was.modified.author.name': PseudoKey(
         description="Name of the author of the most recent commit that modified the item.",
-        implementation=partial(delegate, attribute='fill_modified', key='author.time')
+        implementation=partial(delegate, attribute='_fill_modified', key='author.time')
     ),
     'onyo.was.modified.author.email': PseudoKey(
         description="Email of the author of the most recent commit that modified the item.",
-        implementation=partial(delegate, attribute='fill_modified', key='author.email')
+        implementation=partial(delegate, attribute='_fill_modified', key='author.email')
     ),
     'onyo.was.modified.committer.name': PseudoKey(
         description="Name of the committer of the most recent commit that modified the item.",
-        implementation=partial(delegate, attribute='fill_modified', key='committer.name')
+        implementation=partial(delegate, attribute='_fill_modified', key='committer.name')
     ),
     'onyo.was.modified.committer.email': PseudoKey(
         description="Email of the committer of the most recent commit that modified the item.",
-        implementation=partial(delegate, attribute='fill_modified', key='committer.email')
+        implementation=partial(delegate, attribute='_fill_modified', key='committer.email')
     ),
     'onyo.was.created.hexsha': PseudoKey(
         description="SHA of the commit that created the item.",
-        implementation=partial(delegate, attribute='fill_created', key='hexsha')
+        implementation=partial(delegate, attribute='_fill_created', key='hexsha')
     ),
     'onyo.was.created.time': PseudoKey(
         description="Time of the commit that created the item.",
-        implementation=partial(delegate, attribute='fill_created', key='time')
+        implementation=partial(delegate, attribute='_fill_created', key='time')
     ),
     'onyo.was.created.author.name': PseudoKey(
         description="Name of the author of the commit that created the item.",
-        implementation=partial(delegate, attribute='fill_created', key='author.time')
+        implementation=partial(delegate, attribute='_fill_created', key='author.time')
     ),
     'onyo.was.created.author.email': PseudoKey(
         description="Email of the author of the commit that created the item.",
-        implementation=partial(delegate, attribute='fill_created', key='author.email')
+        implementation=partial(delegate, attribute='_fill_created', key='author.email')
     ),
     'onyo.was.created.committer.name': PseudoKey(
         description="Name of the committer of the commit that created the item.",
-        implementation=partial(delegate, attribute='fill_created', key='committer.name')
+        implementation=partial(delegate, attribute='_fill_created', key='committer.name')
     ),
     'onyo.was.created.committer.email': PseudoKey(
         description="Email of the committer of the commit that created the item.",
-        implementation=partial(delegate, attribute='fill_created', key='committer.email')
+        implementation=partial(delegate, attribute='_fill_created', key='committer.email')
     ),
 }
 r"""Addressable keys that are not part of the on-disk asset YAML.

--- a/onyo/lib/tests/test_commands_new.py
+++ b/onyo/lib/tests/test_commands_new.py
@@ -4,8 +4,10 @@ import pytest
 
 from onyo.lib.consts import ANCHOR_FILE_NAME
 from onyo.lib.inventory import Inventory
-from onyo.lib.items import Item
-from onyo.lib.utils import DotNotationWrapper
+from onyo.lib.items import (
+    Item,
+    ItemSpec,
+)
 from . import check_commit_msg
 from ..commands import onyo_new
 
@@ -36,14 +38,14 @@ def test_onyo_new_keys(inventory: Inventory) -> None:
 
     Each successful call of `onyo_new()` must add one commit.
     """
-    specs = [DotNotationWrapper({'type': 'a type',
-                                 'make': 'I made it',
-                                 'model': {'name': 'a model'},
-                                 'serial': '002'}),
-             DotNotationWrapper({'type': 'a type',
-                                 'make': 'I made it',
-                                 'model': {'name': 'a model'},
-                                 'serial': '003'})
+    specs = [ItemSpec({'type': 'a type',
+                       'make': 'I made it',
+                       'model': {'name': 'a model'},
+                       'serial': '002'}),
+             ItemSpec({'type': 'a type',
+                       'make': 'I made it',
+                       'model': {'name': 'a model'},
+                       'serial': '003'})
              ]
     old_hexsha = inventory.repo.git.get_hexsha()
     onyo_new(inventory,
@@ -61,16 +63,16 @@ def test_onyo_new_keys(inventory: Inventory) -> None:
         assert all(new_asset[k] == s[k] for k in s.keys())
 
     # faux serial and 'directory' key
-    specs = [DotNotationWrapper({'type': 'A',
-                                 'make': 'faux',
-                                 'model': {'name': 'serial'},
-                                 'directory': 'brandnew',
-                                 'serial': 'faux'}),
-             DotNotationWrapper({'type': 'Another',
-                                 'make': 'faux',
-                                 'model': {'name': 'serial'},
-                                 'directory': 'completely/elsewhere',
-                                 'serial': 'faux'})
+    specs = [ItemSpec({'type': 'A',
+                       'make': 'faux',
+                       'model': {'name': 'serial'},
+                       'directory': 'brandnew',
+                       'serial': 'faux'}),
+             ItemSpec({'type': 'Another',
+                       'make': 'faux',
+                       'model': {'name': 'serial'},
+                       'directory': 'completely/elsewhere',
+                       'serial': 'faux'})
              ]
     # 'directory' is in conflict with `directory` being given:
     pytest.raises(ValueError,
@@ -109,11 +111,11 @@ def test_onyo_new_keys(inventory: Inventory) -> None:
     # use templates and `directory`'s default - CWD.
     # Attention: CWD being inventory.root relies on current implementation of
     # the repo fixture, which the inventory fixture builds upon.
-    specs = [DotNotationWrapper({'type': 'flavor',
-                                 'make': 'manufacturer',
-                                 'model': {'name': 'exquisite'},
-                                 'template': 'laptop.example',
-                                 'serial': '1234'})]
+    specs = [ItemSpec({'type': 'flavor',
+                       'make': 'manufacturer',
+                       'model': {'name': 'exquisite'},
+                       'template': 'laptop.example',
+                       'serial': '1234'})]
     onyo_new(inventory,
              keys=specs)  # pyre-ignore[6]
     # another commit added

--- a/onyo/lib/tests/test_items_ItemSpec.py
+++ b/onyo/lib/tests/test_items_ItemSpec.py
@@ -9,7 +9,7 @@ def test_init_pristine_original():
          'nested.deep.key': 'value',
          }
 
-    wrapper = ItemSpec(d, pristine_original=False)
+    wrapper = ItemSpec(d)
     assert wrapper.data['some'] == d['some']
     assert 'nested' in wrapper.data and isinstance(wrapper.data['nested'], dict)
     assert wrapper.data['nested']['one'] == d['nested.one']
@@ -65,15 +65,15 @@ def test_set_values():
     wrapper = ItemSpec(d)
     wrapper['some'] = 'newvalue'
     assert wrapper.get('some') == 'newvalue'
-    assert d['some'] == 'newvalue'
 
     wrapper['nested.deep.key'] = 1
     assert wrapper.get('nested.deep.key') == 1
-    assert d['nested']['deep']['key'] == 1
 
     wrapper['nested.deep.newkey'] = 2
     assert wrapper.get('nested.deep.newkey') == 2
-    assert d['nested']['deep']['newkey'] == 2
+
+    wrapper['nested.newdict.newkey'] = 3
+    assert wrapper.get('nested.newdict.newkey') == 3
 
     # update from regular dict
     updater = {'regular': 'dict', 'some': 'different'}

--- a/onyo/lib/tests/test_items_ItemSpec.py
+++ b/onyo/lib/tests/test_items_ItemSpec.py
@@ -1,5 +1,5 @@
 import pytest
-from onyo.lib.utils import DotNotationWrapper
+from onyo.lib.items import ItemSpec
 
 
 def test_init_pristine_original():
@@ -9,7 +9,7 @@ def test_init_pristine_original():
          'nested.deep.key': 'value',
          }
 
-    wrapper = DotNotationWrapper(d, pristine_original=False)
+    wrapper = ItemSpec(d, pristine_original=False)
     assert wrapper.data['some'] == d['some']
     assert 'nested' in wrapper.data and isinstance(wrapper.data['nested'], dict)
     assert wrapper.data['nested']['one'] == d['nested.one']
@@ -27,7 +27,7 @@ def test_get_values():
                     }
          }
 
-    wrapper = DotNotationWrapper(d)
+    wrapper = ItemSpec(d)
     assert wrapper['some'] == d['some']
     assert wrapper['nested'] == d['nested']  # TODO: check dict-equal-helper
     assert wrapper['nested.one'] == d['nested']['one']
@@ -62,7 +62,7 @@ def test_set_values():
                     }
          }
 
-    wrapper = DotNotationWrapper(d)
+    wrapper = ItemSpec(d)
     wrapper['some'] = 'newvalue'
     assert wrapper.get('some') == 'newvalue'
     assert d['some'] == 'newvalue'
@@ -83,7 +83,7 @@ def test_set_values():
 
     # update from another wrapped dict should allow for "recursive update":
     updater = {'nested': {'one': 3}}
-    wrapper.update(DotNotationWrapper(updater))
+    wrapper.update(ItemSpec(updater))
     assert wrapper['nested.one'] == updater['nested']['one']
     assert wrapper['nested.two'] == '2'
 
@@ -98,7 +98,7 @@ def test_magic_methods():
          }
     dot_keys = ['some', 'nested.one', 'nested.two', 'nested.deep.key']
 
-    wrapper = DotNotationWrapper(d)
+    wrapper = ItemSpec(d)
     # .keys()
     keys = [k for k in wrapper.keys()]
     assert all(k in keys for k in dot_keys)

--- a/onyo/lib/utils.py
+++ b/onyo/lib/utils.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
         Mapping,
         TypeVar,
     )
+    from onyo.lib.items import Item
 
     _KT = TypeVar("_KT")  # Key type
     _VT = TypeVar("_VT")  # Value type
@@ -404,19 +405,20 @@ def validate_yaml(asset_files: list[Path] | None) -> bool:
     return True
 
 
-def write_asset_file(path: Path,
-                     asset: Dict | UserDict) -> None:
-    r"""Write content to an asset file.
+def write_asset_to_file(asset: Item,
+                        path: Path | None = None) -> None:
+    r"""Write asset content to a file.
 
-    All ``RESERVED_KEYS`` will be stripped from the content before writing.
+    Pseudokeys are not included in the written YAML.
 
     Parameters
     ----------
-    path
-        The Path to write content to.
     asset
-        A dictionary of content to write to the path.
+        Item to write to disk.
+    path
+        The Path to write content to. Default is the asset's ``'onyo.path.file'``
+        pseudokey.
     """
 
-    # TODO: Get file path from onyo.path.file?
+    path = asset.repo.git.root / asset.get('onyo.path.file') if path is None else path
     path.write_text(dict_to_asset_yaml(asset))

--- a/onyo/lib/utils.py
+++ b/onyo/lib/utils.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-from collections import UserDict
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -13,16 +12,10 @@ from onyo.lib.ui import ui
 
 if TYPE_CHECKING:
     from typing import (
-        Any,
         Dict,
         Generator,
-        Mapping,
-        TypeVar,
     )
     from onyo.lib.items import Item
-
-    _KT = TypeVar("_KT")  # Key type
-    _VT = TypeVar("_VT")  # Value type
 
 
 def get_patched_yaml() -> YAML:  # pyre-ignore[11]
@@ -60,178 +53,6 @@ def get_patched_yaml() -> YAML:  # pyre-ignore[11]
     )
 
     return yaml
-
-
-class DotNotationWrapper(UserDict):
-    """Access nested dictionaries via hierarchical keys.
-
-    Wrap a dictionary to traverse multidimensional dictionaries using a dot as
-    the delimiter. In other words, it provides a view of the flattened
-    dictionary::
-
-      > d = {'key': 'value', 'nested': {'key': 'another value'}}
-      > wrapper = DotNotationWrapper(d)
-      > wrapper['nested.key']
-      'another value'
-      > list(wrapper.keys())
-      ['key', 'nested.key']
-
-    Iteration only considers the flattened view. Keys that contain a dictionary
-    are not yielded when using ``.keys()``, ``.values()``, and ``.items()``.
-
-    The underlying dictionary is available via the ``.data`` attribute when the
-    standard Python behavior is needed.
-    """
-
-    def __init__(self,
-                 __dict: Mapping[_KT, _VT] | None = None,
-                 pristine_original: bool = True,
-                 **kwargs: _VT) -> None:
-        r"""Initialize a dot notation wrapped dictionary.
-
-        Parameters
-        ----------
-        __dict
-            Dictionary to wrap.
-        pristine_original
-            Store ``__dict`` unaltered in the ``.data`` attribute.
-            This behavior is the primary intended use for the wrapper: just a
-            namespace wrapper for dicts.
-
-            Set to ``False`` to interpret the incoming dict's keys for dot
-            notation and set accordingly.
-        """
-
-        if pristine_original and __dict and isinstance(__dict, dict):
-            # Maintain the original dict object (and class).
-            # NOTE: Would modify wrapped dict w/ kwargs if both are given.
-            #       deepcopy would prevent this, but contradicts the idea of wrapping.
-            super().__init__()
-            self.data = __dict
-            self.update(**kwargs)
-        else:
-            # Resort to `UserDict` behavior.
-            super().__init__(__dict, **kwargs)
-
-    def _keys(self) -> Generator[str, None, None]:
-        """Yield all keys recursively from nested dictionaries in dot notation.
-
-        A by-product of dot notation is that all keys are strings, regardless of
-        their original type in the underlying dictionary.
-
-        Keys that contain a dictionary not yielded.
-        """
-
-        def recursive_keys(d: dict):
-            for k in d.keys():
-                if hasattr(d[k], "keys"):
-                    yield from (k + "." + sk for sk in recursive_keys(d[k]))
-                else:
-                    # Cast as a string. One can't have a key 'some.1.more',
-                    # where 1 remains an integer.
-                    yield str(k)
-
-        yield from recursive_keys(self.data)
-
-    def __getitem__(self,
-                    key: _KT) -> Any:
-        r"""Get the value of a key."""
-
-        if isinstance(key, str):
-            parts = key.split('.')
-            effective_dict = self.data
-            if len(parts) > 1:
-                for lvl in range(len(parts) - 1):
-                    try:
-                        effective_dict = effective_dict[parts[lvl]]
-                    except KeyError as e:
-                        raise KeyError(f"'{'.'.join(parts[:lvl + 1])}'") from e
-                    except TypeError as e:
-                        raise KeyError(f"'{'.'.join(parts[:lvl])}' is not a dictionary.") from e
-
-            try:
-                return effective_dict[parts[-1]]
-            except KeyError as e:
-                raise KeyError(f"'{key}'") from e
-            except TypeError as e:
-                raise KeyError(f"'{'.'.join(parts[:-1])}' is not a dictionary.") from e
-
-        return super().__getitem__(key)
-
-    def __setitem__(self,
-                    key: _KT,
-                    item: _VT) -> None:
-        r"""Set a key.
-
-        Keys that are strings are interpreted for dot notation, and intermediate
-        dictionaries are created as needed.
-        """
-
-        if isinstance(key, str):
-            parts = key.split('.')
-            effective_dict = self.data
-            if len(parts) > 1:
-                for lvl in range(len(parts) - 1):
-                    try:
-                        effective_dict = effective_dict[parts[lvl]]
-                    except KeyError:
-                        # nested dict doesn't exist yet
-                        effective_dict[parts[lvl]] = dict()
-                        effective_dict = effective_dict[parts[lvl]]
-
-            effective_dict[parts[-1]] = item
-        else:
-            super().__setitem__(key, item)
-
-    def __delitem__(self,
-                    key: _KT) -> None:
-        r"""Remove a ``key`` from self."""
-
-        if isinstance(key, str):
-            parts = key.split('.')
-            effective_dict = self.data
-            if len(parts) > 1:
-                for lvl in range(len(parts) - 1):
-                    try:
-                        effective_dict = effective_dict[parts[lvl]]
-                    except KeyError as e:
-                        raise KeyError(f"'{'.'.join(parts[:lvl + 1])}'") from e
-            del effective_dict[parts[-1]]
-        else:
-            super().__delitem__(key)
-
-    def __contains__(self,
-                     key: _KT) -> bool:
-        """Whether ``key`` is in self.
-
-        Unlike iteration over keys, keys that contain a dictionary are
-        matchable and return ``True``.
-        """
-
-        try:
-            self.__getitem__(key)
-            return True
-        except KeyError:
-            return False
-
-    def __iter__(self) -> Generator[str, None, None]:
-        r"""Return the iterator.
-
-        A by-product of dot notation is that all keys are strings, regardless of
-        their original type in the underlying dictionary.
-
-        Keys that contain a dictionary are not yielded.
-        """
-
-        return self._keys()
-
-    def __len__(self) -> int:
-        r"""Return the number of keys in the dot notation view.
-
-        Keys that contain a dictionary are not counted.
-        """
-
-        return len(list(self._keys()))
 
 
 def deduplicate(sequence: list | None) -> list | None:
@@ -303,7 +124,7 @@ def get_asset_content(asset_file: Path) -> dict:
     return contents
 
 
-def yaml_to_dict_multi(stream: Path | str) -> Generator[dict | CommentedMap, None, None]:  # pyre-ignore[11]
+def yaml_to_dict_multi(stream: Path | str) -> Generator[dict | CommentedMap, None, None]:
     """Yield dictionaries from a (potential) multi-document YAML."""
     # TODO: Input should actually be stream (`TextIO` or sth) not str
     #       Figure when utilizing properly via `onyo_new` where things can come in from file or stdin.

--- a/onyo/lib/utils.py
+++ b/onyo/lib/utils.py
@@ -102,7 +102,7 @@ def dict_to_yaml(d: Dict) -> str:
     return s.getvalue()
 
 
-def yaml_to_dict(s: str) -> Dict | CommentedMap:
+def yaml_to_dict(s: str) -> Dict | CommentedMap:  # pyre-ignore[11]
     r"""Convert a YAML string to a dictionary.
 
     YAML that contains comments will have them retained as a comment map.
@@ -244,5 +244,6 @@ def write_asset_to_file(asset: Item,
         pseudokey.
     """
 
-    path = asset.repo.git.root / asset.get('onyo.path.file') if path is None else path
+    # TODO: This assumes that `repo` is always set in Item(). This is not yet true, but one day will be.
+    path = asset.repo.git.root / asset.get('onyo.path.file') if path is None else path  # pyre-ignore[16]
     path.write_text(asset.yaml())

--- a/onyo/lib/utils.py
+++ b/onyo/lib/utils.py
@@ -421,4 +421,4 @@ def write_asset_to_file(asset: Item,
     """
 
     path = asset.repo.git.root / asset.get('onyo.path.file') if path is None else path
-    path.write_text(dict_to_asset_yaml(asset))
+    path.write_text(asset.yaml())

--- a/onyo/tests/benchmark.py
+++ b/onyo/tests/benchmark.py
@@ -13,8 +13,8 @@ from onyo.lib.commands import (
     onyo_set,
 )
 from onyo.lib.inventory import Inventory
+from onyo.lib.items import ItemSpec
 from onyo.lib.onyo import OnyoRepo
-from onyo.lib.utils import DotNotationWrapper
 
 if TYPE_CHECKING:
     from typing import Generator
@@ -60,7 +60,7 @@ class TestOnyoBenchmark:
             inventory = Inventory(repo=repo)
 
             # populate the repo
-            assets = [DotNotationWrapper(a) for a in fake.onyo_asset_dicts(num=num)]
+            assets = [ItemSpec(a) for a in fake.onyo_asset_dicts(num=num)]
             directories = fake.onyo_directories(num=num)
             assets = [a | {'directory': d} for a, d in zip(assets, directories)]
             onyo_new(inventory, keys=assets)  # pyre-ignore[6]
@@ -89,7 +89,7 @@ class TestOnyoBenchmark:
 
         inventory = benchmark_inventory
         # fifty additional assets
-        fifty_assets = [DotNotationWrapper(a) for a in fake.onyo_asset_dicts(num=50)]
+        fifty_assets = [ItemSpec(a) for a in fake.onyo_asset_dicts(num=50)]
         fifty_assets_as_keys = [f'{k}={v}' for a in fifty_assets for k, v in a.items()]
 
         def setup():


### PR DESCRIPTION
This PR got way more complicated than I expected it to.

The primary feature is:
- rename DotNotationWrapper to ItemSpec
- move a lot of Item's functionality into ItemSpec

This lays down the groundwork to eventually require that all `Item`s have a `repo` and have sanity checks on init.

This also includes some other unrelated fixes:
- Itemification of various functions
- make `faux_serials()` lowercase only
- ItemSpec is meant to be used to load YAML strings and dump YAML.