### PR TITLE
NF: use uv to install packages

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,13 +29,14 @@ jobs:
         python -m pip install --upgrade pip
         # get proper PyICU (for natsort)
         sudo apt-get install pkg-config libicu-dev
+        pip install uv
         pip install --no-binary=:pyicu: pyicu
         # install onyo
-        pip install -e ".[tests]"
+        uv pip install --system -e ".[tests]"
         sudo apt-get install -y zsh
     - name: ruff linting
       run: |
-        ruff check
+        uvx ruff check
     - name: Pyre type-checking
       run: |
         pyre --noninteractive check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ tests = [
     'pytest-benchmark',
     'pytest-cov',
     'pytest-randomly',
-    'ruff',
 ]
 docs = [
     'Faker',


### PR DESCRIPTION
Install packages with `uv` instead of `pip`.

As a bonus, this allows us to use `uvx ruff check` (ruff build in into uv) which removes a dependency from `pyproject.toml`.