### PR TITLE
Switch faux serials to uppercase

### DIFF
--- a/onyo/lib/inventory.py
+++ b/onyo/lib/inventory.py
@@ -951,7 +951,7 @@ class Inventory(object):
         if num < 1:
             raise ValueError('The number of faux serial numbers must be >= 1.')
 
-        alphanum = string.ascii_lowercase + string.digits
+        alphanum = string.ascii_uppercase + string.digits
         faux_serials = set()
         # TODO: This split actually puts the entire filename in the set if there's no "faux".
         repo_faux_serials = {str(x.name).split('faux')[-1] for x in self.repo.asset_paths}


### PR DESCRIPTION
This is conforming to our own usecase (INM-7). Otherwise this function is to be replaced by more generic one anyway.